### PR TITLE
♻️ refactor: migrate Kubernetes runtime from official client to kr8s

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "loguru>=0.7.3",
     "matrix-nio>=0.25,<1",
     "markdown>=3,<4",
-    "kubernetes>=35,<36",
+    "kr8s>=0.20,<1",
 ]
 
 [project.scripts]

--- a/src/carapace/sandbox/kubernetes.py
+++ b/src/carapace/sandbox/kubernetes.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import os
+import socket
 from pathlib import Path
 
-from kubernetes import client as k8s_client
-from kubernetes import config as k8s_config
-from kubernetes.client import ApiException
-from kubernetes.stream import stream as k8s_stream
+import kr8s
+from kr8s.asyncio.objects import Deployment, Pod, StatefulSet
 from loguru import logger
 
 from carapace.sandbox.runtime import (
@@ -28,8 +27,26 @@ def _sanitize_pod_name(name: str) -> str:
     return sanitized[:63].strip("-")
 
 
+def _default_command(command: str | list[str] | None) -> list[str]:
+    if isinstance(command, str):
+        return ["bash", "-c", command]
+    if command is None:
+        return ["sh", "-c", "echo 'carapace sandbox ready' && exec sleep infinity"]
+    return command
+
+
+def _standard_labels(app_instance: str) -> dict[str, str]:
+    return {
+        "app.kubernetes.io/instance": app_instance,
+        "app.kubernetes.io/part-of": "carapace",
+        "app.kubernetes.io/component": "sandbox",
+        "app.kubernetes.io/managed-by": "carapace-server",
+        "app": "carapace-sandbox",
+    }
+
+
 class KubernetesRuntime(ContainerRuntime):
-    """ContainerRuntime backed by Kubernetes pods."""
+    """ContainerRuntime backed by Kubernetes pods (using kr8s)."""
 
     def __init__(
         self,
@@ -44,13 +61,6 @@ class KubernetesRuntime(ContainerRuntime):
         session_pvc_size: str = "1Gi",
         session_pvc_storage_class: str = "",
     ) -> None:
-        if os.environ.get("KUBERNETES_SERVICE_HOST"):
-            k8s_config.load_incluster_config()
-        else:
-            k8s_config.load_kube_config()
-
-        self._core = k8s_client.CoreV1Api()
-        self._apps = k8s_client.AppsV1Api()
         self._namespace = namespace
         self._pvc_claim = pvc_claim
         self._data_dir = data_dir
@@ -59,155 +69,140 @@ class KubernetesRuntime(ContainerRuntime):
         self._app_instance = app_instance
         self._session_pvc_size = session_pvc_size
         self._session_pvc_storage_class = session_pvc_storage_class or None
-
-        # Optionally look up the owner Deployment UID for ownerReferences on sandbox pods
-        self._owner_ref: k8s_client.V1OwnerReference | None = None
-        if owner_ref:
-            try:
-                deployment = self._apps.read_namespaced_deployment("carapace", namespace)
-                self._owner_ref = k8s_client.V1OwnerReference(
-                    api_version="apps/v1",
-                    kind="Deployment",
-                    name="carapace",
-                    uid=deployment.metadata.uid,
-                    controller=False,
-                    block_owner_deletion=False,
-                )
-                logger.info(f"KubernetesRuntime: owner Deployment UID = {deployment.metadata.uid}")
-            except ApiException as exc:
-                logger.warning(f"Could not look up owner Deployment: {exc.reason} — sandbox pods will lack ownerRef")
+        self._want_owner_ref = owner_ref
+        self._owner_deployment: Deployment | None = None
 
         logger.info(f"KubernetesRuntime initialized (namespace={namespace}, pvc={pvc_claim}, data_dir={data_dir})")
 
-    def _mount_to_subpath(self, mount: Mount) -> str:
-        """Convert a Mount.source (absolute host/container path) to a PVC subPath.
+    async def _ensure_api(self) -> kr8s.Api:
+        """Lazily create the kr8s API client (must be called from async context)."""
+        return await kr8s.asyncio.api(namespace=self._namespace)
 
-        The SandboxManager builds mounts with source paths like
-        ``/data/memory`` or ``/data/sessions/abc/workspace/skills``.
-        We strip the data_dir prefix to get the PVC-relative subPath.
-        """
+    async def _get_owner_deployment(self) -> Deployment | None:
+        """Look up the owner Deployment once and cache it."""
+        if self._owner_deployment is not None:
+            return self._owner_deployment
+        if not self._want_owner_ref:
+            return None
+        try:
+            api = await self._ensure_api()
+            deploy = await Deployment.get("carapace", namespace=self._namespace, api=api)
+            self._owner_deployment = deploy
+            logger.info(f"KubernetesRuntime: owner Deployment UID = {deploy.raw.metadata.uid}")
+            return deploy
+        except kr8s.NotFoundError:
+            logger.warning("Could not look up owner Deployment — sandbox resources will lack ownerRef")
+            self._want_owner_ref = False
+            return None
+
+    def _owner_ref_dict(self, deploy: Deployment) -> dict:
+        return {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "name": "carapace",
+            "uid": deploy.raw.metadata.uid,
+            "controller": False,
+            "blockOwnerDeletion": False,
+        }
+
+    def _mount_to_subpath(self, mount: Mount) -> str:
+        """Convert a Mount.source path to a PVC subPath."""
         source = Path(mount.source)
         try:
             return str(source.relative_to(self._data_dir))
         except ValueError:
-            # Not under data_dir — use the path as-is (shouldn't happen in practice)
             logger.warning(f"Mount source {mount.source} is not under {self._data_dir}")
             return mount.source
 
-    def _build_pod_spec(self, config: ContainerConfig) -> k8s_client.V1Pod:
-        """Build a V1Pod from a ContainerConfig."""
+    # ------------------------------------------------------------------
+    # Pod-based sandbox (ContainerConfig)
+    # ------------------------------------------------------------------
+
+    def _build_pod_dict(self, config: ContainerConfig) -> dict:
+        """Build a raw Pod dict from a ContainerConfig."""
         pod_name = _sanitize_pod_name(config.name)
 
-        # All mounts reference the single shared PVC via subPath
         volume_mounts = [
-            k8s_client.V1VolumeMount(
-                name="data",
-                mount_path=m.target,
-                sub_path=self._mount_to_subpath(m),
-                read_only=m.read_only,
-            )
+            {
+                "name": "data",
+                "mountPath": m.target,
+                "subPath": self._mount_to_subpath(m),
+                **({"readOnly": True} if m.read_only else {}),
+            }
             for m in config.mounts
         ]
 
-        env_vars = [k8s_client.V1EnvVar(name=k, value=v) for k, v in config.environment.items()]
+        env_vars = [{"name": k, "value": v} for k, v in config.environment.items()]
 
-        command = config.command
-        if isinstance(command, str):
-            command = ["bash", "-c", command]
-        elif command is None:
-            command = ["sh", "-c", "echo 'carapace sandbox ready' && exec sleep infinity"]
-
-        container = k8s_client.V1Container(
-            name="sandbox",
-            image=config.image,
-            command=command,
-            env=env_vars or None,
-            volume_mounts=volume_mounts or None,
-            security_context=k8s_client.V1SecurityContext(
-                allow_privilege_escalation=False,
-                capabilities=k8s_client.V1Capabilities(drop=["ALL"]),
-            ),
-        )
-
-        # Standard labels for NetworkPolicy and ArgoCD
-        labels = {
-            "app.kubernetes.io/instance": self._app_instance,
-            "app.kubernetes.io/part-of": "carapace",
-            "app.kubernetes.io/component": "sandbox",
-            "app.kubernetes.io/managed-by": "carapace-server",
-            "app": "carapace-sandbox",
-        }
+        labels = _standard_labels(self._app_instance)
         labels.update(config.labels)
 
-        # ArgoCD tracking annotation so sandbox pods appear in the app resource tree
-        annotations = {
-            "argocd.argoproj.io/tracking-id": f"{self._app_instance}:/Pod:{self._namespace}/{pod_name}",
-        }
-
-        metadata = k8s_client.V1ObjectMeta(
-            name=pod_name,
-            namespace=self._namespace,
-            labels=labels,
-            annotations=annotations,
-            owner_references=[self._owner_ref] if self._owner_ref else None,
-        )
-
-        pod = k8s_client.V1Pod(
-            api_version="v1",
-            kind="Pod",
-            metadata=metadata,
-            spec=k8s_client.V1PodSpec(
-                containers=[container],
-                volumes=[
-                    k8s_client.V1Volume(
-                        name="data",
-                        persistent_volume_claim=k8s_client.V1PersistentVolumeClaimVolumeSource(
-                            claim_name=self._pvc_claim,
-                        ),
-                    ),
+        return {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": pod_name,
+                "namespace": self._namespace,
+                "labels": labels,
+                "annotations": {
+                    "argocd.argoproj.io/tracking-id": f"{self._app_instance}:/Pod:{self._namespace}/{pod_name}",
+                },
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "name": "sandbox",
+                        "image": config.image,
+                        "command": _default_command(config.command),
+                        **({"env": env_vars} if env_vars else {}),
+                        **({"volumeMounts": volume_mounts} if volume_mounts else {}),
+                        "securityContext": {
+                            "allowPrivilegeEscalation": False,
+                            "capabilities": {"drop": ["ALL"]},
+                        },
+                    }
                 ],
-                restart_policy="Always",
-                service_account_name=self._service_account,
-                automount_service_account_token=False,
-                priority_class_name=self._priority_class,
-            ),
-        )
-        return pod
+                "volumes": [
+                    {
+                        "name": "data",
+                        "persistentVolumeClaim": {"claimName": self._pvc_claim},
+                    }
+                ],
+                "restartPolicy": "Always",
+                **({"serviceAccountName": self._service_account} if self._service_account else {}),
+                "automountServiceAccountToken": False,
+                **({"priorityClassName": self._priority_class} if self._priority_class else {}),
+            },
+        }
 
     async def create(self, config: ContainerConfig) -> str:
         pod_name = _sanitize_pod_name(config.name)
