### PR TITLE
✨ Revamp Carapace architecture with server and CLI client integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,8 @@ Carapace is a security-first personal AI agent with rule-based information flow 
 
 - Install deps: `uv sync`
 - Install with dev deps: `uv sync --dev`
-- Run interactive CLI: `uv run python -m carapace`
+- Start server: `uv run python -m carapace` (or `uv run carapace-server`)
+- Start CLI client: `uv run python -m carapace.cli` (or `uv run carapace`)
 - Run tests: `uv run pytest`
 - Run single test: `uv run pytest tests/test_cli.py -k test_help`
 
@@ -27,8 +28,11 @@ Carapace is a security-first personal AI agent with rule-based information flow 
 
 ```
 src/carapace/          # main package
+  server.py            # FastAPI server (REST + WebSocket)
+  cli.py               # Thin CLI client (HTTP + WS)
   agent.py             # Pydantic AI agent definition and tools
-  cli.py               # Typer CLI
+  auth.py              # Bearer token generation and validation
+  ws_models.py         # WebSocket message protocol models
   config.py            # configuration loading
   models.py            # Pydantic models and dataclasses
   session.py           # session management

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,14 @@ dependencies = [
     "python-dotenv>=1.2.1",
     "tenacity",
     "logfire[httpx]",
+    "fastapi",
+    "uvicorn[standard]",
+    "websockets",
 ]
 
 [project.scripts]
 carapace = "carapace.cli:app"
+carapace-server = "carapace.server:main"
 
 [dependency-groups]
 dev = ["pytest"]

--- a/src/carapace/__main__.py
+++ b/src/carapace/__main__.py
@@ -1,4 +1,4 @@
-from carapace.cli import app
+from carapace.server import main
 
 if __name__ == "__main__":
-    app()
+    main()

--- a/src/carapace/agent.py
+++ b/src/carapace/agent.py
@@ -48,7 +48,7 @@ async def _gate(
             detail += f" rules: {rules_str}"
         if result.needs_approval:
             detail += " -> approval required"
-        
+
         if ctx.deps.tool_call_callback:
             ctx.deps.tool_call_callback(tool_name, args, detail)
         else:

--- a/src/carapace/agent.py
+++ b/src/carapace/agent.py
@@ -48,7 +48,11 @@ async def _gate(
             detail += f" rules: {rules_str}"
         if result.needs_approval:
             detail += " -> approval required"
-        print(f"  \033[2m{tool_name}({args_str}) {detail}\033[0m")
+        
+        if ctx.deps.tool_call_callback:
+            ctx.deps.tool_call_callback(tool_name, args, detail)
+        else:
+            print(f"  \033[2m{tool_name}({args_str}) {detail}\033[0m")
 
     if result.needs_approval:
         raise ApprovalRequired(

--- a/src/carapace/auth.py
+++ b/src/carapace/auth.py
@@ -13,4 +13,5 @@ def ensure_token(data_dir: Path) -> str:
         return token_path.read_text().strip()
     token = secrets.token_urlsafe(32)
     token_path.write_text(token + "\n")
+    token_path.chmod(0o600)
     return token

--- a/src/carapace/auth.py
+++ b/src/carapace/auth.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import secrets
+from pathlib import Path
+
+TOKEN_FILE = "server.token"
+
+
+def ensure_token(data_dir: Path) -> str:
+    """Return the bearer token, generating one on first call."""
+    token_path = data_dir / TOKEN_FILE
+    if token_path.exists():
+        return token_path.read_text().strip()
+    token = secrets.token_urlsafe(32)
+    token_path.write_text(token + "\n")
+    return token

--- a/src/carapace/cli.py
+++ b/src/carapace/cli.py
@@ -1,405 +1,311 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import os
+from typing import Any
 
-import logfire
+import httpx
 import typer
 from dotenv import load_dotenv
-from httpx import AsyncClient, HTTPStatusError
-from pydantic_ai import DeferredToolRequests, DeferredToolResults, ToolDenied
-from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
-from pydantic_ai.models.anthropic import AnthropicModel
-from pydantic_ai.providers.anthropic import AnthropicProvider
-from pydantic_ai.retries import AsyncTenacityTransport, RetryConfig, wait_retry_after
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.table import Table
-from tenacity import (
-    RetryCallState,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential,
-)
+from websockets.asyncio.client import connect as ws_connect
+from websockets.exceptions import ConnectionClosed
 
-from carapace.agent import create_agent
-from carapace.bootstrap import ensure_data_dir
-from carapace.config import get_data_dir, load_config, load_rules
-from carapace.models import Deps
-from carapace.session import SessionManager
-from carapace.skills import SkillRegistry
+from carapace.auth import TOKEN_FILE
+from carapace.config import get_data_dir
 
 load_dotenv()
 
 app = typer.Typer(help="Carapace -- security-first personal AI agent")
 console = Console()
 
-
-def _create_anthropic_model(model_name: str) -> AnthropicModel:
-    """Build an AnthropicModel with automatic retry on 429/5xx errors."""
-
-    def _before_sleep(state: RetryCallState) -> None:
-        wait = state.next_action.sleep if state.next_action else 0
-        console.print(f"[yellow]Rate limited (attempt {state.attempt_number}). Retrying in {wait:.0f}s...[/yellow]")
-
-    transport = AsyncTenacityTransport(
-        config=RetryConfig(
-            retry=retry_if_exception_type((HTTPStatusError, ConnectionError)),
-            wait=wait_retry_after(
-                fallback_strategy=wait_exponential(multiplier=1, max=60),
-                max_wait=300,
-            ),
-            stop=stop_after_attempt(5),
-            before_sleep=_before_sleep,
-            reraise=True,
-        ),
-        validate_response=lambda r: r.raise_for_status() if r.status_code in (429, 502, 503, 504) else None,
-    )
-    http_client = AsyncClient(transport=transport)
-
-    model_id = model_name.removeprefix("anthropic:")
-    return AnthropicModel(model_id, provider=AnthropicProvider(http_client=http_client))
+DEFAULT_SERVER = "http://127.0.0.1:8321"
 
 
-def _replay_history(messages: list, n: int) -> None:
-    """Re-print previous conversation turns. *n=-1* means all."""
-    # Collect (user_text, assistant_text) pairs
-    pairs: list[tuple[str, str]] = []
-    user_text: str | None = None
-    for msg in messages:
-        if isinstance(msg, ModelRequest):
-            for part in msg.parts:
-                if isinstance(part, UserPromptPart) and isinstance(part.content, str):
-                    user_text = part.content
-        elif isinstance(msg, ModelResponse) and user_text is not None:
-            assistant_text = "".join(p.content for p in msg.parts if isinstance(p, TextPart))
-            if assistant_text:
-                pairs.append((user_text, assistant_text))
-            user_text = None
-
-    if not pairs:
-        console.print("[dim]No previous messages to show.[/dim]")
-        return
-
-    show = pairs if n < 0 else pairs[-n:]
-    for user_msg, ai_msg in show:
-        console.print(f"[bold cyan]carapace>[/bold cyan] {user_msg}")
-        console.print()
-        console.print(Markdown(ai_msg))
-        console.print()
-    console.print(f"[dim]({len(show)} previous turn{'s' if len(show) != 1 else ''} replayed)[/dim]")
-    console.print()
+def _server_url() -> str:
+    return os.environ.get("CARAPACE_SERVER", DEFAULT_SERVER)
 
 
-def _handle_slash_command(command: str, deps: Deps, session_mgr: SessionManager) -> bool:
-    """Handle slash commands. Returns True if the command was handled."""
-    parts = command.strip().split(maxsplit=1)
-    cmd = parts[0].lower()
-    arg = parts[1] if len(parts) > 1 else ""
+def _get_token(data_dir: str | None, token: str | None) -> str:
+    """Resolve bearer token from flag, env var, or data dir file."""
+    if token:
+        return token
+    env_token = os.environ.get("CARAPACE_TOKEN")
+    if env_token:
+        return env_token
+    from pathlib import Path
 
-    if cmd == "/help":
-        table = Table(title="Slash Commands")
-        table.add_column("Command", style="bold")
-        table.add_column("Description")
-        table.add_row("/rules", "List all rules and their status")
-        table.add_row("/disable <id>", "Disable a rule for this session")
-        table.add_row("/enable <id>", "Re-enable a disabled rule")
-        table.add_row("/session", "Show current session state")
-        table.add_row("/reset", "Create a new session (clears state)")
-        table.add_row("/skills", "List available skills")
-        table.add_row("/memory", "List memory files")
-        table.add_row("/verbose", "Toggle tool call display")
-        table.add_row("/quit", "Exit")
-        table.add_row("/help", "Show this help")
-        console.print(table)
-        return True
+    data_path = Path(data_dir) if data_dir else get_data_dir()
+    token_path = data_path / TOKEN_FILE
+    if token_path.exists():
+        return token_path.read_text().strip()
+    console.print("[red]No auth token found. Set --token, CARAPACE_TOKEN, or run the server locally first.[/red]")
+    raise typer.Exit(1)
 
-    if cmd == "/rules":
-        table = Table(title="Security Rules")
-        table.add_column("ID", style="bold")
-        table.add_column("Trigger")
-        table.add_column("Mode")
-        table.add_column("Status")
-        for rule in deps.rules:
-            if rule.id in deps.session_state.disabled_rules:
-                status = "[red]disabled[/red]"
-            elif rule.id in deps.session_state.activated_rules:
-                status = "[yellow]activated[/yellow]"
-            elif rule.trigger.strip().lower() == "always":
-                status = "[green]always-on[/green]"
+
+def _auth_headers(bearer: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {bearer}"}
+
+
+def _ws_url(server: str, session_id: str, bearer: str) -> str:
+    """Build WebSocket URL with token query param."""
+    base = server.replace("http://", "ws://").replace("https://", "wss://")
+    return f"{base}/chat/{session_id}?token={bearer}"
+
+
+# --- Rendering helpers for server responses ---
+
+
+def _render_command_result(data: dict[str, Any]) -> None:
+    cmd = data.get("command", "")
+    payload: Any = data.get("data", {})
+
+    match cmd:
+        case "help":
+            table = Table(title="Slash Commands")
+            table.add_column("Command", style="bold")
+            table.add_column("Description")
+            for item in payload.get("commands", []):
+                table.add_row(item["command"], item["description"])
+            console.print(table)
+
+        case "rules":
+            table = Table(title="Security Rules")
+            table.add_column("ID", style="bold")
+            table.add_column("Trigger")
+            table.add_column("Mode")
+            table.add_column("Status")
+            status_styles = {
+                "disabled": "[red]disabled[/red]",
+                "activated": "[yellow]activated[/yellow]",
+                "always-on": "[green]always-on[/green]",
+            }
+            for rule in payload:
+                styled = status_styles.get(rule["status"], rule["status"])
+                table.add_row(rule["id"], rule["trigger"], rule["mode"], styled)
+            console.print(table)
+
+        case "disable":
+            if "error" in payload:
+                console.print(f"[red]{payload['error']}[/red]")
             else:
-                status = "inactive"
-            table.add_row(
-                rule.id,
-                rule.trigger[:50] + ("..." if len(rule.trigger) > 50 else ""),
-                rule.mode.value,
-                status,
-            )
-        console.print(table)
-        return True
+                console.print(f"[yellow]{payload['message']}[/yellow]")
 
-    if cmd == "/disable":
-        if not arg:
-            console.print("[red]Usage: /disable <rule-id>[/red]")
-            return True
-        rule_ids = [r.id for r in deps.rules]
-        if arg not in rule_ids:
-            console.print(f"[red]Unknown rule: {arg}[/red]")
-            return True
-        if arg not in deps.session_state.disabled_rules:
-            deps.session_state.disabled_rules.append(arg)
-            session_mgr.save_state(deps.session_state)
-        console.print(f"[yellow]Rule '{arg}' disabled for this session.[/yellow]")
-        return True
+        case "enable":
+            if "error" in payload:
+                console.print(f"[red]{payload['error']}[/red]")
+            else:
+                console.print(f"[green]{payload['message']}[/green]")
 
-    if cmd == "/enable":
-        if not arg:
-            console.print("[red]Usage: /enable <rule-id>[/red]")
-            return True
-        if arg in deps.session_state.disabled_rules:
-            deps.session_state.disabled_rules.remove(arg)
-            session_mgr.save_state(deps.session_state)
-        console.print(f"[green]Rule '{arg}' re-enabled.[/green]")
-        return True
-
-    if cmd == "/session":
-        console.print(
-            Panel(
-                f"[bold]Session ID:[/bold] {deps.session_state.session_id}\n"
-                f"[bold]Channel:[/bold] {deps.session_state.channel_type}\n"
-                f"[bold]Activated rules:[/bold] {deps.session_state.activated_rules or '(none)'}\n"
-                f"[bold]Disabled rules:[/bold] {deps.session_state.disabled_rules or '(none)'}\n"
-                f"[bold]Approved credentials:[/bold] {deps.session_state.approved_credentials or '(none)'}",
-                title="Session State",
-            )
-        )
-        return True
-
-    if cmd == "/skills":
-        registry = SkillRegistry(deps.data_dir / "skills")
-        catalog = registry.scan()
-        if not catalog:
-            console.print("No skills available.")
-        else:
-            for s in catalog:
-                console.print(f"  [bold]{s.name}[/bold]: {s.description.strip()}")
-        return True
-
-    if cmd == "/memory":
-        from carapace.memory import MemoryStore
-
-        store = MemoryStore(deps.data_dir)
-        files = store.list_files()
-        if not files:
-            console.print("No memory files.")
-        else:
-            for f in files:
-                console.print(f"  {f}")
-        return True
-
-    if cmd in ("/quit", "/exit"):
-        raise typer.Exit()
-
-    return False
-
-
-async def _run_agent_loop(
-    user_input: str,
-    deps: Deps,
-    session_mgr: SessionManager,
-    message_history: list,
-) -> list:
-    """Run the agent, handling approval loops."""
-    agent = create_agent(deps)
-
-    result = await agent.run(
-        user_input,
-        deps=deps,
-        message_history=message_history or None,
-    )
-    messages = result.all_messages()
-
-    while isinstance(result.output, DeferredToolRequests):
-        requests = result.output
-        deferred_results = DeferredToolResults()
-
-        for call in requests.approvals:
-            meta = requests.metadata.get(call.tool_call_id, {})
-            triggered = meta.get("triggered_rules", [])
-            descriptions = meta.get("descriptions", [])
-            classification = meta.get("classification", {})
-
-            console.print()
-            panel_lines = [
-                f"[bold]Tool:[/bold] {meta.get('tool', call.tool_name)}",
-                f"[bold]Args:[/bold] {call.args}",
-            ]
-            if classification:
-                panel_lines.append(
-                    f"[bold]Classified as:[/bold] {classification.get('operation_type', '?')} "
-                    f"(categories: {classification.get('categories', [])})"
-                )
-            if triggered:
-                panel_lines.append(f"[bold]Triggered rules:[/bold] {', '.join(triggered)}")
-            if descriptions:
-                for desc in descriptions:
-                    panel_lines.append(f"  {desc}")
-
+        case "session":
             console.print(
                 Panel(
-                    "\n".join(panel_lines),
-                    title="[yellow]Approval Required[/yellow]",
-                    border_style="yellow",
+                    f"[bold]Session ID:[/bold] {payload['session_id']}\n"
+                    f"[bold]Channel:[/bold] {payload['channel_type']}\n"
+                    f"[bold]Activated rules:[/bold] {payload.get('activated_rules') or '(none)'}\n"
+                    f"[bold]Disabled rules:[/bold] {payload.get('disabled_rules') or '(none)'}\n"
+                    f"[bold]Approved credentials:[/bold] {payload.get('approved_credentials') or '(none)'}",
+                    title="Session State",
                 )
             )
 
-            choice = console.input("[bold][a]pprove / [d]eny?[/bold] ").strip().lower()
-            if choice in ("a", "approve", "y", "yes"):
-                deferred_results.approvals[call.tool_call_id] = True
+        case "skills":
+            if not payload:
+                console.print("No skills available.")
             else:
-                deferred_results.approvals[call.tool_call_id] = ToolDenied("User denied this operation.")
+                for s in payload:
+                    console.print(f"  [bold]{s['name']}[/bold]: {s['description']}")
 
-        result = await agent.run(
-            deps=deps,
-            message_history=messages,
-            deferred_tool_results=deferred_results,
+        case "memory":
+            if not payload:
+                console.print("No memory files.")
+            else:
+                for f in payload:
+                    console.print(f"  {f}")
+
+        case "verbose":
+            console.print(f"[dim]{payload['message']}[/dim]")
+
+        case _:
+            console.print(f"[dim]{payload}[/dim]")
+
+
+def _render_approval_request(data: dict[str, Any]) -> bool:
+    """Render an approval request and return True if approved."""
+    panel_lines = [
+        f"[bold]Tool:[/bold] {data.get('tool', '?')}",
+        f"[bold]Args:[/bold] {data.get('args', {})}",
+    ]
+    classification = data.get("classification", {})
+    if classification:
+        panel_lines.append(
+            f"[bold]Classified as:[/bold] {classification.get('operation_type', '?')} "
+            f"(categories: {classification.get('categories', [])})"
         )
-        messages = result.all_messages()
+    triggered = data.get("triggered_rules", [])
+    if triggered:
+        panel_lines.append(f"[bold]Triggered rules:[/bold] {', '.join(triggered)}")
+    for desc in data.get("descriptions", []):
+        panel_lines.append(f"  {desc}")
 
-    if isinstance(result.output, str):
-        console.print()
-        console.print(Markdown(result.output))
+    console.print()
+    console.print(
+        Panel(
+            "\n".join(panel_lines),
+            title="[yellow]Approval Required[/yellow]",
+            border_style="yellow",
+        )
+    )
+    choice = console.input("[bold][a]pprove / [d]eny?[/bold] ").strip().lower()
+    return choice in ("a", "approve", "y", "yes")
 
-    session_mgr.save_history(deps.session_state.session_id, messages)
-    session_mgr.save_state(deps.session_state)
-    return messages
+
+# --- WebSocket chat loop ---
+
+
+async def _chat_loop(ws_url: str) -> None:
+    """Connect to the server WebSocket and run the interactive REPL."""
+    async with ws_connect(ws_url) as ws:
+        while True:
+            try:
+                user_input = await asyncio.get_event_loop().run_in_executor(
+                    None,
+                    lambda: console.input("[bold cyan]carapace>[/bold cyan] ").strip(),
+                )
+            except (EOFError, KeyboardInterrupt):
+                console.print("\n[dim]Goodbye.[/dim]")
+                break
+
+            if not user_input:
+                continue
+
+            # Client-side quit
+            if user_input.lower() in ("/quit", "/exit"):
+                await ws.send(json.dumps({"type": "message", "content": user_input}))
+                console.print("[dim]Goodbye.[/dim]")
+                break
+
+            await ws.send(json.dumps({"type": "message", "content": user_input}))
+
+            # Read server responses until we get a terminal message
+            try:
+                await _read_server_responses(ws)
+            except ConnectionClosed:
+                console.print("[dim]Server disconnected.[/dim]")
+                break
+            except KeyboardInterrupt:
+                console.print("\n[dim]Interrupted.[/dim]")
+
+
+async def _read_server_responses(ws) -> None:
+    """Read and render server messages until a terminal response (done/command_result/error)."""
+    while True:
+        raw = await ws.recv()
+        msg = json.loads(raw)
+        msg_type = msg.get("type")
+
+        match msg_type:
+            case "done":
+                console.print()
+                console.print(Markdown(msg["content"]))
+                return
+
+            case "token":
+                # Future: incremental streaming display
+                pass
+
+            case "command_result":
+                _render_command_result(msg)
+                return
+
+            case "error":
+                console.print(f"[red]Error: {msg['detail']}[/red]")
+                return
+
+            case "tool_call":
+                detail = msg.get("detail", "")
+                console.print(f"  [dim]{msg['tool']}({msg['args']}) {detail}[/dim]")
+
+            case "approval_request":
+                approved = _render_approval_request(msg)
+                await ws.send(
+                    json.dumps(
+                        {
+                            "type": "approval_response",
+                            "tool_call_id": msg["tool_call_id"],
+                            "approved": approved,
+                        }
+                    )
+                )
+
+            case _:
+                console.print(f"[dim]Unknown server message: {msg_type}[/dim]")
+
+
+# --- CLI commands ---
 
 
 @app.command()
 def chat(
     session: str | None = typer.Option(None, "--session", "-s", help="Resume a session by ID"),
-    data_dir: str | None = typer.Option(None, "--data-dir", "-d", help="Data directory path"),
+    server: str = typer.Option(DEFAULT_SERVER, "--server", envvar="CARAPACE_SERVER", help="Server URL"),
+    data_dir: str | None = typer.Option(None, "--data-dir", "-d", help="Data directory (for token lookup)"),
+    token: str | None = typer.Option(None, "--token", envvar="CARAPACE_TOKEN", help="Bearer token"),
     list_sessions: bool = typer.Option(False, "--list", "-l", help="List existing sessions"),
-    prev: int = typer.Option(-1, "--prev", "-p", help="Replay N previous turns on resume (-1 = all, 0 = none)"),
-    verbose: bool = typer.Option(True, "--verbose/--quiet", "-v/-q", help="Show tool calls"),
 ):
-    """Start an interactive chat session with the Carapace agent."""
-    from pathlib import Path
-
-    data_path = Path(data_dir) if data_dir else get_data_dir()
-    created = ensure_data_dir(data_path)
-    if created:
-        console.print(f"[dim]Initialised: {', '.join(created)}[/dim]")
-    config = load_config(data_path)
-
-    if config.carapace.logfire_token:
-        logfire.configure(token=config.carapace.logfire_token, console=False)
-        logfire.instrument_pydantic_ai()
-        console.print("[dim]Logfire tracing enabled[/dim]")
-
-    rules = load_rules(data_path)
-    session_mgr = SessionManager(data_path)
+    """Start an interactive chat session with the Carapace server."""
+    bearer = _get_token(data_dir, token)
+    headers = _auth_headers(bearer)
 
     if list_sessions:
-        sessions = session_mgr.list_sessions()
+        resp = httpx.get(f"{server}/sessions", headers=headers)
+        resp.raise_for_status()
+        sessions = resp.json()
         if not sessions:
             console.print("No existing sessions.")
         else:
             console.print("[bold]Existing sessions:[/bold]")
-            for sid in sessions:
-                state = session_mgr.resume_session(sid)
-                if state:
-                    console.print(
-                        f"  {sid}  "
-                        f"(created: {state.created_at:%Y-%m-%d %H:%M}, "
-                        f"rules: {len(state.activated_rules)} activated)"
-                    )
+            for s in sessions:
+                console.print(
+                    f"  {s['session_id']}  "
+                    f"(created: {s['created_at']}, "
+                    f"rules: {len(s.get('activated_rules', []))} activated)"
+                )
         raise typer.Exit()
 
     # Create or resume session
     if session:
-        session_state = session_mgr.resume_session(session)
-        if session_state is None:
-            console.print(f"[red]Session '{session}' not found.[/red]")
-            raise typer.Exit(1)
-        console.print(f"[green]Resumed session {session_state.session_id}[/green]")
+        try:
+            resp = httpx.get(f"{server}/sessions/{session}", headers=headers)
+            resp.raise_for_status()
+            session_data = resp.json()
+            session_id = session_data["session_id"]
+            console.print(f"[green]Resumed session {session_id}[/green]")
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                console.print(f"[red]Session '{session}' not found.[/red]")
+            else:
+                console.print(f"[red]Server error: {exc.response.status_code}[/red]")
+            raise typer.Exit(1) from None
     else:
-        session_state = session_mgr.create_session()
-        console.print(f"[green]New session {session_state.session_id}[/green]")
+        resp = httpx.post(f"{server}/sessions", headers=headers)
+        resp.raise_for_status()
+        session_data = resp.json()
+        session_id = session_data["session_id"]
+        console.print(f"[green]New session {session_id}[/green]")
 
-    # Load skill catalog
-    registry = SkillRegistry(data_path / "skills")
-    skill_catalog = registry.scan()
-
-    # Build deps
-    agent_model = _create_anthropic_model(config.agent.model)
-    deps = Deps(
-        config=config,
-        data_dir=data_path,
-        session_state=session_state,
-        rules=rules,
-        skill_catalog=skill_catalog,
-        classifier_model=config.agent.classifier_model,
-        agent_model=agent_model,
-        verbose=verbose,
-    )
-
-    # Load existing history
-    message_history = session_mgr.load_history(session_state.session_id)
-
-    if session and message_history and prev != 0:
-        _replay_history(message_history, prev)
-
-    console.print(
-        f"[dim]Model: {config.agent.model} | "
-        f"Rules: {len(rules)} loaded | "
-        f"Skills: {len(skill_catalog)} available | "
-        f"Type /help for commands[/dim]"
-    )
+    console.print(f"[dim]Server: {server} | Type /help for commands[/dim]")
     console.print()
 
-    # REPL loop
-    while True:
-        try:
-            user_input = console.input("[bold cyan]carapace>[/bold cyan] ").strip()
-        except (EOFError, KeyboardInterrupt):
-            console.print("\n[dim]Goodbye.[/dim]")
-            break
-
-        if not user_input:
-            continue
-
-        if user_input.startswith("/"):
-            if user_input.lower() in ("/quit", "/exit"):
-                console.print("[dim]Goodbye.[/dim]")
-                break
-
-            if user_input.lower() == "/reset":
-                session_state = session_mgr.create_session()
-                message_history = []
-                deps.session_state = session_state
-                console.print(f"[green]New session {session_state.session_id}[/green]")
-                continue
-
-            if user_input.lower() == "/verbose":
-                verbose = not verbose
-                deps.verbose = verbose
-                state = "on" if verbose else "off"
-                console.print(f"[dim]Verbose mode {state}[/dim]")
-                continue
-
-            if _handle_slash_command(user_input, deps, session_mgr):
-                continue
-
-            console.print(f"[red]Unknown command: {user_input.split()[0]}[/red]")
-            continue
-
-        try:
-            message_history = asyncio.run(_run_agent_loop(user_input, deps, session_mgr, message_history))
-        except KeyboardInterrupt:
-            console.print("\n[dim]Interrupted.[/dim]")
-        except Exception as e:
-            console.print(f"[red]Error: {e}[/red]")
+    url = _ws_url(server, session_id, bearer)
+    try:
+        asyncio.run(_chat_loop(url))
+    except Exception as e:
+        console.print(f"[red]Connection error: {e}[/red]")
 
 
 if __name__ == "__main__":

--- a/src/carapace/cli.py
+++ b/src/carapace/cli.py
@@ -26,10 +26,6 @@ console = Console()
 DEFAULT_SERVER = "http://127.0.0.1:8321"
 
 
-def _server_url() -> str:
-    return os.environ.get("CARAPACE_SERVER", DEFAULT_SERVER)
-
-
 def _get_token(data_dir: str | None, token: str | None) -> str:
     """Resolve bearer token from flag, env var, or data dir file."""
     if token:

--- a/src/carapace/cli.py
+++ b/src/carapace/cli.py
@@ -227,7 +227,11 @@ async def _read_server_responses(ws) -> None:
                 console.print(f"  [dim]{msg['tool']}({msg['args']}) {detail}[/dim]")
 
             case "approval_request":
-                approved = _render_approval_request(msg)
+                try:
+                    approved = _render_approval_request(msg)
+                except (KeyboardInterrupt, EOFError):
+                    approved = False
+                    console.print("\n[dim]Denied (interrupted).[/dim]")
                 await ws.send(
                     json.dumps(
                         {

--- a/src/carapace/cli.py
+++ b/src/carapace/cli.py
@@ -130,7 +130,7 @@ def _render_command_result(data: dict[str, Any]) -> None:
             console.print(f"[dim]{payload}[/dim]")
 
 
-def _render_approval_request(data: dict[str, Any]) -> bool:
+async def _render_approval_request(data: dict[str, Any]) -> bool:
     """Render an approval request and return True if approved."""
     panel_lines = [
         f"[bold]Tool:[/bold] {data.get('tool', '?')}",
@@ -156,7 +156,10 @@ def _render_approval_request(data: dict[str, Any]) -> bool:
             border_style="yellow",
         )
     )
-    choice = console.input("[bold][a]pprove / [d]eny?[/bold] ").strip().lower()
+    choice = await asyncio.get_event_loop().run_in_executor(
+        None,
+        lambda: console.input("[bold][a]pprove / [d]eny?[/bold] ").strip().lower(),
+    )
     return choice in ("a", "approve", "y", "yes")
 
 
@@ -228,7 +231,7 @@ async def _read_server_responses(ws) -> None:
 
             case "approval_request":
                 try:
-                    approved = _render_approval_request(msg)
+                    approved = await _render_approval_request(msg)
                 except (KeyboardInterrupt, EOFError):
                     approved = False
                     console.print("\n[dim]Denied (interrupted).[/dim]")

--- a/src/carapace/models.py
+++ b/src/carapace/models.py
@@ -135,6 +135,11 @@ class SessionsConfig(BaseModel):
     history_retention_days: int = 90
 
 
+class ServerConfig(BaseModel):
+    host: str = "127.0.0.1"
+    port: int = 8321
+
+
 class CarapaceConfig(BaseModel):
     log_level: str = "info"
     logfire_token: str = ""
@@ -142,6 +147,7 @@ class CarapaceConfig(BaseModel):
 
 class Config(BaseModel):
     carapace: CarapaceConfig = CarapaceConfig()
+    server: ServerConfig = ServerConfig()
     channels: ChannelsConfig = ChannelsConfig()
     agent: AgentConfig = AgentConfig()
     credentials: CredentialsConfig = CredentialsConfig()

--- a/src/carapace/models.py
+++ b/src/carapace/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -179,3 +180,4 @@ class Deps:
     classifier_model: str = "openai:gpt-4o-mini"
     agent_model: Any = None
     verbose: bool = True
+    tool_call_callback: Callable[[str, dict[str, Any], str], None] | None = None

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -315,9 +315,10 @@ async def chat_ws(
     await websocket.accept()
     verbose = True
     pending_sends: set[asyncio.Task] = set()
-    
+
     def send_tool_call_info(tool: str, args: dict[str, Any], detail: str) -> None:
         """Callback to send tool call info via WebSocket."""
+
         async def _send_and_cleanup() -> None:
             try:
                 await _send(websocket, ToolCallInfo(tool=tool, args=args, detail=detail))
@@ -325,10 +326,10 @@ async def chat_ws(
                 logger.warning("WebSocket send failed for tool call info: %s", exc)
             finally:
                 pending_sends.discard(task)
-        
+
         task = asyncio.create_task(_send_and_cleanup())
         pending_sends.add(task)
-    
+
     deps = _build_deps(session_state, verbose=verbose, tool_call_callback=send_tool_call_info)
 
     try:

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -1,0 +1,451 @@
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Annotated, Any
+
+import logfire
+import uvicorn
+from dotenv import load_dotenv
+from fastapi import Depends, FastAPI, HTTPException, Query, WebSocket, WebSocketDisconnect, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from httpx import AsyncClient, HTTPStatusError
+from pydantic import BaseModel
+from pydantic_ai import DeferredToolRequests, DeferredToolResults, ToolDenied
+from pydantic_ai.models.anthropic import AnthropicModel
+from pydantic_ai.providers.anthropic import AnthropicProvider
+from pydantic_ai.retries import AsyncTenacityTransport, RetryConfig, wait_retry_after
+from tenacity import retry_if_exception_type, stop_after_attempt, wait_exponential
+
+from carapace.agent import create_agent
+from carapace.auth import ensure_token
+from carapace.bootstrap import ensure_data_dir
+from carapace.config import get_data_dir, load_config, load_rules
+from carapace.memory import MemoryStore
+from carapace.models import Config, Deps, Rule, SessionState
+from carapace.session import SessionManager
+from carapace.skills import SkillRegistry
+from carapace.ws_models import (
+    ApprovalRequest,
+    ApprovalResponse,
+    CommandResult,
+    Done,
+    ErrorMessage,
+    ServerEnvelope,
+    UserMessage,
+    parse_client_message,
+)
+
+load_dotenv()
+logger = logging.getLogger("carapace.server")
+
+# --- Shared state populated in lifespan ---
+
+_data_dir: Path
+_config: Config
+_rules: list[Rule]
+_session_mgr: SessionManager
+_skill_catalog: list
+_agent_model: Any
+
+
+def _create_anthropic_model(model_name: str) -> AnthropicModel:
+    transport = AsyncTenacityTransport(
+        config=RetryConfig(
+            retry=retry_if_exception_type((HTTPStatusError, ConnectionError)),
+            wait=wait_retry_after(fallback_strategy=wait_exponential(multiplier=1, max=60), max_wait=300),
+            stop=stop_after_attempt(5),
+            reraise=True,
+        ),
+        validate_response=lambda r: r.raise_for_status() if r.status_code in (429, 502, 503, 504) else None,
+    )
+    model_id = model_name.removeprefix("anthropic:")
+    return AnthropicModel(model_id, provider=AnthropicProvider(http_client=AsyncClient(transport=transport)))
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global _data_dir, _config, _rules, _session_mgr, _skill_catalog, _agent_model
+
+    _data_dir = get_data_dir()
+    ensure_data_dir(_data_dir)
+    _config = load_config(_data_dir)
+
+    if _config.carapace.logfire_token:
+        logfire.configure(token=_config.carapace.logfire_token, console=False)
+        logfire.instrument_pydantic_ai()
+
+    _rules = load_rules(_data_dir)
+    _session_mgr = SessionManager(_data_dir)
+    registry = SkillRegistry(_data_dir / "skills")
+    _skill_catalog = registry.scan()
+    _agent_model = _create_anthropic_model(_config.agent.model)
+
+    token = ensure_token(_data_dir)
+    logger.info(
+        "Carapace server ready — model=%s, rules=%d, skills=%d, token=%s…",
+        _config.agent.model,
+        len(_rules),
+        len(_skill_catalog),
+        token[:8],
+    )
+    yield
+
+
+app = FastAPI(title="Carapace", lifespan=lifespan)
+
+_bearer_scheme = HTTPBearer()
+
+
+async def _verify_token(
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(_bearer_scheme)],
+) -> str:
+    expected = ensure_token(_data_dir)
+    if credentials.credentials != expected:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    return credentials.credentials
+
+
+async def _verify_ws_token(
+    websocket: WebSocket,
+    token: Annotated[str | None, Query()] = None,
+) -> str:
+    expected = ensure_token(_data_dir)
+    if token and token == expected:
+        return token
+    auth = websocket.headers.get("authorization", "")
+    if auth.startswith("Bearer ") and auth.removeprefix("Bearer ") == expected:
+        return expected
+    await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+    raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+
+# --- REST: Sessions ---
+
+
+class SessionCreateRequest(BaseModel):
+    channel_type: str = "cli"
+    channel_ref: str = ""
+
+
+class SessionInfo(BaseModel):
+    session_id: str
+    channel_type: str
+    channel_ref: str
+    created_at: str
+    last_active: str
+    activated_rules: list[str]
+    disabled_rules: list[str]
+
+    @classmethod
+    def from_state(cls, state: SessionState) -> SessionInfo:
+        return cls(
+            session_id=state.session_id,
+            channel_type=state.channel_type,
+            channel_ref=state.channel_ref,
+            created_at=state.created_at.isoformat(),
+            last_active=state.last_active.isoformat(),
+            activated_rules=state.activated_rules,
+            disabled_rules=state.disabled_rules,
+        )
+
+
+@app.post("/sessions", response_model=SessionInfo)
+async def create_session(
+    body: SessionCreateRequest | None = None,
+    _token: str = Depends(_verify_token),
+) -> SessionInfo:
+    body = body or SessionCreateRequest()
+    state = _session_mgr.create_session(body.channel_type, body.channel_ref)
+    return SessionInfo.from_state(state)
+
+
+@app.get("/sessions", response_model=list[SessionInfo])
+async def list_sessions(_token: str = Depends(_verify_token)) -> list[SessionInfo]:
+    results: list[SessionInfo] = []
+    for sid in _session_mgr.list_sessions():
+        state = _session_mgr.resume_session(sid)
+        if state:
+            results.append(SessionInfo.from_state(state))
+    return results
+
+
+@app.get("/sessions/{session_id}", response_model=SessionInfo)
+async def get_session(session_id: str, _token: str = Depends(_verify_token)) -> SessionInfo:
+    state = _session_mgr.resume_session(session_id)
+    if state is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return SessionInfo.from_state(state)
+
+
+# --- WebSocket: Chat ---
+
+
+def _build_deps(session_state: SessionState, *, verbose: bool = True) -> Deps:
+    return Deps(
+        config=_config,
+        data_dir=_data_dir,
+        session_state=session_state,
+        rules=_rules,
+        skill_catalog=_skill_catalog,
+        classifier_model=_config.agent.classifier_model,
+        agent_model=_agent_model,
+        verbose=verbose,
+    )
+
+
+async def _send(ws: WebSocket, msg: ServerEnvelope) -> None:
+    await ws.send_json(msg.model_dump())
+
+
+def _handle_slash_command(command: str, deps: Deps) -> CommandResult | None:
+    """Handle a slash command and return structured data, or None if unrecognised."""
+    parts = command.strip().split(maxsplit=1)
+    cmd = parts[0].lower()
+    arg = parts[1] if len(parts) > 1 else ""
+
+    if cmd == "/help":
+        return CommandResult(
+            command="help",
+            data={
+                "commands": [
+                    {"command": "/rules", "description": "List all rules and their status"},
+                    {"command": "/disable <id>", "description": "Disable a rule for this session"},
+                    {"command": "/enable <id>", "description": "Re-enable a disabled rule"},
+                    {"command": "/session", "description": "Show current session state"},
+                    {"command": "/skills", "description": "List available skills"},
+                    {"command": "/memory", "description": "List memory files"},
+                    {"command": "/verbose", "description": "Toggle tool call display"},
+                    {"command": "/quit", "description": "Disconnect"},
+                    {"command": "/help", "description": "Show this help"},
+                ]
+            },
+        )
+
+    if cmd == "/rules":
+        rules_data = []
+        for rule in deps.rules:
+            if rule.id in deps.session_state.disabled_rules:
+                rule_status = "disabled"
+            elif rule.id in deps.session_state.activated_rules:
+                rule_status = "activated"
+            elif rule.trigger.strip().lower() == "always":
+                rule_status = "always-on"
+            else:
+                rule_status = "inactive"
+            rules_data.append(
+                {
+                    "id": rule.id,
+                    "trigger": rule.trigger[:50] + ("..." if len(rule.trigger) > 50 else ""),
+                    "mode": rule.mode.value,
+                    "status": rule_status,
+                }
+            )
+        return CommandResult(command="rules", data=rules_data)
+
+    if cmd == "/disable":
+        if not arg:
+            return CommandResult(command="disable", data={"error": "Usage: /disable <rule-id>"})
+        rule_ids = [r.id for r in deps.rules]
+        if arg not in rule_ids:
+            return CommandResult(command="disable", data={"error": f"Unknown rule: {arg}"})
+        if arg not in deps.session_state.disabled_rules:
+            deps.session_state.disabled_rules.append(arg)
+            _session_mgr.save_state(deps.session_state)
+        return CommandResult(command="disable", data={"rule_id": arg, "message": f"Rule '{arg}' disabled"})
+
+    if cmd == "/enable":
+        if not arg:
+            return CommandResult(command="enable", data={"error": "Usage: /enable <rule-id>"})
+        if arg in deps.session_state.disabled_rules:
+            deps.session_state.disabled_rules.remove(arg)
+            _session_mgr.save_state(deps.session_state)
+        return CommandResult(command="enable", data={"rule_id": arg, "message": f"Rule '{arg}' re-enabled"})
+
+    if cmd == "/session":
+        return CommandResult(
+            command="session",
+            data={
+                "session_id": deps.session_state.session_id,
+                "channel_type": deps.session_state.channel_type,
+                "activated_rules": deps.session_state.activated_rules,
+                "disabled_rules": deps.session_state.disabled_rules,
+                "approved_credentials": deps.session_state.approved_credentials,
+            },
+        )
+
+    if cmd == "/skills":
+        skills = [{"name": s.name, "description": s.description.strip()} for s in deps.skill_catalog]
+        return CommandResult(command="skills", data=skills)
+
+    if cmd == "/memory":
+        store = MemoryStore(deps.data_dir)
+        files = store.list_files()
+        return CommandResult(command="memory", data=files)
+
+    return None
+
+
+@app.websocket("/chat/{session_id}")
+async def chat_ws(
+    websocket: WebSocket,
+    session_id: str,
+    _token: Annotated[str, Depends(_verify_ws_token)],
+) -> None:
+    session_state = _session_mgr.resume_session(session_id)
+    if session_state is None:
+        await websocket.close(code=4004, reason="Session not found")
+        return
+
+    await websocket.accept()
+    deps = _build_deps(session_state)
+    message_history = _session_mgr.load_history(session_id)
+    verbose = True
+
+    try:
+        while True:
+            raw = await websocket.receive_json()
+            try:
+                client_msg = parse_client_message(raw)
+            except (ValueError, Exception) as exc:
+                await _send(websocket, ErrorMessage(detail=str(exc)))
+                continue
+
+            if not isinstance(client_msg, UserMessage):
+                await _send(websocket, ErrorMessage(detail="Expected a message"))
+                continue
+
+            user_input = client_msg.content.strip()
+            if not user_input:
+                continue
+
+            # --- Slash commands ---
+            if user_input.startswith("/"):
+                if user_input.lower() in ("/quit", "/exit"):
+                    await websocket.close(code=1000)
+                    return
+
+                if user_input.lower() == "/verbose":
+                    verbose = not verbose
+                    deps.verbose = verbose
+                    state_str = "on" if verbose else "off"
+                    await _send(
+                        websocket,
+                        CommandResult(
+                            command="verbose", data={"verbose": verbose, "message": f"Verbose mode {state_str}"}
+                        ),
+                    )
+                    continue
+
+                result = _handle_slash_command(user_input, deps)
+                if result:
+                    await _send(websocket, result)
+                    continue
+
+                await _send(websocket, ErrorMessage(detail=f"Unknown command: {user_input.split()[0]}"))
+                continue
+
+            # --- Agent loop ---
+            try:
+                message_history = await _run_agent_turn(
+                    websocket,
+                    user_input,
+                    deps,
+                    message_history,
+                )
+                _session_mgr.save_history(session_id, message_history)
+                _session_mgr.save_state(deps.session_state)
+            except Exception as exc:
+                logger.exception("Agent error")
+                await _send(websocket, ErrorMessage(detail=str(exc)))
+
+    except WebSocketDisconnect:
+        logger.info("Client disconnected from session %s", session_id)
+
+
+async def _run_agent_turn(
+    ws: WebSocket,
+    user_input: str,
+    deps: Deps,
+    message_history: list,
+) -> list:
+    """Run one agent turn, handling approval loops over the WebSocket."""
+    agent = create_agent(deps)
+
+    result = await agent.run(
+        user_input,
+        deps=deps,
+        message_history=message_history or None,
+    )
+    messages = result.all_messages()
+
+    while isinstance(result.output, DeferredToolRequests):
+        requests = result.output
+        deferred_results = DeferredToolResults()
+
+        for call in requests.approvals:
+            meta = requests.metadata.get(call.tool_call_id, {})
+            await _send(
+                ws,
+                ApprovalRequest(
+                    tool_call_id=call.tool_call_id,
+                    tool=meta.get("tool", call.tool_name),
+                    args=call.args,
+                    classification=meta.get("classification", {}),
+                    triggered_rules=meta.get("triggered_rules", []),
+                    descriptions=meta.get("descriptions", []),
+                ),
+            )
+
+        # Collect all approval responses
+        pending = {call.tool_call_id for call in requests.approvals}
+        while pending:
+            raw = await ws.receive_json()
+            try:
+                client_msg = parse_client_message(raw)
+            except (ValueError, Exception):
+                continue
+            if not isinstance(client_msg, ApprovalResponse):
+                continue
+            if client_msg.tool_call_id in pending:
+                if client_msg.approved:
+                    deferred_results.approvals[client_msg.tool_call_id] = True
+                else:
+                    deferred_results.approvals[client_msg.tool_call_id] = ToolDenied("User denied this operation.")
+                pending.discard(client_msg.tool_call_id)
+
+        result = await agent.run(
+            deps=deps,
+            message_history=messages,
+            deferred_tool_results=deferred_results,
+        )
+        messages = result.all_messages()
+
+    if isinstance(result.output, str):
+        await _send(ws, Done(content=result.output))
+
+    return messages
+
+
+def main() -> None:
+    """Entry point for `python -m carapace` / `carapace-server`."""
+    load_dotenv()
+    data_dir = get_data_dir()
+    ensure_data_dir(data_dir)
+    config = load_config(data_dir)
+    token = ensure_token(data_dir)
+
+    logger.info("Starting Carapace server on %s:%d", config.server.host, config.server.port)
+    logger.info("Bearer token: %s…  (full token in %s)", token[:8], data_dir / "server.token")
+
+    uvicorn.run(
+        "carapace.server:app",
+        host=config.server.host,
+        port=config.server.port,
+        log_level=config.carapace.log_level,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -418,7 +418,10 @@ async def _run_agent_turn(
             except (ValueError, Exception):
                 continue
             if not isinstance(client_msg, ApprovalResponse):
-                continue
+                for tid in pending:
+                    deferred_results.approvals[tid] = ToolDenied("Approval interrupted.")
+                pending.clear()
+                break
             if client_msg.tool_call_id in pending:
                 if client_msg.approved:
                     deferred_results.approvals[client_msg.tool_call_id] = True

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -353,7 +353,7 @@ async def chat_ws(
             if user_input.startswith("/"):
                 if user_input.lower() in ("/quit", "/exit"):
                     await websocket.close(code=1000)
-                    return
+                    break
 
                 if user_input.lower() == "/verbose":
                     verbose = not verbose
@@ -396,6 +396,7 @@ async def chat_ws(
 
     except WebSocketDisconnect:
         logger.info("Client disconnected from session %s", session_id)
+    finally:
         _session_locks.pop(session_id, None)
         for task in pending_sends:
             task.cancel()
@@ -464,6 +465,8 @@ async def _run_agent_turn(
 
     if isinstance(result.output, str):
         await _send(ws, Done(content=result.output))
+    else:
+        await _send(ws, ErrorMessage(detail=f"Unexpected agent output type: {type(result.output).__name__}"))
 
     return messages
 

--- a/src/carapace/ws_models.py
+++ b/src/carapace/ws_models.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+# --- Client → Server ---
+
+
+class UserMessage(BaseModel):
+    type: Literal["message"] = "message"
+    content: str
+
+
+class ApprovalResponse(BaseModel):
+    type: Literal["approval_response"] = "approval_response"
+    tool_call_id: str
+    approved: bool
+
+
+ClientEnvelope = UserMessage | ApprovalResponse
+
+
+def parse_client_message(raw: dict[str, Any]) -> ClientEnvelope:
+    match raw.get("type"):
+        case "message":
+            return UserMessage.model_validate(raw)
+        case "approval_response":
+            return ApprovalResponse.model_validate(raw)
+        case other:
+            msg = f"Unknown client message type: {other}"
+            raise ValueError(msg)
+
+
+# --- Server → Client ---
+
+
+class TokenChunk(BaseModel):
+    type: Literal["token"] = "token"
+    content: str
+
+
+class ToolCallInfo(BaseModel):
+    type: Literal["tool_call"] = "tool_call"
+    tool: str
+    args: dict[str, Any]
+    detail: str
+
+
+class ApprovalRequest(BaseModel):
+    type: Literal["approval_request"] = "approval_request"
+    tool_call_id: str
+    tool: str
+    args: dict[str, Any]
+    classification: dict[str, Any]
+    triggered_rules: list[str]
+    descriptions: list[str]
+
+
+class Done(BaseModel):
+    type: Literal["done"] = "done"
+    content: str
+
+
+class CommandResult(BaseModel):
+    type: Literal["command_result"] = "command_result"
+    command: str
+    data: Any
+
+
+class ErrorMessage(BaseModel):
+    type: Literal["error"] = "error"
+    detail: str
+
+
+ServerEnvelope = TokenChunk | ToolCallInfo | ApprovalRequest | Done | CommandResult | ErrorMessage

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,25 @@
+"""Auth module tests (no LLM tokens needed)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from carapace.auth import TOKEN_FILE, ensure_token
+
+
+def test_ensure_token_creates_file(tmp_path: Path):
+    token = ensure_token(tmp_path)
+    assert len(token) > 20
+    assert (tmp_path / TOKEN_FILE).exists()
+
+
+def test_ensure_token_is_idempotent(tmp_path: Path):
+    t1 = ensure_token(tmp_path)
+    t2 = ensure_token(tmp_path)
+    assert t1 == t2
+
+
+def test_ensure_token_reads_existing(tmp_path: Path):
+    token_path = tmp_path / TOKEN_FILE
+    token_path.write_text("my-custom-token\n")
+    assert ensure_token(tmp_path) == "my-custom-token"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,4 +26,5 @@ def test_chat_help():
     assert result.exit_code == 0
     output = _strip_ansi(result.output)
     assert "--session" in output
-    assert "--data-dir" in output
+    assert "--server" in output
+    assert "--token" in output

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -40,3 +40,25 @@ def test_import_credentials():
 
 def test_import_agent():
     from carapace.agent import build_system_prompt, create_agent  # noqa: F401
+
+
+def test_import_server():
+    from carapace.server import app, main  # noqa: F401
+
+
+def test_import_auth():
+    from carapace.auth import ensure_token  # noqa: F401
+
+
+def test_import_ws_models():
+    from carapace.ws_models import (  # noqa: F401
+        ApprovalRequest,
+        ApprovalResponse,
+        CommandResult,
+        Done,
+        ErrorMessage,
+        TokenChunk,
+        ToolCallInfo,
+        UserMessage,
+        parse_client_message,
+    )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,183 @@
+"""Server smoke tests (no LLM tokens needed)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+# We patch the server module globals directly for testing
+import carapace.server as srv
+from carapace.auth import ensure_token
+from carapace.bootstrap import ensure_data_dir
+from carapace.config import load_config, load_rules
+from carapace.server import app
+from carapace.session import SessionManager
+from carapace.skills import SkillRegistry
+
+
+@pytest.fixture(autouse=True)
+def _setup_server(tmp_path):
+    """Initialise server globals with a temp data dir so tests don't need lifespan."""
+    ensure_data_dir(tmp_path)
+    srv._data_dir = tmp_path
+    srv._config = load_config(tmp_path)
+    srv._rules = load_rules(tmp_path)
+    srv._session_mgr = SessionManager(tmp_path)
+    registry = SkillRegistry(tmp_path / "skills")
+    srv._skill_catalog = registry.scan()
+    srv._agent_model = None
+    ensure_token(tmp_path)
+
+
+@pytest.fixture()
+def bearer(tmp_path) -> str:
+    return ensure_token(tmp_path)
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture()
+def auth_headers(bearer) -> dict[str, str]:
+    return {"Authorization": f"Bearer {bearer}"}
+
+
+# --- Auth ---
+
+
+def test_no_auth_returns_401(client):
+    resp = client.get("/sessions")
+    assert resp.status_code in (401, 403)
+
+
+def test_bad_token_returns_401(client):
+    resp = client.get("/sessions", headers={"Authorization": "Bearer wrong"})
+    assert resp.status_code == 401
+
+
+# --- Sessions REST ---
+
+
+def test_create_session(client, auth_headers):
+    resp = client.post("/sessions", headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "session_id" in data
+    assert data["channel_type"] == "cli"
+
+
+def test_list_sessions(client, auth_headers):
+    client.post("/sessions", headers=auth_headers)
+    client.post("/sessions", headers=auth_headers)
+    resp = client.get("/sessions", headers=auth_headers)
+    assert resp.status_code == 200
+    sessions = resp.json()
+    assert len(sessions) >= 2
+
+
+def test_get_session(client, auth_headers):
+    create_resp = client.post("/sessions", headers=auth_headers)
+    sid = create_resp.json()["session_id"]
+    resp = client.get(f"/sessions/{sid}", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["session_id"] == sid
+
+
+def test_get_nonexistent_session(client, auth_headers):
+    resp = client.get("/sessions/doesnotexist", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+# --- WebSocket: basic slash commands ---
+
+
+def test_ws_auth_required(client):
+    with pytest.raises(Exception), client.websocket_connect("/chat/fake"):  # noqa: B017
+        pass
+
+
+def test_ws_session_not_found(client, bearer):
+    with pytest.raises(Exception), client.websocket_connect(f"/chat/doesnotexist?token={bearer}"):  # noqa: B017
+        pass
+
+
+def test_ws_help_command(client, auth_headers, bearer):
+    create_resp = client.post("/sessions", headers=auth_headers)
+    sid = create_resp.json()["session_id"]
+
+    with client.websocket_connect(f"/chat/{sid}?token={bearer}") as ws:
+        ws.send_json({"type": "message", "content": "/help"})
+        msg = ws.receive_json()
+        assert msg["type"] == "command_result"
+        assert msg["command"] == "help"
+        assert "commands" in msg["data"]
+
+
+def test_ws_rules_command(client, auth_headers, bearer):
+    create_resp = client.post("/sessions", headers=auth_headers)
+    sid = create_resp.json()["session_id"]
+
+    with client.websocket_connect(f"/chat/{sid}?token={bearer}") as ws:
+        ws.send_json({"type": "message", "content": "/rules"})
+        msg = ws.receive_json()
+        assert msg["type"] == "command_result"
+        assert msg["command"] == "rules"
+
+
+def test_ws_session_command(client, auth_headers, bearer):
+    create_resp = client.post("/sessions", headers=auth_headers)
+    sid = create_resp.json()["session_id"]
+
+    with client.websocket_connect(f"/chat/{sid}?token={bearer}") as ws:
+        ws.send_json({"type": "message", "content": "/session"})
+        msg = ws.receive_json()
+        assert msg["type"] == "command_result"
+        assert msg["command"] == "session"
+        assert msg["data"]["session_id"] == sid
+
+
+def test_ws_skills_command(client, auth_headers, bearer):
+    create_resp = client.post("/sessions", headers=auth_headers)
+    sid = create_resp.json()["session_id"]
+
+    with client.websocket_connect(f"/chat/{sid}?token={bearer}") as ws:
+        ws.send_json({"type": "message", "content": "/skills"})
+        msg = ws.receive_json()
+        assert msg["type"] == "command_result"
+        assert msg["command"] == "skills"
+
+
+def test_ws_memory_command(client, auth_headers, bearer):
+    create_resp = client.post("/sessions", headers=auth_headers)
+    sid = create_resp.json()["session_id"]
+
+    with client.websocket_connect(f"/chat/{sid}?token={bearer}") as ws:
+        ws.send_json({"type": "message", "content": "/memory"})
+        msg = ws.receive_json()
+        assert msg["type"] == "command_result"
+        assert msg["command"] == "memory"
+
+
+def test_ws_verbose_command(client, auth_headers, bearer):
+    create_resp = client.post("/sessions", headers=auth_headers)
+    sid = create_resp.json()["session_id"]
+
+    with client.websocket_connect(f"/chat/{sid}?token={bearer}") as ws:
+        ws.send_json({"type": "message", "content": "/verbose"})
+        msg = ws.receive_json()
+        assert msg["type"] == "command_result"
+        assert msg["command"] == "verbose"
+        assert msg["data"]["verbose"] is False
+
+
+def test_ws_unknown_command(client, auth_headers, bearer):
+    create_resp = client.post("/sessions", headers=auth_headers)
+    sid = create_resp.json()["session_id"]
+
+    with client.websocket_connect(f"/chat/{sid}?token={bearer}") as ws:
+        ws.send_json({"type": "message", "content": "/foobar"})
+        msg = ws.receive_json()
+        assert msg["type"] == "error"
+        assert "Unknown command" in msg["detail"]

--- a/uv.lock
+++ b/uv.lock
@@ -249,9 +249,10 @@ wheels = [
 
 [[package]]
 name = "carapace"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
+    { name = "fastapi" },
     { name = "logfire", extra = ["httpx"] },
     { name = "pydantic-ai" },
     { name = "python-dotenv" },
@@ -259,6 +260,8 @@ dependencies = [
     { name = "rich" },
     { name = "tenacity" },
     { name = "typer" },
+    { name = "uvicorn", extra = ["standard"] },
+    { name = "websockets" },
 ]
 
 [package.dev-dependencies]
@@ -268,6 +271,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "fastapi" },
     { name = "logfire", extras = ["httpx"] },
     { name = "pydantic-ai" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
@@ -275,6 +279,8 @@ requires-dist = [
     { name = "rich" },
     { name = "tenacity" },
     { name = "typer" },
+    { name = "uvicorn", extras = ["standard"] },
+    { name = "websockets" },
 ]
 
 [package.metadata.requires-dev]
@@ -637,6 +643,22 @@ wheels = [
 [package.optional-dependencies]
 lua = [
     { name = "lupa" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.129.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/47/75f6bea02e797abff1bca968d5997793898032d9923c1935ae2efdece642/fastapi-0.129.0.tar.gz", hash = "sha256:61315cebd2e65df5f97ec298c888f9de30430dd0612d59d6480beafbc10655af", size = 375450, upload-time = "2026-02-12T13:54:52.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/dd/d0ee25348ac58245ee9f90b6f3cbb666bf01f69be7e0911f9851bddbda16/fastapi-0.129.0-py3-none-any.whl", hash = "sha256:b4946880e48f462692b31c083be0432275cbfb6e2274566b1be91479cc1a84ec", size = 102950, upload-time = "2026-02-12T13:54:54.528Z" },
 ]
 
 [[package]]
@@ -1014,6 +1036,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/7f/403e5d787dc4942316e515e949b0c8a013d84078a915910e9f391ba9b3ed/httptools-0.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:38e0c83a2ea9746ebbd643bdfb521b9aa4a91703e2cd705c20443405d2fd16a5", size = 206280, upload-time = "2025-10-10T03:54:39.274Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0d/7f3fd28e2ce311ccc998c388dd1c53b18120fda3b70ebb022b135dc9839b/httptools-0.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f25bbaf1235e27704f1a7b86cd3304eabc04f569c828101d94a0e605ef7205a5", size = 110004, upload-time = "2025-10-10T03:54:40.403Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a6/b3965e1e146ef5762870bbe76117876ceba51a201e18cc31f5703e454596/httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c15f37ef679ab9ecc06bfc4e6e8628c32a8e4b305459de7cf6785acd57e4d03", size = 517655, upload-time = "2025-10-10T03:54:41.347Z" },
+    { url = "https://files.pythonhosted.org/packages/11/7d/71fee6f1844e6fa378f2eddde6c3e41ce3a1fb4b2d81118dd544e3441ec0/httptools-0.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fe6e96090df46b36ccfaf746f03034e5ab723162bc51b0a4cf58305324036f2", size = 511440, upload-time = "2025-10-10T03:54:42.452Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a5/079d216712a4f3ffa24af4a0381b108aa9c45b7a5cc6eb141f81726b1823/httptools-0.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f72fdbae2dbc6e68b8239defb48e6a5937b12218e6ffc2c7846cc37befa84362", size = 495186, upload-time = "2025-10-10T03:54:43.937Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/025ad7b65278745dee3bd0ebf9314934c4592560878308a6121f7f812084/httptools-0.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e99c7b90a29fd82fea9ef57943d501a16f3404d7b9ee81799d41639bdaae412c", size = 499192, upload-time = "2025-10-10T03:54:45.003Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/de/40a8f202b987d43afc4d54689600ff03ce65680ede2f31df348d7f368b8f/httptools-0.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:3e14f530fefa7499334a79b0cf7e7cd2992870eb893526fb097d51b4f2d0f321", size = 86694, upload-time = "2025-10-10T03:54:45.923Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8f/c77b1fcbfd262d422f12da02feb0d218fa228d52485b77b953832105bb90/httptools-0.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6babce6cfa2a99545c60bfef8bee0cc0545413cb0018f617c8059a30ad985de3", size = 202889, upload-time = "2025-10-10T03:54:47.089Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1a/22887f53602feaa066354867bc49a68fc295c2293433177ee90870a7d517/httptools-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:601b7628de7504077dd3dcb3791c6b8694bbd967148a6d1f01806509254fb1ca", size = 108180, upload-time = "2025-10-10T03:54:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c", size = 478596, upload-time = "2025-10-10T03:54:48.919Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66", size = 473268, upload-time = "2025-10-10T03:54:49.993Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4d/9dd616c38da088e3f436e9a616e1d0cc66544b8cdac405cc4e81c8679fc7/httptools-0.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:44c8f4347d4b31269c8a9205d8a5ee2df5322b09bbbd30f8f862185bb6b05346", size = 455517, upload-time = "2025-10-10T03:54:51.066Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3a/a6c595c310b7df958e739aae88724e24f9246a514d909547778d776799be/httptools-0.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:465275d76db4d554918aba40bf1cbebe324670f3dfc979eaffaa5d108e2ed650", size = 458337, upload-time = "2025-10-10T03:54:52.196Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/82/88e8d6d2c51edc1cc391b6e044c6c435b6aebe97b1abc33db1b0b24cd582/httptools-0.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:322d00c2068d125bd570f7bf78b2d367dad02b919d8581d7476d8b75b294e3e6", size = 85743, upload-time = "2025-10-10T03:54:53.448Z" },
+    { url = "https://files.pythonhosted.org/packages/34/50/9d095fcbb6de2d523e027a2f304d4551855c2f46e0b82befd718b8b20056/httptools-0.7.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:c08fe65728b8d70b6923ce31e3956f859d5e1e8548e6f22ec520a962c6757270", size = 203619, upload-time = "2025-10-10T03:54:54.321Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f0/89720dc5139ae54b03f861b5e2c55a37dba9a5da7d51e1e824a1f343627f/httptools-0.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7aea2e3c3953521c3c51106ee11487a910d45586e351202474d45472db7d72d3", size = 108714, upload-time = "2025-10-10T03:54:55.163Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/eea88506f191fb552c11787c23f9a405f4c7b0c5799bf73f2249cd4f5228/httptools-0.7.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0e68b8582f4ea9166be62926077a3334064d422cf08ab87d8b74664f8e9058e1", size = 472909, upload-time = "2025-10-10T03:54:56.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/4a/a548bdfae6369c0d078bab5769f7b66f17f1bfaa6fa28f81d6be6959066b/httptools-0.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df091cf961a3be783d6aebae963cc9b71e00d57fa6f149025075217bc6a55a7b", size = 470831, upload-time = "2025-10-10T03:54:57.219Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/31/14df99e1c43bd132eec921c2e7e11cda7852f65619bc0fc5bdc2d0cb126c/httptools-0.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f084813239e1eb403ddacd06a30de3d3e09a9b76e7894dcda2b22f8a726e9c60", size = 452631, upload-time = "2025-10-10T03:54:58.219Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d2/b7e131f7be8d854d48cb6d048113c30f9a46dca0c9a8b08fcb3fcd588cdc/httptools-0.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7347714368fb2b335e9063bc2b96f2f87a9ceffcd9758ac295f8bbcd3ffbc0ca", size = 452910, upload-time = "2025-10-10T03:54:59.366Z" },
+    { url = "https://files.pythonhosted.org/packages/53/cf/878f3b91e4e6e011eff6d1fa9ca39f7eb17d19c9d7971b04873734112f30/httptools-0.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:cfabda2a5bb85aa2a904ce06d974a3f30fb36cc63d7feaddec05d2050acede96", size = 88205, upload-time = "2025-10-10T03:55:00.389Z" },
 ]
 
 [[package]]
@@ -2893,6 +2944,119 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485, upload-time = "2025-10-14T15:04:50.155Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813, upload-time = "2025-10-14T15:04:51.059Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816, upload-time = "2025-10-14T15:04:52.031Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186, upload-time = "2025-10-14T15:04:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657, upload-time = "2025-10-14T15:04:57.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Introduced a FastAPI server for handling requests and WebSocket connections.
- Updated CLI to connect to the server, replacing the previous interactive model.
- Enhanced documentation in AGENTS.md and README.md to reflect new server and client structure.
- Added bearer token authentication for secure communication between CLI and server.
- Updated project dependencies to include FastAPI, Uvicorn, and WebSockets.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because this is a major architectural shift from an in-process CLI agent loop to a networked server with bearer-token auth, new REST/WS protocols, and concurrency/approval handling that can affect security and session integrity.
> 
> **Overview**
> Shifts Carapace to a **client–server architecture**: `python -m carapace` now starts a FastAPI server (REST for sessions, WebSocket for chat/commands/approvals) and the CLI becomes a thin client using `httpx` + `websockets`.
> 
> Adds **bearer-token authentication** with auto-generated `data/server.token` (`auth.ensure_token`) enforced for both REST and WebSocket, plus a typed WebSocket message protocol in `ws_models.py` and server-side handling for slash commands, tool-call notifications, and approval roundtrips.
> 
> Updates config/models to include `server.host/port` and a `Deps.tool_call_callback`, adjusts docs and packaging (`fastapi`, `uvicorn`, `websockets`, `carapace-server` script), and adds smoke tests covering token creation and basic server REST/WS behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64ad97104d718829c734e3387a1840697f7072d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->