### PR TITLE
✨ Structured tool results with exit codes

### DIFF
--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -53,16 +53,14 @@ export function ChatView({ server, token, sessionId, onTitleUpdate }: ChatViewPr
           } else if (h.role === "tool_call") {
             // Look ahead for a matching tool_result
             const next = history[i + 1];
-            const result =
-              next?.role === "tool_result" && next.tool === h.tool
-                ? next.result
-                : undefined;
+            const hasResult = next?.role === "tool_result" && next.tool === h.tool;
             msgs.push({
               kind: "tool_call",
               tool: h.tool ?? "",
               args: h.args ?? {},
               detail: h.detail ?? "",
-              result: result ?? undefined,
+              result: hasResult ? next.result : undefined,
+              exitCode: hasResult ? next.exit_code : undefined,
             });
           } else if (h.role === "tool_result") {
             // Skip — already consumed by the tool_call above
@@ -232,7 +230,7 @@ export function ChatView({ server, token, sessionId, onTitleUpdate }: ChatViewPr
           for (let i = updated.length - 1; i >= 0; i--) {
             const m = updated[i];
             if (m.kind === "tool_call" && m.loading && m.tool === msg.tool) {
-              updated[i] = { ...m, result: msg.result, loading: false };
+              updated[i] = { ...m, result: msg.result, exitCode: msg.exit_code, loading: false };
               break;
             }
           }

--- a/frontend/src/components/message.tsx
+++ b/frontend/src/components/message.tsx
@@ -58,6 +58,7 @@ export function Message({
           args={message.args}
           detail={message.detail}
           result={message.result}
+          exitCode={message.exitCode}
           loading={message.loading}
         />
       );

--- a/frontend/src/components/tool-call-badge.tsx
+++ b/frontend/src/components/tool-call-badge.tsx
@@ -9,6 +9,7 @@ interface ToolCallBadgeProps {
   args: Record<string, unknown>;
   detail: string;
   result?: string;
+  exitCode?: number;
   loading?: boolean;
 }
 
@@ -98,11 +99,13 @@ export function ToolCallBadge({
   args,
   detail,
   result,
+  exitCode,
   loading,
 }: ToolCallBadgeProps) {
   const [open, setOpen] = useState(false);
   const { source, verdict, explanation } = parseDetail(detail);
   const argsSummary = formatArgsSummary(args);
+  const isError = exitCode != null && exitCode !== 0;
 
   return (
     <div className="my-1">
@@ -151,7 +154,12 @@ export function ToolCallBadge({
               <summary className="cursor-pointer text-muted-foreground hover:text-foreground transition-colors font-medium select-none">
                 Result
               </summary>
-              <pre className="mt-1.5 rounded-md bg-muted p-2.5 font-mono overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap border border-border/40">
+              <pre className={cn(
+                "mt-1.5 rounded-md p-2.5 font-mono overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap border",
+                isError
+                  ? "bg-destructive/10 text-destructive border-destructive/30"
+                  : "bg-muted border-border/40",
+              )}>
                 {result}
               </pre>
             </details>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -19,6 +19,7 @@ export interface HistoryMessage {
   args?: Record<string, unknown>;
   detail?: string;
   result?: string;
+  exit_code?: number;
   command?: string;
   data?: unknown;
   request_id?: string;
@@ -49,6 +50,7 @@ export interface ToolResultInfo {
   type: "tool_result";
   tool: string;
   result: string;
+  exit_code?: number;
 }
 
 export interface ApprovalRequest {
@@ -176,6 +178,7 @@ export type ChatMessage =
       args: Record<string, unknown>;
       detail: string;
       result?: string;
+      exitCode?: number;
       loading?: boolean;
     }
   | { kind: "approval"; request: ApprovalRequest }

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -8,7 +8,7 @@ from pydantic_ai import Agent, DeferredToolRequests, RunContext, ToolDenied
 import carapace.security as security
 from carapace.config import load_workspace_file
 from carapace.memory import MemoryStore
-from carapace.models import Deps
+from carapace.models import Deps, ToolResult
 from carapace.sandbox.runtime import SkillVenvError
 from carapace.security.context import SkillActivatedEntry, ToolResultEntry
 from carapace.skills import SkillRegistry
@@ -41,9 +41,9 @@ def _notify_approved_start(ctx: RunContext[Deps], tool_name: str, args: dict[str
         ctx.deps.tool_call_callback(tool_name, args, "[user approved]")
 
 
-def _notify_result(ctx: RunContext[Deps], tool_name: str, result: str) -> None:
+def _notify_result(ctx: RunContext[Deps], tool_name: str, result: str, exit_code: int = 0) -> None:
     if ctx.deps.tool_result_callback:
-        ctx.deps.tool_result_callback(tool_name, result[:2000])
+        ctx.deps.tool_result_callback(ToolResult(tool=tool_name, output=result[:2000], exit_code=exit_code))
 
 
 def build_system_prompt(deps: Deps) -> str:
@@ -197,8 +197,13 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
             return denied
 
         session_id = ctx.deps.session_state.session_id
-        result = await ctx.deps.sandbox.file_read(session_id, path)
-        _notify_result(ctx, "read", result)
+        exit_code = 0
+        try:
+            result = await ctx.deps.sandbox.file_read(session_id, path)
+        except Exception as exc:
+            result = f"Error: {exc}"
+            exit_code = -1
+        _notify_result(ctx, "read", result, exit_code)
         return result
 
     @agent.tool
@@ -210,8 +215,13 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
             return denied
 
         session_id = ctx.deps.session_state.session_id
-        result = await ctx.deps.sandbox.file_write(session_id, path, content)
-        _notify_result(ctx, "write", result)
+        exit_code = 0
+        try:
+            result = await ctx.deps.sandbox.file_write(session_id, path, content)
+        except Exception as exc:
+            result = f"Error: {exc}"
+            exit_code = -1
+        _notify_result(ctx, "write", result, exit_code)
         return result
 
     @agent.tool
@@ -237,8 +247,13 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
             return denied
 
         session_id = ctx.deps.session_state.session_id
-        result = await ctx.deps.sandbox.file_edit(session_id, path, old_string, new_string)
-        _notify_result(ctx, "edit", result)
+        exit_code = 0
+        try:
+            result = await ctx.deps.sandbox.file_edit(session_id, path, old_string, new_string)
+        except Exception as exc:
+            result = f"Error: {exc}"
+            exit_code = -1
+        _notify_result(ctx, "edit", result, exit_code)
         return result
 
     @agent.tool
@@ -259,8 +274,13 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
             return denied
 
         session_id = ctx.deps.session_state.session_id
-        result = await ctx.deps.sandbox.file_apply_patch(session_id, changes)
-        _notify_result(ctx, "apply_patch", result)
+        exit_code = 0
+        try:
+            result = await ctx.deps.sandbox.file_apply_patch(session_id, changes)
+        except Exception as exc:
+            result = f"Error: {exc}"
+            exit_code = -1
+        _notify_result(ctx, "apply_patch", result, exit_code)
         return result
 
     # --- Runtime ---
@@ -275,13 +295,19 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
             _notify_approved_start(ctx, "exec", {"command": command})
 
         session_id = ctx.deps.session_state.session_id
-        result = await ctx.deps.sandbox.exec_command(session_id, command)
+        try:
+            exec_result = await ctx.deps.sandbox.exec_command(session_id, command)
+            result = exec_result.output
+            exit_code = exec_result.exit_code
+        except Exception as exc:
+            result = f"Error: {exc}"
+            exit_code = -1
 
         ctx.deps.security.append(
-            ToolResultEntry(tool="exec", status="error" if result.startswith("Error") else "success"),
+            ToolResultEntry(tool="exec", status="error" if exit_code != 0 else "success"),
         )
 
-        _notify_result(ctx, "exec", result)
+        _notify_result(ctx, "exec", result, exit_code)
         return result
 
     # --- Memory ---

--- a/src/carapace/channels/matrix/subscriber.py
+++ b/src/carapace/channels/matrix/subscriber.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 from carapace.channels.matrix.approval import TYPING_INTERVAL, PendingApproval, PendingDomainApproval
 from carapace.channels.matrix.formatting import format_approval_request, format_domain_escalation
+from carapace.models import ToolResult
 from carapace.ws_models import ApprovalRequest, TurnUsage
 
 if TYPE_CHECKING:
@@ -67,11 +68,11 @@ class MatrixSubscriber:
             notice = f"🔧 `{tool}({args_brief})`" + (f" {detail}" if detail else "")
             await self._channel._send_notice(self._room_id, notice)
 
-    async def on_tool_result(self, tool: str, result: str) -> None:
+    async def on_tool_result(self, result: ToolResult) -> None:
         if self._channel._verbose.get(self._room_id, True):
             # Truncate long results to keep Matrix messages manageable
-            preview = result[:500] + ("…" if len(result) > 500 else "")
-            notice = f"📎 `{tool}` result:\n```\n{preview}\n```"
+            preview = result.output[:500] + ("…" if len(result.output) > 500 else "")
+            notice = f"📎 `{result.tool}` result:\n```\n{preview}\n```"
             await self._channel._send_notice(self._room_id, notice)
 
     _STREAM_EDIT_THRESHOLD = 200  # min chars between edits

--- a/src/carapace/models.py
+++ b/src/carapace/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal
@@ -189,6 +190,15 @@ class Config(BaseModel):
 # --- Skill Catalog Entry ---
 
 
+@dataclass(frozen=True, slots=True)
+class ToolResult:
+    """Structured result passed through ``tool_result_callback``."""
+
+    tool: str
+    output: str
+    exit_code: int = 0
+
+
 class SkillNetworkConfig(BaseModel):
     domains: list[str] = []
 
@@ -226,5 +236,5 @@ class Deps(BaseModel):
     agent_model: Model
     verbose: bool = True
     tool_call_callback: Callable[[str, dict[str, Any], str], None] | None = None
-    tool_result_callback: Callable[[str, str], None] | None = None
+    tool_result_callback: Callable[[ToolResult], None] | None = None
     usage_tracker: UsageTracker

--- a/src/carapace/sandbox/manager.py
+++ b/src/carapace/sandbox/manager.py
@@ -434,8 +434,8 @@ class SandboxManager:
 
     _KNOWLEDGE_WORKDIR = "/workspace"
 
-    async def exec_command(self, session_id: str, command: str, timeout: int = 3600) -> str:
-        """Run a command in the sandbox and return formatted output."""
+    async def exec_command(self, session_id: str, command: str, timeout: int = 3600) -> ExecResult:
+        """Run a command in the sandbox and return the result."""
         result = await self._exec(
             session_id,
             command,
@@ -446,7 +446,7 @@ class SandboxManager:
         if result.exit_code != 0 and f"[exit code: {result.exit_code}]" not in output:
             logger.debug(f"Command failed in session {session_id} (exit {result.exit_code}): {command}")
             output += f"\n[exit code: {result.exit_code}]"
-        return output or "(no output)"
+        return ExecResult(exit_code=result.exit_code, output=output or "(no output)")
 
     # ------------------------------------------------------------------
     # File operations (executed inside the sandbox container via

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -42,7 +42,7 @@ from carapace.bootstrap import ensure_data_dir, ensure_knowledge_dir
 from carapace.config import _resolve_data_dir, _resolve_knowledge_dir, get_config_path, get_data_dir, load_config
 from carapace.git.http import GitHttpHandler
 from carapace.git.store import GitStore
-from carapace.models import Config, SessionState
+from carapace.models import Config, SessionState, ToolResult
 from carapace.sandbox.manager import SandboxManager
 from carapace.sandbox.proxy import ProxyServer
 from carapace.sandbox.runtime import ContainerRuntime
@@ -564,8 +564,8 @@ class WebSocketSubscriber:
     async def on_tool_call(self, tool: str, args: dict[str, Any], detail: str) -> None:
         await self._safe_send(ToolCallInfo(tool=tool, args=args, detail=detail))
 
-    async def on_tool_result(self, tool: str, result: str) -> None:
-        await self._safe_send(ToolResultInfo(tool=tool, result=result))
+    async def on_tool_result(self, result: ToolResult) -> None:
+        await self._safe_send(ToolResultInfo(tool=result.tool, result=result.output, exit_code=result.exit_code))
 
     async def on_token(self, content: str) -> None:
         await self._safe_send(TokenChunk(content=content))

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -18,7 +18,7 @@ import carapace.security as security_mod
 from carapace.agent.loop import run_agent_turn
 from carapace.git.store import GitStore
 from carapace.memory import MemoryStore
-from carapace.models import Config, Deps, SessionState, SkillInfo
+from carapace.models import Config, Deps, SessionState, SkillInfo, ToolResult
 from carapace.sandbox.manager import SandboxManager
 from carapace.security.context import SessionSecurity, UserVouchedEntry
 from carapace.security.sentinel import Sentinel
@@ -41,7 +41,7 @@ ModelType = Literal["agent", "sentinel", "title"]
 class SessionSubscriber(Protocol):
     async def on_user_message(self, content: str, *, from_self: bool) -> None: ...
     async def on_tool_call(self, tool: str, args: dict[str, Any], detail: str) -> None: ...
-    async def on_tool_result(self, tool: str, result: str) -> None: ...
+    async def on_tool_result(self, result: ToolResult) -> None: ...
     async def on_token(self, content: str) -> None: ...
     async def on_done(self, content: str, usage: TurnUsage) -> None: ...
     async def on_error(self, detail: str) -> None: ...
@@ -268,7 +268,7 @@ class SessionEngine:
         active: ActiveSession,
         *,
         tool_call_callback: Callable[[str, dict[str, Any], str], None] | None = None,
-        tool_result_callback: Callable[[str, str], None] | None = None,
+        tool_result_callback: Callable[[ToolResult], None] | None = None,
     ) -> Deps:
         assert active.security is not None and active.sentinel is not None
         return Deps(
@@ -587,12 +587,12 @@ class SessionEngine:
             active._pending_sends.add(task)
             task.add_done_callback(active._pending_sends.discard)
 
-        def _tool_result_cb(tool: str, result: str) -> None:
+        def _tool_result_cb(tr: ToolResult) -> None:
             self._session_mgr.append_events(
                 session_id,
-                [{"role": "tool_result", "tool": tool, "result": result}],
+                [{"role": "tool_result", "tool": tr.tool, "result": tr.output, "exit_code": tr.exit_code}],
             )
-            task = asyncio.ensure_future(self._broadcast(active, "on_tool_result", tool, result))
+            task = asyncio.ensure_future(self._broadcast(active, "on_tool_result", tr))
             active._pending_sends.add(task)
             task.add_done_callback(active._pending_sends.discard)
 

--- a/src/carapace/ws_models.py
+++ b/src/carapace/ws_models.py
@@ -94,6 +94,7 @@ class ToolResultInfo(BaseModel):
     type: Literal["tool_result"] = "tool_result"
     tool: str
     result: str
+    exit_code: int = 0
 
 
 class ApprovalRequest(BaseModel):

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -197,7 +197,7 @@ async def test_exec_recreate_preserves_domains(tmp_path: Path):
     mgr.allow_domains(session_id, {"api.example.com"})
 
     output = await mgr.exec_command(session_id, "curl https://api.example.com")
-    assert output == "ok"
+    assert output.output == "ok"
     assert mgr.get_allowed_domains(session_id) == {"api.example.com"}
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -13,6 +13,7 @@ from pydantic_ai.models.test import TestModel
 from carapace.bootstrap import ensure_data_dir
 from carapace.config import load_config
 from carapace.git.store import GitStore
+from carapace.models import ToolResult
 from carapace.sandbox.manager import SandboxManager
 from carapace.security.sentinel import Sentinel
 from carapace.session import SessionEngine, SessionManager
@@ -87,7 +88,7 @@ class _FakeSubscriber:
     async def on_tool_call(self, tool: str, args: dict[str, Any], detail: str) -> None:
         pass
 
-    async def on_tool_result(self, tool: str, result: str) -> None:
+    async def on_tool_result(self, result: ToolResult) -> None:
         pass
 
     async def on_done(self, content: str, usage: TurnUsage) -> None:


### PR DESCRIPTION
## Summary

Introduce a `ToolResult` dataclass replacing loose callback args, and propagate sandbox exit codes through the full stack so the frontend can display errors with proper styling.

### Backend
- **`ToolResult` dataclass** (`tool`, `output`, `exit_code`) in `models.py`
- **Catch sandbox exceptions** in all tool functions so infrastructure errors become tool results instead of crashing the agent turn
- `exec` tool passes actual exit code from `ExecResult`; other tools use `0` / `-1`
- `exec_command` returns `ExecResult` instead of plain `str`
- `ToolResultInfo` WS model gains `exit_code` field
- Subscriber protocol, engine, server, and Matrix channel updated

### Frontend
- Tool call badge renders result with red destructive styling when `exit_code != 0`
- Stale tool-call spinners cleared on error, cancel, and WebSocket disconnect
- `exit_code` persisted in session events and restored on reload

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the tool execution/event pipeline and WebSocket protocol across backend + frontend; regressions could break tool result rendering or session history replay if any consumer still expects string-only results.
> 
> **Overview**
> **Tool results are now structured and include exit codes end-to-end.** The backend introduces a `ToolResult` dataclass and updates tool callbacks/subscriber interfaces (WebSocket + Matrix) to pass `{tool, output, exit_code}`, while `exec_command` returns an `ExecResult` so real command exit codes can be forwarded.
> 
> Tool implementations (`read`/`write`/`edit`/`apply_patch`/`exec`) now catch sandbox exceptions and emit error tool results (with non-zero exit codes) instead of failing the turn, and session events/WS models persist `exit_code` for history replay.
> 
> On the frontend, `exit_code` is stored on `tool_call` messages, restored from history, and shown in `ToolCallBadge` with destructive styling when non-zero; tool-call spinners are also cleared when results/errors/disconnects finalize waiting state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f99e66f862577f383dd49046f57211a1b7e1f369. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->