-
-        # Remove stale pod with the same name if it exists
         await self._delete_pod_if_exists(pod_name)
 
-        pod = self._build_pod_spec(config)
+        api = await self._ensure_api()
+        pod_dict = self._build_pod_dict(config)
+        owner = await self._get_owner_deployment()
+        if owner:
+            pod_dict["metadata"]["ownerReferences"] = [self._owner_ref_dict(owner)]
 
-        def _create() -> str:
-            self._core.create_namespaced_pod(namespace=self._namespace, body=pod)
-            return pod_name
-
-        container_id = await asyncio.to_thread(_create)
+        pod = await Pod(pod_dict, api=api)
+        await pod.create()
         logger.info(f"Created pod {pod_name} (image={config.image})")
 
-        # Wait for the pod to be Running
         await self._wait_for_running(pod_name, timeout=120)
-        return container_id
+        return pod_name
 
     async def _wait_for_running(self, pod_name: str, timeout: int = 120) -> None:
         """Poll until the pod reaches Running phase."""
+        api = await self._ensure_api()
         deadline = asyncio.get_event_loop().time() + timeout
         while True:
+            try:
+                pod = await Pod.get(pod_name, namespace=self._namespace, api=api)
+                phase = pod.status.phase or "Unknown"
+            except kr8s.NotFoundError:
+                phase = "Pending"
 
-            def _check() -> str:
-                try:
-                    pod = self._core.read_namespaced_pod(name=pod_name, namespace=self._namespace)
-                except ApiException as exc:
-                    if exc.status == 404:
-                        return "Pending"
-                    raise
-                return pod.status.phase or "Unknown"
-
-            phase = await asyncio.to_thread(_check)
             if phase == "Running":
                 return
             if phase in ("Failed", "Succeeded"):
@@ -220,109 +215,90 @@ class KubernetesRuntime(ContainerRuntime):
     # StatefulSet lifecycle (internal)
     # ------------------------------------------------------------------
 
-    def _build_statefulset_spec(self, config: SandboxConfig) -> k8s_client.V1StatefulSet:
-        """Build a V1StatefulSet with a volumeClaimTemplate for the session PVC."""
+    def _build_statefulset_dict(self, config: SandboxConfig) -> dict:
+        """Build a raw StatefulSet dict."""
         sts_name = _sanitize_pod_name(config.name)
 
-        env_vars = [k8s_client.V1EnvVar(name=k, value=v) for k, v in config.environment.items()]
+        env_vars = [{"name": k, "value": v} for k, v in config.environment.items()]
 
-        command = config.command
-        if isinstance(command, str):
-            command = ["bash", "-c", command]
-        elif command is None:
-            command = ["sh", "-c", "echo 'carapace sandbox ready' && exec sleep infinity"]
-
-        container = k8s_client.V1Container(
-            name="sandbox",
-            image=config.image,
-            command=command,
-            env=env_vars or None,
-            volume_mounts=[
-                k8s_client.V1VolumeMount(
-                    name="session-data",
-                    mount_path="/workspace",
-                ),
-            ],
-            security_context=k8s_client.V1SecurityContext(
-                allow_privilege_escalation=False,
-                capabilities=k8s_client.V1Capabilities(drop=["ALL"]),
-            ),
-        )
-
-        labels = {
-            "app.kubernetes.io/instance": self._app_instance,
-            "app.kubernetes.io/part-of": "carapace",
-            "app.kubernetes.io/component": "sandbox",
-            "app.kubernetes.io/managed-by": "carapace-server",
-            "app": "carapace-sandbox",
-        }
+        labels = _standard_labels(self._app_instance)
         labels.update(config.labels)
 
-        annotations = {
-            "argocd.argoproj.io/tracking-id": (f"{self._app_instance}:apps/StatefulSet:{self._namespace}/{sts_name}"),
+        pvc_spec: dict = {
+            "accessModes": ["ReadWriteOnce"],
+            "resources": {"requests": {"storage": self._session_pvc_size}},
         }
-
-        pvc_spec = k8s_client.V1PersistentVolumeClaimSpec(
-            access_modes=["ReadWriteOnce"],
-            resources=k8s_client.V1VolumeResourceRequirements(
-                requests={"storage": self._session_pvc_size},
-            ),
-        )
         if self._session_pvc_storage_class:
-            pvc_spec.storage_class_name = self._session_pvc_storage_class
+            pvc_spec["storageClassName"] = self._session_pvc_storage_class
 
-        return k8s_client.V1StatefulSet(
-            api_version="apps/v1",
-            kind="StatefulSet",
-            metadata=k8s_client.V1ObjectMeta(
-                name=sts_name,
-                namespace=self._namespace,
-                labels=labels,
-                annotations=annotations,
-                owner_references=[self._owner_ref] if self._owner_ref else None,
-            ),
-            spec=k8s_client.V1StatefulSetSpec(
-                replicas=1,
-                service_name="",
-                persistent_volume_claim_retention_policy=k8s_client.V1StatefulSetPersistentVolumeClaimRetentionPolicy(
-                    when_deleted="Delete",
-                    when_scaled="Retain",
-                ),
-                selector=k8s_client.V1LabelSelector(
-                    match_labels={"carapace.session": config.labels.get("carapace.session", sts_name)},
-                ),
-                template=k8s_client.V1PodTemplateSpec(
-                    metadata=k8s_client.V1ObjectMeta(labels=labels),
-                    spec=k8s_client.V1PodSpec(
-                        containers=[container],
-                        restart_policy="Always",
-                        service_account_name=self._service_account,
-                        automount_service_account_token=False,
-                        priority_class_name=self._priority_class,
+        return {
+            "apiVersion": "apps/v1",
+            "kind": "StatefulSet",
+            "metadata": {
+                "name": sts_name,
+                "namespace": self._namespace,
+                "labels": labels,
+                "annotations": {
+                    "argocd.argoproj.io/tracking-id": (
+                        f"{self._app_instance}:apps/StatefulSet:{self._namespace}/{sts_name}"
                     ),
-                ),
-                volume_claim_templates=[
-                    k8s_client.V1PersistentVolumeClaim(
-                        metadata=k8s_client.V1ObjectMeta(name="session-data"),
-                        spec=pvc_spec,
-                    ),
+                },
+            },
+            "spec": {
+                "replicas": 1,
+                "serviceName": "",
+                "persistentVolumeClaimRetentionPolicy": {
+                    "whenDeleted": "Delete",
+                    "whenScaled": "Retain",
+                },
+                "selector": {
+                    "matchLabels": {"carapace.session": config.labels.get("carapace.session", sts_name)},
+                },
+                "template": {
+                    "metadata": {"labels": labels},
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "sandbox",
+                                "image": config.image,
+                                "command": _default_command(config.command),
+                                **({"env": env_vars} if env_vars else {}),
+                                "volumeMounts": [{"name": "session-data", "mountPath": "/workspace"}],
+                                "securityContext": {
+                                    "allowPrivilegeEscalation": False,
+                                    "capabilities": {"drop": ["ALL"]},
+                                },
+                            }
+                        ],
+                        "restartPolicy": "Always",
+                        **({"serviceAccountName": self._service_account} if self._service_account else {}),
+                        "automountServiceAccountToken": False,
+                        **({"priorityClassName": self._priority_class} if self._priority_class else {}),
+                    },
+                },
+                "volumeClaimTemplates": [
+                    {
+                        "metadata": {"name": "session-data"},
+                        "spec": pvc_spec,
+                    }
                 ],
-            ),
-        )
+            },
+        }
 
     async def _create_statefulset(self, config: SandboxConfig) -> str:
         sts_name = _sanitize_pod_name(config.name)
         pod_name = f"{sts_name}-0"
 
