### PR TITLE
💚 Fix CI: add pytest dev dep and gitmoji PR title check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,18 @@ jobs:
         with:
           python-version: "3.14"
       - uses: pre-commit/action@v3.0.1
+
+  pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title starts with gitmoji
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if echo "$PR_TITLE" | grep -Pq '^\p{So}|^\p{Emoji_Presentation}|^:[a-z0-9_+-]+:'; then
+            echo "✅ PR title starts with a gitmoji: $PR_TITLE"
+          else
+            echo "❌ PR title must start with a gitmoji (e.g. ✨ or :sparkles:)"
+            echo "   Got: $PR_TITLE"
+            exit 1
+          fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
 [project.scripts]
 carapace = "carapace.cli:app"
 
+[dependency-groups]
+dev = ["pytest"]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ from typer.testing import CliRunner
 
 from carapace.cli import app
 
-runner = CliRunner(color=False)
+runner = CliRunner(env={"NO_COLOR": "1"})
 
 
 def test_help():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ from typer.testing import CliRunner
 
 from carapace.cli import app
 
-runner = CliRunner()
+runner = CliRunner(color=False)
 
 
 def test_help():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,20 +1,29 @@
 """CLI smoke tests (no LLM tokens needed)."""
 
+import re
+
 from typer.testing import CliRunner
 
 from carapace.cli import app
 
-runner = CliRunner(env={"NO_COLOR": "1"})
+runner = CliRunner()
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
 
 
 def test_help():
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
-    assert "Carapace" in result.output
+    assert "Carapace" in _strip_ansi(result.output)
 
 
 def test_chat_help():
     result = runner.invoke(app, ["chat", "--help"])
     assert result.exit_code == 0
-    assert "--session" in result.output
-    assert "--data-dir" in result.output
+    output = _strip_ansi(result.output)
+    assert "--session" in output
+    assert "--data-dir" in output


### PR DESCRIPTION
## Summary
- Add `pytest` to `[dependency-groups]` in `pyproject.toml` so `uv sync --dev` installs it (fixes CI test job)
- Add `pr-title` CI job to enforce that PR titles start with a gitmoji

## Test plan
- [ ] CI test job passes (pytest is found)
- [ ] PR title check passes for this PR (starts with 💚)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly CI/policy and test hardening changes; low risk aside from potential false positives/negatives in the PR title regex that could block merges.
> 
> **Overview**
> Fixes the CI test job by adding `pytest` as a dev dependency via `[dependency-groups].dev`, aligning with `uv sync --dev`.
> 
> Adds a new `pr-title` GitHub Actions job that enforces PR titles begin with an emoji/gitmoji (unicode emoji or `:shortcode:`) and fails the workflow otherwise.
> 
> Updates CLI smoke tests to strip ANSI color codes before assertions, making help-output checks robust to colored `rich`/Typer output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcbecf9afa63afe61c22d6555084e7bcc9d69b12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->