### PR TITLE
✨ Context-scoped skill allowlists

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,9 +9,6 @@
 - [ ] compaction
 - [ ] image input
 - [ ] custom sentinel instructions for skills, e.g. moneydb: make sure that the agent only does mutations based on user approval
-- [ ] remove support for env exporting passwords in carapace.yaml? files seem a bit more secure. (even only by ease of access — exfiltrating `env` output is the most obvious for an attacker to do)
-- [ ] ! network access taucht nicht mehr auf in der UI wenn über skill freigegeben
-- [ ] exec braucht "skills" liste, nur die credentials von diesen skills werden reingetan in env/file für den befehl
 
 ## UI Improvements
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,9 @@
 - [ ] compaction
 - [ ] image input
 - [ ] custom sentinel instructions for skills, e.g. moneydb: make sure that the agent only does mutations based on user approval
-- [ ] replace tool: show diff
+- [ ] remove support for env exporting passwords in carapace.yaml? files seem a bit more secure. (even only by ease of access — exfiltrating `env` output is the most obvious for an attacker to do)
+- [ ] ! network access taucht nicht mehr auf in der UI wenn über skill freigegeben
+- [ ] exec braucht "skills" liste, nur die credentials von diesen skills werden reingetan in env/file für den befehl
 
 ## UI Improvements
 