-        # Delete stale StatefulSet if it exists (e.g. leftover from crash)
         await self._delete_sts_if_exists(sts_name)
 
-        sts = self._build_statefulset_spec(config)
+        api = await self._ensure_api()
+        sts_dict = self._build_statefulset_dict(config)
+        owner = await self._get_owner_deployment()
+        if owner:
+            sts_dict["metadata"]["ownerReferences"] = [self._owner_ref_dict(owner)]
 
-        def _create() -> None:
-            self._apps.create_namespaced_stateful_set(namespace=self._namespace, body=sts)
-
-        await asyncio.to_thread(_create)
+        sts = await StatefulSet(sts_dict, api=api)
+        await sts.create()
         logger.info(f"Created StatefulSet {sts_name} (image={config.image})")
 
         await self._wait_for_running(pod_name, timeout=120)
@@ -330,15 +306,9 @@ class KubernetesRuntime(ContainerRuntime):
 
     async def _scale_statefulset(self, name: str, replicas: int) -> None:
         sts_name = _sanitize_pod_name(name)
-
-        def _scale() -> None:
-            self._apps.patch_namespaced_stateful_set_scale(
-                name=sts_name,
-                namespace=self._namespace,
-                body={"spec": {"replicas": replicas}},
-            )
-
-        await asyncio.to_thread(_scale)
+        api = await self._ensure_api()
+        sts = await StatefulSet.get(sts_name, namespace=self._namespace, api=api)
+        await sts.scale(replicas)
         logger.info(f"Scaled StatefulSet {sts_name} to {replicas} replicas")
 
         if replicas > 0:
@@ -371,35 +341,54 @@ class KubernetesRuntime(ContainerRuntime):
     async def sandbox_exists(self, name: str) -> str | None:
         """Return the pod name if the StatefulSet exists, else None."""
         sts_name = _sanitize_pod_name(name)
-
-        def _check() -> str | None:
-            try:
-                self._apps.read_namespaced_stateful_set(name=sts_name, namespace=self._namespace)
-                return f"{sts_name}-0"
-            except ApiException as exc:
-                if exc.status == 404:
-                    return None
-                raise
-
-        return await asyncio.to_thread(_check)
+        api = await self._ensure_api()
+        sts = await StatefulSet(
+            {
+                "apiVersion": "apps/v1",
+                "kind": "StatefulSet",
+                "metadata": {"name": sts_name, "namespace": self._namespace},
+            },
+            api=api,
+        )
+        if await sts.exists():
+            return f"{sts_name}-0"
+        return None
 
     async def _delete_sts_if_exists(self, sts_name: str) -> None:
-        def _delete() -> None:
-            try:
-                self._apps.delete_namespaced_stateful_set(
-                    name=sts_name,
-                    namespace=self._namespace,
-                    grace_period_seconds=0,
-                    propagation_policy="Foreground",
-                )
-                logger.info(f"Deleted StatefulSet {sts_name}")
-            except ApiException as exc:
-                if exc.status == 404:
-                    logger.debug(f"StatefulSet {sts_name} already gone, skip delete")
-                else:
-                    raise
+        api = await self._ensure_api()
+        sts = await StatefulSet(
+            {
+                "apiVersion": "apps/v1",
+                "kind": "StatefulSet",
+                "metadata": {"name": sts_name, "namespace": self._namespace},
+            },
+            api=api,
+        )
+        if await sts.exists():
+            await sts.delete(propagation_policy="Foreground", force=True)
+            logger.info(f"Deleted StatefulSet {sts_name}")
+        else:
+            logger.debug(f"StatefulSet {sts_name} already gone, skip delete")
 
-        await asyncio.to_thread(_delete)
+    # ------------------------------------------------------------------
+    # Pod helpers
+    # ------------------------------------------------------------------
+
+    async def _delete_pod_if_exists(self, pod_name: str) -> None:
+        api = await self._ensure_api()
+        pod = await Pod(
+            {"apiVersion": "v1", "kind": "Pod", "metadata": {"name": pod_name, "namespace": self._namespace}},
+            api=api,
+        )
+        if await pod.exists():
+            await pod.delete(force=True)
+            logger.info(f"Deleted pod {pod_name}")
+        else:
+            logger.debug(f"Pod {pod_name} already gone, skip delete")
+
+    # ------------------------------------------------------------------
+    # Exec
+    # ------------------------------------------------------------------
 
     async def exec(
         self,
@@ -411,8 +400,6 @@ class KubernetesRuntime(ContainerRuntime):
     ) -> ExecResult:
         shell_cmd = command if isinstance(command, str) else " ".join(command)
 
-        # Kubernetes exec doesn't support workdir or env natively,
-        # so we prepend cd and env vars to the shell command.
         if workdir:
             shell_cmd = f"cd {workdir} && {shell_cmd}"
         if env:
@@ -420,62 +407,37 @@ class KubernetesRuntime(ContainerRuntime):
             shell_cmd = f"env {env_prefix} {shell_cmd}"
 
         exec_command = ["bash", "-c", shell_cmd]
+        logger.debug(f"Exec in pod {container_id}: {shell_cmd} (timeout={timeout}s)")
 
