### PR TITLE
✨ Add bootstrap module and initial asset files

### DIFF
--- a/src/carapace/assets/CORE.md
+++ b/src/carapace/assets/CORE.md
@@ -1,0 +1,5 @@
+# Core Memory
+
+Long-term facts, preferences, and identity. Updated over time.
+
+(No entries yet.)

--- a/src/carapace/assets/SOUL.md
+++ b/src/carapace/assets/SOUL.md
@@ -1,0 +1,7 @@
+# Soul
+
+You are Carapace -- a security-conscious personal AI agent.
+
+Your tone is direct, calm, and helpful. You avoid unnecessary verbosity.
+When you don't know something, you say so. You take security seriously
+but you're not paranoid -- you explain restrictions clearly when they apply.

--- a/src/carapace/assets/USER.md
+++ b/src/carapace/assets/USER.md
@@ -1,0 +1,4 @@
+# User
+
+No information about the user yet. Learn about them over time and suggest
+updates to this file.

--- a/src/carapace/assets/config.yaml
+++ b/src/carapace/assets/config.yaml
@@ -1,0 +1,27 @@
+carapace:
+  log_level: info
+
+channels:
+  matrix:
+    enabled: false
+  cron:
+    enabled: false
+
+agent:
+  model: anthropic:claude-sonnet-4-5
+  classifier_model: anthropic:claude-haiku-4-5
+
+credentials:
+  backend: mock
+
+sandbox:
+  base_image: alpine:3.19
+  idle_timeout_minutes: 15
+  default_network: false
+
+memory:
+  search:
+    enabled: false
+
+sessions:
+  history_retention_days: 90