@@ -19,7 +21,6 @@
 - [ ] replace pull / push slash commands (that aren't really tied to the session anyway) with a global indicator how many commits ahead/behind the backend's global repo is compared to the remote repo
 - [ ] show which sessions have sandboxes, size of the PVCs, is the sandbox in standby
 - [ ] tell the user what exactly is happening in the exec — sandbox creation, sentinel, execution? where is the command right now?
-- [ ] remove support for env exporting passwords in carapace.yaml? files seem a bit more secure. (even only by ease of access — exfiltrating `env` output is the most obvious for an attacker to do)
 
 ## Authentication & Multi-User
 

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -5,7 +5,7 @@ Carapace keeps credentials in external vault backends and exposes them to sandbo
 ## Design: pull, not push
 
 - Credentials are fetched by sandbox workloads via the sandbox API (`/credentials`).
-- Skill-declared credentials are fetched during `use_skill` and injected as env vars/files.
+- Skill-declared credentials are cached at `use_skill` time, then injected per-exec via the `contexts` parameter.
 - The agent should use credentials without printing them.
 
 In short: credentials are consumed inside the sandbox, not returned to the user-facing agent response.
@@ -73,11 +73,20 @@ credentials:
 On `use_skill`:
 
 1. Credential vault paths are included in the gated `use_skill` decision.
-2. After approval, Carapace fetches the values from the configured backend.
-3. `env_var` entries are stored in session env and available for subsequent `exec` calls.
-4. `file` entries are written inside the sandbox with mode `0400`.
+2. After approval, Carapace fetches and **caches** the values from the configured backend (in memory only, never persisted to disk).
+3. A **context grant** is registered for the skill, recording which vault paths and injection mappings are available.
+4. Credentials are **not injected** into the session environment. They are only available during `exec` calls that explicitly request the skill's context (see [skills.md — Context-scoped access](skills.md#context-scoped-access)).
 
-Already-approved credentials are re-injected if the sandbox is recreated.
+### Per-exec injection
+
+When the agent runs `exec(command, contexts=["skill-name"])`:
+
+- `env_var` entries are injected as environment variables for that single command.
+- `file` entries are written inside the sandbox with mode `0400` before the command, then deleted immediately after it completes (in a `finally` block).
+
+### Container restart
+
+Cached credential values are re-fetched from the vault when the session is reloaded. File-based credentials are re-written only for the next exec that requests the context.
 
 ## On-demand use with `ccred`
 
@@ -105,9 +114,10 @@ These endpoints are served on the sandbox API port (`8322`) and require Basic au
 
 ## Approval and audit behavior
 
-- First access to a credential in a session requires user approval.
-- Decisions are visible in UI approval cards (including bundled skill requests).
-- Approved credential metadata is tracked in session state (`approved_credentials`).
+- **Every** credential access goes through the sentinel LLM for evaluation — there is no session-wide short-circuit.
+- **Context fast path**: If the credential is covered by a context grant from an activated skill, and the current exec has that skill in its `contexts`, access is allowed with `approval_source="skill"` without sentinel evaluation.
+- **No context match**: Credentials accessed outside a matching context always go through the sentinel, which may allow, deny, or escalate to the user.
+- All access attempts are visible in the UI: skill-granted (teal badge), sentinel-allowed (green), user-approved (purple), or denied (red).
 - Access attempts are appended to the session action log as `credential_access`.
 
 Use `/session` to inspect approved credentials for the current session.

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -120,7 +120,7 @@ These endpoints are served on the sandbox API port (`8322`) and require Basic au
 - All access attempts are visible in the UI: skill-granted (teal badge), sentinel-allowed (green), user-approved (purple), or denied (red).
 - Access attempts are appended to the session action log as `credential_access`.
 
-Use `/session` to inspect approved credentials for the current session.
+Use `/session` to inspect context grants and cached credentials for the current session.
 
 ## Security notes
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -120,7 +120,7 @@ Credential access is mediated through the sandbox API and session state:
 - Sandbox scripts use `ccred` (or direct HTTP) to call `GET /credentials` and `GET /credentials/{vault_path}`.
 - `list` / `search` expose metadata only and are security-reviewed at the `exec` tool-call layer.
 - `fetch` is per-session approval-based: if a credential is not yet approved for the session, Carapace sends a credential approval request and blocks until approve/deny.
-- Approved credential metadata is tracked in `approved_credentials` and reflected in `/session`.
+- Approved credential metadata is tracked via context grants in `SessionState.context_grants` and reflected in `/session`.
 - Credential access decisions are recorded as `CredentialAccessEntry` action-log events.
 
 As with the rest of Carapace's model, the "keep secrets out of model output" guarantee is defense-in-depth: policy + sentinel + agent behavior. It is not a protocol-level cryptographic boundary, so secret-echoing commands must remain prohibited.

--- a/docs/sessions-and-channels.md
+++ b/docs/sessions-and-channels.md
@@ -12,9 +12,9 @@ class SessionState(BaseModel):
     channel_type: str           # "cli" | "matrix" | "web" | ...
     channel_ref: str | None     # channel-specific ID (room_id, etc.)
     title: str | None           # auto-generated after first messages
-    approved_credentials: list[str]
     approved_operations: list[str]
     activated_skills: list[str]
+    context_grants: dict[str, ContextGrant]  # per-skill domain & credential grants
     created_at: datetime
     last_active: datetime
 ```

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -80,16 +80,33 @@ credentials:
 
 ### Fields
 
-**`network.domains`** — list of domains the skill needs to access. These are automatically added to the session's proxy allowlist when the skill is activated. Supports wildcard matching (`*.example.com`).
+**`network.domains`** — list of domains the skill needs to access. These are registered as a **context grant** when the skill is activated. The domains are only allowed during commands that explicitly request the skill's context (see [Context-scoped access](#context-scoped-access) below). Supports wildcard matching (`*.example.com`).
 
 **`credentials`** — list of credentials the skill needs. Each entry has:
 
 - `vault_path` — path in the password manager
 - `description` — human-readable explanation shown in approval prompts
-- `env_var` — environment variable name for auto-injection (optional)
-- `file` — file path for auto-injection with mode `0400` (optional)
+- `env_var` — environment variable name for per-exec injection (optional)
+- `file` — file path for per-exec injection with mode `0400` (optional)
 
 > **Note**: Credential declarations are implemented. See [credentials.md](credentials.md) for approval flow, backend config, and `ccred` usage.
+
+## Context-scoped access
+
+Skill-declared domains and credentials are **not globally available** in the session. Instead, they're scoped to individual `exec` calls via the `contexts` parameter.
+
+### How it works
+
+1. **Activation** creates a context grant: `use_skill("moneydb")` registers the skill's declared domains and credential vault paths as a grant keyed by `"moneydb"`.
+2. **Exec requests contexts**: The agent passes `contexts=["moneydb"]` when running commands that need the skill's resources.
+3. **Per-exec injection**: Domains are temporarily allowed in the proxy. Credential values are injected as env vars or written as files for the duration of that single exec. File-based credentials are deleted immediately after the command completes.
+4. **No context = no access**: An exec without `contexts` (or with unrelated contexts) does not get the skill's domains or credentials. The sentinel evaluates any credential access without a matching context.
+
+### Matching semantics
+
+- **Subset matching**: `contexts=["moneydb", "example"]` matches grants for both `"moneydb"` and `"example"` (union of both grants' resources).
+- **Validation**: Every context string must correspond to an activated skill. Unknown context names are rejected.
+- **Piping**: When piping output between skill scripts, pass all relevant contexts: `contexts=["moneydb", "web-search"]`.
 
 ## pyproject.toml-based dependencies
 

--- a/docs/websocket-session.md
+++ b/docs/websocket-session.md
@@ -84,8 +84,12 @@ Exact args depend on the producer; see `WebSocketSubscriber` in [`src/carapace/s
 
 When present:
 
-- `approval_source`: `safe-list` \| `sentinel` \| `user` \| `unknown`
+- `approval_source`: `safe-list` \| `sentinel` \| `user` \| `skill` \| `bypass` \| `unknown`
 - `approval_verdict`: `allow` \| `deny` \| `escalate`
+
+**`skill`** — the action was allowed because it's covered by a context grant from an activated skill (e.g., domain access or credential fetch within a matching `contexts` exec).
+
+**`bypass`** — the action was silently allowed without sentinel evaluation (e.g., proxy bypass during venv install).
 
 ## Typical turn flow (server → client)
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,30 +1,30 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Carapace Frontend
+
+Web UI for Carapace, built with Next.js (App Router).
+
+## Tech Stack
+
+- **Framework:** [Next.js](https://nextjs.org) (App Router) with React 19
+- **Language:** TypeScript
+- **Styling:** [Tailwind CSS 4](https://tailwindcss.com)
+- **Icons:** [Lucide React](https://lucide.dev) (`lucide-react`)
+- **Fonts:** [Geist](https://vercel.com/font) via `next/font`
+- **Markdown:** `react-markdown` with `remark-gfm`, `remark-math`, `rehype-katex`, `rehype-pretty-code`
+- **Theming:** `next-themes` (light/dark mode)
 
 ## Getting Started
 
-First, run the development server:
-
 ```bash
+pnpm install
 pnpm dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000).
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Code Style
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- Use [Lucide](https://lucide.dev/icons) for all icons — import from `lucide-react`
+- Use Tailwind CSS utility classes for styling; avoid custom CSS
+- Use `clsx` / `tailwind-merge` for conditional class composition
+- Components live in `src/components/`, hooks in `src/hooks/`
+- Lint with `pnpm lint`

--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
+import { AlertCircle } from "lucide-react";
 import type { ApprovalRequest } from "@/lib/types";
 
 interface ApprovalCardProps {
@@ -24,19 +25,7 @@ export function ApprovalCard({
       )}
     >
       <div className="mb-2 flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-warning-foreground/70">
-        <svg
-          className="h-3.5 w-3.5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-          />
-        </svg>
+        <AlertCircle className="h-3.5 w-3.5" />
         Approval Required
       </div>
 

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -184,19 +184,23 @@ export function ChatView({
                 next.request_id === h.request_id
                   ? (next.decision as EscalationDecision)
                   : undefined;
-              msgs.push({
-                kind: "credential_approval",
-                request: {
-                  type: "credential_approval_request",
-                  request_id: h.request_id,
-                  vault_paths: h.vault_paths ?? [],
-                  names: h.names ?? [],
-                  descriptions: h.descriptions ?? [],
-                  skill_name: h.skill_name,
-                  explanation: h.explanation ?? "",
-                },
-                decision,
-              });
+              // Only show the card if it was actually escalated to the user
+              // (no immediate decision in the next history entry).
+              if (!decision) {
+                msgs.push({
+                  kind: "credential_approval",
+                  request: {
+                    type: "credential_approval_request",
+                    request_id: h.request_id,
+                    vault_paths: h.vault_paths ?? [],
+                    names: h.names ?? [],
+                    descriptions: h.descriptions ?? [],
+                    skill_name: h.skill_name,
+                    explanation: h.explanation ?? "",
+                  },
+                  decision,
+                });
+              }
             }
           } else if (h.role === "git_push") {
             msgs.push({

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -68,6 +68,21 @@ export function ChatView({
         const msgs: ChatMessage[] = [];
         const pendingToolCallIndices = new Map<string, number[]>();
         const approvals = new Map<string, boolean>();
+
+        function findLaterEscalationDecision(
+          fromIndex: number,
+          requestId: string,
+          roleMatches: (role: string) => boolean,
+        ): EscalationDecision | undefined {
+          for (let j = fromIndex + 1; j < history.length; j++) {
+            const e = history[j];
+            if (e.request_id !== requestId || !roleMatches(e.role)) continue;
+            const d = e.decision;
+            if (d === "allow" || d === "deny") return d;
+          }
+          return undefined;
+        }
+
         for (let i = 0; i < history.length; i++) {
           const h = history[i];
           if (h.role === "user") {
@@ -134,15 +149,15 @@ export function ChatView({
               h.role === "proxy_approval") &&
             h.request_id
           ) {
-            // Domain access approval: first event is the request, second has the decision
+            // Domain access approval: request entry, then decision (may be non-adjacent)
             if (!h.decision) {
-              const next = history[i + 1];
-              const decision =
-                (next?.role === "domain_access_approval" ||
-                  next?.role === "proxy_approval") &&
-                next.request_id === h.request_id
-                  ? (next.decision as EscalationDecision)
-                  : undefined;
+              const decision = findLaterEscalationDecision(
+                i,
+                h.request_id,
+                (role) =>
+                  role === "domain_access_approval" ||
+                  role === "proxy_approval",
+              );
               if (!decision) {
                 msgs.push({
                   kind: "domain_access_approval",
@@ -158,14 +173,13 @@ export function ChatView({
             }
             // Skip decision-only events (consumed above)
           } else if (h.role === "git_push_approval" && h.request_id) {
-            // Git push approval: first event is the request, second has the decision
+            // Git push approval: request entry, then decision (may be non-adjacent)
             if (!h.decision) {
-              const next = history[i + 1];
-              const decision =
-                next?.role === "git_push_approval" &&
-                next.request_id === h.request_id
-                  ? (next.decision as EscalationDecision)
-                  : undefined;
+              const decision = findLaterEscalationDecision(
+                i,
+                h.request_id,
+                (role) => role === "git_push_approval",
+              );
               if (!decision) {
                 msgs.push({
                   kind: "git_push_approval",
@@ -183,13 +197,11 @@ export function ChatView({
             }
           } else if (h.role === "credential_approval" && h.request_id) {
             if (!h.decision) {
-              const next = history[i + 1];
-              const decision =
-                next?.role === "credential_approval" &&
-                next.request_id === h.request_id
-                  ? (next.decision as EscalationDecision)
-                  : undefined;
-              // Only show the card while pending (no decision in the next entry).
+              const decision = findLaterEscalationDecision(
+                i,
+                h.request_id,
+                (role) => role === "credential_approval",
+              );
               if (!decision) {
                 msgs.push({
                   kind: "credential_approval",

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -73,11 +73,13 @@ export function ChatView({
           if (h.role === "user") {
             msgs.push({ kind: "user", content: h.content });
           } else if (h.role === "tool_call") {
+            const rawContexts = h.contexts ?? h.args?.contexts;
             msgs.push({
               kind: "tool_call",
               tool: h.tool ?? "",
               args: h.args ?? {},
               detail: h.detail ?? "",
+              contexts: Array.isArray(rawContexts) ? rawContexts as string[] : undefined,
               approvalSource: h.approval_source,
               approvalVerdict: h.approval_verdict,
               approvalExplanation: h.approval_explanation,
@@ -280,6 +282,7 @@ export function ChatView({
           const verdict = msg.approval_verdict;
           const isLoading =
             msg.tool !== "proxy_domain" && !isGitPush && verdict === "allow";
+          const rawContexts = msg.contexts ?? msg.args?.contexts;
           setMessages((prev) => [
             ...prev,
             {
@@ -287,6 +290,7 @@ export function ChatView({
               tool: msg.tool,
               args: msg.args,
               detail: msg.detail,
+              contexts: Array.isArray(rawContexts) ? rawContexts as string[] : undefined,
               approvalSource: msg.approval_source,
               approvalVerdict: msg.approval_verdict,
               approvalExplanation: msg.approval_explanation,

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -79,7 +79,9 @@ export function ChatView({
               tool: h.tool ?? "",
               args: h.args ?? {},
               detail: h.detail ?? "",
-              contexts: Array.isArray(rawContexts) ? rawContexts as string[] : undefined,
+              contexts: Array.isArray(rawContexts)
+                ? (rawContexts as string[])
+                : undefined,
               approvalSource: h.approval_source,
               approvalVerdict: h.approval_verdict,
               approvalExplanation: h.approval_explanation,
@@ -134,7 +136,6 @@ export function ChatView({
           ) {
             // Domain access approval: first event is the request, second has the decision
             if (!h.decision) {
-              // Look ahead for the matching decision event
               const next = history[i + 1];
               const decision =
                 (next?.role === "domain_access_approval" ||
@@ -142,16 +143,18 @@ export function ChatView({
                 next.request_id === h.request_id
                   ? (next.decision as EscalationDecision)
                   : undefined;
-              msgs.push({
-                kind: "domain_access_approval",
-                request: {
-                  type: "domain_access_approval_request",
-                  request_id: h.request_id,
-                  domain: h.domain ?? "",
-                  command: h.command ?? "",
-                },
-                decision,
-              });
+              if (!decision) {
+                msgs.push({
+                  kind: "domain_access_approval",
+                  request: {
+                    type: "domain_access_approval_request",
+                    request_id: h.request_id,
+                    domain: h.domain ?? "",
+                    command: h.command ?? "",
+                  },
+                  decision,
+                });
+              }
             }
             // Skip decision-only events (consumed above)
           } else if (h.role === "git_push_approval" && h.request_id) {
@@ -163,18 +166,20 @@ export function ChatView({
                 next.request_id === h.request_id
                   ? (next.decision as EscalationDecision)
                   : undefined;
-              msgs.push({
-                kind: "git_push_approval",
-                request: {
-                  type: "git_push_approval_request",
-                  request_id: h.request_id,
-                  ref: h.ref ?? "",
-                  explanation: h.explanation ?? "",
-                  changed_files:
-                    (h.changed_files as string[] | undefined) ?? [],
-                },
-                decision,
-              });
+              if (!decision) {
+                msgs.push({
+                  kind: "git_push_approval",
+                  request: {
+                    type: "git_push_approval_request",
+                    request_id: h.request_id,
+                    ref: h.ref ?? "",
+                    explanation: h.explanation ?? "",
+                    changed_files:
+                      (h.changed_files as string[] | undefined) ?? [],
+                  },
+                  decision,
+                });
+              }
             }
           } else if (h.role === "credential_approval" && h.request_id) {
             if (!h.decision) {
@@ -184,8 +189,7 @@ export function ChatView({
                 next.request_id === h.request_id
                   ? (next.decision as EscalationDecision)
                   : undefined;
-              // Only show the card if it was actually escalated to the user
-              // (no immediate decision in the next history entry).
+              // Only show the card while pending (no decision in the next entry).
               if (!decision) {
                 msgs.push({
                   kind: "credential_approval",
@@ -294,7 +298,9 @@ export function ChatView({
               tool: msg.tool,
               args: msg.args,
               detail: msg.detail,
-              contexts: Array.isArray(rawContexts) ? rawContexts as string[] : undefined,
+              contexts: Array.isArray(rawContexts)
+                ? (rawContexts as string[])
+                : undefined,
               approvalSource: msg.approval_source,
               approvalVerdict: msg.approval_verdict,
               approvalExplanation: msg.approval_explanation,
@@ -461,12 +467,13 @@ export function ChatView({
   function handleEscalation(requestId: string, decision: EscalationDecision) {
     send({ type: "escalation_response", request_id: requestId, decision });
     setMessages((prev) =>
-      prev.map((m) =>
-        (m.kind === "domain_access_approval" ||
-          m.kind === "git_push_approval") &&
-        m.request.request_id === requestId
-          ? { ...m, decision }
-          : m,
+      prev.filter(
+        (m) =>
+          !(
+            (m.kind === "domain_access_approval" ||
+              m.kind === "git_push_approval") &&
+            m.request.request_id === requestId
+          ),
       ),
     );
   }
@@ -477,10 +484,12 @@ export function ChatView({
   ) {
     send({ type: "escalation_response", request_id: requestId, decision });
     setMessages((prev) =>
-      prev.map((m) =>
-        m.kind === "credential_approval" && m.request.request_id === requestId
-          ? { ...m, decision }
-          : m,
+      prev.filter(
+        (m) =>
+          !(
+            m.kind === "credential_approval" &&
+            m.request.request_id === requestId
+          ),
       ),
     );
   }

--- a/frontend/src/components/credential-approval-card.tsx
+++ b/frontend/src/components/credential-approval-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
+import { KeyRound } from "lucide-react";
 import type {
   CredentialApprovalRequest,
   EscalationDecision,
@@ -34,19 +35,7 @@ export function CredentialApprovalCard({
       )}
     >
       <div className="mb-2 flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-warning-foreground/70">
-        <svg
-          className="h-3.5 w-3.5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M15.75 5.25a3 3 0 013 3m3 0a6 6 0 01-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1121.75 8.25z"
-          />
-        </svg>
+        <KeyRound className="h-3.5 w-3.5" />
         Credential Request
       </div>
 

--- a/frontend/src/components/domain-access-approval-card.tsx
+++ b/frontend/src/components/domain-access-approval-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
+import { CircleCheckBig } from "lucide-react";
 import type { EscalationDecision, DomainAccessApprovalRequest } from "@/lib/types";
 
 interface DomainAccessApprovalCardProps {
@@ -31,19 +32,7 @@ export function DomainAccessApprovalCard({
       )}
     >
       <div className="mb-2 flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-warning-foreground/70">
-        <svg
-          className="h-3.5 w-3.5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z M9 10l2 2 4-4"
-          />
-        </svg>
+        <CircleCheckBig className="h-3.5 w-3.5" />
         Domain Access Request
       </div>
 

--- a/frontend/src/components/domain-access-approval-card.tsx
+++ b/frontend/src/components/domain-access-approval-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { CircleCheckBig } from "lucide-react";
+import { Globe } from "lucide-react";
 import type { EscalationDecision, DomainAccessApprovalRequest } from "@/lib/types";
 
 interface DomainAccessApprovalCardProps {
@@ -32,7 +32,7 @@ export function DomainAccessApprovalCard({
       )}
     >
       <div className="mb-2 flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-warning-foreground/70">
-        <CircleCheckBig className="h-3.5 w-3.5" />
+        <Globe className="h-3.5 w-3.5" />
         Domain Access Request
       </div>
 

--- a/frontend/src/components/git-push-approval-card.tsx
+++ b/frontend/src/components/git-push-approval-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { CircleCheckBig } from "lucide-react";
+import { GitBranch } from "lucide-react";
 import type { EscalationDecision, GitPushApprovalRequest } from "@/lib/types";
 
 interface GitPushApprovalCardProps {
@@ -32,7 +32,7 @@ export function GitPushApprovalCard({
       )}
     >
       <div className="mb-2 flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-warning-foreground/70">
-        <CircleCheckBig className="h-3.5 w-3.5" />
+        <GitBranch className="h-3.5 w-3.5" />
         Git Push Request
       </div>
 

--- a/frontend/src/components/git-push-approval-card.tsx
+++ b/frontend/src/components/git-push-approval-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
+import { CircleCheckBig } from "lucide-react";
 import type { EscalationDecision, GitPushApprovalRequest } from "@/lib/types";
 
 interface GitPushApprovalCardProps {
@@ -31,19 +32,7 @@ export function GitPushApprovalCard({
       )}
     >
       <div className="mb-2 flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-warning-foreground/70">
-        <svg
-          className="h-3.5 w-3.5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z M9 10l2 2 4-4"
-          />
-        </svg>
+        <CircleCheckBig className="h-3.5 w-3.5" />
         Git Push Request
       </div>
 

--- a/frontend/src/components/message.tsx
+++ b/frontend/src/components/message.tsx
@@ -113,6 +113,7 @@ export function Message({
           tool={message.tool}
           args={message.args}
           detail={message.detail}
+          contexts={message.contexts}
           approvalSource={message.approvalSource}
           approvalVerdict={message.approvalVerdict}
           approvalExplanation={message.approvalExplanation}

--- a/frontend/src/components/tool-call-badge.tsx
+++ b/frontend/src/components/tool-call-badge.tsx
@@ -7,6 +7,8 @@ import {
   ShieldCheck,
   ShieldAlert,
   UserCheck,
+  Puzzle,
+  Zap,
 } from "lucide-react";
 import { diffLines } from "diff";
 import { MarkdownContent } from "./markdown-content";
@@ -29,7 +31,7 @@ interface ToolCallBadgeProps {
   loading?: boolean;
 }
 
-type ApprovalSource = "safe-list" | "sentinel" | "user" | "unknown";
+type ApprovalSource = "safe-list" | "sentinel" | "user" | "skill" | "bypass" | "unknown";
 type ApprovalVerdict = "allow" | "deny" | "escalate";
 
 const SHORT_KEYS: Record<string, string> = {
@@ -259,6 +261,33 @@ function ApprovalBadge({
     );
   }
 
+  if (source === "skill") {
+    return (
+      <span className="inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[10px] font-medium bg-teal-500/10 text-teal-600 dark:text-teal-400">
+        <Puzzle className="h-2.5 w-2.5" />
+        skill
+      </span>
+    );
+  }
+
+  if (source === "bypass") {
+    return (
+      <span className="inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[10px] font-medium bg-gray-500/10 text-gray-500 dark:text-gray-400">
+        <Zap className="h-2.5 w-2.5" />
+        bypass
+      </span>
+    );
+  }
+
+  if (verdict === "deny") {
+    return (
+      <span className="inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[10px] font-medium bg-red-500/10 text-red-600 dark:text-red-400">
+        <ShieldAlert className="h-2.5 w-2.5" />
+        denied
+      </span>
+    );
+  }
+
   return null;
 }
 
@@ -332,9 +361,13 @@ export function ToolCallBadge({
             : isCredentialAccessTool
               ? isCredentialList
                 ? "listed credentials"
-                : "accessed credential"
+                : verdict === "deny"
+                  ? "credential denied"
+                  : "accessed credential"
               : isProxyDomainTool
-                ? "accessed domain"
+                ? verdict === "deny"
+                  ? "domain denied"
+                  : "accessed domain"
                 : tool
     : isUseSkillTool
       ? "activate skill"

--- a/frontend/src/components/tool-call-badge.tsx
+++ b/frontend/src/components/tool-call-badge.tsx
@@ -167,6 +167,7 @@ function formatArgsSummary(
   tool: string,
   args: Record<string, unknown>,
 ): string {
+  if (tool === "use_skill") return stringArg(args, "skill_name");
   if (tool === "write") return formatWriteSummary(args);
   if (tool === "str_replace") return formatStrReplaceSummary(args);
   if (tool === "credential_access") return formatCredentialAccessSummary(args);
@@ -511,6 +512,31 @@ export function ToolCallBadge({
                 </span>{" "}
                 skill.
               </div>
+
+              {Array.isArray(args.requested_domains) && args.requested_domains.length > 0 && (
+                <div className="text-[11px] text-muted-foreground">
+                  <span className="font-medium text-foreground/70">Domains: </span>
+                  {(args.requested_domains as string[]).map((d, i) => (
+                    <span key={d}>
+                      {i > 0 && ", "}
+                      <span className="font-mono">{d}</span>
+                    </span>
+                  ))}
+                </div>
+              )}
+
+              {Array.isArray(args.requested_creds) && args.requested_creds.length > 0 && (
+                <div className="text-[11px] text-muted-foreground">
+                  <span className="font-medium text-foreground/70">Credentials: </span>
+                  {(args.requested_creds as Array<{ vault_path: string; description?: string }>).map((c, i) => (
+                    <span key={c.vault_path}>
+                      {i > 0 && ", "}
+                      <span className="font-mono">{c.vault_path}</span>
+                      {c.description && <span className="text-muted-foreground/70"> ({c.description})</span>}
+                    </span>
+                  ))}
+                </div>
+              )}
 
               {result != null && (
                 <div

--- a/frontend/src/components/tool-call-badge.tsx
+++ b/frontend/src/components/tool-call-badge.tsx
@@ -23,6 +23,7 @@ interface ToolCallBadgeProps {
   tool: string;
   args: Record<string, unknown>;
   detail: string;
+  contexts?: string[];
   approvalSource?: ApprovalSource;
   approvalVerdict?: ApprovalVerdict;
   approvalExplanation?: string;
@@ -295,6 +296,7 @@ export function ToolCallBadge({
   tool,
   args,
   detail: _detail,
+  contexts,
   approvalSource,
   approvalVerdict,
   approvalExplanation,
@@ -448,6 +450,21 @@ export function ToolCallBadge({
             <div className="text-muted-foreground leading-relaxed">
               <span className="font-medium text-foreground/70">Sentinel: </span>
               {explanation}
+            </div>
+          )}
+
+          {contexts && contexts.length > 0 && (
+            <div className="flex items-center gap-1.5 flex-wrap">
+              <span className="text-[11px] font-medium text-muted-foreground">Contexts:</span>
+              {contexts.map((ctx) => (
+                <span
+                  key={ctx}
+                  className="inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[10px] font-medium bg-teal-500/10 text-teal-600 dark:text-teal-400 font-mono"
+                >
+                  <Puzzle className="h-2.5 w-2.5" />
+                  {ctx}
+                </span>
+              ))}
             </div>
           )}
 

--- a/frontend/src/components/tool-call-badge.tsx
+++ b/frontend/src/components/tool-call-badge.tsx
@@ -3,13 +3,20 @@
 import { useState } from "react";
 import {
   ChevronRight,
+  FileText,
+  FilePen,
+  Globe,
+  KeyRound,
   Loader2,
-  ShieldCheck,
-  ShieldAlert,
-  UserCheck,
   Puzzle,
+  Replace,
+  ShieldAlert,
+  ShieldCheck,
+  Terminal,
+  UserCheck,
   Zap,
 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { diffLines } from "diff";
 import { MarkdownContent } from "./markdown-content";
 import {
@@ -34,6 +41,16 @@ interface ToolCallBadgeProps {
 
 type ApprovalSource = "safe-list" | "sentinel" | "user" | "skill" | "bypass" | "unknown";
 type ApprovalVerdict = "allow" | "deny" | "escalate";
+
+const TOOL_ICONS: Record<string, LucideIcon> = {
+  exec: Terminal,
+  read: FileText,
+  write: FilePen,
+  str_replace: Replace,
+  use_skill: Puzzle,
+  credential_access: KeyRound,
+  proxy_domain: Globe,
+};
 
 const SHORT_KEYS: Record<string, string> = {
   command: "cmd",
@@ -425,6 +442,12 @@ export function ToolCallBadge({
             open && "rotate-90",
           )}
         />
+        {(() => {
+          const ToolIcon = TOOL_ICONS[tool];
+          return ToolIcon ? (
+            <ToolIcon className="h-3 w-3 shrink-0 text-muted-foreground" />
+          ) : null;
+        })()}
         <span className="shrink-0 font-mono font-medium text-foreground/80">
           {toolLabel}
         </span>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -18,6 +18,7 @@ export interface HistoryMessage {
   tool?: string;
   args?: Record<string, unknown>;
   detail?: string;
+  contexts?: string[];
   approval_source?:
     | "safe-list"
     | "sentinel"

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -18,7 +18,7 @@ export interface HistoryMessage {
   tool?: string;
   args?: Record<string, unknown>;
   detail?: string;
-  approval_source?: "safe-list" | "sentinel" | "user" | "unknown";
+  approval_source?: "safe-list" | "sentinel" | "user" | "skill" | "bypass" | "unknown";
   approval_verdict?: "allow" | "deny" | "escalate";
   approval_explanation?: string;
   result?: string;
@@ -51,7 +51,7 @@ export interface ToolCallInfo {
   tool: string;
   args: Record<string, unknown>;
   detail: string;
-  approval_source?: "safe-list" | "sentinel" | "user" | "unknown";
+  approval_source?: "safe-list" | "sentinel" | "user" | "skill" | "bypass" | "unknown";
   approval_verdict?: "allow" | "deny" | "escalate";
   approval_explanation?: string;
 }
@@ -213,7 +213,7 @@ export type ChatMessage =
       tool: string;
       args: Record<string, unknown>;
       detail: string;
-      approvalSource?: "safe-list" | "sentinel" | "user" | "unknown";
+      approvalSource?: "safe-list" | "sentinel" | "user" | "skill" | "bypass" | "unknown";
       approvalVerdict?: "allow" | "deny" | "escalate";
       approvalExplanation?: string;
       result?: string;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -18,7 +18,13 @@ export interface HistoryMessage {
   tool?: string;
   args?: Record<string, unknown>;
   detail?: string;
-  approval_source?: "safe-list" | "sentinel" | "user" | "skill" | "bypass" | "unknown";
+  approval_source?:
+    | "safe-list"
+    | "sentinel"
+    | "user"
+    | "skill"
+    | "bypass"
+    | "unknown";
   approval_verdict?: "allow" | "deny" | "escalate";
   approval_explanation?: string;
   result?: string;
@@ -51,7 +57,14 @@ export interface ToolCallInfo {
   tool: string;
   args: Record<string, unknown>;
   detail: string;
-  approval_source?: "safe-list" | "sentinel" | "user" | "skill" | "bypass" | "unknown";
+  contexts?: string[];
+  approval_source?:
+    | "safe-list"
+    | "sentinel"
+    | "user"
+    | "skill"
+    | "bypass"
+    | "unknown";
   approval_verdict?: "allow" | "deny" | "escalate";
   approval_explanation?: string;
 }
@@ -213,7 +226,14 @@ export type ChatMessage =
       tool: string;
       args: Record<string, unknown>;
       detail: string;
-      approvalSource?: "safe-list" | "sentinel" | "user" | "skill" | "bypass" | "unknown";
+      contexts?: string[];
+      approvalSource?:
+        | "safe-list"
+        | "sentinel"
+        | "user"
+        | "skill"
+        | "bypass"
+        | "unknown";
       approvalVerdict?: "allow" | "deny" | "escalate";
       approvalExplanation?: string;
       result?: string;

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -185,7 +185,6 @@ async def _cache_skill_credentials(
 
     # Fetch values and cache (not inject)
     cached = 0
-    cached_paths: list[str] = []
     fetch_errors: list[str] = []
     for decl in cred_decls:
         if decl.vault_path in failed_vault_paths:
@@ -203,17 +202,6 @@ async def _cache_skill_credentials(
             continue
         ctx.deps.sandbox.cache_credential(session_id, decl.vault_path, value)
         cached += 1
-        cached_paths.append(decl.vault_path)
-
-    # Notify live subscribers (dedupe handled by the per-exec notified set)
-    for vp in cached_paths:
-        ctx.deps.security.notify_credential_decision(
-            vp,
-            f"[skill] {vp}",
-            approval_source="skill",
-            approval_verdict="allow",
-            approval_explanation=f"skill-declared credential ({skill_name})",
-        )
 
     parts: list[str] = []
     if cached:
@@ -564,6 +552,7 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
         context_domains: set[str] = set()
         context_file_creds: list[tuple[str, str, str]] = []  # (skill_name, file_path, vault_path)
         missing_cached: list[tuple[str, str]] = []
+        injected_creds: list[tuple[str, str]] = []  # (ctx_name, vault_path)
         for ctx_name in contexts:
             grant = grants[ctx_name]
             context_domains.update(grant.domains)
@@ -574,6 +563,7 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
                 if cached is None:
                     missing_cached.append((ctx_name, decl.vault_path))
                     continue
+                injected_creds.append((ctx_name, decl.vault_path))
                 if decl.env_var:
                     extra_env[decl.env_var] = cached
                 if decl.file:
@@ -602,6 +592,16 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
                 "(re-run use_skill for the skill if you need them):\n"
                 f"{lines}\n\n"
             ) + result
+
+        # Notify credential injection for each context-scoped credential
+        for ctx_name, vp in injected_creds:
+            ctx.deps.security.notify_credential_decision(
+                vp,
+                f"[skill] {vp}",
+                approval_source="skill",
+                approval_verdict="allow",
+                approval_explanation=f"skill-declared credential ({ctx_name})",
+            )
 
         ctx.deps.security.append(
             ToolResultEntry(tool="exec", status="error" if exit_code != 0 else "success"),

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -560,12 +560,16 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
         extra_env: dict[str, str] = {}
         context_domains: set[str] = set()
         context_file_creds: list[tuple[str, str, str]] = []  # (skill_name, file_path, vault_path)
+        missing_cached: list[tuple[str, str]] = []
         for ctx_name in contexts:
             grant = grants[ctx_name]
             context_domains.update(grant.domains)
             for decl in grant.credential_decls:
+                if not (decl.env_var or decl.file):
+                    continue
                 cached = ctx.deps.sandbox.get_cached_credential(session_id, decl.vault_path)
                 if cached is None:
+                    missing_cached.append((ctx_name, decl.vault_path))
                     continue
                 if decl.env_var:
                     extra_env[decl.env_var] = cached
@@ -587,6 +591,14 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
             _log_sandbox_tool_exception("exec", session_id)
             result = f"Error: {exc}"
             exit_code = -1
+
+        if missing_cached:
+            lines = "\n".join(f"  - skill {name!r}, vault path {vp!r}" for name, vp in dict.fromkeys(missing_cached))
+            result = (
+                "Warning: these credentials are not in the session cache and were not injected "
+                "(re-run use_skill for the skill if you need them):\n"
+                f"{lines}\n\n"
+            ) + result
 
         ctx.deps.security.append(
             ToolResultEntry(tool="exec", status="error" if exit_code != 0 else "success"),

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -341,20 +341,19 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
             sandbox_msg = f"ERROR: {exc}"
 
         # Register context grant (replaces permanent allow_domains + session env injection)
-        if requested_domains or requested_creds:
-            grant = ContextGrant(
+        grant = ContextGrant(
+            skill_name=skill_name,
+            domains=set(requested_domains),
+            credential_decls=list(requested_creds),
+        )
+        ctx.deps.session_state.context_grants[skill_name] = grant
+        ctx.deps.security.append(
+            ContextGrantEntry(
                 skill_name=skill_name,
-                domains=set(requested_domains),
-                credential_decls=list(requested_creds),
-            )
-            ctx.deps.session_state.context_grants[skill_name] = grant
-            ctx.deps.security.append(
-                ContextGrantEntry(
-                    skill_name=skill_name,
-                    domains=requested_domains,
-                    vault_paths=[c.vault_path for c in requested_creds],
-                ),
-            )
+                domains=requested_domains,
+                vault_paths=[c.vault_path for c in requested_creds],
+            ),
+        )
 
         # Cache credential values for per-exec injection
         cred_msg = await _cache_skill_credentials(ctx, requested_creds, skill_name)

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -569,6 +569,16 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
                 if decl.file:
                     context_file_creds.append((ctx_name, decl.file, decl.vault_path))
 
+        def _notify_injected_skill_creds() -> None:
+            for ctx_name, vp in injected_creds:
+                ctx.deps.security.notify_credential_decision(
+                    vp,
+                    f"[skill] {vp}",
+                    approval_source="skill",
+                    approval_verdict="allow",
+                    approval_explanation=f"skill-declared credential ({ctx_name})",
+                )
+
         try:
             exec_result = await ctx.deps.sandbox.exec_command(
                 session_id,
@@ -577,6 +587,7 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
                 extra_env=extra_env or None,
                 context_domains=context_domains or None,
                 context_file_creds=context_file_creds or None,
+                after_exec_credential_notify=_notify_injected_skill_creds if injected_creds else None,
             )
             result = exec_result.output
             exit_code = exec_result.exit_code
@@ -592,16 +603,6 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
                 "(re-run use_skill for the skill if you need them):\n"
                 f"{lines}\n\n"
             ) + result
-
-        # Notify credential injection for each context-scoped credential
-        for ctx_name, vp in injected_creds:
-            ctx.deps.security.notify_credential_decision(
-                vp,
-                f"[skill] {vp}",
-                approval_source="skill",
-                approval_verdict="allow",
-                approval_explanation=f"skill-declared credential ({ctx_name})",
-            )
 
         ctx.deps.security.append(
             ToolResultEntry(tool="exec", status="error" if exit_code != 0 else "success"),

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -11,10 +11,21 @@ from pydantic_ai import Agent, DeferredToolRequests, RunContext, ToolDenied
 
 import carapace.security as security
 from carapace.config import load_workspace_file
-from carapace.models import CredentialMetadata, CredentialRegistryProtocol, Deps, SkillCredentialDecl, ToolResult
+from carapace.models import (
+    ContextGrant,
+    CredentialMetadata,
+    Deps,
+    SkillCredentialDecl,
+    ToolResult,
+)
 from carapace.sandbox.manager import READ_TOOL_MAX_LINE_WINDOW
 from carapace.sandbox.runtime import SkillVenvError
-from carapace.security.context import CredentialAccessEntry, SkillActivatedEntry, ToolResultEntry
+from carapace.security.context import (
+    ContextGrantEntry,
+    CredentialAccessEntry,
+    SkillActivatedEntry,
+    ToolResultEntry,
+)
 from carapace.skills import SkillRegistry
 from carapace.usage import LlmRequestLogCapability
 
@@ -105,12 +116,16 @@ def _log_sandbox_tool_exception(tool: str, session_id: str) -> None:
     logger.exception(f"Sandbox tool {tool!r} failed (session {session_id})")
 
 
-async def _inject_skill_credentials(
+async def _cache_skill_credentials(
     ctx: RunContext[Deps],
     cred_decls: list[SkillCredentialDecl],
     skill_name: str,
 ) -> str:
-    """Fetch and inject declared skill credentials into the sandbox.
+    """Fetch declared skill credentials and cache them for per-exec injection.
+
+    Values are stored in ``SandboxManager._credential_cache`` — **not** in
+    ``session_env``.  They will be injected (env vars) or written (files) only
+    for ``exec`` calls that carry a matching context.
 
     Returns a human-readable summary for the agent (never includes values).
     """
@@ -118,19 +133,12 @@ async def _inject_skill_credentials(
         return ""
 
     cred_registry = ctx.deps.credential_registry
+    session_id = ctx.deps.session_state.session_id
 
-    approved_paths = {c.vault_path for c in ctx.deps.session_state.approved_credentials}
-
-    # Filter to credentials not yet approved
-    needed = [c for c in cred_decls if c.vault_path not in approved_paths]
-    if not needed:
-        # All already approved — re-inject in case container was recreated
-        return await _do_inject(ctx, cred_decls, cred_registry, skill_name)
-
-    # Fetch metadata for all needed credentials (vault HTTP errors must not abort use_skill)
+    # Fetch metadata for UI / action-log
     meta_errors: list[str] = []
     metas: list[CredentialMetadata] = []
-    for decl in needed:
+    for decl in cred_decls:
         try:
             meta = await cred_registry.fetch_metadata(decl.vault_path)
         except KeyError:
@@ -141,17 +149,9 @@ async def _inject_skill_credentials(
             continue
         metas.append(meta)
 
-    # No separate approval prompt here — the user already approved the
-    # use_skill tool call which listed these credential vault paths in its
-    # gate_args.  Skill-declared credentials are covered by that approval.
+    # Append action-log entry so the sentinel is aware
     if metas:
         ctx.deps.security.append(CredentialAccessEntry(vault_paths=[m.vault_path for m in metas], decision="approved"))
-
-        # Record approvals in session state
-        for meta in metas:
-            if not any(c.vault_path == meta.vault_path for c in ctx.deps.session_state.approved_credentials):
-                ctx.deps.session_state.approved_credentials.append(meta)
-
         if ctx.deps.append_session_events:
             request_id = secrets.token_hex(8)
             vault_paths = [m.vault_path for m in metas]
@@ -181,67 +181,33 @@ async def _inject_skill_credentials(
                 ]
             )
 
-    approved_paths_now = {c.vault_path for c in ctx.deps.session_state.approved_credentials}
-    decls_to_inject = [c for c in cred_decls if c.vault_path in approved_paths_now]
-    inject_msg = await _do_inject(ctx, decls_to_inject, cred_registry, skill_name)
-
-    parts: list[str] = []
-    if meta_errors:
-        parts.append(
-            "Credential vault unavailable for some declarations (not approved or injected): " + "; ".join(meta_errors)
-        )
-    if inject_msg:
-        parts.append(inject_msg)
-    return " ".join(parts)
-
-
-async def _do_inject(
-    ctx: RunContext[Deps],
-    cred_decls: list[SkillCredentialDecl],
-    cred_registry: CredentialRegistryProtocol,
-    skill_name: str,
-) -> str:
-    """Fetch credential values and inject them into the sandbox."""
-    session_id = ctx.deps.session_state.session_id
-    injected = 0
-    errors: list[str] = []
-
+    # Fetch values and cache (not inject)
+    cached = 0
+    fetch_errors: list[str] = []
     for decl in cred_decls:
+        if decl.vault_path in {e.split(":")[0] for e in meta_errors}:
+            continue  # skip if metadata fetch already failed
         try:
             value = await cred_registry.fetch(decl.vault_path)
         except KeyError:
-            errors.append(f"Credential {decl.vault_path} not found in vault")
+            fetch_errors.append(f"Credential {decl.vault_path} not found in vault")
             continue
         except (httpx.RequestError, httpx.HTTPStatusError) as exc:
             logger.warning(
                 f"Credential fetch failed for {decl.vault_path!r} (session {session_id}, skill {skill_name!r}): {exc}"
             )
-            errors.append(f"Credential {decl.vault_path}: vault request failed ({type(exc).__name__})")
+            fetch_errors.append(f"Credential {decl.vault_path}: vault request failed ({type(exc).__name__})")
             continue
-
-        placed = False
-        if decl.env_var:
-            ctx.deps.sandbox.set_session_env(session_id, {decl.env_var: value})
-            placed = True
-
-        if decl.file:
-            skill_dir = f"/workspace/skills/{skill_name}"
-            fw = await ctx.deps.sandbox.file_write(
-                session_id, decl.file, value, mode=0o400, workdir=skill_dir, quote=False
-            )
-            if fw.exit_code != 0:
-                errors.append(f"Failed to write {decl.file}: {fw.output}")
-            else:
-                placed = True
-
-        if placed:
-            injected += 1
+        ctx.deps.sandbox.cache_credential(session_id, decl.vault_path, value)
+        cached += 1
 
     parts: list[str] = []
-    if injected:
-        parts.append(f"{injected} credential(s) injected for skill '{skill_name}'.")
-    if errors:
-        parts.append("Credential errors: " + "; ".join(errors))
+    if cached:
+        parts.append(f"{cached} credential(s) cached for skill '{skill_name}' (injected per-exec via contexts).")
+    if meta_errors:
+        parts.append("Credential vault unavailable for some declarations (not cached): " + "; ".join(meta_errors))
+    if fetch_errors:
+        parts.append("Credential errors: " + "; ".join(fetch_errors))
     return " ".join(parts)
 
 
@@ -372,14 +338,25 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
             logger.exception(f"Error activating skill {skill_name}: {exc}")
             sandbox_msg = f"ERROR: {exc}"
 
-        if requested_domains:
-            ctx.deps.sandbox.allow_domains(
-                ctx.deps.session_state.session_id,
-                set(requested_domains),
+        # Register context grant (replaces permanent allow_domains + session env injection)
+        if requested_domains or requested_creds:
+            grant = ContextGrant(
+                skill_name=skill_name,
+                domains=set(requested_domains),
+                vault_paths={c.vault_path for c in requested_creds},
+                credential_decls=list(requested_creds),
+            )
+            ctx.deps.session_state.context_grants[skill_name] = grant
+            ctx.deps.security.append(
+                ContextGrantEntry(
+                    skill_name=skill_name,
+                    domains=requested_domains,
+                    vault_paths=[c.vault_path for c in requested_creds],
+                ),
             )
 
-        # Credential auto-injection
-        cred_msg = await _inject_skill_credentials(ctx, requested_creds, skill_name)
+        # Cache credential values for per-exec injection
+        cred_msg = await _cache_skill_credentials(ctx, requested_creds, skill_name)
 
         ctx.deps.activated_skills.append(skill_name)
         if skill_name not in ctx.deps.session_state.activated_skills:
@@ -530,17 +507,35 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
     # --- Runtime ---
 
     @agent.tool
-    async def exec(ctx: RunContext[Deps], command: str, title: str | None = None) -> str | ToolDenied:
+    async def exec(
+        ctx: RunContext[Deps],
+        command: str,
+        title: str | None = None,
+        contexts: list[str] | None = None,
+    ) -> str | ToolDenied:
         """Run a shell command (typically bash) and return its output. Runs in a Docker sandbox.
 
         Args:
             command: The shell command to execute.
             title: Optional short label (a few words) describing the purpose of this command,
                 e.g. "clean up temp files and commit".
+            contexts: Optional list of activated skill names whose declared network domains
+                and credentials should be available for this command. Each entry must match
+                an activated skill; unknown names are rejected.
         """
+        contexts = contexts or []
+
+        # Validate contexts against activated skills
+        grants = ctx.deps.session_state.context_grants
+        invalid = [c for c in contexts if c not in grants]
+        if invalid:
+            return f"Unknown contexts (not activated skills): {', '.join(invalid)}"
+
         args: dict[str, Any] = {"command": command}
         if title is not None:
             args["title"] = title
+        if contexts:
+            args["contexts"] = contexts
         if not ctx.tool_call_approved:
             if denied := await _gate(ctx, "exec", args):
                 return denied
@@ -548,8 +543,32 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
             _notify_approved_start(ctx, "exec", args)
 
         session_id = ctx.deps.session_state.session_id
+
+        # Build per-exec injection data from matching context grants
+        extra_env: dict[str, str] = {}
+        context_domains: set[str] = set()
+        context_file_creds: list[tuple[str, str, str]] = []  # (skill_name, file_path, vault_path)
+        for ctx_name in contexts:
+            grant = grants[ctx_name]
+            context_domains.update(grant.domains)
+            for decl in grant.credential_decls:
+                cached = ctx.deps.sandbox.get_cached_credential(session_id, decl.vault_path)
+                if cached is None:
+                    continue
+                if decl.env_var:
+                    extra_env[decl.env_var] = cached
+                if decl.file:
+                    context_file_creds.append((ctx_name, decl.file, decl.vault_path))
+
         try:
-            exec_result = await ctx.deps.sandbox.exec_command(session_id, command)
+            exec_result = await ctx.deps.sandbox.exec_command(
+                session_id,
+                command,
+                contexts=contexts,
+                extra_env=extra_env or None,
+                context_domains=context_domains or None,
+                context_file_creds=context_file_creds or None,
+            )
             result = exec_result.output
             exit_code = exec_result.exit_code
         except Exception as exc:

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -222,7 +222,7 @@ async def _cache_skill_credentials(
         parts.append("Credential vault unavailable for some declarations (not cached): " + "; ".join(meta_errors))
     if fetch_errors:
         parts.append("Credential errors: " + "; ".join(fetch_errors))
-    return " ".join(parts)
+    return "\n".join(parts)
 
 
 def build_system_prompt(deps: Deps) -> str:
@@ -383,15 +383,18 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
             ),
         )
 
-        parts = [f"Skill '{skill_name}' activated."]
+        status_lines: list[str] = []
         if sandbox_msg:
-            parts.append(sandbox_msg)
+            status_lines.append(sandbox_msg)
+        else:
+            status_lines.append(f"Skill '{skill_name}' activated.")
         if requested_domains:
-            parts.append(f"Network access granted for: {', '.join(requested_domains)}")
+            status_lines.append(f"Network access granted for: {', '.join(requested_domains)}")
         if cred_msg:
-            parts.append(cred_msg)
-        parts.append(f"Instructions:\n\n{instructions}")
-        result = "\n".join(parts)
+            status_lines.append(cred_msg)
+
+        result = "\n".join(f"- {line}" for line in status_lines)
+        result += f"\n\nInstructions:\n\n{instructions}"
         _notify_result(ctx, "use_skill", result)
         return result
 

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -185,6 +185,7 @@ async def _cache_skill_credentials(
 
     # Fetch values and cache (not inject)
     cached = 0
+    cached_paths: list[str] = []
     fetch_errors: list[str] = []
     for decl in cred_decls:
         if decl.vault_path in failed_vault_paths:
@@ -202,6 +203,17 @@ async def _cache_skill_credentials(
             continue
         ctx.deps.sandbox.cache_credential(session_id, decl.vault_path, value)
         cached += 1
+        cached_paths.append(decl.vault_path)
+
+    # Notify live subscribers (dedupe handled by the per-exec notified set)
+    for vp in cached_paths:
+        ctx.deps.security.notify_credential_decision(
+            vp,
+            f"[skill] {vp}",
+            approval_source="skill",
+            approval_verdict="allow",
+            approval_explanation=f"skill-declared credential ({skill_name})",
+        )
 
     parts: list[str] = []
     if cached:

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -373,13 +373,13 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
 
         status_lines: list[str] = []
         if sandbox_msg:
-            status_lines.append(sandbox_msg)
+            status_lines.extend(sandbox_msg.splitlines())
         else:
             status_lines.append(f"Skill '{skill_name}' activated.")
         if requested_domains:
             status_lines.append(f"Network access granted for: {', '.join(requested_domains)}")
         if cred_msg:
-            status_lines.append(cred_msg)
+            status_lines.extend(cred_msg.splitlines())
 
         result = "\n".join(f"- {line}" for line in status_lines)
         result += f"\n\nInstructions:\n\n{instructions}"

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -345,7 +345,6 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
             grant = ContextGrant(
                 skill_name=skill_name,
                 domains=set(requested_domains),
-                vault_paths={c.vault_path for c in requested_creds},
                 credential_decls=list(requested_creds),
             )
             ctx.deps.session_state.context_grants[skill_name] = grant

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -137,6 +137,7 @@ async def _cache_skill_credentials(
 
     # Fetch metadata for UI / action-log
     meta_errors: list[str] = []
+    failed_vault_paths: set[str] = set()
     metas: list[CredentialMetadata] = []
     for decl in cred_decls:
         try:
@@ -146,6 +147,7 @@ async def _cache_skill_credentials(
         except (httpx.RequestError, httpx.HTTPStatusError) as exc:
             logger.warning(f"Credential metadata fetch failed for {decl.vault_path!r} (skill {skill_name!r}): {exc}")
             meta_errors.append(f"{decl.vault_path}: vault unreachable or error ({type(exc).__name__})")
+            failed_vault_paths.add(decl.vault_path)
             continue
         metas.append(meta)
 
@@ -185,7 +187,7 @@ async def _cache_skill_credentials(
     cached = 0
     fetch_errors: list[str] = []
     for decl in cred_decls:
-        if decl.vault_path in {e.split(":")[0] for e in meta_errors}:
+        if decl.vault_path in failed_vault_paths:
             continue  # skip if metadata fetch already failed
         try:
             value = await cred_registry.fetch(decl.vault_path)
@@ -529,7 +531,7 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
         grants = ctx.deps.session_state.context_grants
         invalid = [c for c in contexts if c not in grants]
         if invalid:
-            return f"Unknown contexts (not activated skills): {', '.join(invalid)}"
+            return f"Unknown contexts: {', '.join(invalid)}. If these are skills, please activate them first."
 
         args: dict[str, Any] = {"command": command}
         if title is not None:

--- a/src/carapace/channels/matrix/commands.py
+++ b/src/carapace/channels/matrix/commands.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from carapace.memory import MemoryStore
-from carapace.models import Deps
+from carapace.models import Deps, context_grants_session_summary
 from carapace.security.context import UserVouchedEntry
 from carapace.ws_models import CommandResult
 
@@ -49,16 +47,11 @@ def handle_matrix_slash_command(
 
     if cmd == "/session":
         session_id = deps.session_state.session_id
-        grants_summary: dict[str, dict[str, Any]] = {}
-        for skill, grant in deps.session_state.context_grants.items():
-            cached = sum(
-                1 for vp in grant.vault_paths if deps.sandbox.get_cached_credential(session_id, vp) is not None
-            )
-            grants_summary[skill] = {
-                "domains": sorted(grant.domains),
-                "vault_paths": sorted(grant.vault_paths),
-                "cached_credentials": cached,
-            }
+        grants_summary = context_grants_session_summary(
+            session_id,
+            deps.session_state.context_grants,
+            deps.sandbox.get_cached_credential,
+        )
         return CommandResult(
             command="session",
             data={

--- a/src/carapace/channels/matrix/commands.py
+++ b/src/carapace/channels/matrix/commands.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from carapace.memory import MemoryStore
 from carapace.models import Deps
 from carapace.security.context import UserVouchedEntry
@@ -47,12 +49,22 @@ def handle_matrix_slash_command(
 
     if cmd == "/session":
         session_id = deps.session_state.session_id
+        grants_summary: dict[str, dict[str, Any]] = {}
+        for skill, grant in deps.session_state.context_grants.items():
+            cached = sum(
+                1 for vp in grant.vault_paths if deps.sandbox.get_cached_credential(session_id, vp) is not None
+            )
+            grants_summary[skill] = {
+                "domains": sorted(grant.domains),
+                "vault_paths": sorted(grant.vault_paths),
+                "cached_credentials": cached,
+            }
         return CommandResult(
             command="session",
             data={
                 "session_id": session_id,
                 "channel_type": deps.session_state.channel_type,
-                "approved_credentials": deps.session_state.approved_credentials,
+                "context_grants": grants_summary,
                 "allowed_domains": deps.sandbox.get_domain_info(session_id),
             },
         )

--- a/src/carapace/channels/matrix/formatting.py
+++ b/src/carapace/channels/matrix/formatting.py
@@ -9,15 +9,6 @@ import markdown as md
 from carapace.ws_models import ApprovalRequest, CommandResult
 
 
-def _credential_name(credential: object) -> str:
-    if isinstance(credential, dict):
-        name = credential.get("name")
-        return str(name) if name else str(credential)
-
-    name = getattr(credential, "name", None)
-    return str(name) if name else str(credential)
-
-
 def md_to_html(text: str) -> str:
     """Convert markdown text to HTML for Matrix rich-text messages."""
     return md.markdown(text, extensions=["fenced_code", "tables"])
@@ -47,8 +38,22 @@ def format_command_result_text(result: CommandResult) -> str:
             return data.get("message", "Context approved.")
 
         case "session":
-            creds: list[object] = data.get("approved_credentials") or []
-            creds_str = ", ".join(_credential_name(c) for c in creds) if creds else "(none)"
+            grants: dict[str, dict[str, object]] = data.get("context_grants") or {}
+            if grants:
+                grant_lines: list[str] = []
+                for skill, info in grants.items():
+                    parts_g = [f"- **{skill}**"]
+                    domains_list = info.get("domains") or []
+                    if domains_list:
+                        parts_g.append(f"  domains: {', '.join(str(d) for d in domains_list)}")
+                    vps = info.get("vault_paths") or []
+                    cached = info.get("cached_credentials", 0)
+                    if vps:
+                        parts_g.append(f"  credentials: {len(vps)} declared, {cached} cached")
+                    grant_lines.append("\n".join(parts_g))
+                grants_str = "\n" + "\n".join(grant_lines)
+            else:
+                grants_str = " (none)"
             domain_entries: list[dict[str, str]] = data.get("allowed_domains") or []
             if domain_entries:
                 domains_str = "\n" + "\n".join(f"  - `{e['domain']}` ({e['scope']})" for e in domain_entries)
@@ -57,7 +62,7 @@ def format_command_result_text(result: CommandResult) -> str:
             lines = [
                 f"**Session:** `{data.get('session_id', '?')}`",
                 f"**Channel:** {data.get('channel_type', '?')}",
-                f"**Approved credentials:** {creds_str}",
+                f"**Context grants:**{grants_str}",
                 f"**Allowed domains:**{domains_str}",
             ]
             return "\n".join(lines)

--- a/src/carapace/cli.py
+++ b/src/carapace/cli.py
@@ -86,13 +86,6 @@ def _replay_history(server: str, session_id: str, headers: dict[str, str], limit
 # --- Rendering helpers for server responses ---
 
 
-def _format_credentials(creds: list[dict[str, str]] | None) -> str:
-    """Format approved credentials for display."""
-    if not creds:
-        return "(none)"
-    return ", ".join(c["name"] if isinstance(c, dict) else str(c) for c in creds)
-
-
 def _render_command_result(data: dict[str, Any]) -> None:
     cmd = data.get("command", "")
     payload: Any = data.get("data", {})
@@ -131,11 +124,26 @@ def _render_command_result(data: dict[str, Any]) -> None:
                 domains_str = f"\n{domain_lines}"
             else:
                 domains_str = " (none)"
+            grants: dict[str, dict[str, Any]] = payload.get("context_grants") or {}
+            if grants:
+                grant_lines: list[str] = []
+                for skill, info in grants.items():
+                    parts_g = [f"  [bold]{skill}[/bold]"]
+                    if info.get("domains"):
+                        parts_g.append(f"    domains: {', '.join(info['domains'])}")
+                    vps = info.get("vault_paths") or []
+                    cached = info.get("cached_credentials", 0)
+                    if vps:
+                        parts_g.append(f"    credentials: {len(vps)} declared, {cached} cached")
+                    grant_lines.append("\n".join(parts_g))
+                grants_str = "\n" + "\n".join(grant_lines)
+            else:
+                grants_str = " (none)"
             console.print(
                 Panel(
                     f"[bold]Session ID:[/bold] {payload['session_id']}\n"
                     f"[bold]Channel:[/bold] {payload['channel_type']}\n"
-                    f"[bold]Approved credentials:[/bold] {_format_credentials(payload.get('approved_credentials'))}\n"
+                    f"[bold]Context grants:[/bold]{grants_str}\n"
                     f"[bold]Allowed domains:[/bold]{domains_str}",
                     title="Session State",
                 )

--- a/src/carapace/models.py
+++ b/src/carapace/models.py
@@ -48,6 +48,7 @@ class SessionState(BaseModel):
     approved_credentials: list[CredentialMetadata] = []
     approved_operations: list[str] = []
     activated_skills: list[str] = []
+    context_grants: dict[str, ContextGrant] = {}
     created_at: datetime
     last_active: datetime
 
@@ -390,6 +391,19 @@ class SkillCarapaceConfig(BaseModel):
     network: SkillNetworkConfig = SkillNetworkConfig()
     credentials: list[SkillCredentialDecl] = []
     hints: dict[str, str] = {}
+
+
+class ContextGrant(BaseModel):
+    """Context-scoped grant for a skill's declared domains and credentials.
+
+    Registered at ``use_skill`` time, keyed by skill name.  The agent must pass
+    matching ``contexts`` on ``exec`` for these grants to take effect.
+    """
+
+    skill_name: str
+    domains: set[str] = set()
+    vault_paths: set[str] = set()
+    credential_decls: list[SkillCredentialDecl] = []
 
 
 class SkillInfo(BaseModel):

--- a/src/carapace/models.py
+++ b/src/carapace/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -404,6 +404,23 @@ class ContextGrant(BaseModel):
     @property
     def vault_paths(self) -> set[str]:
         return {c.vault_path for c in self.credential_decls}
+
+
+def context_grants_session_summary(
+    session_id: str,
+    context_grants: Mapping[str, ContextGrant],
+    get_cached_credential: Callable[[str, str], str | None],
+) -> dict[str, dict[str, Any]]:
+    """Build per-skill ``context_grants`` payload for ``/session`` (all channels)."""
+    summary: dict[str, dict[str, Any]] = {}
+    for skill, grant in context_grants.items():
+        cached = sum(1 for vp in grant.vault_paths if get_cached_credential(session_id, vp) is not None)
+        summary[skill] = {
+            "domains": sorted(grant.domains),
+            "vault_paths": sorted(grant.vault_paths),
+            "cached_credentials": cached,
+        }
+    return summary
 
 
 class SkillInfo(BaseModel):

--- a/src/carapace/models.py
+++ b/src/carapace/models.py
@@ -402,8 +402,11 @@ class ContextGrant(BaseModel):
 
     skill_name: str
     domains: set[str] = set()
-    vault_paths: set[str] = set()
     credential_decls: list[SkillCredentialDecl] = []
+
+    @property
+    def vault_paths(self) -> set[str]:
+        return {c.vault_path for c in self.credential_decls}
 
 
 class SkillInfo(BaseModel):

--- a/src/carapace/models.py
+++ b/src/carapace/models.py
@@ -45,7 +45,6 @@ class SessionState(BaseModel):
     channel_type: str = "cli"
     channel_ref: str | None = None
     title: str | None = None
-    approved_credentials: list[CredentialMetadata] = []
     approved_operations: list[str] = []
     activated_skills: list[str] = []
     context_grants: dict[str, ContextGrant] = {}
@@ -60,7 +59,6 @@ class SessionState(BaseModel):
         channel_type: str = "cli",
         channel_ref: str | None = None,
         title: str | None = None,
-        approved_credentials: list[CredentialMetadata] | None = None,
         approved_operations: list[str] | None = None,
     ) -> SessionState:
         ts = datetime.now(tz=UTC)
@@ -69,7 +67,6 @@ class SessionState(BaseModel):
             channel_type=channel_type,
             channel_ref=channel_ref,
             title=title,
-            approved_credentials=approved_credentials or [],
             approved_operations=approved_operations or [],
             created_at=ts,
             last_active=ts,

--- a/src/carapace/sandbox/manager.py
+++ b/src/carapace/sandbox/manager.py
@@ -452,7 +452,7 @@ class SandboxManager:
             are written before the command and deleted in the ``finally`` block.
         """
         contexts = contexts or []
-        written_files: list[tuple[str, str]] = []  # (session_id-relative path written, skill_name)
+        written_files: list[tuple[str, str]] = []  # (file_path, skill_name)
 
         async with self._get_exec_lock(session_id):
             if bypass_proxy:
@@ -475,25 +475,10 @@ class SandboxManager:
                     self._exec_temp_domains[session_id].update(context_domains)
                     self._exec_context_skill_domains[session_id].update(context_domains)
 
-                # Write file-based credentials before exec
-                if context_file_creds:
-                    for skill_name, file_path, vault_path in context_file_creds:
-                        value = self.get_cached_credential(session_id, vault_path)
-                        if value is None:
-                            logger.warning(
-                                f"Cached credential missing for {vault_path!r} (skill {skill_name!r}), skipping file"
-                            )
-                            continue
-                        skill_dir = f"/workspace/skills/{skill_name}"
-                        fw = await self._file_write_in_container(
-                            sc, file_path, value, mode=0o400, workdir=skill_dir, quote=False
-                        )
-                        if fw.exit_code != 0:
-                            logger.error(f"Failed to write credential file {file_path} for {skill_name}: {fw.output}")
-                        else:
-                            written_files.append((file_path, skill_name))
-
                 try:
+                    # Write file-based credentials + run the command
+                    if context_file_creds:
+                        written_files = await self._write_context_file_credentials(sc, context_file_creds)
                     return await self._exec_in_container(
                         sc, command, timeout, workdir=workdir, bypass_proxy=False, extra_env=extra_env
                     )
@@ -507,17 +492,7 @@ class SandboxManager:
                     # Re-write file credentials after container recreation
                     written_files.clear()
                     if context_file_creds:
-                        for skill_name, file_path, vault_path in context_file_creds:
-                            value = self.get_cached_credential(session_id, vault_path)
-                            if value is None:
-                                continue
-                            skill_dir = f"/workspace/skills/{skill_name}"
-                            fw = await self._file_write_in_container(
-                                sc, file_path, value, mode=0o400, workdir=skill_dir, quote=False
-                            )
-                            if fw.exit_code == 0:
-                                written_files.append((file_path, skill_name))
-
+                        written_files = await self._write_context_file_credentials(sc, context_file_creds)
                     return await self._exec_in_container(
                         sc, command, timeout, workdir=workdir, bypass_proxy=False, extra_env=extra_env
                     )
@@ -532,19 +507,7 @@ class SandboxManager:
 
                 # Delete file-based credentials written for this exec
                 if written_files:
-                    sc_now = self._sessions.get(session_id)
-                    if sc_now:
-                        for file_path, skill_name in written_files:
-                            skill_dir = f"/workspace/skills/{skill_name}"
-                            rm_path = f"{skill_dir}/{file_path}" if not file_path.startswith("/") else file_path
-                            try:
-                                await self._runtime.exec(
-                                    sc_now.container_id,
-                                    f"rm -f {shlex.quote(rm_path)}",
-                                    timeout=5,
-                                )
-                            except Exception:
-                                logger.warning(f"Failed to delete credential file {rm_path} after exec")
+                    await self._delete_context_file_credentials(session_id, written_files)
 
     _KNOWLEDGE_WORKDIR = "/workspace"
 
@@ -732,6 +695,39 @@ class SandboxManager:
             return ExecResult(exit_code=result.exit_code, output=output)
         lines = _line_count(content)
         return ExecResult(exit_code=0, output=f"Wrote {lines} line(s) to {path}.")
+
+    async def _file_delete_in_container(
+        self,
+        sc: SessionContainer,
+        path: str,
+        *,
+        workdir: str | None = None,
+        quote: bool = True,
+    ) -> ExecResult:
+        """Delete a file using an existing container while the exec lock is already held."""
+        shell_path = _shell_path(path, quote=quote)
+        cmd = f"rm -f {shell_path}"
+        return await self._exec_in_container(sc, cmd, timeout=5, workdir=workdir)
+
+    async def _write_context_file_credentials(
+        self,
+        sc: SessionContainer,
+        context_file_creds: list[tuple[str, str, str]],
+    ) -> list[tuple[str, str]]:
+        """Write file-based credentials into the container, returning written ``(file_path, skill_name)`` pairs."""
+        written: list[tuple[str, str]] = []
+        for skill_name, file_path, vault_path in context_file_creds:
+            value = self.get_cached_credential(sc.session_id, vault_path)
+            if value is None:
+                logger.warning(f"Cached credential missing for {vault_path!r} (skill {skill_name!r}), skipping file")
+                continue
+            skill_dir = f"/workspace/skills/{skill_name}"
+            fw = await self._file_write_in_container(sc, file_path, value, mode=0o400, workdir=skill_dir, quote=False)
+            if fw.exit_code != 0:
+                logger.error(f"Failed to write credential file {file_path} for {skill_name}: {fw.output}")
+            else:
+                written.append((file_path, skill_name))
+        return written
 
     async def _reinject_credential_files(self, sc: SessionContainer, skill_name: str) -> None:
         """Re-inject file-based credentials after container recreation.

--- a/src/carapace/sandbox/manager.py
+++ b/src/carapace/sandbox/manager.py
@@ -1138,6 +1138,8 @@ class SandboxManager:
         self._exec_context_skill_domains.pop(session_id, None)
         self._session_current_command.pop(session_id, None)
         self._proxy_bypass_sessions.discard(session_id)
+        self._credential_cache.pop(session_id, None)
+        self._session_current_contexts.pop(session_id, None)
         self._exec_locks.pop(session_id, None)
         self._domain_approval_cbs.pop(session_id, None)
         self._domain_notify_cbs.pop(session_id, None)

--- a/src/carapace/sandbox/manager.py
+++ b/src/carapace/sandbox/manager.py
@@ -121,6 +121,8 @@ class SandboxManager:
         self._stashed_session_env: dict[str, dict[str, str]] = {}
         self._credential_cache: dict[str, dict[str, str]] = {}  # session_id -> {vault_path: value}
         self._session_current_contexts: dict[str, list[str]] = {}
+        self._exec_notified_domains: dict[str, set[str]] = {}  # dedupe silent-allow domain UI notifications
+        self._exec_notified_credentials: dict[str, set[str]] = {}  # dedupe credential UI notifications
         self._get_activated_skills_cb: Callable[[str], list[str]] | None = None
         self._reinject_credentials_cb: Callable[[str, str], Awaitable[list[tuple[str, str]]]] | None = None
         logger.info(
@@ -469,6 +471,8 @@ class SandboxManager:
                 self._session_current_contexts[session_id] = contexts
                 self._exec_temp_domains[session_id] = set()
                 self._exec_context_skill_domains[session_id] = set()
+                self._exec_notified_domains[session_id] = set()
+                self._exec_notified_credentials[session_id] = set()
 
                 # Add context-scoped domains to exec-temp allowlist
                 if context_domains:
@@ -504,6 +508,8 @@ class SandboxManager:
                 self._session_current_contexts.pop(session_id, None)
                 self._exec_temp_domains.pop(session_id, None)
                 self._exec_context_skill_domains.pop(session_id, None)
+                self._exec_notified_domains.pop(session_id, None)
+                self._exec_notified_credentials.pop(session_id, None)
 
                 # Delete file-based credentials written for this exec
                 if written_files:
@@ -866,6 +872,8 @@ class SandboxManager:
         self._proxy_bypass_sessions.discard(session_id)
         self._credential_cache.pop(session_id, None)
         self._session_current_contexts.pop(session_id, None)
+        self._exec_notified_domains.pop(session_id, None)
+        self._exec_notified_credentials.pop(session_id, None)
 
     async def reset_session(self, session_id: str) -> None:
         """Full sandbox reset: destroy and let ``ensure_session`` create a fresh one."""
@@ -996,11 +1004,22 @@ class SandboxManager:
         """Return True if the session is currently in proxy bypass mode."""
         return session_id in self._proxy_bypass_sessions
 
+    def mark_credential_notified(self, session_id: str, vault_path: str) -> bool:
+        """Return True if *vault_path* was already notified in this exec; otherwise mark it."""
+        notified = self._exec_notified_credentials.get(session_id)
+        if notified is None:
+            return False
+        if vault_path in notified:
+            return True
+        notified.add(vault_path)
+        return False
+
     def notify_domain_access(self, session_id: str, domain: str, allowed: bool) -> None:
         """Called by the proxy for silently allowed/denied domain accesses.
 
         Determines the approval source (skill, bypass, permanent allowlist)
-        and fires the session's domain info callback.
+        and fires the session's domain info callback.  Skill-granted and
+        bypass domains are notified at most once per exec to avoid UI spam.
         """
         cb = self._domain_notify_cbs.get(session_id)
         if cb is None:
@@ -1008,8 +1027,18 @@ class SandboxManager:
 
         if allowed:
             if self.is_domain_bypass(session_id):
+                notified = self._exec_notified_domains.get(session_id)
+                if notified is not None and domain in notified:
+                    return
+                if notified is not None:
+                    notified.add(domain)
                 cb(domain, f"[bypass] {domain}", "bypass", "allow", "proxy bypass active")
             elif self.is_domain_skill_granted(session_id, domain):
+                notified = self._exec_notified_domains.get(session_id)
+                if notified is not None and domain in notified:
+                    return
+                if notified is not None:
+                    notified.add(domain)
                 cb(domain, f"[skill] {domain}", "skill", "allow", "skill-declared domain")
             else:
                 # Permanently allowed or exec-temp sentinel-approved (already notified by sentinel)
@@ -1101,3 +1130,5 @@ class SandboxManager:
         self._exec_locks.pop(session_id, None)
         self._domain_approval_cbs.pop(session_id, None)
         self._domain_notify_cbs.pop(session_id, None)
+        self._exec_notified_domains.pop(session_id, None)
+        self._exec_notified_credentials.pop(session_id, None)

--- a/src/carapace/sandbox/manager.py
+++ b/src/carapace/sandbox/manager.py
@@ -1127,6 +1127,12 @@ class SandboxManager:
         token file is not removed — it lives in the session directory and
         will be overwritten on the next attempt or deleted when the session
         is permanently removed.
+
+        Credential cache entries are **not** cleared: values are tied to the
+        session (``use_skill``), not to a specific container, and must survive
+        a transient create failure so the next ``ensure_session`` can inject
+        them on ``exec``.  ``destroy_session`` clears the cache when all
+        session tracking is purged.
         """
         self._sessions.pop(session_id, None)
         self._stashed_session_env.pop(session_id, None)
@@ -1138,7 +1144,6 @@ class SandboxManager:
         self._exec_context_skill_domains.pop(session_id, None)
         self._session_current_command.pop(session_id, None)
         self._proxy_bypass_sessions.discard(session_id)
-        self._credential_cache.pop(session_id, None)
         self._session_current_contexts.pop(session_id, None)
         self._exec_locks.pop(session_id, None)
         self._domain_approval_cbs.pop(session_id, None)

--- a/src/carapace/sandbox/manager.py
+++ b/src/carapace/sandbox/manager.py
@@ -644,7 +644,7 @@ class SandboxManager:
         parts = [f"Skill '{skill_name}' activated at /workspace/skills/{skill_name}/"]
         if venv_msg:
             parts.append(venv_msg)
-        return " ".join(parts)
+        return "\n".join(parts)
 
     async def _build_skill_venv(self, session_id: str, skill_name: str) -> None:
         """Build a skill venv inside the session container with proxy bypass.

--- a/src/carapace/sandbox/manager.py
+++ b/src/carapace/sandbox/manager.py
@@ -747,9 +747,15 @@ class SandboxManager:
         for file_path, skill_name in written_files:
             skill_dir = f"/workspace/skills/{skill_name}"
             try:
-                await self._file_delete_in_container(sc, file_path, workdir=skill_dir, quote=False)
-            except Exception:
-                logger.warning(f"Failed to delete credential file {file_path} (skill {skill_name!r}) after exec")
+                dr = await self._file_delete_in_container(sc, file_path, workdir=skill_dir, quote=False)
+            except ContainerGoneError as exc:
+                logger.warning(f"Could not delete credential file {file_path} (skill {skill_name!r}) after exec: {exc}")
+                continue
+            if dr.exit_code != 0:
+                logger.warning(
+                    f"Failed to delete credential file {file_path} (skill {skill_name!r}) after exec: "
+                    f"{dr.output or '(no output)'}"
+                )
 
     async def _reinject_credential_files(self, sc: SessionContainer, skill_name: str) -> None:
         """Re-inject file-based credentials after container recreation.

--- a/src/carapace/sandbox/manager.py
+++ b/src/carapace/sandbox/manager.py
@@ -729,6 +729,22 @@ class SandboxManager:
                 written.append((file_path, skill_name))
         return written
 
+    async def _delete_context_file_credentials(
+        self,
+        session_id: str,
+        written_files: list[tuple[str, str]],
+    ) -> None:
+        """Delete file-based credentials that were written for an exec."""
+        sc = self._sessions.get(session_id)
+        if sc is None:
+            return
+        for file_path, skill_name in written_files:
+            skill_dir = f"/workspace/skills/{skill_name}"
+            try:
+                await self._file_delete_in_container(sc, file_path, workdir=skill_dir, quote=False)
+            except Exception:
+                logger.warning(f"Failed to delete credential file {file_path} (skill {skill_name!r}) after exec")
+
     async def _reinject_credential_files(self, sc: SessionContainer, skill_name: str) -> None:
         """Re-inject file-based credentials after container recreation.
 

--- a/src/carapace/sandbox/manager.py
+++ b/src/carapace/sandbox/manager.py
@@ -748,7 +748,8 @@ class SandboxManager:
             skill_dir = f"/workspace/skills/{skill_name}"
             try:
                 dr = await self._file_delete_in_container(sc, file_path, workdir=skill_dir, quote=False)
-            except ContainerGoneError as exc:
+            except Exception as exc:
+                # Never let cleanup failures replace the exec's original exception (finally runs during unwind).
                 logger.warning(f"Could not delete credential file {file_path} (skill {skill_name!r}) after exec: {exc}")
                 continue
             if dr.exit_code != 0:

--- a/src/carapace/sandbox/manager.py
+++ b/src/carapace/sandbox/manager.py
@@ -443,6 +443,7 @@ class SandboxManager:
         extra_env: dict[str, str] | None = None,
         context_domains: set[str] | None = None,
         context_file_creds: list[tuple[str, str, str]] | None = None,
+        after_exec_credential_notify: Callable[[], None] | None = None,
     ) -> ExecResult:
         """Run a command in the sandbox and return the raw ExecResult.
 
@@ -456,6 +457,9 @@ class SandboxManager:
         *context_domains*: skill-declared domains to add to exec-scoped temp allowlist.
         *context_file_creds*: ``(skill_name, file_path, vault_path)`` tuples; files
             are written before the command and deleted in the ``finally`` block.
+        *after_exec_credential_notify*: optional sync hook invoked after the container
+            command finishes but **before** per-exec notification state is torn down,
+            so UI dedupe via `mark_credential_notified` still applies.
         """
         contexts = contexts or []
         written_files: list[tuple[str, str]] = []  # (file_path, skill_name)
@@ -487,7 +491,7 @@ class SandboxManager:
                     # Write file-based credentials + run the command
                     if context_file_creds:
                         written_files = await self._write_context_file_credentials(sc, context_file_creds)
-                    return await self._exec_in_container(
+                    exec_result = await self._exec_in_container(
                         sc, command, timeout, workdir=workdir, bypass_proxy=False, extra_env=extra_env
                     )
                 except ContainerGoneError:
@@ -501,9 +505,13 @@ class SandboxManager:
                     written_files.clear()
                     if context_file_creds:
                         written_files = await self._write_context_file_credentials(sc, context_file_creds)
-                    return await self._exec_in_container(
+                    exec_result = await self._exec_in_container(
                         sc, command, timeout, workdir=workdir, bypass_proxy=False, extra_env=extra_env
                     )
+
+                if after_exec_credential_notify is not None:
+                    after_exec_credential_notify()
+                return exec_result
             finally:
                 if bypass_proxy:
                     self._proxy_bypass_sessions.discard(session_id)
@@ -531,6 +539,7 @@ class SandboxManager:
         extra_env: dict[str, str] | None = None,
         context_domains: set[str] | None = None,
         context_file_creds: list[tuple[str, str, str]] | None = None,
+        after_exec_credential_notify: Callable[[], None] | None = None,
     ) -> ExecResult:
         """Run a command in the sandbox and return the result.
 
@@ -539,6 +548,7 @@ class SandboxManager:
         *context_domains*: domains to add to exec-scoped temp allowlist.
         *context_file_creds*: ``(skill_name, file_path, vault_path)`` tuples for file-based
             credentials to be written before exec and deleted after.
+        *after_exec_credential_notify*: passed through to `_exec` (see there).
         """
         result = await self._exec(
             session_id,
@@ -549,6 +559,7 @@ class SandboxManager:
             extra_env=extra_env,
             context_domains=context_domains,
             context_file_creds=context_file_creds,
+            after_exec_credential_notify=after_exec_credential_notify,
         )
         output = result.output
         if result.exit_code != 0 and f"[exit code: {result.exit_code}]" not in output:

--- a/src/carapace/sandbox/manager.py
+++ b/src/carapace/sandbox/manager.py
@@ -112,11 +112,15 @@ class SandboxManager:
         self._session_tokens: dict[str, str] = {}
         self._allowed_domains: dict[str, set[str]] = {}
         self._exec_temp_domains: dict[str, set[str]] = {}  # session_id -> domains, cleared after each exec
+        self._exec_context_skill_domains: dict[str, set[str]] = {}  # skill-sourced subset of exec_temp_domains
         self._session_current_command: dict[str, str] = {}
         self._domain_approval_cbs: dict[str, Callable[[str, str], Awaitable[bool]]] = {}
+        self._domain_notify_cbs: dict[str, Callable[[str, str, str | None, str | None, str | None], None]] = {}
         self._exec_locks: dict[str, asyncio.Lock] = {}
         self._proxy_bypass_sessions: set[str] = set()
         self._stashed_session_env: dict[str, dict[str, str]] = {}
+        self._credential_cache: dict[str, dict[str, str]] = {}  # session_id -> {vault_path: value}
+        self._session_current_contexts: dict[str, list[str]] = {}
         self._get_activated_skills_cb: Callable[[str], list[str]] | None = None
         self._reinject_credentials_cb: Callable[[str, str], Awaitable[list[tuple[str, str]]]] | None = None
         logger.info(
@@ -391,23 +395,30 @@ class SandboxManager:
         *,
         bypass_proxy: bool = False,
         workdir: str | None = None,
+        extra_env: dict[str, str] | None = None,
     ) -> ExecResult:
         """Run *command* in *sc* without acquiring the exec lock.
 
         When *bypass_proxy* is True, the bypass window covers only this call.
         Callers running under ``_exec`` with bypass already enabled must pass
         ``bypass_proxy=False`` so the session is not added to the set twice.
+
+        *extra_env* is merged on top of the session env for this single exec
+        (used for per-exec credential injection via contexts).
         """
         if bypass_proxy:
             self._proxy_bypass_sessions.add(sc.session_id)
             logger.info(f"Proxy bypass ENABLED for session {sc.session_id}")
         try:
+            env = sc.session_env or None
+            if extra_env:
+                env = {**(sc.session_env or {}), **extra_env}
             return await self._runtime.exec(
                 sc.container_id,
                 command,
                 timeout=timeout,
                 workdir=workdir,
-                env=sc.session_env or None,
+                env=env,
             )
         finally:
             if bypass_proxy:
@@ -422,6 +433,10 @@ class SandboxManager:
         *,
         bypass_proxy: bool = False,
         workdir: str | None = None,
+        contexts: list[str] | None = None,
+        extra_env: dict[str, str] | None = None,
+        context_domains: set[str] | None = None,
+        context_file_creds: list[tuple[str, str, str]] | None = None,
     ) -> ExecResult:
         """Run a command in the sandbox and return the raw ExecResult.
 
@@ -429,7 +444,16 @@ class SandboxManager:
         for the duration of this exec (used during venv builds).  The bypass
         flag is set/cleared **under the exec lock** so no concurrent command
         can exploit the open window.
+
+        *contexts*: activated skill names active for this exec.
+        *extra_env*: per-exec env vars (credential values).
+        *context_domains*: skill-declared domains to add to exec-scoped temp allowlist.
+        *context_file_creds*: ``(skill_name, file_path, vault_path)`` tuples; files
+            are written before the command and deleted in the ``finally`` block.
         """
+        contexts = contexts or []
+        written_files: list[tuple[str, str]] = []  # (session_id-relative path written, skill_name)
+
         async with self._get_exec_lock(session_id):
             if bypass_proxy:
                 self._proxy_bypass_sessions.add(session_id)
@@ -442,32 +466,116 @@ class SandboxManager:
                 logger.debug(f"Exec in session {session_id}: {command}")
 
                 self._session_current_command[session_id] = command
+                self._session_current_contexts[session_id] = contexts
                 self._exec_temp_domains[session_id] = set()
+                self._exec_context_skill_domains[session_id] = set()
+
+                # Add context-scoped domains to exec-temp allowlist
+                if context_domains:
+                    self._exec_temp_domains[session_id].update(context_domains)
+                    self._exec_context_skill_domains[session_id].update(context_domains)
+
+                # Write file-based credentials before exec
+                if context_file_creds:
+                    for skill_name, file_path, vault_path in context_file_creds:
+                        value = self.get_cached_credential(session_id, vault_path)
+                        if value is None:
+                            logger.warning(
+                                f"Cached credential missing for {vault_path!r} (skill {skill_name!r}), skipping file"
+                            )
+                            continue
+                        skill_dir = f"/workspace/skills/{skill_name}"
+                        fw = await self._file_write_in_container(
+                            sc, file_path, value, mode=0o400, workdir=skill_dir, quote=False
+                        )
+                        if fw.exit_code != 0:
+                            logger.error(f"Failed to write credential file {file_path} for {skill_name}: {fw.output}")
+                        else:
+                            written_files.append((file_path, skill_name))
+
                 try:
-                    return await self._exec_in_container(sc, command, timeout, workdir=workdir, bypass_proxy=False)
+                    return await self._exec_in_container(
+                        sc, command, timeout, workdir=workdir, bypass_proxy=False, extra_env=extra_env
+                    )
                 except ContainerGoneError:
                     logger.warning(f"Container gone for session {session_id}, recreating sandbox")
                     await self._log_container_tail(sc.container_id, session_id)
                     self._prepare_session_recreate(session_id)
                     sc, _ = await self.ensure_session(session_id)
                     await self._rebuild_skill_venvs(session_id)
-                    return await self._exec_in_container(sc, command, timeout, workdir=workdir, bypass_proxy=False)
+
+                    # Re-write file credentials after container recreation
+                    written_files.clear()
+                    if context_file_creds:
+                        for skill_name, file_path, vault_path in context_file_creds:
+                            value = self.get_cached_credential(session_id, vault_path)
+                            if value is None:
+                                continue
+                            skill_dir = f"/workspace/skills/{skill_name}"
+                            fw = await self._file_write_in_container(
+                                sc, file_path, value, mode=0o400, workdir=skill_dir, quote=False
+                            )
+                            if fw.exit_code == 0:
+                                written_files.append((file_path, skill_name))
+
+                    return await self._exec_in_container(
+                        sc, command, timeout, workdir=workdir, bypass_proxy=False, extra_env=extra_env
+                    )
             finally:
                 if bypass_proxy:
                     self._proxy_bypass_sessions.discard(session_id)
                     logger.info(f"Proxy bypass DISABLED for session {session_id}")
                 self._session_current_command.pop(session_id, None)
+                self._session_current_contexts.pop(session_id, None)
                 self._exec_temp_domains.pop(session_id, None)
+                self._exec_context_skill_domains.pop(session_id, None)
+
+                # Delete file-based credentials written for this exec
+                if written_files:
+                    sc_now = self._sessions.get(session_id)
+                    if sc_now:
+                        for file_path, skill_name in written_files:
+                            skill_dir = f"/workspace/skills/{skill_name}"
+                            rm_path = f"{skill_dir}/{file_path}" if not file_path.startswith("/") else file_path
+                            try:
+                                await self._runtime.exec(
+                                    sc_now.container_id,
+                                    f"rm -f {shlex.quote(rm_path)}",
+                                    timeout=5,
+                                )
+                            except Exception:
+                                logger.warning(f"Failed to delete credential file {rm_path} after exec")
 
     _KNOWLEDGE_WORKDIR = "/workspace"
 
-    async def exec_command(self, session_id: str, command: str, timeout: int = 3600) -> ExecResult:
-        """Run a command in the sandbox and return the result."""
+    async def exec_command(
+        self,
+        session_id: str,
+        command: str,
+        timeout: int = 3600,
+        *,
+        contexts: list[str] | None = None,
+        extra_env: dict[str, str] | None = None,
+        context_domains: set[str] | None = None,
+        context_file_creds: list[tuple[str, str, str]] | None = None,
+    ) -> ExecResult:
+        """Run a command in the sandbox and return the result.
+
+        *contexts*: activated skill names active for this exec.
+        *extra_env*: per-exec env vars (credential values) — merged on top of session env.
+        *context_domains*: domains to add to exec-scoped temp allowlist.
+        *context_file_creds*: ``(skill_name, file_path, vault_path)`` tuples for file-based
+            credentials to be written before exec and deleted after.
+        """
         result = await self._exec(
             session_id,
             command,
             timeout=timeout,
             workdir=self._KNOWLEDGE_WORKDIR,
+            contexts=contexts,
+            extra_env=extra_env,
+            context_domains=context_domains,
+            context_file_creds=context_file_creds,
         )
         output = result.output
         if result.exit_code != 0 and f"[exit code: {result.exit_code}]" not in output:
@@ -626,6 +734,12 @@ class SandboxManager:
         return ExecResult(exit_code=0, output=f"Wrote {lines} line(s) to {path}.")
 
     async def _reinject_credential_files(self, sc: SessionContainer, skill_name: str) -> None:
+        """Re-inject file-based credentials after container recreation.
+
+        With context-scoped grants, file credentials are normally injected
+        per-exec.  This method is kept as a fallback for container rebuilds
+        that happen outside an exec context (e.g. venv rebuild).
+        """
         if not self._reinject_credentials_cb:
             return
         credentials = await self._reinject_credentials_cb(sc.session_id, skill_name)
@@ -732,10 +846,14 @@ class SandboxManager:
             self._token_to_session.pop(token, None)
         self._allowed_domains.pop(session_id, None)
         self._exec_temp_domains.pop(session_id, None)
+        self._exec_context_skill_domains.pop(session_id, None)
         self._session_current_command.pop(session_id, None)
         self._domain_approval_cbs.pop(session_id, None)
+        self._domain_notify_cbs.pop(session_id, None)
         self._exec_locks.pop(session_id, None)
         self._proxy_bypass_sessions.discard(session_id)
+        self._credential_cache.pop(session_id, None)
+        self._session_current_contexts.pop(session_id, None)
 
     async def reset_session(self, session_id: str) -> None:
         """Full sandbox reset: destroy and let ``ensure_session`` create a fresh one."""
@@ -839,6 +957,57 @@ class SandboxManager:
         return domains
 
     # ------------------------------------------------------------------
+    # Credential cache (per-exec injection, not session_env)
+    # ------------------------------------------------------------------
+
+    def cache_credential(self, session_id: str, vault_path: str, value: str) -> None:
+        """Store a credential value in memory for later per-exec injection."""
+        self._credential_cache.setdefault(session_id, {})[vault_path] = value
+
+    def get_cached_credential(self, session_id: str, vault_path: str) -> str | None:
+        """Return a cached credential value, or *None* if not cached."""
+        return self._credential_cache.get(session_id, {}).get(vault_path)
+
+    def get_current_contexts(self, session_id: str) -> list[str]:
+        """Return the contexts active for the current exec, if any."""
+        return self._session_current_contexts.get(session_id, [])
+
+    def is_domain_skill_granted(self, session_id: str, domain: str) -> bool:
+        """Return True if *domain* is in the exec-scoped skill-granted set."""
+        from carapace.sandbox.proxy import domain_matches
+
+        skill_domains = self._exec_context_skill_domains.get(session_id, set())
+        domain_lower = domain.lower()
+        return any(domain_matches(domain_lower, p.lower()) for p in skill_domains)
+
+    def is_domain_bypass(self, session_id: str) -> bool:
+        """Return True if the session is currently in proxy bypass mode."""
+        return session_id in self._proxy_bypass_sessions
+
+    def notify_domain_access(self, session_id: str, domain: str, allowed: bool) -> None:
+        """Called by the proxy for silently allowed/denied domain accesses.
+
+        Determines the approval source (skill, bypass, permanent allowlist)
+        and fires the session's domain info callback.
+        """
+        cb = self._domain_notify_cbs.get(session_id)
+        if cb is None:
+            return
+
+        if allowed:
+            if self.is_domain_bypass(session_id):
+                cb(domain, f"[bypass] {domain}", "bypass", "allow", "proxy bypass active")
+            elif self.is_domain_skill_granted(session_id, domain):
+                cb(domain, f"[skill] {domain}", "skill", "allow", "skill-declared domain")
+            else:
+                # Permanently allowed or exec-temp sentinel-approved (already notified by sentinel)
+                # Don't double-notify for sentinel-approved domains
+                pass
+        else:
+            # Denied without sentinel evaluation (no approval callback set)
+            cb(domain, f"[denied] {domain}", "unknown", "deny", "no approval callback configured")
+
+    # ------------------------------------------------------------------
     # Proxy domain approval
     # ------------------------------------------------------------------
 
@@ -848,6 +1017,20 @@ class SandboxManager:
             self._domain_approval_cbs.pop(session_id, None)
         else:
             self._domain_approval_cbs[session_id] = cb
+
+    def set_domain_notify_callback(
+        self,
+        session_id: str,
+        cb: Callable[[str, str, str | None, str | None, str | None], None] | None,
+    ) -> None:
+        """Register or remove a per-session domain access notification callback.
+
+        Signature: ``cb(domain, detail, approval_source, approval_verdict, approval_explanation)``.
+        """
+        if cb is None:
+            self._domain_notify_cbs.pop(session_id, None)
+        else:
+            self._domain_notify_cbs[session_id] = cb
 
     async def request_domain_approval(self, session_id: str, domain: str) -> bool:
         """Called by the proxy when a domain is not in the allowlist.
@@ -900,7 +1083,9 @@ class SandboxManager:
             self._token_to_session.pop(token, None)
         self._allowed_domains.pop(session_id, None)
         self._exec_temp_domains.pop(session_id, None)
+        self._exec_context_skill_domains.pop(session_id, None)
         self._session_current_command.pop(session_id, None)
         self._proxy_bypass_sessions.discard(session_id)
         self._exec_locks.pop(session_id, None)
         self._domain_approval_cbs.pop(session_id, None)
+        self._domain_notify_cbs.pop(session_id, None)

--- a/src/carapace/sandbox/manager.py
+++ b/src/carapace/sandbox/manager.py
@@ -25,6 +25,7 @@ from carapace.sandbox.runtime import (
     SandboxConfig,
     SkillVenvError,
 )
+from carapace.security.context import ApprovalSource, ApprovalVerdict
 
 _SKILL_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
 
@@ -115,7 +116,10 @@ class SandboxManager:
         self._exec_context_skill_domains: dict[str, set[str]] = {}  # skill-sourced subset of exec_temp_domains
         self._session_current_command: dict[str, str] = {}
         self._domain_approval_cbs: dict[str, Callable[[str, str], Awaitable[bool]]] = {}
-        self._domain_notify_cbs: dict[str, Callable[[str, str, str | None, str | None, str | None], None]] = {}
+        self._domain_notify_cbs: dict[
+            str,
+            Callable[[str, str, ApprovalSource | None, ApprovalVerdict | None, str | None], None],
+        ] = {}
         self._exec_locks: dict[str, asyncio.Lock] = {}
         self._proxy_bypass_sessions: set[str] = set()
         self._stashed_session_env: dict[str, dict[str, str]] = {}
@@ -637,10 +641,10 @@ class SandboxManager:
                 ) from exc
 
         logger.info(f"Activated skill '{skill_name}' in session {session_id}")
-        result = f"Skill '{skill_name}' activated at /workspace/skills/{skill_name}/"
+        parts = [f"Skill '{skill_name}' activated at /workspace/skills/{skill_name}/"]
         if venv_msg:
-            result += f"\n{venv_msg}"
-        return result
+            parts.append(venv_msg)
+        return " ".join(parts)
 
     async def _build_skill_venv(self, session_id: str, skill_name: str) -> None:
         """Build a skill venv inside the session container with proxy bypass.
@@ -1069,7 +1073,7 @@ class SandboxManager:
     def set_domain_notify_callback(
         self,
         session_id: str,
-        cb: Callable[[str, str, str | None, str | None, str | None], None] | None,
+        cb: Callable[[str, str, ApprovalSource | None, ApprovalVerdict | None, str | None], None] | None,
     ) -> None:
         """Register or remove a per-session domain access notification callback.
 

--- a/src/carapace/sandbox/proxy.py
+++ b/src/carapace/sandbox/proxy.py
@@ -40,12 +40,14 @@ class ProxyServer:
         verify_session_token: Callable[[str, str], bool],
         get_allowed_domains: Callable[[str], set[str]],
         request_approval: Callable[[str, str], Awaitable[bool]] | None = None,
+        notify_domain_access: Callable[[str, str, bool], None] | None = None,
         host: str = "0.0.0.0",
         port: int = 3128,
     ) -> None:
         self._verify_session_token = verify_session_token
         self._get_domains = get_allowed_domains
         self._request_approval = request_approval
+        self._notify_domain_access = notify_domain_access
         self._host = host
         self._port = port
         self._server: asyncio.Server | None = None
@@ -322,11 +324,19 @@ class ProxyServer:
         denied immediately.
         """
         if self._is_allowed(session_id, domain):
+            if self._notify_domain_access:
+                self._notify_domain_access(session_id, domain, True)
             return True
         if self._request_approval is None:
+            if self._notify_domain_access:
+                self._notify_domain_access(session_id, domain, False)
             return False
         logger.info(f"Proxy: suspending connection to {domain} (session={session_id}), requesting approval")
-        return await self._request_approval(session_id, domain)
+        allowed = await self._request_approval(session_id, domain)
+        # Note: request_approval already notifies for sentinel/user outcomes,
+        # but for denied-without-callback and silently-allowed cases, we
+        # notify above.
+        return allowed
 
     def _is_allowed(self, session_id: str, domain: str) -> bool:
         allowed = self._get_domains(session_id)

--- a/src/carapace/security/__init__.py
+++ b/src/carapace/security/__init__.py
@@ -342,30 +342,18 @@ async def evaluate_credential_with(
     cred_decision: Literal["approved", "escalated", "denied"] = (
         "approved" if decision == "allowed" else "denied" if decision == "denied" else "escalated"
     )
-    entry = CredentialAccessEntry(
+    source: ApprovalSource = "sentinel" if verdict.decision != "escalate" else "user"
+    approval_verdict: ApprovalVerdict = "allow" if allowed else "deny"
+
+    session.record_credential_access(
         vault_paths=[vault_path],
         decision=cred_decision,
         explanation=verdict.explanation,
-    )
-    session.append(entry)
-
-    source: ApprovalSource = "sentinel" if verdict.decision != "escalate" else "user"
-    approval_verdict: ApprovalVerdict = "allow" if allowed else "deny"
-    session.notify_credential_decision(
-        vault_path,
-        detail,
+        ui_label=detail,
         approval_source=source,
         approval_verdict=approval_verdict,
-        approval_explanation=verdict.explanation,
-    )
-
-    session.write_audit(
-        AuditEntry.now(
-            kind="credential_access",
-            sentinel_verdict=verdict,
-            final_decision=decision,
-            explanation=verdict.explanation,
-        )
+        audit_final=decision,
+        sentinel_verdict=verdict,
     )
 
     return CredentialAccessEvaluation(

--- a/src/carapace/security/context.py
+++ b/src/carapace/security/context.py
@@ -293,6 +293,39 @@ class SessionSecurity:
         if self._credential_info_callback is not None:
             self._credential_info_callback(vault_path, detail, approval_source, approval_verdict, approval_explanation)
 
+    def record_credential_access(
+        self,
+        *,
+        vault_paths: list[str],
+        decision: Literal["approved", "escalated", "denied"],
+        explanation: str,
+        ui_label: str,
+        approval_source: ApprovalSource,
+        approval_verdict: ApprovalVerdict,
+        audit_final: Literal["auto_allowed", "allowed", "escalated", "denied"],
+        audit_args: dict[str, Any] | None = None,
+        sentinel_verdict: SentinelVerdict | None = None,
+    ) -> None:
+        """Record a credential access in action log, audit log, and UI notification."""
+        self.append(CredentialAccessEntry(vault_paths=vault_paths, decision=decision, explanation=explanation))
+        self.write_audit(
+            AuditEntry.now(
+                kind="credential_access",
+                sentinel_verdict=sentinel_verdict,
+                final_decision=audit_final,
+                args_summary=audit_args or {},
+                explanation=explanation,
+            ),
+        )
+        display_path = vault_paths[0] if len(vault_paths) == 1 else "<list>"
+        self.notify_credential_decision(
+            display_path,
+            ui_label,
+            approval_source=approval_source,
+            approval_verdict=approval_verdict,
+            approval_explanation=explanation,
+        )
+
     async def escalate_to_user(self, subject: str, context: dict[str, Any]) -> bool:
         if self._user_escalation_callback is None:
             logger.warning(f"No user escalation callback for session {self.session_id}, denying {subject}")

--- a/src/carapace/security/context.py
+++ b/src/carapace/security/context.py
@@ -73,6 +73,13 @@ class CredentialAccessEntry(BaseModel):
     explanation: str = ""
 
 
+class ContextGrantEntry(BaseModel):
+    type: Literal["context_grant"] = "context_grant"
+    skill_name: str
+    domains: list[str] = []
+    vault_paths: list[str] = []
+
+
 ActionLogEntry = Annotated[
     UserMessageEntry
     | ToolCallEntry
@@ -82,7 +89,8 @@ ActionLogEntry = Annotated[
     | SkillActivatedEntry
     | UserVouchedEntry
     | GitPushEntry
-    | CredentialAccessEntry,
+    | CredentialAccessEntry
+    | ContextGrantEntry,
     Field(discriminator="type"),
 ]
 
@@ -96,7 +104,7 @@ class SentinelVerdict(BaseModel):
     risk_level: Literal["low", "medium", "high"] = "medium"
 
 
-ApprovalSource = Literal["safe-list", "sentinel", "user", "unknown"]
+ApprovalSource = Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"]
 ApprovalVerdict = Literal["allow", "deny", "escalate"]
 
 
@@ -155,6 +163,7 @@ class SessionSecurity:
             | UserVouchedEntry
             | GitPushEntry
             | CredentialAccessEntry
+            | ContextGrantEntry
         ] = []
         self.sentinel_eval_count: int = 0
         self._last_synced_idx: int = 0
@@ -185,6 +194,7 @@ class SessionSecurity:
         | UserVouchedEntry
         | GitPushEntry
         | CredentialAccessEntry
+        | ContextGrantEntry
     ]:
         """Return action log entries added since the last sentinel sync."""
         entries = self.action_log[self._last_synced_idx :]

--- a/src/carapace/security/context.py
+++ b/src/carapace/security/context.py
@@ -178,6 +178,7 @@ class SessionSecurity:
         self._credential_info_callback: (
             Callable[[str, str, ApprovalSource | None, ApprovalVerdict | None, str | None], None] | None
         ) = None
+        self._credential_notify_suppress: Callable[[str], bool] | None = None
 
     def append(self, entry: ActionLogEntry) -> None:
         self.action_log.append(entry)
@@ -282,7 +283,21 @@ class SessionSecurity:
         """
         self._credential_info_callback = callback
 
-    def notify_credential_decision(
+    def set_credential_notify_suppress(
+        self,
+        suppress: Callable[[str], bool] | None,
+    ) -> None:
+        """Set per-exec duplicate suppression for credential UI + logs.
+
+        When set, *suppress* is called with the same vault-path key used for UI
+        (single path or ``\"<list>\"`` for batched list operations). If it
+        returns True, ``record_credential_access`` and ``notify_credential_decision``
+        skip all side effects for that key (action log, audit, session events,
+        websocket). Typically wired to ``SandboxManager.mark_credential_notified``.
+        """
+        self._credential_notify_suppress = suppress
+
+    def _emit_credential_ui(
         self,
         vault_path: str,
         detail: str,
@@ -292,6 +307,18 @@ class SessionSecurity:
     ) -> None:
         if self._credential_info_callback is not None:
             self._credential_info_callback(vault_path, detail, approval_source, approval_verdict, approval_explanation)
+
+    def notify_credential_decision(
+        self,
+        vault_path: str,
+        detail: str,
+        approval_source: ApprovalSource | None = None,
+        approval_verdict: ApprovalVerdict | None = None,
+        approval_explanation: str | None = None,
+    ) -> None:
+        if self._credential_notify_suppress is not None and self._credential_notify_suppress(vault_path):
+            return
+        self._emit_credential_ui(vault_path, detail, approval_source, approval_verdict, approval_explanation)
 
     def record_credential_access(
         self,
@@ -307,6 +334,9 @@ class SessionSecurity:
         sentinel_verdict: SentinelVerdict | None = None,
     ) -> None:
         """Record a credential access in action log, audit log, and UI notification."""
+        display_path = vault_paths[0] if len(vault_paths) == 1 else "<list>"
+        if self._credential_notify_suppress is not None and self._credential_notify_suppress(display_path):
+            return
         self.append(CredentialAccessEntry(vault_paths=vault_paths, decision=decision, explanation=explanation))
         self.write_audit(
             AuditEntry.now(
@@ -317,8 +347,7 @@ class SessionSecurity:
                 explanation=explanation,
             ),
         )
-        display_path = vault_paths[0] if len(vault_paths) == 1 else "<list>"
-        self.notify_credential_decision(
+        self._emit_credential_ui(
             display_path,
             ui_label,
             approval_source=approval_source,

--- a/src/carapace/security/sentinel.py
+++ b/src/carapace/security/sentinel.py
@@ -12,6 +12,7 @@ from carapace.security.context import (
     ActionLogEntry,
     AgentResponseEntry,
     ApprovalEntry,
+    ContextGrantEntry,
     CredentialAccessEntry,
     GitPushEntry,
     SentinelVerdict,
@@ -85,6 +86,13 @@ def _format_entry(entry: ActionLogEntry) -> str:
             if explanation:
                 line += f" ({explanation})"
             return line
+        case ContextGrantEntry(skill_name=name, domains=domains, vault_paths=vault_paths):
+            parts = [f"[context_grant]: {name}"]
+            if domains:
+                parts.append(f"domains={sorted(domains)}")
+            if vault_paths:
+                parts.append(f"credentials={sorted(vault_paths)}")
+            return " ".join(parts)
         case _:
             return f"[unknown]: {entry}"
 

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -568,11 +568,14 @@ class WebSocketSubscriber:
         approval_verdict: ApprovalVerdict | None = None,
         approval_explanation: str | None = None,
     ) -> None:
+        contexts_raw = args.get("contexts")
+        contexts = list(contexts_raw) if isinstance(contexts_raw, list) else []
         await self._safe_send(
             ToolCallInfo(
                 tool=tool,
                 args=args,
                 detail=detail,
+                contexts=contexts,
                 approval_source=approval_source,
                 approval_verdict=approval_verdict,
                 approval_explanation=approval_explanation,

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -43,7 +43,7 @@ from carapace.models import Config, SessionState, ToolResult
 from carapace.sandbox.manager import SandboxManager
 from carapace.sandbox.proxy import ProxyServer
 from carapace.sandbox.runtime import ContainerRuntime
-from carapace.security.context import AuditEntry, CredentialAccessEntry
+from carapace.security.context import ApprovalSource, ApprovalVerdict, AuditEntry, CredentialAccessEntry
 from carapace.session import SessionEngine, SessionManager
 from carapace.skills import SkillRegistry
 from carapace.usage import gauge_breakdown_pct_dict, last_record_for_source
@@ -469,8 +469,8 @@ class HistoryMessage(BaseModel):
     tool: str | None = None
     args: dict[str, Any] | None = None
     detail: str | None = None
-    approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None
-    approval_verdict: Literal["allow", "deny", "escalate"] | None = None
+    approval_source: ApprovalSource | None = None
+    approval_verdict: ApprovalVerdict | None = None
     approval_explanation: str | None = None
     result: str | None = None
     command: str | None = None
@@ -564,8 +564,8 @@ class WebSocketSubscriber:
         tool: str,
         args: dict[str, Any],
         detail: str,
-        approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
-        approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
+        approval_source: ApprovalSource | None = None,
+        approval_verdict: ApprovalVerdict | None = None,
         approval_explanation: str | None = None,
     ) -> None:
         await self._safe_send(
@@ -614,8 +614,8 @@ class WebSocketSubscriber:
         self,
         domain: str,
         detail: str,
-        approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
-        approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
+        approval_source: ApprovalSource | None = None,
+        approval_verdict: ApprovalVerdict | None = None,
         approval_explanation: str | None = None,
     ) -> None:
         await self._safe_send(
@@ -634,8 +634,8 @@ class WebSocketSubscriber:
         ref: str,
         decision: str,
         detail: str,
-        approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
-        approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
+        approval_source: ApprovalSource | None = None,
+        approval_verdict: ApprovalVerdict | None = None,
         approval_explanation: str | None = None,
     ) -> None:
         await self._safe_send(
@@ -653,8 +653,8 @@ class WebSocketSubscriber:
         self,
         vault_path: str,
         detail: str,
-        approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
-        approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
+        approval_source: ApprovalSource | None = None,
+        approval_verdict: ApprovalVerdict | None = None,
         approval_explanation: str | None = None,
     ) -> None:
         await self._safe_send(

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -1069,9 +1069,10 @@ async def fetch_credential(request: Request, vault_path: str) -> Response:
     current_contexts = _engine.sandbox_mgr.get_current_contexts(session_id)
     skill_covered = False
     if current_contexts:
-        context_set = set(current_contexts)
-        for grant in active.state.context_grants.values():
-            if grant.skill_name in context_set and vault_path in grant.vault_paths:
+        grants = active.state.context_grants
+        for ctx_name in current_contexts:
+            grant = grants.get(ctx_name)
+            if grant is not None and vault_path in grant.vault_paths:
                 skill_covered = True
                 break
 

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -1076,19 +1076,20 @@ async def fetch_credential(request: Request, vault_path: str) -> Response:
                 break
 
     if skill_covered:
-        # Allowed by skill context — record + notify, skip sentinel
-        if active.security:
-            explanation = "skill-declared credential under active context"
-            active.security.record_credential_access(
-                vault_paths=[vault_path],
-                decision="approved",
-                explanation=explanation,
-                ui_label=f"[skill] {meta.name}",
-                approval_source="skill",
-                approval_verdict="allow",
-                audit_final="auto_allowed",
-                audit_args={"operation": "fetch", "vault_path": vault_path, "source": "skill_context"},
-            )
+        # Allowed by skill context — must still record; same bar as list / sentinel path
+        if active.security is None:
+            return Response(status_code=403, content="Session not initialized")
+        explanation = "skill-declared credential under active context"
+        active.security.record_credential_access(
+            vault_paths=[vault_path],
+            decision="approved",
+            explanation=explanation,
+            ui_label=f"[skill] {meta.name}",
+            approval_source="skill",
+            approval_verdict="allow",
+            audit_final="auto_allowed",
+            audit_args={"operation": "fetch", "vault_path": vault_path, "source": "skill_context"},
+        )
     else:
         # Always evaluate via sentinel (no session-wide short-circuit)
         if active.security is None or active.sentinel is None:

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -7,7 +7,7 @@ import os
 import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Self
 
 import logfire
 import loguru
@@ -30,7 +30,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from genai_prices import UpdatePrices
 from loguru import logger
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from carapace.auth import get_token
 from carapace.bootstrap import ensure_data_dir, ensure_knowledge_dir
@@ -469,6 +469,7 @@ class HistoryMessage(BaseModel):
     tool: str | None = None
     args: dict[str, Any] | None = None
     detail: str | None = None
+    contexts: list[str] | None = None
     approval_source: ApprovalSource | None = None
     approval_verdict: ApprovalVerdict | None = None
     approval_explanation: str | None = None
@@ -487,6 +488,16 @@ class HistoryMessage(BaseModel):
     names: list[str] | None = None
     descriptions: list[str] | None = None
     skill_name: str | None = None
+
+    @model_validator(mode="after")
+    def _contexts_from_args_when_missing(self) -> Self:
+        """Legacy events only stored contexts inside ``args``; expose them top-level."""
+        if self.role != "tool_call" or self.contexts is not None:
+            return self
+        raw = self.args.get("contexts") if self.args else None
+        if isinstance(raw, list):
+            return self.model_copy(update={"contexts": list(raw)})
+        return self
 
 
 @router.get("/sessions/{session_id}/history", response_model=list[HistoryMessage])
@@ -521,7 +532,17 @@ def _history_from_messages(session_id: str) -> list[HistoryMessage]:
             for part in msg.parts:
                 if isinstance(part, ToolCallPart):
                     args = part.args if isinstance(part.args, dict) else {}
-                    result.append(HistoryMessage(role="tool_call", content="", tool=part.tool_name, args=args))
+                    ctx_raw = args.get("contexts")
+                    contexts = list(ctx_raw) if isinstance(ctx_raw, list) else None
+                    result.append(
+                        HistoryMessage(
+                            role="tool_call",
+                            content="",
+                            tool=part.tool_name,
+                            args=args,
+                            contexts=contexts,
+                        )
+                    )
                 elif isinstance(part, TextPart):
                     result.append(HistoryMessage(role="assistant", content=part.content))
     return result

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -4,7 +4,6 @@ import asyncio
 import contextlib
 import logging  # stdlib logging used only for _InterceptHandler → loguru bridge
 import os
-import secrets
 import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -260,6 +259,7 @@ async def lifespan(app: FastAPI):
         verify_session_token=_sandbox_mgr.verify_session_token,
         get_allowed_domains=_sandbox_mgr.get_effective_domains,
         request_approval=_sandbox_mgr.request_domain_approval,
+        notify_domain_access=_sandbox_mgr.notify_domain_access,
         host="0.0.0.0",
         port=proxy_port,
     )
@@ -469,7 +469,7 @@ class HistoryMessage(BaseModel):
     tool: str | None = None
     args: dict[str, Any] | None = None
     detail: str | None = None
-    approval_source: Literal["safe-list", "sentinel", "user", "unknown"] | None = None
+    approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None
     approval_verdict: Literal["allow", "deny", "escalate"] | None = None
     approval_explanation: str | None = None
     result: str | None = None
@@ -564,7 +564,7 @@ class WebSocketSubscriber:
         tool: str,
         args: dict[str, Any],
         detail: str,
-        approval_source: Literal["safe-list", "sentinel", "user", "unknown"] | None = None,
+        approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
         approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
         approval_explanation: str | None = None,
     ) -> None:
@@ -614,7 +614,7 @@ class WebSocketSubscriber:
         self,
         domain: str,
         detail: str,
-        approval_source: Literal["safe-list", "sentinel", "user", "unknown"] | None = None,
+        approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
         approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
         approval_explanation: str | None = None,
     ) -> None:
@@ -634,7 +634,7 @@ class WebSocketSubscriber:
         ref: str,
         decision: str,
         detail: str,
-        approval_source: Literal["safe-list", "sentinel", "user", "unknown"] | None = None,
+        approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
         approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
         approval_explanation: str | None = None,
     ) -> None:
@@ -653,7 +653,7 @@ class WebSocketSubscriber:
         self,
         vault_path: str,
         detail: str,
-        approval_source: Literal["safe-list", "sentinel", "user", "unknown"] | None = None,
+        approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
         approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
         approval_explanation: str | None = None,
     ) -> None:
@@ -1054,7 +1054,12 @@ async def list_credentials(request: Request, q: str = "") -> list[dict[str, str]
 
 @sandbox_app.get("/credentials/{vault_path:path}")
 async def fetch_credential(request: Request, vault_path: str) -> Response:
-    """Fetch a credential value (sentinel-gated, may escalate to user)."""
+    """Fetch a credential value (sentinel-gated, may escalate to user).
+
+    Fast path: if the credential is declared by a skill whose context is
+    active for the current exec, it is allowed without sentinel evaluation.
+    Otherwise, **every** access goes through ``evaluate_credential_with``.
+    """
     session_id = _authenticate_sandbox(request.headers.get("authorization"))
     if session_id is None:
         raise HTTPException(status_code=401, detail="Unauthorized")
@@ -1066,9 +1071,28 @@ async def fetch_credential(request: Request, vault_path: str) -> Response:
 
     active = _engine.get_or_activate(session_id)
 
-    already_approved = any(c.vault_path == vault_path for c in active.state.approved_credentials)
+    # Context fast path: check if the credential is covered by active contexts
+    current_contexts = _engine.sandbox_mgr.get_current_contexts(session_id)
+    skill_covered = False
+    if current_contexts:
+        context_set = set(current_contexts)
+        for grant in active.state.context_grants.values():
+            if grant.skill_name in context_set and vault_path in grant.vault_paths:
+                skill_covered = True
+                break
 
-    if not already_approved:
+    if skill_covered:
+        # Allowed by skill context — notify UI and skip sentinel
+        if active.security:
+            active.security.notify_credential_decision(
+                vault_path,
+                f"[skill] {meta.name}",
+                approval_source="skill",
+                approval_verdict="allow",
+                approval_explanation="skill-declared credential under active context",
+            )
+    else:
+        # Always evaluate via sentinel (no session-wide short-circuit)
         if active.security is None or active.sentinel is None:
             return Response(status_code=403, content="Session not initialized")
 
@@ -1086,31 +1110,6 @@ async def fetch_credential(request: Request, vault_path: str) -> Response:
             )
         if not cred_eval.allowed:
             return Response(status_code=403, content="Credential access denied")
-
-        if not any(c.vault_path == vault_path for c in active.state.approved_credentials):
-            active.state.approved_credentials.append(meta)
-            _engine.session_mgr.save_state(active.state)
-            if not cred_eval.user_was_prompted:
-                request_id = secrets.token_hex(8)
-                _engine.session_mgr.append_events(
-                    session_id,
-                    [
-                        {
-                            "role": "credential_approval",
-                            "request_id": request_id,
-                            "vault_paths": [vault_path],
-                            "names": [meta.name],
-                            "descriptions": [meta.description],
-                            "explanation": f"Sandbox credential fetch (sentinel allowed): {cred_eval.explanation}",
-                        },
-                        {
-                            "role": "credential_approval",
-                            "request_id": request_id,
-                            "vault_paths": [vault_path],
-                            "decision": "allow",
-                        },
-                    ],
-                )
 
     try:
         value = await _credential_registry.fetch(vault_path)

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -43,7 +43,7 @@ from carapace.models import Config, SessionState, ToolResult
 from carapace.sandbox.manager import SandboxManager
 from carapace.sandbox.proxy import ProxyServer
 from carapace.sandbox.runtime import ContainerRuntime
-from carapace.security.context import ApprovalSource, ApprovalVerdict, AuditEntry, CredentialAccessEntry
+from carapace.security.context import ApprovalSource, ApprovalVerdict
 from carapace.session import SessionEngine, SessionManager
 from carapace.skills import SkillRegistry
 from carapace.usage import gauge_breakdown_pct_dict, last_record_for_source
@@ -1032,21 +1032,15 @@ async def list_credentials(request: Request, q: str = "") -> list[dict[str, str]
     items = await _credential_registry.list(q)
     paths = [i.vault_path for i in items]
     explanation = f"Sandbox listed credential metadata (query={q!r}, {len(paths)} item(s))"
-    active.security.append(CredentialAccessEntry(vault_paths=paths, decision="approved", explanation=explanation))
-    active.security.write_audit(
-        AuditEntry.now(
-            kind="credential_access",
-            final_decision="auto_allowed",
-            args_summary={"operation": "list", "query": q, "count": len(paths)},
-            explanation=explanation,
-        )
-    )
-    active.security.notify_credential_decision(
-        "<list>",
-        f"[sandbox: list metadata] {explanation}",
+    active.security.record_credential_access(
+        vault_paths=paths,
+        decision="approved",
+        explanation=explanation,
+        ui_label=f"[sandbox: list metadata] {explanation}",
         approval_source="safe-list",
         approval_verdict="allow",
-        approval_explanation=explanation,
+        audit_final="auto_allowed",
+        audit_args={"operation": "list", "query": q, "count": len(paths)},
     )
 
     return [i.model_dump() for i in items]
@@ -1082,14 +1076,18 @@ async def fetch_credential(request: Request, vault_path: str) -> Response:
                 break
 
     if skill_covered:
-        # Allowed by skill context — notify UI and skip sentinel
+        # Allowed by skill context — record + notify, skip sentinel
         if active.security:
-            active.security.notify_credential_decision(
-                vault_path,
-                f"[skill] {meta.name}",
+            explanation = "skill-declared credential under active context"
+            active.security.record_credential_access(
+                vault_paths=[vault_path],
+                decision="approved",
+                explanation=explanation,
+                ui_label=f"[skill] {meta.name}",
                 approval_source="skill",
                 approval_verdict="allow",
-                approval_explanation="skill-declared credential under active context",
+                audit_final="auto_allowed",
+                audit_args={"operation": "fetch", "vault_path": vault_path, "source": "skill_context"},
             )
     else:
         # Always evaluate via sentinel (no session-wide short-circuit)

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -865,20 +865,19 @@ class SessionEngine:
             approval_verdict: ApprovalVerdict | None = None,
             approval_explanation: str | None = None,
         ) -> None:
-            self._session_mgr.append_events(
-                session_id,
-                [
-                    {
-                        "role": "tool_call",
-                        "tool": tool,
-                        "args": args,
-                        "detail": detail,
-                        "approval_source": approval_source,
-                        "approval_verdict": approval_verdict,
-                        "approval_explanation": approval_explanation,
-                    }
-                ],
-            )
+            event: dict[str, Any] = {
+                "role": "tool_call",
+                "tool": tool,
+                "args": args,
+                "detail": detail,
+                "approval_source": approval_source,
+                "approval_verdict": approval_verdict,
+                "approval_explanation": approval_explanation,
+            }
+            contexts_raw = args.get("contexts")
+            if isinstance(contexts_raw, list):
+                event["contexts"] = list(contexts_raw)
+            self._session_mgr.append_events(session_id, [event])
             task = asyncio.ensure_future(
                 self._broadcast(
                     active,

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -92,7 +92,7 @@ class SessionSubscriber(Protocol):
         tool: str,
         args: dict[str, Any],
         detail: str,
-        approval_source: Literal["safe-list", "sentinel", "user", "unknown"] | None = None,
+        approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
         approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
         approval_explanation: str | None = None,
     ) -> None: ...
@@ -111,7 +111,7 @@ class SessionSubscriber(Protocol):
         self,
         domain: str,
         detail: str,
-        approval_source: Literal["safe-list", "sentinel", "user", "unknown"] | None = None,
+        approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
         approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
         approval_explanation: str | None = None,
     ) -> None: ...
@@ -120,7 +120,7 @@ class SessionSubscriber(Protocol):
         ref: str,
         decision: str,
         detail: str,
-        approval_source: Literal["safe-list", "sentinel", "user", "unknown"] | None = None,
+        approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
         approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
         approval_explanation: str | None = None,
     ) -> None: ...
@@ -128,7 +128,7 @@ class SessionSubscriber(Protocol):
         self,
         vault_path: str,
         detail: str,
-        approval_source: Literal["safe-list", "sentinel", "user", "unknown"] | None = None,
+        approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
         approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
         approval_explanation: str | None = None,
     ) -> None: ...
@@ -337,6 +337,12 @@ class SessionEngine:
             session_id,
             self._make_domain_eval_cb(security, sentinel, active),
         )
+        # Register a domain-notify callback so skill-granted and bypass
+        # domain accesses also emit UI events.
+        self._sandbox_mgr.set_domain_notify_callback(
+            session_id,
+            self._make_domain_info_cb(active),
+        )
 
         return active
 
@@ -394,6 +400,7 @@ class SessionEngine:
         if active and active.agent_task and not active.agent_task.done():
             active.agent_task.cancel()
         self._sandbox_mgr.set_domain_approval_callback(session_id, None)
+        self._sandbox_mgr.set_domain_notify_callback(session_id, None)
 
     # -- subscribers --
 
@@ -845,7 +852,7 @@ class SessionEngine:
             tool: str,
             args: dict[str, Any],
             detail: str,
-            approval_source: Literal["safe-list", "sentinel", "user", "unknown"] | None = None,
+            approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
             approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
             approval_explanation: str | None = None,
         ) -> None:
@@ -1250,7 +1257,7 @@ class SessionEngine:
         [
             str,
             str,
-            Literal["safe-list", "sentinel", "user", "unknown"] | None,
+            Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None,
             Literal["allow", "deny", "escalate"] | None,
             str | None,
         ],
@@ -1262,7 +1269,7 @@ class SessionEngine:
         def _notify(
             domain: str,
             detail: str,
-            approval_source: Literal["safe-list", "sentinel", "user", "unknown"] | None = None,
+            approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
             approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
             approval_explanation: str | None = None,
         ) -> None:
@@ -1304,7 +1311,7 @@ class SessionEngine:
             str,
             str,
             str,
-            Literal["safe-list", "sentinel", "user", "unknown"] | None,
+            Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None,
             Literal["allow", "deny", "escalate"] | None,
             str | None,
         ],
@@ -1317,7 +1324,7 @@ class SessionEngine:
             ref: str,
             decision: str,
             detail: str,
-            approval_source: Literal["safe-list", "sentinel", "user", "unknown"] | None = None,
+            approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
             approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
             approval_explanation: str | None = None,
         ) -> None:
@@ -1355,7 +1362,7 @@ class SessionEngine:
         [
             str,
             str,
-            Literal["safe-list", "sentinel", "user", "unknown"] | None,
+            Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None,
             Literal["allow", "deny", "escalate"] | None,
             str | None,
         ],
@@ -1367,7 +1374,7 @@ class SessionEngine:
         def _notify(
             vault_path: str,
             detail: str,
-            approval_source: Literal["safe-list", "sentinel", "user", "unknown"] | None = None,
+            approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
             approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
             approval_explanation: str | None = None,
         ) -> None:

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -1389,6 +1389,10 @@ class SessionEngine:
             approval_verdict: ApprovalVerdict | None = None,
             approval_explanation: str | None = None,
         ) -> None:
+            # Dedupe: skip if this vault_path was already notified in the current exec
+            if self._sandbox_mgr.mark_credential_notified(session_id, vault_path):
+                return
+
             self._session_mgr.append_events(
                 session_id,
                 [

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -37,6 +37,7 @@ from carapace.models import (
     ToolCallCallback,
     ToolResult,
     agent_available_model_entries,
+    context_grants_session_summary,
 )
 from carapace.sandbox.manager import SandboxManager
 from carapace.security.context import ApprovalSource, ApprovalVerdict, SessionSecurity, UserVouchedEntry
@@ -572,16 +573,11 @@ class SessionEngine:
             }
 
         if cmd == "/session":
-            grants_summary: dict[str, dict[str, Any]] = {}
-            for skill, grant in active.state.context_grants.items():
-                cached = sum(
-                    1 for vp in grant.vault_paths if self._sandbox_mgr.get_cached_credential(session_id, vp) is not None
-                )
-                grants_summary[skill] = {
-                    "domains": sorted(grant.domains),
-                    "vault_paths": sorted(grant.vault_paths),
-                    "cached_credentials": cached,
-                }
+            grants_summary = context_grants_session_summary(
+                session_id,
+                active.state.context_grants,
+                self._sandbox_mgr.get_cached_credential,
+            )
             return {
                 "command": "session",
                 "data": {

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -363,7 +363,7 @@ class SessionEngine:
         if not carapace_cfg or not carapace_cfg.credentials:
             return []
 
-        approved_paths = self._get_approved_credential_paths(session_id)
+        approved_paths = self._credential_vault_paths_for_skill(session_id, skill_name)
         reinject: list[tuple[str, str]] = []
         for decl in carapace_cfg.credentials:
             if decl.vault_path not in approved_paths or not decl.file:
@@ -376,16 +376,14 @@ class SessionEngine:
             reinject.append((decl.file, value))
         return reinject
 
-    def _get_approved_credential_paths(self, session_id: str) -> set[str]:
-        """Return approved credential vault paths derived from context grants."""
+    def _credential_vault_paths_for_skill(self, session_id: str, skill_name: str) -> set[str]:
+        """Vault paths allowed for file re-injection: that skill's context grant (from ``use_skill``)."""
         active = self._active.get(session_id)
         state = active.state if active else self._session_mgr.load_state(session_id)
         if not state:
             return set()
-        paths: set[str] = set()
-        for grant in state.context_grants.values():
-            paths.update(grant.vault_paths)
-        return paths
+        grant = state.context_grants.get(skill_name)
+        return grant.vault_paths if grant else set()
 
     def get_active(self, session_id: str) -> ActiveSession | None:
         """Return the ``ActiveSession`` if loaded, else ``None``."""

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -39,7 +39,7 @@ from carapace.models import (
     agent_available_model_entries,
 )
 from carapace.sandbox.manager import SandboxManager
-from carapace.security.context import SessionSecurity, UserVouchedEntry
+from carapace.security.context import ApprovalSource, ApprovalVerdict, SessionSecurity, UserVouchedEntry
 from carapace.security.sentinel import Sentinel
 from carapace.session.manager import SessionManager
 from carapace.session.titler import generate_title
@@ -92,8 +92,8 @@ class SessionSubscriber(Protocol):
         tool: str,
         args: dict[str, Any],
         detail: str,
-        approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
-        approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
+        approval_source: ApprovalSource | None = None,
+        approval_verdict: ApprovalVerdict | None = None,
         approval_explanation: str | None = None,
     ) -> None: ...
     async def on_tool_result(self, result: ToolResult) -> None: ...
@@ -111,8 +111,8 @@ class SessionSubscriber(Protocol):
         self,
         domain: str,
         detail: str,
-        approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
-        approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
+        approval_source: ApprovalSource | None = None,
+        approval_verdict: ApprovalVerdict | None = None,
         approval_explanation: str | None = None,
     ) -> None: ...
     async def on_git_push_info(
@@ -120,16 +120,16 @@ class SessionSubscriber(Protocol):
         ref: str,
         decision: str,
         detail: str,
-        approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
-        approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
+        approval_source: ApprovalSource | None = None,
+        approval_verdict: ApprovalVerdict | None = None,
         approval_explanation: str | None = None,
     ) -> None: ...
     async def on_credential_info(
         self,
         vault_path: str,
         detail: str,
-        approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
-        approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
+        approval_source: ApprovalSource | None = None,
+        approval_verdict: ApprovalVerdict | None = None,
         approval_explanation: str | None = None,
     ) -> None: ...
     async def on_credential_approval_request(
@@ -852,8 +852,8 @@ class SessionEngine:
             tool: str,
             args: dict[str, Any],
             detail: str,
-            approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
-            approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
+            approval_source: ApprovalSource | None = None,
+            approval_verdict: ApprovalVerdict | None = None,
             approval_explanation: str | None = None,
         ) -> None:
             self._session_mgr.append_events(
@@ -1257,8 +1257,8 @@ class SessionEngine:
         [
             str,
             str,
-            Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None,
-            Literal["allow", "deny", "escalate"] | None,
+            ApprovalSource | None,
+            ApprovalVerdict | None,
             str | None,
         ],
         None,
@@ -1269,8 +1269,8 @@ class SessionEngine:
         def _notify(
             domain: str,
             detail: str,
-            approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
-            approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
+            approval_source: ApprovalSource | None = None,
+            approval_verdict: ApprovalVerdict | None = None,
             approval_explanation: str | None = None,
         ) -> None:
             self._session_mgr.append_events(
@@ -1311,8 +1311,8 @@ class SessionEngine:
             str,
             str,
             str,
-            Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None,
-            Literal["allow", "deny", "escalate"] | None,
+            ApprovalSource | None,
+            ApprovalVerdict | None,
             str | None,
         ],
         Awaitable[None],
@@ -1324,8 +1324,8 @@ class SessionEngine:
             ref: str,
             decision: str,
             detail: str,
-            approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
-            approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
+            approval_source: ApprovalSource | None = None,
+            approval_verdict: ApprovalVerdict | None = None,
             approval_explanation: str | None = None,
         ) -> None:
             self._session_mgr.append_events(
@@ -1362,8 +1362,8 @@ class SessionEngine:
         [
             str,
             str,
-            Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None,
-            Literal["allow", "deny", "escalate"] | None,
+            ApprovalSource | None,
+            ApprovalVerdict | None,
             str | None,
         ],
         None,
@@ -1374,8 +1374,8 @@ class SessionEngine:
         def _notify(
             vault_path: str,
             detail: str,
-            approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None,
-            approval_verdict: Literal["allow", "deny", "escalate"] | None = None,
+            approval_source: ApprovalSource | None = None,
+            approval_verdict: ApprovalVerdict | None = None,
             approval_explanation: str | None = None,
         ) -> None:
             self._session_mgr.append_events(

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -377,14 +377,15 @@ class SessionEngine:
         return reinject
 
     def _get_approved_credential_paths(self, session_id: str) -> set[str]:
-        """Return approved credential vault paths for a session."""
+        """Return approved credential vault paths derived from context grants."""
         active = self._active.get(session_id)
-        if active:
-            return {credential.vault_path for credential in active.state.approved_credentials}
-        state = self._session_mgr.load_state(session_id)
-        if state:
-            return {credential.vault_path for credential in state.approved_credentials}
-        return set()
+        state = active.state if active else self._session_mgr.load_state(session_id)
+        if not state:
+            return set()
+        paths: set[str] = set()
+        for grant in state.context_grants.values():
+            paths.update(grant.vault_paths)
+        return paths
 
     def get_active(self, session_id: str) -> ActiveSession | None:
         """Return the ``ActiveSession`` if loaded, else ``None``."""
@@ -573,12 +574,22 @@ class SessionEngine:
             }
 
         if cmd == "/session":
+            grants_summary: dict[str, dict[str, Any]] = {}
+            for skill, grant in active.state.context_grants.items():
+                cached = sum(
+                    1 for vp in grant.vault_paths if self._sandbox_mgr.get_cached_credential(session_id, vp) is not None
+                )
+                grants_summary[skill] = {
+                    "domains": sorted(grant.domains),
+                    "vault_paths": sorted(grant.vault_paths),
+                    "cached_credentials": cached,
+                }
             return {
                 "command": "session",
                 "data": {
                     "session_id": session_id,
                     "channel_type": active.state.channel_type,
-                    "approved_credentials": active.state.approved_credentials,
+                    "context_grants": grants_summary,
                     "allowed_domains": self._sandbox_mgr.get_domain_info(session_id),
                 },
             }

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -331,6 +331,9 @@ class SessionEngine:
         security.set_domain_info_callback(self._make_domain_info_cb(active))
         security.set_push_info_callback(self._make_push_info_cb(active))
         security.set_credential_info_callback(self._make_credential_info_cb(active))
+        security.set_credential_notify_suppress(
+            lambda vp: self._sandbox_mgr.mark_credential_notified(state.session_id, vp),
+        )
 
         # Register a domain-approval callback so the sandbox proxy can
         # evaluate domain requests through the per-session sentinel.
@@ -1382,10 +1385,6 @@ class SessionEngine:
             approval_verdict: ApprovalVerdict | None = None,
             approval_explanation: str | None = None,
         ) -> None:
-            # Dedupe: skip if this vault_path was already notified in the current exec
-            if self._sandbox_mgr.mark_credential_notified(session_id, vault_path):
-                return
-
             self._session_mgr.append_events(
                 session_id,
                 [

--- a/src/carapace/ws_models.py
+++ b/src/carapace/ws_models.py
@@ -98,6 +98,7 @@ class ToolCallInfo(BaseModel):
     tool: str
     args: dict[str, Any]
     detail: str
+    contexts: list[str] = []
     approval_source: ApprovalSource | None = None
     approval_verdict: ApprovalVerdict | None = None
     approval_explanation: str | None = None

--- a/src/carapace/ws_models.py
+++ b/src/carapace/ws_models.py
@@ -4,6 +4,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel
 
+from carapace.security.context import ApprovalSource, ApprovalVerdict
+
 SLASH_COMMANDS: list[dict[str, str]] = [
     {"command": "/security", "description": "Show security policy summary"},
     {"command": "/approve-context", "description": "Vouch for the current agent context as trustworthy"},
@@ -96,8 +98,8 @@ class ToolCallInfo(BaseModel):
     tool: str
     args: dict[str, Any]
     detail: str
-    approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None
-    approval_verdict: Literal["allow", "deny", "escalate"] | None = None
+    approval_source: ApprovalSource | None = None
+    approval_verdict: ApprovalVerdict | None = None
     approval_explanation: str | None = None
 
 

--- a/src/carapace/ws_models.py
+++ b/src/carapace/ws_models.py
@@ -96,7 +96,7 @@ class ToolCallInfo(BaseModel):
     tool: str
     args: dict[str, Any]
     detail: str
-    approval_source: Literal["safe-list", "sentinel", "user", "unknown"] | None = None
+    approval_source: Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"] | None = None
     approval_verdict: Literal["allow", "deny", "escalate"] | None = None
     approval_explanation: str | None = None
 

--- a/tests/test_context_grants.py
+++ b/tests/test_context_grants.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from carapace.models import ContextGrant, SessionState, SkillCredentialDecl, context_grants_session_summary
 from carapace.sandbox.manager import SandboxManager
@@ -150,11 +152,21 @@ class TestSandboxManagerCredentialCache:
         mgr = self._make_manager(tmp_path)
         assert mgr.get_cached_credential("sess-1", "dev/token") is None
 
-    def test_cache_cleared_on_destroy(self, tmp_path: Path):
+    def test_credential_cache_survives_cleanup_tracking(self, tmp_path: Path):
         mgr = self._make_manager(tmp_path)
         mgr.cache_credential("sess-1", "dev/token", "secret-value")
-        # _cleanup_tracking rolls back all in-memory session tracking, including cache
+        # ensure_session error path: container bookkeeping only, not skill cache
         mgr._cleanup_tracking("sess-1")
+        assert mgr.get_cached_credential("sess-1", "dev/token") == "secret-value"
+
+    @pytest.mark.anyio
+    async def test_credential_cache_cleared_on_destroy_session(self, tmp_path: Path):
+        runtime = MagicMock(spec=ContainerRuntime)
+        runtime.destroy_sandbox = AsyncMock()
+        mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+        mgr.cache_credential("sess-1", "dev/token", "secret-value")
+        mgr._sessions["sess-1"] = MagicMock(container_id="c1", session_env={})
+        await mgr.destroy_session("sess-1")
         assert mgr.get_cached_credential("sess-1", "dev/token") is None
 
 

--- a/tests/test_context_grants.py
+++ b/tests/test_context_grants.py
@@ -26,7 +26,6 @@ class TestContextGrantModel:
         grant = ContextGrant(
             skill_name="moneydb",
             domains={"api.moneydb.io", "*.storage.googleapis.com"},
-            vault_paths={"dev/token"},
             credential_decls=[decl],
         )
         assert "api.moneydb.io" in grant.domains
@@ -37,13 +36,13 @@ class TestContextGrantModel:
         grant = ContextGrant(
             skill_name="example",
             domains={"a.com"},
-            vault_paths={"dev/key"},
             credential_decls=[SkillCredentialDecl(vault_path="dev/key", file="/tmp/key")],
         )
         data = grant.model_dump()
         restored = ContextGrant.model_validate(data)
         assert restored.skill_name == "example"
         assert restored.domains == {"a.com"}
+        assert restored.vault_paths == {"dev/key"}
         assert restored.credential_decls[0].file == "/tmp/key"
 
 
@@ -90,7 +89,7 @@ class TestSessionStateContextGrants:
         state.context_grants["example"] = ContextGrant(
             skill_name="example",
             domains={"a.com"},
-            vault_paths={"dev/key"},
+            credential_decls=[SkillCredentialDecl(vault_path="dev/key")],
         )
         data = state.model_dump()
         restored = SessionState.model_validate(data)

--- a/tests/test_context_grants.py
+++ b/tests/test_context_grants.py
@@ -9,6 +9,7 @@ from carapace.models import ContextGrant, SessionState, SkillCredentialDecl
 from carapace.sandbox.manager import SandboxManager
 from carapace.sandbox.runtime import ContainerRuntime
 from carapace.security.context import ApprovalSource, ContextGrantEntry
+from carapace.security.sentinel import _format_entry
 
 # ── ContextGrant model ──────────────────────────────────────────────
 
@@ -64,6 +65,18 @@ class TestContextGrantEntry:
         )
         assert entry.skill_name == "moneydb"
         assert "api.moneydb.io" in entry.domains
+
+    def test_sentinel_action_log_format(self):
+        line = _format_entry(
+            ContextGrantEntry(
+                skill_name="moneydb",
+                domains=["z.io", "a.io"],
+                vault_paths=["b/v", "a/v"],
+            ),
+        )
+        assert line.startswith("[context_grant]: moneydb")
+        assert "domains=['a.io', 'z.io']" in line
+        assert "credentials=['a/v', 'b/v']" in line
 
 
 # ── SessionState context_grants field ────────────────────────────────

--- a/tests/test_context_grants.py
+++ b/tests/test_context_grants.py
@@ -1,0 +1,188 @@
+"""Tests for context-scoped skill allowlists (context grants)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from carapace.models import ContextGrant, SessionState, SkillCredentialDecl
+from carapace.sandbox.manager import SandboxManager
+from carapace.sandbox.runtime import ContainerRuntime
+from carapace.security.context import ApprovalSource, ContextGrantEntry
+
+# ── ContextGrant model ──────────────────────────────────────────────
+
+
+class TestContextGrantModel:
+    def test_defaults(self):
+        grant = ContextGrant(skill_name="moneydb")
+        assert grant.skill_name == "moneydb"
+        assert grant.domains == set()
+        assert grant.vault_paths == set()
+        assert grant.credential_decls == []
+
+    def test_with_domains_and_creds(self):
+        decl = SkillCredentialDecl(vault_path="dev/token", env_var="TOKEN")
+        grant = ContextGrant(
+            skill_name="moneydb",
+            domains={"api.moneydb.io", "*.storage.googleapis.com"},
+            vault_paths={"dev/token"},
+            credential_decls=[decl],
+        )
+        assert "api.moneydb.io" in grant.domains
+        assert "dev/token" in grant.vault_paths
+        assert grant.credential_decls[0].env_var == "TOKEN"
+
+    def test_serialization_roundtrip(self):
+        grant = ContextGrant(
+            skill_name="example",
+            domains={"a.com"},
+            vault_paths={"dev/key"},
+            credential_decls=[SkillCredentialDecl(vault_path="dev/key", file="/tmp/key")],
+        )
+        data = grant.model_dump()
+        restored = ContextGrant.model_validate(data)
+        assert restored.skill_name == "example"
+        assert restored.domains == {"a.com"}
+        assert restored.credential_decls[0].file == "/tmp/key"
+
+
+# ── ContextGrantEntry (action log) ──────────────────────────────────
+
+
+class TestContextGrantEntry:
+    def test_defaults(self):
+        entry = ContextGrantEntry(skill_name="moneydb")
+        assert entry.type == "context_grant"
+        assert entry.domains == []
+        assert entry.vault_paths == []
+
+    def test_with_data(self):
+        entry = ContextGrantEntry(
+            skill_name="moneydb",
+            domains=["api.moneydb.io"],
+            vault_paths=["dev/token"],
+        )
+        assert entry.skill_name == "moneydb"
+        assert "api.moneydb.io" in entry.domains
+
+
+# ── SessionState context_grants field ────────────────────────────────
+
+
+class TestSessionStateContextGrants:
+    def _state(self) -> SessionState:
+        return SessionState.now(session_id="test-session")
+
+    def test_empty_by_default(self):
+        state = self._state()
+        assert state.context_grants == {}
+
+    def test_add_and_retrieve(self):
+        state = self._state()
+        grant = ContextGrant(skill_name="moneydb", domains={"api.moneydb.io"})
+        state.context_grants["moneydb"] = grant
+        assert "moneydb" in state.context_grants
+        assert state.context_grants["moneydb"].domains == {"api.moneydb.io"}
+
+    def test_survives_serialization(self):
+        state = self._state()
+        state.context_grants["example"] = ContextGrant(
+            skill_name="example",
+            domains={"a.com"},
+            vault_paths={"dev/key"},
+        )
+        data = state.model_dump()
+        restored = SessionState.model_validate(data)
+        assert "example" in restored.context_grants
+        assert restored.context_grants["example"].domains == {"a.com"}
+
+
+# ── SandboxManager credential cache ─────────────────────────────────
+
+
+class TestSandboxManagerCredentialCache:
+    def _make_manager(self, tmp_path: Path) -> SandboxManager:
+        runtime = MagicMock(spec=ContainerRuntime)
+        return SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+
+    def test_cache_and_retrieve(self, tmp_path: Path):
+        mgr = self._make_manager(tmp_path)
+        mgr.cache_credential("sess-1", "dev/token", "secret-value")
+        assert mgr.get_cached_credential("sess-1", "dev/token") == "secret-value"
+
+    def test_retrieve_missing_returns_none(self, tmp_path: Path):
+        mgr = self._make_manager(tmp_path)
+        assert mgr.get_cached_credential("sess-1", "dev/token") is None
+
+    def test_cache_cleared_on_destroy(self, tmp_path: Path):
+        mgr = self._make_manager(tmp_path)
+        mgr.cache_credential("sess-1", "dev/token", "secret-value")
+        # _credential_cache survives _cleanup_tracking (error-path cleanup)
+        mgr._cleanup_tracking("sess-1")
+        assert mgr.get_cached_credential("sess-1", "dev/token") == "secret-value"
+        # but is cleared when the credential cache itself is popped (destroy_session)
+        mgr._credential_cache.pop("sess-1", None)
+        assert mgr.get_cached_credential("sess-1", "dev/token") is None
+
+
+# ── SandboxManager context tracking ─────────────────────────────────
+
+
+class TestSandboxManagerContextTracking:
+    def _make_manager(self, tmp_path: Path) -> SandboxManager:
+        runtime = MagicMock(spec=ContainerRuntime)
+        return SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+
+    def test_no_contexts_by_default(self, tmp_path: Path):
+        mgr = self._make_manager(tmp_path)
+        assert mgr.get_current_contexts("sess-1") == []
+
+    def test_set_and_read_contexts(self, tmp_path: Path):
+        mgr = self._make_manager(tmp_path)
+        mgr._session_current_contexts["sess-1"] = ["moneydb", "example"]
+        assert mgr.get_current_contexts("sess-1") == ["moneydb", "example"]
+
+    def test_domain_skill_granted_false_by_default(self, tmp_path: Path):
+        mgr = self._make_manager(tmp_path)
+        assert mgr.is_domain_skill_granted("sess-1", "api.com") is False
+
+    def test_domain_skill_granted_with_entry(self, tmp_path: Path):
+        mgr = self._make_manager(tmp_path)
+        mgr._exec_context_skill_domains["sess-1"] = {"api.moneydb.io"}
+        assert mgr.is_domain_skill_granted("sess-1", "api.moneydb.io") is True
+        assert mgr.is_domain_skill_granted("sess-1", "evil.com") is False
+
+    def test_cleanup_clears_tracking(self, tmp_path: Path):
+        mgr = self._make_manager(tmp_path)
+        # _exec_context_skill_domains is cleared in _cleanup_tracking
+        mgr._exec_context_skill_domains["sess-1"] = {"api.com"}
+        mgr._cleanup_tracking("sess-1")
+        assert mgr.is_domain_skill_granted("sess-1", "api.com") is False
+
+    def test_current_contexts_per_exec(self, tmp_path: Path):
+        """_session_current_contexts is per-exec, set/cleared in _exec's finally."""
+        mgr = self._make_manager(tmp_path)
+        mgr._session_current_contexts["sess-1"] = ["moneydb"]
+        # Simulating exec finally cleanup
+        mgr._session_current_contexts.pop("sess-1", None)
+        assert mgr.get_current_contexts("sess-1") == []
+
+
+# ── ApprovalSource type ─────────────────────────────────────────────
+
+
+class TestApprovalSource:
+    def test_skill_is_valid(self):
+        source: ApprovalSource = "skill"
+        assert source == "skill"
+
+    def test_bypass_is_valid(self):
+        source: ApprovalSource = "bypass"
+        assert source == "bypass"
+
+    def test_all_values(self):
+        valid: set[str] = {"safe-list", "sentinel", "user", "skill", "bypass", "unknown"}
+        for v in valid:
+            source: ApprovalSource = v  # type: ignore[assignment]
+            assert source in valid

--- a/tests/test_context_grants.py
+++ b/tests/test_context_grants.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from carapace.models import ContextGrant, SessionState, SkillCredentialDecl
+from carapace.models import ContextGrant, SessionState, SkillCredentialDecl, context_grants_session_summary
 from carapace.sandbox.manager import SandboxManager
 from carapace.sandbox.runtime import ContainerRuntime
 from carapace.security.context import ApprovalSource, ContextGrantEntry
@@ -45,6 +45,29 @@ class TestContextGrantModel:
         assert restored.domains == {"a.com"}
         assert restored.vault_paths == {"dev/key"}
         assert restored.credential_decls[0].file == "/tmp/key"
+
+
+def test_context_grants_session_summary():
+    grants = {
+        "moneydb": ContextGrant(
+            skill_name="moneydb",
+            domains={"b.com", "a.com"},
+            credential_decls=[
+                SkillCredentialDecl(vault_path="v/p2"),
+                SkillCredentialDecl(vault_path="v/p1"),
+            ],
+        ),
+    }
+    cached = {"v/p1"}
+
+    def get_cached(session_id: str, vault_path: str) -> str | None:
+        assert session_id == "sess-x"
+        return "secret" if vault_path in cached else None
+
+    summary = context_grants_session_summary("sess-x", grants, get_cached)
+    assert summary["moneydb"]["domains"] == ["a.com", "b.com"]
+    assert summary["moneydb"]["vault_paths"] == ["v/p1", "v/p2"]
+    assert summary["moneydb"]["cached_credentials"] == 1
 
 
 # ── ContextGrantEntry (action log) ──────────────────────────────────
@@ -130,11 +153,8 @@ class TestSandboxManagerCredentialCache:
     def test_cache_cleared_on_destroy(self, tmp_path: Path):
         mgr = self._make_manager(tmp_path)
         mgr.cache_credential("sess-1", "dev/token", "secret-value")
-        # _credential_cache survives _cleanup_tracking (error-path cleanup)
+        # _cleanup_tracking rolls back all in-memory session tracking, including cache
         mgr._cleanup_tracking("sess-1")
-        assert mgr.get_cached_credential("sess-1", "dev/token") == "secret-value"
-        # but is cleared when the credential cache itself is popped (destroy_session)
-        mgr._credential_cache.pop("sess-1", None)
         assert mgr.get_cached_credential("sess-1", "dev/token") is None
 
 

--- a/tests/test_context_grants.py
+++ b/tests/test_context_grants.py
@@ -9,8 +9,8 @@ import pytest
 
 from carapace.models import ContextGrant, SessionState, SkillCredentialDecl, context_grants_session_summary
 from carapace.sandbox.manager import SandboxManager
-from carapace.sandbox.runtime import ContainerRuntime
-from carapace.security.context import ApprovalSource, ContextGrantEntry
+from carapace.sandbox.runtime import ContainerRuntime, ExecResult
+from carapace.security.context import ApprovalSource, ContextGrantEntry, CredentialAccessEntry, SessionSecurity
 from carapace.security.sentinel import _format_entry
 
 # ── ContextGrant model ──────────────────────────────────────────────
@@ -303,6 +303,36 @@ class TestExecNotificationDedupe:
         # Different path still works
         assert mgr.mark_credential_notified("s1", "dev/other") is False
 
+    def test_record_credential_access_dedupe_skips_action_audit_and_ui(self, tmp_path: Path):
+        """Second in-exec record for the same UI key must not touch action log, audit, or UI."""
+        mgr = self._make_manager(tmp_path)
+        audit_dir = tmp_path / "audit"
+        sec = SessionSecurity("s1", audit_dir=audit_dir)
+        mgr._exec_notified_credentials["s1"] = set()
+        sec.set_credential_notify_suppress(lambda vp: mgr.mark_credential_notified("s1", vp))
+        ui_calls: list[tuple] = []
+        sec.set_credential_info_callback(lambda *a: ui_calls.append(a))
+
+        kwargs = {
+            "vault_paths": ["dev/token"],
+            "decision": "approved",
+            "explanation": "e1",
+            "ui_label": "l1",
+            "approval_source": "skill",
+            "approval_verdict": "allow",
+            "audit_final": "auto_allowed",
+            "audit_args": {"operation": "fetch"},
+        }
+        sec.record_credential_access(**kwargs)
+        sec.record_credential_access(**kwargs)
+
+        assert len(sec.action_log) == 1
+        assert isinstance(sec.action_log[0], CredentialAccessEntry)
+        assert len(ui_calls) == 1
+        audit_file = audit_dir / "audit.yaml"
+        assert audit_file.is_file()
+        assert audit_file.read_text().count("---\n") == 1
+
     def test_cleanup_clears_notified_sets(self, tmp_path: Path):
         mgr = self._make_manager(tmp_path)
         mgr._exec_notified_domains["s1"] = {"a.com"}
@@ -310,3 +340,70 @@ class TestExecNotificationDedupe:
         mgr._cleanup_tracking("s1")
         assert "s1" not in mgr._exec_notified_domains
         assert "s1" not in mgr._exec_notified_credentials
+
+    @pytest.mark.asyncio
+    async def test_after_exec_credential_notify_runs_before_notified_set_cleared(self, tmp_path: Path):
+        """Skill injection UI notify must run while per-exec dedupe is still active."""
+        mgr = self._make_manager(tmp_path)
+        sc = MagicMock()
+        sc.container_id = "c1"
+        sc.session_id = "s1"
+        sc.session_env = {}
+
+        async def fake_ensure(sid: str):
+            return sc, False
+
+        async def fake_rebuild(sid: str) -> None:
+            return None
+
+        post_calls: list[str] = []
+
+        async def fake_exec_in_container(*_a, **_kw):
+            assert mgr._exec_notified_credentials.get("s1") is not None
+            mgr.mark_credential_notified("s1", "dev/token")
+            return ExecResult(exit_code=0, output="ok")
+
+        mgr.ensure_session = fake_ensure
+        mgr._rebuild_skill_venvs = fake_rebuild
+        mgr._exec_in_container = fake_exec_in_container
+
+        def after_notify() -> None:
+            if mgr.mark_credential_notified("s1", "dev/token"):
+                return
+            post_calls.append("dev/token")
+
+        result = await mgr._exec("s1", "echo", after_exec_credential_notify=after_notify)
+        assert result.exit_code == 0
+        assert post_calls == []
+        assert "s1" not in mgr._exec_notified_credentials
+
+    @pytest.mark.asyncio
+    async def test_after_exec_credential_notify_fires_when_not_pre_notified(self, tmp_path: Path):
+        mgr = self._make_manager(tmp_path)
+        sc = MagicMock()
+        sc.container_id = "c1"
+        sc.session_id = "s1"
+        sc.session_env = {}
+
+        async def fake_ensure(sid: str):
+            return sc, False
+
+        async def fake_rebuild(sid: str) -> None:
+            return None
+
+        post_calls: list[str] = []
+
+        async def fake_exec_in_container(*_a, **_kw):
+            return ExecResult(exit_code=0, output="ok")
+
+        mgr.ensure_session = fake_ensure
+        mgr._rebuild_skill_venvs = fake_rebuild
+        mgr._exec_in_container = fake_exec_in_container
+
+        def after_notify() -> None:
+            if mgr.mark_credential_notified("s1", "dev/token"):
+                return
+            post_calls.append("dev/token")
+
+        await mgr._exec("s1", "echo", after_exec_credential_notify=after_notify)
+        assert post_calls == ["dev/token"]

--- a/tests/test_context_grants.py
+++ b/tests/test_context_grants.py
@@ -185,3 +185,83 @@ class TestApprovalSource:
         for v in valid:
             source: ApprovalSource = v  # type: ignore[assignment]
             assert source in valid
+
+
+# ── Per-exec notification dedupe ─────────────────────────────────────
+
+
+class TestExecNotificationDedupe:
+    def _make_manager(self, tmp_path: Path) -> SandboxManager:
+        runtime = MagicMock(spec=ContainerRuntime)
+        return SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+
+    # -- domain dedupe --
+
+    def test_domain_dedupe_outside_exec(self, tmp_path: Path):
+        """Without an active exec, domain notifications always fire."""
+        mgr = self._make_manager(tmp_path)
+        calls: list[tuple] = []
+        mgr._domain_notify_cbs["s1"] = lambda *a: calls.append(a)
+        mgr._proxy_bypass_sessions.add("s1")
+        mgr.notify_domain_access("s1", "a.com", True)
+        mgr.notify_domain_access("s1", "a.com", True)
+        # No exec → no notified set → both fire
+        assert len(calls) == 2
+
+    def test_domain_dedupe_bypass_during_exec(self, tmp_path: Path):
+        """During an exec, repeated bypass domain notifications are deduped."""
+        mgr = self._make_manager(tmp_path)
+        calls: list[tuple] = []
+        mgr._domain_notify_cbs["s1"] = lambda *a: calls.append(a)
+        mgr._proxy_bypass_sessions.add("s1")
+        mgr._exec_notified_domains["s1"] = set()
+        mgr.notify_domain_access("s1", "a.com", True)
+        mgr.notify_domain_access("s1", "a.com", True)
+        mgr.notify_domain_access("s1", "b.com", True)
+        assert len(calls) == 2  # a.com once, b.com once
+
+    def test_domain_dedupe_skill_during_exec(self, tmp_path: Path):
+        """During an exec, repeated skill-granted domain notifications are deduped."""
+        mgr = self._make_manager(tmp_path)
+        calls: list[tuple] = []
+        mgr._domain_notify_cbs["s1"] = lambda *a: calls.append(a)
+        mgr._exec_context_skill_domains["s1"] = {"api.example.com"}
+        mgr._exec_notified_domains["s1"] = set()
+        mgr.notify_domain_access("s1", "api.example.com", True)
+        mgr.notify_domain_access("s1", "api.example.com", True)
+        assert len(calls) == 1
+
+    def test_domain_denied_not_deduped(self, tmp_path: Path):
+        """Denied domain notifications are never deduped."""
+        mgr = self._make_manager(tmp_path)
+        calls: list[tuple] = []
+        mgr._domain_notify_cbs["s1"] = lambda *a: calls.append(a)
+        mgr._exec_notified_domains["s1"] = set()
+        mgr.notify_domain_access("s1", "evil.com", False)
+        mgr.notify_domain_access("s1", "evil.com", False)
+        assert len(calls) == 2
+
+    # -- credential dedupe --
+
+    def test_mark_credential_notified_outside_exec(self, tmp_path: Path):
+        """Outside an exec, mark_credential_notified returns False (no-op)."""
+        mgr = self._make_manager(tmp_path)
+        assert mgr.mark_credential_notified("s1", "dev/token") is False
+        assert mgr.mark_credential_notified("s1", "dev/token") is False
+
+    def test_mark_credential_notified_during_exec(self, tmp_path: Path):
+        """During an exec, first call returns False, subsequent True."""
+        mgr = self._make_manager(tmp_path)
+        mgr._exec_notified_credentials["s1"] = set()
+        assert mgr.mark_credential_notified("s1", "dev/token") is False
+        assert mgr.mark_credential_notified("s1", "dev/token") is True
+        # Different path still works
+        assert mgr.mark_credential_notified("s1", "dev/other") is False
+
+    def test_cleanup_clears_notified_sets(self, tmp_path: Path):
+        mgr = self._make_manager(tmp_path)
+        mgr._exec_notified_domains["s1"] = {"a.com"}
+        mgr._exec_notified_credentials["s1"] = {"dev/token"}
+        mgr._cleanup_tracking("s1")
+        assert "s1" not in mgr._exec_notified_domains
+        assert "s1" not in mgr._exec_notified_credentials

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -204,7 +204,7 @@ def test_agent_config_mixed_available_models():
 def test_session_state_defaults():
     state = SessionState.now(session_id="abc123")
     assert state.channel_type == "cli"
-    assert state.approved_credentials == []
+    assert state.context_grants == {}
 
 
 def test_sentinel_verdict():

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -200,6 +200,60 @@ async def test_exec_recreate_preserves_domains(tmp_path: Path):
     assert mgr.get_allowed_domains(session_id) == {"api.example.com"}
 
 
+@pytest.mark.anyio
+async def test_exec_recreate_reinjects_credential_files(tmp_path: Path):
+    """After container recreation, _rebuild_skill_venvs re-injects file credentials."""
+    runtime = MagicMock(spec=ContainerRuntime)
+    runtime.get_host_ip = AsyncMock(return_value="172.18.0.1")
+    runtime.create_sandbox = AsyncMock(side_effect=["container-1", "container-2"])
+    runtime.get_ip = AsyncMock(return_value="172.18.0.22")
+    runtime.logs = AsyncMock(return_value="carapace sandbox ready")
+
+    _ok = ExecResult(exit_code=0, output="")
+    runtime.exec = AsyncMock(
+        side_effect=[
+            _ok,  # _clone_knowledge_repo probe after first create
+            ContainerGoneError(),  # exec_command triggers recreate
+            _ok,  # _clone_knowledge_repo probe after recreate
+            _ok,  # git checkout carapace.yaml
+            _ok,  # git checkout pyproject.toml
+            _ok,  # git checkout uv.lock
+            _ok,  # _file_write_in_container (credential re-injection)
+            ExecResult(exit_code=0, output="ok"),  # actual command retry
+        ]
+    )
+
+    # Create a skill dir without pyproject.toml so venv build is skipped
+    skill_dir = tmp_path / "skills" / "moneydb"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: moneydb\n---\nBody.\n")
+
+    mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+    session_id = "sess-1"
+
+    # Register callbacks — the activated-skills callback returns "moneydb",
+    # and the reinject callback returns one file credential to write.
+    mgr.set_activated_skills_callback(lambda sid: ["moneydb"])
+    reinject_cb = AsyncMock(return_value=[("/tmp/creds/api_key.json", "secret-key-value")])
+    mgr.set_reinject_credentials_callback(reinject_cb)
+
+    await mgr.ensure_session(session_id)
+    output = await mgr.exec_command(session_id, "run-moneydb")
+    assert output.output == "ok"
+
+    # Verify the reinject callback was called for the right session + skill
+    reinject_cb.assert_awaited_once_with(session_id, "moneydb")
+
+    # Verify the credential file was written into the new container via exec.
+    # The 7th exec call (index 6) is the _file_write_in_container for the
+    # credential — check that it targeted the correct workdir.
+    write_call = runtime.exec.call_args_list[6]
+    shell_cmd = write_call.args[1]
+    assert "/tmp/creds/api_key.json" in shell_cmd
+    assert base64.b64encode(b"secret-key-value").decode() in shell_cmd
+    assert write_call.kwargs.get("workdir") == "/workspace/skills/moneydb"
+
+
 # ── carapace.yaml parsing ───────────────────────────────────────────
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -15,7 +15,7 @@ from carapace.bootstrap import ensure_data_dir
 from carapace.config import load_config
 from carapace.credentials import CredentialRegistry
 from carapace.git.store import GitStore
-from carapace.models import ToolResult
+from carapace.models import ContextGrant, CredentialRegistryProtocol, SkillCredentialDecl, ToolResult
 from carapace.sandbox.manager import SandboxManager
 from carapace.security.sentinel import Sentinel
 from carapace.session import SessionEngine, SessionManager
@@ -77,6 +77,57 @@ def test_save_and_resume_state(tmp_path: Path):
     assert resumed is not None
     assert "my-skill" in resumed.context_grants
     assert "dev/test" in resumed.context_grants["my-skill"].vault_paths
+
+
+@pytest.mark.anyio
+async def test_reinject_skill_credentials_uses_context_grant(tmp_path: Path):
+    """Venv/container rebuild re-fetches file creds when the skill has a persisted context grant."""
+    skill_name = "reinject-skill"
+    skill_dir = tmp_path / "skills" / skill_name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(f"---\nname: {skill_name}\n---\n")
+    (skill_dir / "carapace.yaml").write_text(
+        "credentials:\n  - vault_path: vault/secret\n    description: API key\n    file: .secrets/key.txt\n"
+    )
+
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path)
+
+    state = engine.session_mgr.create_session()
+    sid = state.session_id
+    active = engine.get_or_activate(sid)
+    active.state.context_grants[skill_name] = ContextGrant(
+        skill_name=skill_name,
+        credential_decls=[
+            SkillCredentialDecl(vault_path="vault/secret", description="API key", file=".secrets/key.txt"),
+        ],
+    )
+
+    mock_reg = AsyncMock(spec=CredentialRegistryProtocol)
+    mock_reg.fetch = AsyncMock(return_value="secret-value")
+    engine._credential_registry = mock_reg
+
+    result = await engine._reinject_skill_credentials(sid, skill_name)
+    assert result == [(".secrets/key.txt", "secret-value")]
+    mock_reg.fetch.assert_awaited_once_with("vault/secret")
+
+    active.state.context_grants.pop(skill_name, None)
+    mock_reg.fetch.reset_mock()
+    assert await engine._reinject_skill_credentials(sid, skill_name) == []
+    mock_reg.fetch.assert_not_called()
+
+    # Reload from disk when session is not active (same path as idle resume + venv sync)
+    active.state.context_grants[skill_name] = ContextGrant(
+        skill_name=skill_name,
+        credential_decls=[
+            SkillCredentialDecl(vault_path="vault/secret", description="API key", file=".secrets/key.txt"),
+        ],
+    )
+    engine.session_mgr.save_state(active.state)
+    engine.deactivate(sid)
+    mock_reg.fetch.reset_mock()
+    mock_reg.fetch = AsyncMock(return_value="from-disk")
+    assert await engine._reinject_skill_credentials(sid, skill_name) == [(".secrets/key.txt", "from-disk")]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -62,16 +62,21 @@ def test_list_sessions(tmp_path: Path):
 
 
 def test_save_and_resume_state(tmp_path: Path):
-    from carapace.models import CredentialMetadata
+    from carapace.models import ContextGrant, SkillCredentialDecl
 
     mgr = SessionManager(tmp_path)
     state = mgr.create_session()
-    state.approved_credentials.append(CredentialMetadata(vault_path="dev/test", name="test-cred"))
+    state.context_grants["my-skill"] = ContextGrant(
+        skill_name="my-skill",
+        domains={"example.com"},
+        credential_decls=[SkillCredentialDecl(vault_path="dev/test", description="test cred")],
+    )
     mgr.save_state(state)
 
     resumed = mgr.resume_session(state.session_id)
     assert resumed is not None
-    assert any(c.vault_path == "dev/test" for c in resumed.approved_credentials)
+    assert "my-skill" in resumed.context_grants
+    assert "dev/test" in resumed.context_grants["my-skill"].vault_paths
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replace session-wide domain/credential approvals with **context-scoped grants** keyed by skill name. Every credential access goes through the sentinel except when covered by an activated skill under matching contexts. Emit proxy and credential events to the UI for full visibility, including denied requests.

## Changes

### Data Model
- `ContextGrant` model (`skill_name`, `domains`, `vault_paths`, `credential_decls`) in `models.py`
- `context_grants: dict[str, ContextGrant]` field on `SessionState`
- Extend `ApprovalSource` with `"skill"` and `"bypass"` literals
- `ContextGrantEntry` action log entry type

### Context Grant Registration
- `use_skill` registers context grants instead of session-wide injection
- Credential value cache in `SandboxManager` (in-memory, never persisted to disk)
- `ContextGrantEntry` appended to action log for sentinel awareness

### Exec Context Threading
- `contexts: list[str] | None` parameter on the `exec` tool
- Per-exec env injection from matching grants' cached credentials
- Per-exec file credential write/delete lifecycle (`finally` cleanup)
- Context-scoped domains added to temp allowlist during exec

### Domain Auth Fast Path
- Domain origin tracking (skill vs sentinel vs bypass)
- `notify_domain_access` callback from proxy for silently allowed/denied domains
- Skill/bypass/deny events emitted to UI

### Credential Gate
- Removed session-wide `already_approved` short-circuit
- Context fast path: skill-declared vault paths allowed without sentinel when under matching context
- Otherwise every credential access goes through sentinel

### Frontend UI
- "skill" badge (teal, Puzzle icon) for context-granted access
- "bypass" badge (gray, Zap icon) for proxy bypass
- "denied" badge (red) for denied proxy/credential access
- Updated `ApprovalSource` types across all frontend and backend definitions

### Tests + Docs
- 20 new tests in `tests/test_context_grants.py`
- Updated `docs/skills.md`, `docs/credentials.md`, `docs/websocket-session.md`

## Verification
- 345 tests passing (325 existing + 20 new)
- `ruff check` clean
- `prek run` all hooks passed


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes credential and network authorization semantics by replacing session-wide approvals with per-exec context grants, which is security-critical and could break existing skill workflows if contexts/caching behave unexpectedly.
> 
> **Overview**
> Introduces **context-scoped skill grants**: `use_skill` now registers a per-skill `ContextGrant` (domains + credential declarations) and caches credential values in memory, while `exec` gains a `contexts` parameter to temporarily allow those domains and inject credentials only for that command (including write-then-delete lifecycle for file creds).
> 
> Removes session-wide credential approval short-circuiting so credential fetches are evaluated every time unless covered by an active context grant; adds richer audit/action-log coverage (`ContextGrantEntry`) and new approval sources (`skill`, `bypass`) plus proxy notifications for silently allowed/denied domain access.
> 
> Updates WebSocket/REST history payloads and frontend badges/UI to display `contexts`, `skill`/`bypass`/`denied` states, adjusts `/session` output to report context grants + cached credential counts, and adds comprehensive tests for the new grant/caching/dedupe behavior alongside refreshed docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9bfea1cc337e719744e28865cfbac87986cc159. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->