-        def _exec() -> ExecResult:
-            try:
-                resp = k8s_stream(
-                    self._core.connect_get_namespaced_pod_exec,
-                    name=container_id,
-                    namespace=self._namespace,
-                    command=exec_command,
+        try:
+            api = await self._ensure_api()
+            pod = await Pod.get(container_id, namespace=self._namespace, api=api)
+
+            async def _do_exec() -> ExecResult:
+                completed = await pod.exec(
+                    exec_command,
                     container="sandbox",
-                    stderr=True,
-                    stdin=False,
-                    stdout=True,
-                    tty=False,
-                    _preload_content=False,
+                    check=False,
+                    capture_output=True,
                 )
-                resp.run_forever(timeout=timeout)
-                stdout = resp.read_stdout() or ""
-                stderr = resp.read_stderr() or ""
-                exit_code = resp.returncode if hasattr(resp, "returncode") and resp.returncode is not None else 0
-
-                # Check the channel for the exit code (kubernetes websocket protocol)
-                if hasattr(resp, "returncode") and resp.returncode is not None:
-                    exit_code = resp.returncode
-                else:
-                    # Try to get exit code from the error channel
-                    import json
-
-                    err_data = resp.read_channel(3)  # ERROR channel
-                    if err_data:
-                        try:
-                            status_obj = json.loads(err_data)
-                            if status_obj.get("status") == "Success":
-                                exit_code = 0
-                            else:
-                                causes = status_obj.get("details", {}).get("causes", [{}])
-                                exit_code = int(causes[0].get("message", "1"))
-                        except (json.JSONDecodeError, IndexError, ValueError, KeyError):
-                            exit_code = 1 if stderr else 0
+                stdout = completed.stdout.decode() if completed.stdout else ""
+                stderr = completed.stderr.decode() if completed.stderr else ""
+                exit_code = completed.returncode
 
                 output = stdout
                 if stderr:
                     output += f"\n[stderr] {stderr}"
                 return ExecResult(exit_code=exit_code, output=output)
 
-            except ApiException as exc:
-                if exc.status == 404:
-                    raise ContainerGoneError(f"Pod {container_id} no longer exists") from exc
-                raise
+            if timeout:
+                result = await asyncio.wait_for(_do_exec(), timeout=timeout)
+            else:
+                result = await _do_exec()
 
-        logger.debug(f"Exec in pod {container_id}: {shell_cmd} (timeout={timeout}s)")
-
-        try:
-            coro = asyncio.to_thread(_exec)
-            result = await (asyncio.wait_for(coro, timeout=timeout) if timeout else coro)
-        except ContainerGoneError:
-            raise
+        except kr8s.NotFoundError as exc:
+            raise ContainerGoneError(f"Pod {container_id} no longer exists") from exc
+        except kr8s.ExecError:
+            return ExecResult(exit_code=1, output="Error: exec protocol error")
         except TimeoutError:
             logger.warning(f"Command timed out in pod {container_id} after {timeout}s: {shell_cmd}")
             return ExecResult(exit_code=-1, output=f"Error: command timed out ({timeout}s)")
@@ -484,67 +446,43 @@ class KubernetesRuntime(ContainerRuntime):
             logger.debug(f"Command exited {result.exit_code} in pod {container_id}: {shell_cmd}")
         return result
 
+    # ------------------------------------------------------------------
+    # Low-level operations
+    # ------------------------------------------------------------------
+
     async def remove(self, container_id: str) -> None:
         await self._delete_pod_if_exists(container_id)
 
-    async def _delete_pod_if_exists(self, pod_name: str) -> None:
-        def _delete() -> None:
-            try:
-                self._core.delete_namespaced_pod(
-                    name=pod_name,
-                    namespace=self._namespace,
-                    grace_period_seconds=0,
-                )
-                logger.info(f"Deleted pod {pod_name}")
-            except ApiException as exc:
-                if exc.status == 404:
-                    logger.debug(f"Pod {pod_name} already gone, skip delete")
-                else:
-                    raise
-
-        await asyncio.to_thread(_delete)
-
     async def is_running(self, container_id: str) -> bool:
-        def _check() -> bool:
-            try:
-                pod = self._core.read_namespaced_pod(name=container_id, namespace=self._namespace)
-                return pod.status.phase == "Running"
-            except ApiException:
-                return False
-
-        return await asyncio.to_thread(_check)
+        try:
+            api = await self._ensure_api()
+            pod = await Pod.get(container_id, namespace=self._namespace, api=api)
+            return pod.status.phase == "Running"
+        except (kr8s.NotFoundError, kr8s.ServerError):
+            return False
 
     async def logs(self, container_id: str, tail: int = 40) -> str:
-        def _logs() -> str:
-            try:
-                return self._core.read_namespaced_pod_log(
-                    name=container_id,
-                    namespace=self._namespace,
-                    tail_lines=tail,
-                    timestamps=True,
-                )
-            except ApiException:
-                return "(pod not found or logs unavailable)"
-
-        return await asyncio.to_thread(_logs)
+        try:
+            api = await self._ensure_api()
+            pod = await Pod.get(container_id, namespace=self._namespace, api=api)
+            lines: list[str] = []
+            async for line in pod.logs(tail_lines=tail, timestamps=True):
+                lines.append(line)
+            return "\n".join(lines)
+        except (kr8s.NotFoundError, kr8s.ServerError):
+            return "(pod not found or logs unavailable)"
 
     def image_exists(self, tag: str) -> bool:
-        """In Kubernetes, image pulls are handled by the kubelet.
-
-        We can't check locally — always return True and let pod creation
-        fail with ImagePullBackOff if the image doesn't exist.
-        """
+        """In Kubernetes, image pulls are handled by the kubelet."""
         return True
 
     async def get_ip(self, container_id: str, network: str) -> str | None:
-        def _get_ip() -> str | None:
-            try:
-                pod = self._core.read_namespaced_pod(name=container_id, namespace=self._namespace)
-                return pod.status.pod_ip
-            except ApiException:
-                return None
-
-        return await asyncio.to_thread(_get_ip)
+        try:
+            api = await self._ensure_api()
+            pod = await Pod.get(container_id, namespace=self._namespace, api=api)
+            return pod.status.get("podIP")
+        except (kr8s.NotFoundError, kr8s.ServerError):
+            return None
 
     async def resolve_self_network_name(self, logical_name: str) -> str:
         """No-op in Kubernetes — network names don't need resolution."""
@@ -555,36 +493,26 @@ class KubernetesRuntime(ContainerRuntime):
 
     async def get_self_network_info(self) -> dict[str, str]:
         """Return the pod's own IP address."""
-        import socket
-
         hostname = os.environ.get("HOSTNAME", socket.gethostname())
         try:
-            pod = await asyncio.to_thread(self._core.read_namespaced_pod, name=hostname, namespace=self._namespace)
-            ip = pod.status.pod_ip
+            api = await self._ensure_api()
+            pod = await Pod.get(hostname, namespace=self._namespace, api=api)
+            ip = pod.status.get("podIP")
             if ip:
                 return {"pod": ip}
-        except ApiException:
+        except (kr8s.NotFoundError, kr8s.ServerError):
             pass
 
-        # Fallback
         try:
             return {"hostname": socket.gethostbyname(hostname)}
         except Exception:
             return {}
 
     async def get_host_ip(self, network: str) -> str | None:
-        """Return the Carapace service ClusterIP.
-
-        In K8s, sandbox pods reach the proxy via the Service ClusterIP.
-        We check CARAPACE_SERVICE_HOST (injected by K8s for services in
-        the same namespace), then fall back to DNS.
-        """
+        """Return the Carapace service ClusterIP."""
         service_host = os.environ.get("CARAPACE_SERVICE_HOST")
         if service_host:
             return service_host
-
-        # Fallback: DNS resolution of the service
-        import socket
 
         svc_dns = f"carapace.{self._namespace}.svc.cluster.local"
         try:

--- a/src/carapace/sandbox/kubernetes.py
+++ b/src/carapace/sandbox/kubernetes.py
@@ -91,7 +91,7 @@ class KubernetesRuntime(ContainerRuntime):
             self._owner_deployment = deploy
             logger.info(f"KubernetesRuntime: owner Deployment UID = {deploy.raw.metadata.uid}")
             return deploy
-        except kr8s.NotFoundError:
+        except (kr8s.NotFoundError, kr8s.ServerError):
             logger.warning("Could not look up owner Deployment — sandbox resources will lack ownerRef")
             self._want_owner_ref = False
             return None

--- a/src/carapace/sandbox/kubernetes.py
+++ b/src/carapace/sandbox/kubernetes.py
@@ -6,6 +6,7 @@ import socket
 from pathlib import Path
 
 import kr8s
+from kr8s._api import Api
 from kr8s.asyncio.objects import Deployment, Pod, StatefulSet
 from loguru import logger
 
@@ -74,7 +75,7 @@ class KubernetesRuntime(ContainerRuntime):
 
         logger.info(f"KubernetesRuntime initialized (namespace={namespace}, pvc={pvc_claim}, data_dir={data_dir})")
 
-    async def _ensure_api(self) -> kr8s.Api:
+    async def _ensure_api(self) -> Api:
         """Lazily create the kr8s API client (must be called from async context)."""
         return await kr8s.asyncio.api(namespace=self._namespace)
 

--- a/src/carapace/sandbox/kubernetes.py
+++ b/src/carapace/sandbox/kubernetes.py
@@ -364,10 +364,10 @@ class KubernetesRuntime(ContainerRuntime):
             },
             api=api,
         )
-        if await sts.exists():
+        try:
             await sts.delete(propagation_policy="Foreground", force=True)
             logger.info(f"Deleted StatefulSet {sts_name}")
-        else:
+        except kr8s.NotFoundError:
             logger.debug(f"StatefulSet {sts_name} already gone, skip delete")
 
     # ------------------------------------------------------------------
@@ -380,10 +380,10 @@ class KubernetesRuntime(ContainerRuntime):
             {"apiVersion": "v1", "kind": "Pod", "metadata": {"name": pod_name, "namespace": self._namespace}},
             api=api,
         )
-        if await pod.exists():
+        try:
             await pod.delete(force=True)
             logger.info(f"Deleted pod {pod_name}")