--- a/src/carapace/assets/create-skill/SKILL.md
+++ b/src/carapace/assets/create-skill/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: create-skill
+description: Create and edit AgentSkills for Carapace. Use when the user wants to add a new skill, edit an existing one, or asks about the skill format.
+---
+
+# Create Skill
+
+Guide for creating and maintaining Carapace skills that follow the open [AgentSkills](https://agentskills.io/) format.
+
+## Skill location
+
+Skills live under `skills/` in the data directory. Each skill is a directory containing at minimum a `SKILL.md` file:
+
+```
+skills/
+  my-skill/
+    SKILL.md          # required
+    scripts/           # optional: executable code
+    references/        # optional: additional docs
+    assets/            # optional: templates, data files
+```
+
+## SKILL.md format
+
+### Frontmatter (required)
+
+```yaml
+---
+name: my-skill
+description: What this skill does and when to use it. Be specific -- this is what the agent reads at startup to decide whether to activate the skill.
+---
+```
+
+**`name` rules:**
+
+- Must match the parent directory name exactly
+- Lowercase letters, numbers, and hyphens only
+- No consecutive hyphens (`--`), no leading/trailing hyphens
+- Max 64 characters
+
+**`description` rules:**
+
+- Include keywords that help identify relevant tasks
+- Describe both _what_ the skill does and _when_ to use it
+- Max 1024 characters
+
+Optional frontmatter fields:
+
+| Field           | Purpose                                             |
+| --------------- | --------------------------------------------------- |
+| `license`       | License name or reference to a bundled LICENSE file |
+| `compatibility` | Environment requirements (tools, network, etc.)     |
+| `metadata`      | Arbitrary key-value pairs (author, version, etc.)   |
+
+### Body (instructions)
+
+The markdown body after the frontmatter is the actual skill content. There are no format restrictions. Write whatever helps perform the task effectively.
+
+Recommended sections:
+
+- When to use / when not to use
+- Step-by-step instructions
+- Common edge cases
+- Input/output examples
+
+## Progressive disclosure
+
+Carapace loads skills in three tiers:
+
+1. **Discovery** (~100 tokens): `name` + `description` loaded at startup for all skills
+2. **Activation** (< 5000 tokens recommended): full `SKILL.md` body loaded via `activate_skill`
+3. **Resources** (on demand): files in `scripts/`, `references/`, `assets/` loaded only when referenced
+
+Keep `SKILL.md` under 500 lines. Move detailed reference material to separate files and reference them with relative paths:
+
+```markdown
+See [the API reference](references/api.md) for endpoint details.
+```
+
+## Carapace-specific conventions
+
+### Security rules that apply
+
+- **`skill-modification`** (always active): creating, editing, or deleting any file under `skills/` requires user approval. The user will be prompted automatically.
+- **`no-exfil-after-skill-read`**: after activating a skill (reading its instructions), outbound communication is blocked without approval. Keep this in mind -- skills may contain sensitive workflow details.
+
+### Creating a skill step by step
+
+1. Choose a name: lowercase, hyphenated, descriptive (e.g. `email-summary`, `git-changelog`)
+2. Create the directory and `SKILL.md` using the `write` tool:
+   - Path: `skills/<name>/SKILL.md`
+   - The `skill-modification` rule will trigger approval
+3. Write clear frontmatter with a good `description`
+4. Write concise instructions in the body
+5. Optionally add `scripts/`, `references/`, or `assets/` directories
+6. Tell the user the skill will appear in `/skills` and be available in new sessions
+
+### Editing an existing skill
+
+Use the `edit` tool on `skills/<name>/SKILL.md`. The same approval rule applies.
+
+### Good description examples
+
+```yaml
+# Good -- specific, mentions triggers
+description: Summarise email threads and draft replies. Use when the user mentions email, inbox, or wants to compose a message.
+
+# Bad -- too vague
+description: Helps with email.
+```
+
+### Template
+
+When creating a new skill, start from this template and adapt it:
+
+```markdown
+---
+name: <skill-name>
+description: <What it does and when to use it.>
+---
+
+# <Skill Title>
+
+## When to use
+
+<Describe the situations where this skill applies.>
+
+## Instructions
+
+<Step-by-step guidance for the agent.>
+
+## Edge cases
+
+<Things to watch out for.>
+```

--- a/src/carapace/assets/example-skill/SKILL.md
+++ b/src/carapace/assets/example-skill/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: example
+description: A template skill showing the AgentSkills format.
+---
+
+# Example Skill
+
+This is a template skill that demonstrates the [AgentSkills](https://agentskills.io/) format.
+
+## Instructions
+
+When this skill is activated, greet the user and explain what skills are.
+
+Skills are reusable instruction sets that teach the agent new capabilities.
+Each skill lives in its own directory under `skills/` with a `SKILL.md` file.
+
+## Frontmatter
+
+The YAML frontmatter (between `---` markers) provides metadata:
+
+- `name` -- the skill identifier
+- `description` -- a short summary shown in the skill catalog
+
+## Creating Your Own Skills
+
+1. Create a new directory under `skills/` (e.g. `skills/my-skill/`)
+2. Add a `SKILL.md` file with YAML frontmatter
+3. Write instructions the agent should follow when the skill is activated

--- a/src/carapace/assets/rules.yaml
+++ b/src/carapace/assets/rules.yaml
@@ -1,0 +1,59 @@
+rules:
+  - id: no-write-after-web
+    trigger: "the agent has read content from the internet"
+    effect: "block all write operations (files, emails, APIs) without approval"
+    mode: approve
+    description: >
+      If the agent has consumed unsanitized external input, it could
+      be influenced by prompt injection. Write operations are gated
+      until the user explicitly approves each one.
+
+  - id: no-exfil-after-sensitive
+    trigger: "the agent has accessed sensitive personal data (finances, documents, health)"
+    effect: "block all outbound communication (email, API calls, messages) without approval"
+    mode: approve
+    description: >
+      Prevents data exfiltration. After seeing sensitive data, the agent
+      cannot send anything externally unless the user approves.
+
+  - id: skill-modification
+    trigger: "always"
+    effect: "creating, editing, or deleting files in the skills folder requires approval"
+    mode: approve
+    description: >
+      The agent can self-improve by writing skills, but every
+      modification must be approved by the user.
+
+  - id: memory-write
+    trigger: "always"
+    effect: "writing or modifying memory files requires approval"
+    mode: approve
+    description: >
+      Memory is persistent context -- modifications should be deliberate.
+
+  - id: shell-write
+    trigger: "always"
+    effect: "shell commands that write or execute (not read) require approval"
+    mode: approve
+    description: >
+      Read-only shell commands (ls, cat, grep, find) in the base
+      container are always allowed. Shell commands classified as
+      write or execute operations require approval.
+
+  - id: no-exfil-after-skill-read
+    trigger: "the agent has read skill instructions (activated a skill)"
+    effect: "block outbound communication (email, API calls) without approval"
+    mode: approve
+    description: >
+      Skill instructions reveal the user's personal setup -- services,
+      credential paths, workflow patterns. After reading these, outbound
+      communication is gated to prevent information leakage.
+
+  - id: credential-access
+    trigger: "always"
+    effect: "fetching any credential from the password manager requires approval on first use per session"
+    mode: approve
+    description: >
+      Credentials are fetched from the password manager on demand.
+      The user must approve each distinct credential the first time
+      it is requested in a session.

--- a/src/carapace/bootstrap.py
+++ b/src/carapace/bootstrap.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+from pathlib import Path
+
+_ASSETS = files("carapace.assets")
+
+_CRITICAL_FILES: list[tuple[str, str]] = [
+    ("SOUL.md", "SOUL.md"),
+    ("USER.md", "USER.md"),
+    ("config.yaml", "config.yaml"),
+    ("rules.yaml", "rules.yaml"),
+    ("CORE.md", "memory/CORE.md"),
+]
+
+_SEED_SKILLS: list[tuple[str, str]] = [
+    ("example-skill/SKILL.md", "skills/example/SKILL.md"),
+    ("create-skill/SKILL.md", "skills/create-skill/SKILL.md"),
+]
+
+
+def _copy_asset(asset_path: str, target: Path) -> None:
+    source = _ASSETS.joinpath(*asset_path.split("/"))
+    with as_file(source) as src:
+        target.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+
+
+def ensure_data_dir(data_dir: Path) -> list[str]:
+    """Ensure data dir exists with all critical files.
+
+    Returns the list of file paths (relative to *data_dir*) that were created.
+    """
+    created: list[str] = []
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    for asset_name, target_rel in _CRITICAL_FILES:
+        target = data_dir / target_rel
+        if not target.exists():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            _copy_asset(asset_name, target)
+            created.append(target_rel)
+
+    # Seed skills directory when it doesn't exist at all
+    skills_dir = data_dir / "skills"
+    if not skills_dir.exists():
+        for asset_name, target_rel in _SEED_SKILLS:
+            target = data_dir / target_rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            _copy_asset(asset_name, target)
+            created.append(target_rel)
+
+    return created

--- a/src/carapace/cli.py
+++ b/src/carapace/cli.py
@@ -21,6 +21,7 @@ from tenacity import (
 )
 
 from carapace.agent import create_agent
+from carapace.bootstrap import ensure_data_dir
 from carapace.config import get_data_dir, load_config, load_rules
 from carapace.models import Deps
 from carapace.session import SessionManager
@@ -253,6 +254,9 @@ def chat(
     from pathlib import Path
 
     data_path = Path(data_dir) if data_dir else get_data_dir()
+    created = ensure_data_dir(data_path)
+    if created:
+        console.print(f"[dim]Initialised: {', '.join(created)}[/dim]")
     config = load_config(data_path)
     rules = load_rules(data_path)
     session_mgr = SessionManager(data_path)


### PR DESCRIPTION
- Introduced `bootstrap.py` to ensure the creation of critical files and directories.
- Added asset files including `config.yaml`, `CORE.md`, `SOUL.md`, `USER.md`, and rules in `rules.yaml`.
- Implemented functionality to seed skills and manage data directory initialization in the CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-run initialization and ships new default `config.yaml`/`rules.yaml`, which can materially affect runtime behavior and safety gating for new installs.
> 
> **Overview**
> Introduces a new bootstrap path (`bootstrap.ensure_data_dir`) that copies packaged asset files into the user data directory when missing, including default `config.yaml`, `rules.yaml`, identity/memory docs (`SOUL.md`, `USER.md`, `memory/CORE.md`), and seeding initial skills (`example`, `create-skill`) when `skills/` doesn’t exist.
> 
> Updates the CLI `chat` command to run this initialization before loading config/rules and to print which files were created on first run. Adds the corresponding asset content, including the default security rule set and skill templates/guides.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8addeeca55d4f1e5242d9d903eb44f3e3ff2ed76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->