-        else:
+        except kr8s.NotFoundError:
             logger.debug(f"Pod {pod_name} already gone, skip delete")
 
     # ------------------------------------------------------------------

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -1,109 +1,37 @@
-"""Unit tests for KubernetesRuntime — mock all K8s API calls."""
+"""Unit tests for KubernetesRuntime — mock all kr8s API calls."""
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
-from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
-def _ns_factory(**defaults):
-    """Create a callable that returns a SimpleNamespace with given kwargs."""
-
-    def factory(**kwargs):
-        merged = {**defaults, **kwargs}
-        return SimpleNamespace(**merged)
-
-    return factory
-
-
-# Mock the kubernetes package before importing KubernetesRuntime.
-# Use force-set (not setdefault) in case a previous test run cached stale mocks.
-_mock_k8s_client = MagicMock()
-_mock_k8s_config = MagicMock()
-_mock_k8s_stream = MagicMock()
-_mock_k8s_top = MagicMock()
-
-# Wire up `from kubernetes import client` → our custom mock
-_mock_k8s_top.client = _mock_k8s_client
-_mock_k8s_top.config = _mock_k8s_config
-
-# Replace model constructors with SimpleNamespace factories so tests can
-# inspect constructed objects by attribute access.
-_mock_k8s_client.V1Pod = _ns_factory()
-_mock_k8s_client.V1PodSpec = _ns_factory()
-_mock_k8s_client.V1Container = _ns_factory()
-_mock_k8s_client.V1ObjectMeta = _ns_factory()
-_mock_k8s_client.V1Volume = _ns_factory()
-_mock_k8s_client.V1VolumeMount = _ns_factory()
-_mock_k8s_client.V1EnvVar = _ns_factory()
-_mock_k8s_client.V1SecurityContext = _ns_factory()
-_mock_k8s_client.V1Capabilities = _ns_factory()
-_mock_k8s_client.V1PersistentVolumeClaimVolumeSource = _ns_factory()
-_mock_k8s_client.V1OwnerReference = _ns_factory()
-_mock_k8s_client.V1StatefulSet = _ns_factory()
-_mock_k8s_client.V1StatefulSetSpec = _ns_factory()
-_mock_k8s_client.V1StatefulSetPersistentVolumeClaimRetentionPolicy = _ns_factory()
-_mock_k8s_client.V1PodTemplateSpec = _ns_factory()
-_mock_k8s_client.V1LabelSelector = _ns_factory()
-_mock_k8s_client.V1PersistentVolumeClaim = _ns_factory()
-_mock_k8s_client.V1PersistentVolumeClaimSpec = _ns_factory()
-_mock_k8s_client.V1VolumeResourceRequirements = _ns_factory()
-_mock_k8s_client.CoreV1Api = MagicMock
-_mock_k8s_client.AppsV1Api = MagicMock
-
-sys.modules["kubernetes"] = _mock_k8s_top
-sys.modules["kubernetes.client"] = _mock_k8s_client
-sys.modules["kubernetes.config"] = _mock_k8s_config
-sys.modules["kubernetes.stream"] = _mock_k8s_stream
-sys.modules["kubernetes.client.rest"] = MagicMock()
-
-
-# Provide real exception class on the mocked module
-def _make_api_exception(status: int = 500, reason: str = "") -> Exception:
-    exc = Exception(reason)
-    exc.status = status  # type: ignore[attr-defined]
-    exc.reason = reason  # type: ignore[attr-defined]
-    return exc
-
-
-_ApiException = type("ApiException", (Exception,), {})
-
-
-def _api_exc_init(self: Exception, status: int = 500, reason: str = "") -> None:
-    super(_ApiException, self).__init__(reason)
-    self.status = status  # type: ignore[attr-defined]
-    self.reason = reason  # type: ignore[attr-defined]
-
-
-_ApiException.__init__ = _api_exc_init  # type: ignore[assignment]
-_mock_k8s_client.ApiException = _ApiException
-
-# Force reimport so the module picks up our stub constructors
-sys.modules.pop("carapace.sandbox.kubernetes", None)
-
-from carapace.sandbox.kubernetes import KubernetesRuntime, _sanitize_pod_name  # noqa: E402
-from carapace.sandbox.runtime import ContainerConfig, Mount, SandboxConfig  # noqa: E402
+from carapace.sandbox.kubernetes import (
+    KubernetesRuntime,
+    _default_command,
+    _sanitize_pod_name,
+    _standard_labels,
+)
+from carapace.sandbox.runtime import ContainerConfig, Mount, SandboxConfig
 
 # --- Helpers ---
 
 
 def _make_runtime(*, namespace: str = "carapace", data_dir: str = "/data") -> KubernetesRuntime:
-    """Build a KubernetesRuntime with mocked K8s clients."""
+    """Build a KubernetesRuntime without triggering __init__ side effects."""
     with patch.object(KubernetesRuntime, "__init__", lambda self, **kw: None):
         rt = KubernetesRuntime.__new__(KubernetesRuntime)
-    rt._core = MagicMock()
-    rt._apps = MagicMock()
     rt._namespace = namespace
     rt._pvc_claim = "carapace-data"
     rt._data_dir = Path(data_dir)
     rt._service_account = None
     rt._priority_class = None
-    rt._owner_ref = None
     rt._app_instance = "carapace"
     rt._session_pvc_size = "1Gi"
     rt._session_pvc_storage_class = None
+    rt._want_owner_ref = False
+    rt._owner_deployment = None
     return rt
 
 
@@ -127,6 +55,31 @@ def test_sanitize_pod_name_strips_hyphens():
     assert _sanitize_pod_name("--abc--") == "abc"
 
 
+# --- _default_command ---
+
+
+def test_default_command_none():
+    assert _default_command(None) == ["sh", "-c", "echo 'carapace sandbox ready' && exec sleep infinity"]
+
+
+def test_default_command_string():
+    assert _default_command("echo hello") == ["bash", "-c", "echo hello"]
+
+
+def test_default_command_list():
+    assert _default_command(["sleep", "infinity"]) == ["sleep", "infinity"]
+
+
+# --- _standard_labels ---
+
+
+def test_standard_labels():
+    labels = _standard_labels("carapace")
+    assert labels["app"] == "carapace-sandbox"
+    assert labels["app.kubernetes.io/component"] == "sandbox"
+    assert labels["app.kubernetes.io/managed-by"] == "carapace-server"
+
+
 # --- _mount_to_subpath ---
 
 
@@ -148,10 +101,10 @@ def test_mount_to_subpath_outside_data_dir():
     assert rt._mount_to_subpath(mount) == "/other/path"
 
 
-# --- _build_pod_spec ---
+# --- _build_pod_dict ---
 
 
-def test_build_pod_spec_basic():
+def test_build_pod_dict_basic():
     rt = _make_runtime()
     config = ContainerConfig(
         image="sandbox:latest",
@@ -165,35 +118,38 @@ def test_build_pod_spec_basic():
         command=["sleep", "infinity"],
         environment={"HTTP_PROXY": "http://proxy:3128"},
     )
-    pod = rt._build_pod_spec(config)
-    assert pod.metadata is not None
-    assert pod.spec is not None
-    assert pod.metadata.name == "carapace-sandbox-test123"
-    assert pod.metadata.namespace == "carapace"
-    assert pod.spec.containers[0].image == "sandbox:latest"
-    assert pod.spec.containers[0].command == ["sleep", "infinity"]
-    assert pod.spec.restart_policy == "Always"
-    assert pod.spec.automount_service_account_token is False
+    pod = rt._build_pod_dict(config)
 
-    # Standard labels should be merged with config labels
-    labels = pod.metadata.labels
+    assert pod["metadata"]["name"] == "carapace-sandbox-test123"
+    assert pod["metadata"]["namespace"] == "carapace"
+
+    container = pod["spec"]["containers"][0]
+    assert container["image"] == "sandbox:latest"
+    assert container["command"] == ["sleep", "infinity"]
+
+    assert pod["spec"]["restartPolicy"] == "Always"
+    assert pod["spec"]["automountServiceAccountToken"] is False
+
+    # Standard labels merged with config labels
+    labels = pod["metadata"]["labels"]
     assert labels["app"] == "carapace-sandbox"
     assert labels["app.kubernetes.io/component"] == "sandbox"
     assert labels["carapace.session"] == "test123"
 
-    # Volume mounts should use subPath from PVC
-    vmounts = pod.spec.containers[0].volume_mounts
+    # Volume mounts use subPath from PVC
+    vmounts = container["volumeMounts"]
     assert len(vmounts) == 2
-    assert vmounts[0].sub_path == "memory"
-    assert vmounts[0].read_only is True
-    assert vmounts[1].sub_path == "sessions/s1/workspace/skills"
+    assert vmounts[0]["subPath"] == "memory"
+    assert vmounts[0].get("readOnly") is True
+    assert vmounts[1]["subPath"] == "sessions/s1/workspace/skills"
 
     # Single PVC volume
-    assert len(pod.spec.volumes) == 1
-    assert pod.spec.volumes[0].persistent_volume_claim.claim_name == "carapace-data"
+    volumes = pod["spec"]["volumes"]
+    assert len(volumes) == 1
+    assert volumes[0]["persistentVolumeClaim"]["claimName"] == "carapace-data"
 
 
-def test_build_pod_spec_string_command():
+def test_build_pod_dict_string_command():
     rt = _make_runtime()
     config = ContainerConfig(
         image="sandbox:latest",
@@ -201,90 +157,159 @@ def test_build_pod_spec_string_command():
         network=None,
         command="echo hello",
     )
-    pod = rt._build_pod_spec(config)
-    assert pod.spec is not None
-    assert pod.spec.containers[0].command == ["bash", "-c", "echo hello"]
+    pod = rt._build_pod_dict(config)
+    assert pod["spec"]["containers"][0]["command"] == ["bash", "-c", "echo hello"]
 
 
-def test_build_pod_spec_no_command():
+def test_build_pod_dict_no_command():
     rt = _make_runtime()
     config = ContainerConfig(
         image="sandbox:latest",
         name="test",
         network=None,
     )
-    pod = rt._build_pod_spec(config)
-    assert pod.spec is not None
-    assert pod.spec.containers[0].command == ["sh", "-c", "echo 'carapace sandbox ready' && exec sleep infinity"]
+    pod = rt._build_pod_dict(config)
+    assert pod["spec"]["containers"][0]["command"] == [
+        "sh",
+        "-c",
+        "echo 'carapace sandbox ready' && exec sleep infinity",
+    ]
 
 
-def test_build_pod_spec_security_context():
+def test_build_pod_dict_security_context():
     rt = _make_runtime()
     config = ContainerConfig(image="sandbox:latest", name="test", network=None)
-    pod = rt._build_pod_spec(config)
-    assert pod.spec is not None
-    sc = pod.spec.containers[0].security_context
-    assert sc.allow_privilege_escalation is False
-    assert sc.capabilities.drop == ["ALL"]
+    pod = rt._build_pod_dict(config)
+    sc = pod["spec"]["containers"][0]["securityContext"]
+    assert sc["allowPrivilegeEscalation"] is False
+    assert sc["capabilities"]["drop"] == ["ALL"]
+
+
+# --- _build_statefulset_dict ---
+
+
+def test_build_statefulset_dict():
+    rt = _make_runtime()
+    config = SandboxConfig(
+        name="carapace-sandbox-abc",
+        session_id="abc",
+        image="sandbox:latest",
+        labels={"carapace.session": "abc", "carapace.managed": "true"},
+        environment={"HTTP_PROXY": "http://proxy"},
+    )
+    sts = rt._build_statefulset_dict(config)
+
+    assert sts["kind"] == "StatefulSet"
+    assert sts["metadata"]["name"] == "carapace-sandbox-abc"
+
+    # Retention policy
+    policy = sts["spec"]["persistentVolumeClaimRetentionPolicy"]
+    assert policy["whenDeleted"] == "Delete"
+    assert policy["whenScaled"] == "Retain"
+
+    # volumeClaimTemplate
+    templates = sts["spec"]["volumeClaimTemplates"]
+    assert len(templates) == 1
+    assert templates[0]["metadata"]["name"] == "session-data"
+    assert templates[0]["spec"]["accessModes"] == ["ReadWriteOnce"]
+
+    # Container mounts /workspace
+    container = sts["spec"]["template"]["spec"]["containers"][0]
+    assert any(vm["mountPath"] == "/workspace" for vm in container["volumeMounts"])
 
 
 # --- create ---
 
 
+@pytest.mark.asyncio
 async def test_create_calls_api():
     rt = _make_runtime()
-    rt._core.read_namespaced_pod.return_value = SimpleNamespace(status=SimpleNamespace(phase="Running"))
 
-    config = ContainerConfig(
-        image="sandbox:latest",
-        name="carapace-sandbox-abc",
-        network="carapace-sandbox",
-        command=["sleep", "infinity"],
-    )
-    container_id = await rt.create(config)
+    mock_pod_instance = AsyncMock()
+
+    async def _fake_pod(*args, **kwargs):
+        return mock_pod_instance
+
+    rt._ensure_api = AsyncMock()
+    rt._get_owner_deployment = AsyncMock(return_value=None)
+    rt._delete_pod_if_exists = AsyncMock()
+    rt._wait_for_running = AsyncMock()
+
+    with patch("carapace.sandbox.kubernetes.Pod", side_effect=_fake_pod):
+        config = ContainerConfig(
+            image="sandbox:latest",
+            name="carapace-sandbox-abc",
+            network="carapace-sandbox",
+            command=["sleep", "infinity"],
+        )
+        container_id = await rt.create(config)
+
     assert container_id == "carapace-sandbox-abc"
-    rt._core.create_namespaced_pod.assert_called_once()
+    mock_pod_instance.create.assert_called_once()
+    rt._wait_for_running.assert_called_once()
 
 
 # --- is_running ---
 
 
+@pytest.mark.asyncio
 async def test_is_running_true():
     rt = _make_runtime()
-    rt._core.read_namespaced_pod.return_value = SimpleNamespace(status=SimpleNamespace(phase="Running"))
-    assert await rt.is_running("test-pod") is True
+    rt._ensure_api = AsyncMock()
+
+    mock_pod = MagicMock()
+    mock_pod.status.phase = "Running"
+
+    with patch("carapace.sandbox.kubernetes.Pod") as mock_pod_cls:
+        mock_pod_cls.get = AsyncMock(return_value=mock_pod)
+        assert await rt.is_running("test-pod") is True
 
 
+@pytest.mark.asyncio
 async def test_is_running_false():
     rt = _make_runtime()
-    rt._core.read_namespaced_pod.return_value = SimpleNamespace(status=SimpleNamespace(phase="Pending"))
-    assert await rt.is_running("test-pod") is False
+    rt._ensure_api = AsyncMock()
+
+    mock_pod = MagicMock()
+    mock_pod.status.phase = "Pending"
+
+    with patch("carapace.sandbox.kubernetes.Pod") as mock_pod_cls:
+        mock_pod_cls.get = AsyncMock(return_value=mock_pod)
+        assert await rt.is_running("test-pod") is False
 
 
 # --- get_ip ---
 
 
+@pytest.mark.asyncio
 async def test_get_ip():
     rt = _make_runtime()
-    rt._core.read_namespaced_pod.return_value = SimpleNamespace(status=SimpleNamespace(pod_ip="10.42.0.5"))
-    ip = await rt.get_ip("test-pod", "any-network")
+    rt._ensure_api = AsyncMock()
+
+    mock_pod = MagicMock()
+    mock_pod.status.get.return_value = "10.42.0.5"
+
+    with patch("carapace.sandbox.kubernetes.Pod") as mock_pod_cls:
+        mock_pod_cls.get = AsyncMock(return_value=mock_pod)
+        ip = await rt.get_ip("test-pod", "any-network")
     assert ip == "10.42.0.5"
 
 
 # --- remove ---
 
 
+@pytest.mark.asyncio
 async def test_remove():
     rt = _make_runtime()
+    rt._delete_pod_if_exists = AsyncMock()
     await rt.remove("test-pod")
-    rt._core.delete_namespaced_pod.assert_called_once_with(
-        name="test-pod", namespace="carapace", grace_period_seconds=0
-    )
+    rt._delete_pod_if_exists.assert_called_once_with("test-pod")
 
 
 # --- resolve_self_network_name ---
 
 
+@pytest.mark.asyncio
 async def test_resolve_self_network_name_noop():
     rt = _make_runtime()
     assert await rt.resolve_self_network_name("carapace-sandbox") == "carapace-sandbox"
@@ -301,6 +326,7 @@ def test_image_exists_always_true():
 # --- get_host_ip ---
 
 
+@pytest.mark.asyncio
 async def test_get_host_ip_from_env(monkeypatch):
     rt = _make_runtime()
     monkeypatch.setenv("CARAPACE_SERVICE_HOST", "10.43.0.100")
@@ -311,64 +337,58 @@ async def test_get_host_ip_from_env(monkeypatch):
 # --- StatefulSet lifecycle ---
 
 
-def test_build_statefulset_spec():
-    rt = _make_runtime()
-    config = SandboxConfig(
-        name="carapace-sandbox-abc",
-        session_id="abc",
-        image="sandbox:latest",
-        labels={"carapace.session": "abc", "carapace.managed": "true"},
-        environment={"HTTP_PROXY": "http://proxy"},
-    )
-    sts = rt._build_statefulset_spec(config)
-    assert sts.kind == "StatefulSet"
-    assert sts.metadata.name == "carapace-sandbox-abc"
-    # Check retention policy
-    policy = sts.spec.persistent_volume_claim_retention_policy
-    assert policy.when_deleted == "Delete"
-    assert policy.when_scaled == "Retain"
-    # Check volumeClaimTemplate
-    assert len(sts.spec.volume_claim_templates) == 1
-    pvc_tpl = sts.spec.volume_claim_templates[0]
-    assert pvc_tpl.metadata.name == "session-data"
-    assert pvc_tpl.spec.access_modes == ["ReadWriteOnce"]
-    # Check container mounts /workspace
-    container = sts.spec.template.spec.containers[0]
-    assert any(vm.mount_path == "/workspace" for vm in container.volume_mounts)
-
-
+@pytest.mark.asyncio
 async def test_create_sandbox_calls_api():
     rt = _make_runtime()
-    rt._core.read_namespaced_pod.return_value = SimpleNamespace(status=SimpleNamespace(phase="Running"))
-    rt._apps.delete_namespaced_stateful_set.side_effect = _ApiException(status=404, reason="Not Found")
+    rt._ensure_api = AsyncMock()
+    rt._get_owner_deployment = AsyncMock(return_value=None)
+    rt._delete_sts_if_exists = AsyncMock()
+    rt._wait_for_running = AsyncMock()
 
-    config = SandboxConfig(
-        name="carapace-sandbox-abc",
-        session_id="abc",
-        image="sandbox:latest",
-        labels={"carapace.session": "abc"},
-    )
-    pod_name = await rt.create_sandbox(config)
+    mock_sts_instance = AsyncMock()
+
+    async def _fake_sts(*args, **kwargs):
+        return mock_sts_instance
+
+    with patch("carapace.sandbox.kubernetes.StatefulSet", side_effect=_fake_sts):
+        config = SandboxConfig(
+            name="carapace-sandbox-abc",
+            session_id="abc",
+            image="sandbox:latest",
+            labels={"carapace.session": "abc"},
+        )
+        pod_name = await rt.create_sandbox(config)
+
     assert pod_name == "carapace-sandbox-abc-0"
-    rt._apps.create_namespaced_stateful_set.assert_called_once()
+    mock_sts_instance.create.assert_called_once()
 
 
+@pytest.mark.asyncio
 async def test_resume_sandbox():
     rt = _make_runtime()
-    rt._core.read_namespaced_pod.return_value = SimpleNamespace(status=SimpleNamespace(phase="Running"))
+    rt._ensure_api = AsyncMock()
+    rt._wait_for_running = AsyncMock()
 
-    await rt.resume_sandbox("carapace-sandbox-abc")
-    rt._apps.patch_namespaced_stateful_set_scale.assert_called_once()
+    mock_sts = AsyncMock()
+
+    with patch("carapace.sandbox.kubernetes.StatefulSet") as mock_sts_cls:
+        mock_sts_cls.get = AsyncMock(return_value=mock_sts)
+        await rt.resume_sandbox("carapace-sandbox-abc")
+
+    mock_sts.scale.assert_called_once_with(1)
 
 
+@pytest.mark.asyncio
 async def test_destroy_sandbox():
     rt = _make_runtime()
+    rt._delete_sts_if_exists = AsyncMock()
     await rt.destroy_sandbox("carapace-sandbox-abc", "carapace-sandbox-abc-0")
-    rt._apps.delete_namespaced_stateful_set.assert_called_once()
+    rt._delete_sts_if_exists.assert_called_once_with("carapace-sandbox-abc")
 
 
+@pytest.mark.asyncio
 async def test_destroy_sandbox_not_found():
     rt = _make_runtime()
-    rt._apps.delete_namespaced_stateful_set.side_effect = _ApiException(status=404, reason="Not Found")
+    rt._delete_sts_if_exists = AsyncMock()
     # Should not raise
     await rt.destroy_sandbox("carapace-sandbox-abc", "carapace-sandbox-abc-0")

--- a/uv.lock
+++ b/uv.lock
@@ -310,7 +310,7 @@ dependencies = [
     { name = "docker" },
     { name = "fastapi" },
     { name = "genai-prices" },
-    { name = "kubernetes" },
+    { name = "kr8s" },
     { name = "logfire", extra = ["httpx"] },
     { name = "loguru" },
     { name = "markdown" },
@@ -337,7 +337,7 @@ requires-dist = [
     { name = "docker", specifier = ">=7,<8" },
     { name = "fastapi", specifier = ">=0.115,<1" },
     { name = "genai-prices", specifier = ">=0.0.53" },
-    { name = "kubernetes", specifier = ">=35,<36" },
+    { name = "kr8s", specifier = ">=0.20,<1" },
     { name = "logfire", extras = ["httpx"], specifier = ">=4,<5" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "markdown", specifier = ">=3,<4" },
@@ -654,15 +654,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
-]
-
-[[package]]
-name = "durationpy"
-version = "0.10"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
 ]
 
 [[package]]
@@ -1159,6 +1150,21 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-ws"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore" },
+    { name = "httpx" },
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/cd/ca91a07ae446451f7476bf3fcc909e98cb942ff032ebfda0e3fe449aca7b/httpx_ws-0.9.0.tar.gz", hash = "sha256:797373326f70eec1ae96f6e43ae9f12002fd7d73aee139a4985eaab964338a08", size = 107105, upload-time = "2026-03-28T14:11:10.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/f8/a6bc80313a9e93c888fa10534dfce2ad76ff86911b6f485777ce6de6a073/httpx_ws-0.9.0-py3-none-any.whl", hash = "sha256:71640d2fb1bf9a225775015b33cd755cfd4c5f7e21c885192fe3adc4c387b248", size = 15759, upload-time = "2026-03-28T14:11:11.887Z" },
+]
+
+[[package]]
 name = "huggingface-hub"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1413,23 +1419,23 @@ wheels = [
 ]
 
 [[package]]
-name = "kubernetes"
-version = "35.0.0"
+name = "kr8s"
+version = "0.20.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "durationpy" },
-    { name = "python-dateutil" },
+    { name = "anyio" },
+    { name = "cachetools" },
+    { name = "cryptography" },
+    { name = "httpx" },
+    { name = "httpx-ws" },
+    { name = "packaging" },
+    { name = "python-box" },
+    { name = "python-jsonpath" },
     { name = "pyyaml" },
-    { name = "requests" },
-    { name = "requests-oauthlib" },
-    { name = "six" },
-    { name = "urllib3" },
-    { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/8f/85bf51ad4150f64e8c665daf0d9dfe9787ae92005efb9a4d1cba592bd79d/kubernetes-35.0.0.tar.gz", hash = "sha256:3d00d344944239821458b9efd484d6df9f011da367ecb155dadf9513f05f09ee", size = 1094642, upload-time = "2026-01-16T01:05:27.76Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/55/ca9ff53d97413a0dca36c30da80750415350876aa23ea8a762a0b06c6d1f/kr8s-0.20.15.tar.gz", hash = "sha256:484d5206bbebd48f8cc00dd3ed749d4419294d2f08cd50c6232114cf62ed6d3a", size = 2839774, upload-time = "2026-01-16T15:23:42.645Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/70/05b685ea2dffcb2adbf3cdcea5d8865b7bc66f67249084cf845012a0ff13/kubernetes-35.0.0-py2.py3-none-any.whl", hash = "sha256:39e2b33b46e5834ef6c3985ebfe2047ab39135d41de51ce7641a7ca5b372a13d", size = 2017602, upload-time = "2026-01-16T01:05:25.991Z" },
+    { url = "https://files.pythonhosted.org/packages/59/08/4247abe88116c1e59dd9b62992d8a69b7178f4046c85cca03eda7e3d87e3/kr8s-0.20.15-py3-none-any.whl", hash = "sha256:eacc6eb72b6354d932a1e22c0cb698c88adbd815c36164c24c2232a69dfabe40", size = 87670, upload-time = "2026-01-16T15:23:40.593Z" },
 ]
 
 [[package]]
@@ -1688,15 +1694,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/35/d5/cd1ffb202b76ebc1b33c1332a3416e55a39929006982adc2b1eb069aaa9b/nexus_rpc-1.4.0.tar.gz", hash = "sha256:3b8b373d4865671789cc43623e3dc0bcbf192562e40e13727e17f1c149050fba", size = 82367, upload-time = "2026-02-25T22:01:34.053Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/52/6327a5f4fda01207205038a106a99848a41c83e933cd23ea2cab3d2ebc6c/nexus_rpc-1.4.0-py3-none-any.whl", hash = "sha256:14c953d3519113f8ccec533a9efdb6b10c28afef75d11cdd6d422640c40b3a49", size = 29645, upload-time = "2026-02-25T22:01:33.122Z" },
-]
-
-[[package]]
-name = "oauthlib"
-version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
 ]
 
 [[package]]
@@ -2395,6 +2392,23 @@ wheels = [
 ]
 
 [[package]]
+name = "python-box"
+version = "7.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/0f/34e7ee0a72f1464b4c7a2e8bafb389f230477256af586bc82bcfad85295a/python_box-7.4.1.tar.gz", hash = "sha256:e412e36c25fca8223560516d53ef6c7993591c3b0ec8bb4ec582bf7defdd79f0", size = 49859, upload-time = "2026-02-21T16:21:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/d9/d05f317b38b42253422d8483f5d7dc16d382c99ddc253e426639a0f2f235/python_box-7.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dfb91effff00d9e23486c4f0db3b19e03d602ebb7c9e20fc6a287c704fad2552", size = 1849441, upload-time = "2026-02-21T16:21:37.314Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/a3/383eb3d658f36c6e531c8cf1e348ccb4b5031231df4aeb7742bb159a3166/python_box-7.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b7f977f00e715b030cee6ffef2322ff8ce100ffbf1dbcc4ef91099c75752d5f8", size = 4485153, upload-time = "2026-02-21T16:26:04.507Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f9/5de3c18415dd6f5286f00e6539c0ae3cceb1c6aaf28d1d5f17b0b568c97f/python_box-7.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:2ca9a18fd15326bc267e9cc7e0e6e3a0cb78d11507940f43f687adf7e156d882", size = 1295520, upload-time = "2026-02-21T16:22:26.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e9/48d1b1eb21efc3f82a31b037b6903c9139018f686d96d251faa4cb0d593a/python_box-7.4.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:85db37b43094bf6c4884b931fb149a7850db5ce331f6e191edf98b453e6cf2d6", size = 1845195, upload-time = "2026-02-21T16:21:46.235Z" },
+    { url = "https://files.pythonhosted.org/packages/da/79/48d38c855f277223caf3aa79518476f95abc07f04386940855b7bd3d95f6/python_box-7.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb204822c7638bd2dbed5c55d6ab264c6903c37d18dee5c45bdbda58b2e1e17a", size = 4468245, upload-time = "2026-02-21T16:26:05.701Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1d/7a1e04f37674399e0f3076cfe1fa358f6a51540ae98299a06f2c0424c471/python_box-7.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:615da3fafd41572aec1b905832555c0ea08b6fbc27cc917356e257a9a5721af7", size = 1295564, upload-time = "2026-02-21T16:22:36.547Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a2/771b5e526bba2214ac2d30e321209a66680c40788616a45cf01005e95204/python_box-7.4.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:33c6701faa51fd87f0dcc538873c0fad2b3a1cc3750eab85835cd071cadf1948", size = 1875508, upload-time = "2026-02-21T16:21:37.432Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/5f/0e7ea7640ba60ff459ce37e340d816ac5e91b7a9a7c3c161f9dabe622be6/python_box-7.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:ae8c540a0457f52350211d24690211251912018e1e0c1857f50792729d6f562c", size = 1314304, upload-time = "2026-02-21T16:22:22.173Z" },
+    { url = "https://files.pythonhosted.org/packages/06/a6/5d3f3abf46b37aa44b1f6788d287c8b4f2319b55013191dddf25b9e6d62c/python_box-7.4.1-py3-none-any.whl", hash = "sha256:a3b0d84d003882fb6abe505b1b883b3a5dcbf226b0fe168d24bc5ff75d9826e5", size = 30402, upload-time = "2026-02-21T16:21:14.78Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2413,6 +2427,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-jsonpath"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/e5/07f99c0fb448eeb2c9db5e817f8a9c43e3f4a7b59934adbe421a39677025/python_jsonpath-2.0.2.tar.gz", hash = "sha256:41abb6660b3ee54d5ae77e4b0e901049fb1662ad90de241f038df47edc75ee60", size = 49672, upload-time = "2026-01-06T08:21:01.194Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/2c/c1282c47a8bb641c3068f47780c5f1f5c97cdc39cda3ec507c64c029764e/python_jsonpath-2.0.2-py3-none-any.whl", hash = "sha256:3f8ab612f815ce10c03bf0deaede87235f3381b109a60b4a22744069953627e3", size = 64071, upload-time = "2026-01-06T08:20:59.751Z" },
 ]
 
 [[package]]
@@ -2619,19 +2642,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
-]
-
-[[package]]
-name = "requests-oauthlib"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "oauthlib" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
 ]
 
 [[package]]
@@ -3152,15 +3162,6 @@ wheels = [
 ]
 
 [[package]]
-name = "websocket-client"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
-]
-
-[[package]]
 name = "websockets"
 version = "16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3261,6 +3262,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
     { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
     { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
+]
+
+[[package]]
+name = "wsproto"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Replace the kubernetes Python client with kr8s, a modern async-native typed Kubernetes client.

## Changes

- **Dependency**: kubernetes to kr8s
- **All K8s operations are now natively async** - removed all asyncio.to_thread() wrappers
- **Pod/StatefulSet specs** built as plain dicts instead of V1* model objects
- **API client** lazily initialized via kr8s.asyncio.api()
- **Owner references** via dict instead of V1OwnerReference
- **Exceptions**: kr8s.NotFoundError / ServerError / ExecError replace ApiException
- **Exec** uses kr8s CompletedExec (subprocess.run-like API)
- **Tests simplified**: no more sys.modules hacking to mock the kubernetes package

## Motivation

The official kubernetes Python client has no type hints (open issue since 2017), is synchronous-only, and uses auto-generated swagger code. kr8s provides native async support, proper typing, and a cleaner API.

## Testing

All 232 tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Kubernetes sandbox runtime lifecycle (create/exec/logs/statefulset scaling) and swaps client libraries, so behavior changes could impact sandbox startup/teardown and command execution in production clusters.
> 
> **Overview**
> Migrates the Kubernetes-backed sandbox runtime from the official synchronous `kubernetes` Python client to async-native `kr8s`, removing `asyncio.to_thread()` wrappers and switching to kr8s objects for Pods/StatefulSets/Deployments.
> 
> Pod/StatefulSet manifests are now built as plain dicts (with new helpers like `_default_command` and `_standard_labels`), ownerReferences are resolved lazily via a cached Deployment lookup, and error handling is updated to kr8s exceptions; `exec`, `logs`, `is_running`, and IP lookup are reimplemented using kr8s APIs.
> 
> Updates dependencies (`kubernetes` → `kr8s`) and rewrites `tests/test_kubernetes.py` to mock kr8s calls directly (dropping `sys.modules` stubbing of the kubernetes client).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b1eb820b49ef3bcc1162a54dcda1f13dfba5a8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->