### PR TITLE
✨ feat: Add session budgets and budget gauges

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,6 @@
 
 - [ ] Proper Icon + Logo, rewrite README to be more ... advertising
 - [ ] warm-up a sandbox as soon as the session is created? (or keep a warmed sandbox for the next session?) would need to be configurable + maybe we should even delete old PVCs after a while if they are not used?
-- [ ] would be nice to be able to give the session a budget in dollars / tokens
 - [ ] compaction
 - [ ] image input ([plan](docs/plans/images.md))
 - [ ] image output — agent tools producing images (screenshots, charts, renders)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -64,7 +64,7 @@ agent:
   # default_session_budget:
   #   input_tokens: 100000
   #   output_tokens: 50000
-  #   total_cost_usd: 5.00
+  #   cost_usd: 5.00
 ```
 
 ## 5. Connect Matrix (optional)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -59,6 +59,12 @@ A minimal config:
 agent:
   model: anthropic:claude-sonnet-4-6
   sentinel_model: anthropic:claude-haiku-4-5
+  # Optional defaults for every new session.
+  # Omit a field, or set it to 0, to keep that budget unlimited.
+  # default_session_budget:
+  #   input_tokens: 100000
+  #   output_tokens: 50000
+  #   total_cost_usd: 5.00
 ```
 
 ## 5. Connect Matrix (optional)

--- a/frontend/src/components/chat-input.tsx
+++ b/frontend/src/components/chat-input.tsx
@@ -4,12 +4,47 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowUp, Clock, Square } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { AvailableModelInfo, SlashCommand } from "@/lib/api";
-import type { TurnUsage, TurnUsageBreakdownPct } from "@/lib/types";
+import type { BudgetGauge, TurnUsage, TurnUsageBreakdownPct } from "@/lib/types";
 
 function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
   return String(n);
+}
+
+function budgetGauges(u: TurnUsage): BudgetGauge[] {
+  return Array.isArray(u.budget_gauges) ? u.budget_gauges : [];
+}
+
+function budgetGaugeCurrentAmount(gauge: BudgetGauge): number | null {
+  if (
+    typeof gauge.current_amount === "number" &&
+    Number.isFinite(gauge.current_amount)
+  ) {
+    return gauge.current_amount;
+  }
+
+  const value = gauge.current_value.trim();
+  if (gauge.key === "cost") {
+    const match = value.match(/^\$(\d+(?:\.\d+)?)$/);
+    return match ? Number(match[1]) : null;
+  }
+
+  const match = value.match(/^(\d+(?:\.\d+)?)([kKmM]?) tokens$/);
+  if (!match) return null;
+
+  const amount = Number(match[1]);
+  if (!Number.isFinite(amount)) return null;
+  if (match[2] === "k" || match[2] === "K") return amount * 1_000;
+  if (match[2] === "m" || match[2] === "M") return amount * 1_000_000;
+  return amount;
+}
+
+function visibleBudgetGauges(u: TurnUsage): BudgetGauge[] {
+  return budgetGauges(u).filter((gauge) => {
+    const current = budgetGaugeCurrentAmount(gauge);
+    return current !== null && current > 0;
+  });
 }
 
 const MODEL_COMMANDS = [
@@ -330,9 +365,9 @@ export function ChatInput({
           </button>
         </div>
 
-        {/* Token usage gauge */}
-        {usage && turnGaugeTokens(usage) > 0 && (
-          <TokenGauge
+        {/* Context and session budget gauges */}
+        {usage && (turnGaugeTokens(usage) > 0 || visibleBudgetGauges(usage).length > 0) && (
+          <UsageGaugeStack
             usage={usage}
             availableModelEntries={availableModelEntries}
             onClickUsage={
@@ -403,8 +438,108 @@ function contextTokenCap(
   return DEFAULT_CONTEXT_CAP;
 }
 
-/** Compact context-window gauge rendered below the input box. */
-function TokenGauge({
+function gaugeStress(fillPct: number, reached: boolean): "high" | "mid" | "low" {
+  if (reached || fillPct > 75) return "high";
+  if (fillPct > 50) return "mid";
+  return "low";
+}
+
+function GaugeRow({
+  fillPct,
+  tooltip,
+  label,
+  fillClassName,
+  onClick,
+  reached = false,
+}: {
+  fillPct: number;
+  tooltip: string;
+  label: string;
+  fillClassName: string;
+  onClick?: () => void;
+  reached?: boolean;
+}) {
+  const stress = gaugeStress(fillPct, reached);
+  const trackRing =
+    stress === "high"
+      ? "ring-1 ring-destructive/35"
+      : stress === "mid"
+        ? "ring-1 ring-warning/30"
+        : "";
+
+  return (
+    <div className="flex items-center gap-2">
+      <div
+        title={tooltip}
+        className="flex min-h-6 flex-1 cursor-default items-center py-2 -my-2"
+      >
+        <div
+          className={cn(
+            "relative h-1 w-full overflow-hidden rounded-full bg-muted",
+            trackRing,
+          )}
+        >
+          <div
+            className={cn(
+              "absolute left-0 top-0 h-full transition-[width]",
+              fillClassName,
+            )}
+            style={{ width: `${Math.max(0, Math.min(fillPct, 100))}%` }}
+          />
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={!onClick}
+        title={tooltip}
+        className={cn(
+          "shrink-0 text-[10px] tabular-nums text-muted-foreground",
+          onClick &&
+            "cursor-pointer transition-colors hover:text-foreground",
+          !onClick && "cursor-default",
+        )}
+      >
+        {label}
+      </button>
+    </div>
+  );
+}
+
+/** Compact usage gauge stack rendered below the input box. */
+function UsageGaugeStack({
+  usage,
+  availableModelEntries,
+  onClickUsage,
+}: {
+  usage: TurnUsage;
+  availableModelEntries: AvailableModelInfo[];
+  onClickUsage?: () => void;
+}) {
+  const budgets = visibleBudgetGauges(usage);
+  const showContextGauge = turnGaugeTokens(usage) > 0;
+
+  return (
+    <div className="mt-1.5 space-y-1 px-1">
+      {showContextGauge ? (
+        <ContextGauge
+          usage={usage}
+          availableModelEntries={availableModelEntries}
+          onClickUsage={onClickUsage}
+        />
+      ) : null}
+      {budgets.map((gauge) => (
+        <BudgetGaugeRow
+          key={gauge.key}
+          gauge={gauge}
+          onClickUsage={onClickUsage}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ContextGauge({
   usage,
   availableModelEntries,
   onClickUsage,
@@ -418,13 +553,7 @@ function TokenGauge({
   const fillPct = Math.min((ctx / cap) * 100, 100);
   const bp = usage.breakdown_pct;
 
-  const stress = fillPct > 75 ? "high" : fillPct > 50 ? "mid" : "low";
-  const trackRing =
-    stress === "high"
-      ? "ring-1 ring-destructive/35"
-      : stress === "mid"
-        ? "ring-1 ring-warning/30"
-        : "";
+  const stress = gaugeStress(fillPct, false);
 
   const matched = findModelEntryForGauge(usage.model, availableModelEntries);
   const limitFromConfig = matched?.max_input_tokens != null;
@@ -444,7 +573,7 @@ function TokenGauge({
   const tooltip = tooltipLines.join("\n");
 
   return (
-    <div className="mt-1.5 flex items-center gap-2 px-1">
+    <div className="flex items-center gap-2">
       <div
         title={tooltip}
         className="flex min-h-6 flex-1 cursor-default items-center py-2 -my-2"
@@ -452,7 +581,11 @@ function TokenGauge({
         <div
           className={cn(
             "relative h-1 w-full rounded-full bg-muted overflow-hidden",
-            trackRing,
+            stress === "high"
+              ? "ring-1 ring-destructive/35"
+              : stress === "mid"
+                ? "ring-1 ring-warning/30"
+                : "",
           )}
         >
           <div
@@ -501,5 +634,46 @@ function TokenGauge({
         {formatTokens(ctx)} tokens
       </button>
     </div>
+  );
+}
+
+function BudgetGaugeRow({
+  gauge,
+  onClickUsage,
+}: {
+  gauge: BudgetGauge;
+  onClickUsage?: () => void;
+}) {
+  const fillClassName =
+    gauge.key === "input"
+      ? "rounded-l-full bg-emerald-500/75"
+      : gauge.key === "output"
+        ? "rounded-l-full bg-sky-500/75"
+        : "rounded-l-full bg-amber-500/80";
+
+  const tooltipLines = [
+    `${gauge.label} budget`,
+    `Current: ${gauge.current_value}`,
+    `Max: ${gauge.limit_value}`,
+  ];
+  if (gauge.remaining_value) {
+    tooltipLines.push(`Remaining: ${gauge.remaining_value}`);
+  }
+  if (gauge.unavailable_reason) {
+    tooltipLines.push(gauge.unavailable_reason);
+  }
+  if (gauge.reached) {
+    tooltipLines.push("Budget exhausted.");
+  }
+
+  return (
+    <GaugeRow
+      fillPct={gauge.fill_pct}
+      tooltip={tooltipLines.join("\n")}
+      label={gauge.current_value}
+      fillClassName={fillClassName}
+      onClick={onClickUsage}
+      reached={gauge.reached}
+    />
   );
 }

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -594,6 +594,7 @@ export function ChatView({
           break;
         case "session_title":
           onTitleUpdate?.(msg.title);
+          if (msg.usage) setUsage(msg.usage);
           break;
         case "status":
           if (msg.agent_running) setWaiting(true);

--- a/frontend/src/components/command-result.tsx
+++ b/frontend/src/components/command-result.tsx
@@ -218,6 +218,10 @@ export function CommandResultView({ command, data }: CommandResultViewProps) {
     return <UsageView data={data} />;
   }
 
+  if (command === "budget" && isBudgetData(data)) {
+    return <BudgetView data={data} />;
+  }
+
   if (isPlainMessagePayload(data)) {
     if (data.error) {
       return <p className="my-1 text-sm text-destructive">{data.error}</p>;
@@ -295,6 +299,17 @@ interface UsageBucket {
   requests: number;
 }
 
+interface BudgetGaugeData {
+  key: "input" | "output" | "cost";
+  label: string;
+  current_value: string;
+  limit_value: string;
+  remaining_value?: string | null;
+  fill_pct: number;
+  reached: boolean;
+  unavailable_reason?: string | null;
+}
+
 /** % of tiktoken mass over the prompt only (sum 100); unrelated to API billing tokens. */
 interface LastLlmBreakdownPct {
   system: number | null;
@@ -324,12 +339,24 @@ interface UsagePayload {
   total_output: number;
   costs?: Record<string, string>;
   category_costs?: Record<string, string>;
+  budget_gauges?: BudgetGaugeData[];
   last_llm_agent?: LastLlmRequestRow | null;
   last_llm_sentinel?: LastLlmRequestRow | null;
 }
 
+interface BudgetPayload {
+  gauges: BudgetGaugeData[];
+  message?: string;
+  error?: string;
+  usage_hint?: string;
+}
+
 function isUsageData(d: unknown): d is UsagePayload {
   return !!d && typeof d === "object" && "models" in d && "categories" in d;
+}
+
+function isBudgetData(d: unknown): d is BudgetPayload {
+  return !!d && typeof d === "object" && "gauges" in d;
 }
 
 function fmt(n: number): string {
@@ -357,6 +384,7 @@ function lastRequestRowsShowOtherPct(rows: LastLlmRequestRow[]): boolean {
 }
 
 function UsageView({ data }: { data: UsagePayload }) {
+  const budgetGauges = Array.isArray(data.budget_gauges) ? data.budget_gauges : [];
   const allBuckets = [
     ...Object.values(data.models),
     ...Object.values(data.categories),
@@ -371,7 +399,8 @@ function UsageView({ data }: { data: UsagePayload }) {
   );
   const isEmpty =
     Object.keys(data.models).length === 0 &&
-    Object.keys(data.categories).length === 0;
+    Object.keys(data.categories).length === 0 &&
+    budgetGauges.length === 0;
   if (isEmpty) {
     return (
       <p className="my-1 text-sm text-muted-foreground">
@@ -472,6 +501,7 @@ function UsageView({ data }: { data: UsagePayload }) {
         Total: {fmt(total)} tokens ({fmt(data.total_input)} in +{" "}
         {fmt(data.total_output)} out){costStr}
       </p>
+      {budgetGauges.length > 0 ? <BudgetTable gauges={budgetGauges} /> : null}
       {Object.keys(data.models).length > 0 &&
         renderTable("By Model", data.models, true)}
       {Object.keys(data.categories).length > 0 &&
@@ -544,6 +574,75 @@ function UsageView({ data }: { data: UsagePayload }) {
           </table>
         </div>
       ) : null}
+    </div>
+  );
+}
+
+function BudgetView({ data }: { data: BudgetPayload }) {
+  if (data.error) {
+    return <p className="my-1 text-sm text-destructive">{data.error}</p>;
+  }
+  if (data.gauges.length === 0) {
+    return (
+      <div className="my-1 text-sm text-muted-foreground">
+        <p>{data.message ?? "No session budgets configured."}</p>
+        {data.usage_hint ? <p className="mt-1 text-xs">{data.usage_hint}</p> : null}
+      </div>
+    );
+  }
+  return (
+    <div className="my-2 text-sm">
+      {data.message ? (
+        <p className="mb-2 text-sm text-muted-foreground">{data.message}</p>
+      ) : null}
+      {data.usage_hint ? (
+        <p className="mb-2 text-xs text-muted-foreground">{data.usage_hint}</p>
+      ) : null}
+      <BudgetTable gauges={data.gauges} />
+    </div>
+  );
+}
+
+function BudgetTable({ gauges }: { gauges: BudgetGaugeData[] }) {
+  return (
+    <div className="my-2 text-sm">
+      <p className="mb-1 text-xs font-medium text-muted-foreground">
+        Session Budgets
+      </p>
+      <table className="w-full">
+        <thead>
+          <tr className="border-b border-border text-left text-xs text-muted-foreground">
+            <th className="pb-1 pr-3 font-medium">Metric</th>
+            <th className="pb-1 pr-3 font-medium text-right">Current</th>
+            <th className="pb-1 pr-3 font-medium text-right">Limit</th>
+            <th className="pb-1 pr-3 font-medium text-right">Remaining</th>
+            <th className="pb-1 font-medium text-right">Used</th>
+          </tr>
+        </thead>
+        <tbody>
+          {gauges.map((gauge) => (
+            <tr key={gauge.key} className="border-b border-border/50">
+              <td className="py-1 pr-3 text-xs font-medium">{gauge.label}</td>
+              <td className="py-1 pr-3 text-xs text-right tabular-nums">
+                {gauge.current_value}
+              </td>
+              <td className="py-1 pr-3 text-xs text-right tabular-nums">
+                {gauge.limit_value}
+              </td>
+              <td className="py-1 pr-3 text-xs text-right tabular-nums">
+                {gauge.remaining_value ?? "—"}
+              </td>
+              <td className="py-1 text-xs text-right tabular-nums">
+                {gauge.unavailable_reason ? (
+                  <span className="text-destructive">blocked</span>
+                ) : (
+                  `${gauge.fill_pct.toFixed(1)}%`
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -188,6 +188,7 @@ export interface Cancelled {
 export interface SessionTitleUpdate {
   type: "session_title";
   title: string;
+  usage?: TurnUsage | null;
 }
 
 export interface StatusUpdate {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -138,6 +138,18 @@ export interface TurnUsageBreakdownPct {
   other: number;
 }
 
+export interface BudgetGauge {
+  key: "input" | "output" | "cost";
+  label: string;
+  current_value: string;
+  current_amount?: number | null;
+  limit_value: string;
+  remaining_value?: string | null;
+  fill_pct: number;
+  reached: boolean;
+  unavailable_reason?: string | null;
+}
+
 export interface TurnUsage {
   input_tokens: number;
   output_tokens: number;
@@ -146,6 +158,8 @@ export interface TurnUsage {
   model?: string | null;
   /** Backend-resolved context window for this usage row. */
   context_cap_tokens?: number | null;
+  /** Session budget gauges rendered below the context gauge. */
+  budget_gauges?: BudgetGauge[];
 }
 
 export interface Done {

--- a/src/carapace/agent/loop.py
+++ b/src/carapace/agent/loop.py
@@ -47,6 +47,7 @@ async def run_agent_turn(
     on_token: Callable[[str], Awaitable[None]] | None = None,
     on_thinking_token: Callable[[str], Awaitable[None]] | None = None,
     on_messages_snapshot: Callable[[list[Any]], None] | None = None,
+    before_llm_call: Callable[[], None] | None = None,
 ) -> tuple[list[Any], str, str]:
     """Run one full agent turn, handling approval loops.
 
@@ -81,6 +82,8 @@ async def run_agent_turn(
                 if on_token is not None:
                     await on_token(event.delta.content_delta)
 
+    if before_llm_call is not None:
+        before_llm_call()
     result = await agent.run(
         user_input,
         deps=deps,
@@ -139,6 +142,8 @@ async def run_agent_turn(
                     ),
                 )
 
+        if before_llm_call is not None:
+            before_llm_call()
         result = await agent.run(
             deps=deps,
             message_history=messages,

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -88,6 +88,7 @@ async def _gate(ctx: RunContext[Deps], tool_name: str, args: dict[str, Any]) -> 
             tool_name,
             args,
             usage_tracker=ctx.deps.usage_tracker,
+            assert_llm_budget_available=ctx.deps.assert_llm_budget_available,
             verbose=ctx.deps.verbose,
             tool_call_callback=ctx.deps.tool_call_callback,
         )

--- a/src/carapace/channels/matrix/channel.py
+++ b/src/carapace/channels/matrix/channel.py
@@ -240,7 +240,11 @@ class MatrixChannel:
             self._room_sessions[room_id] = existing
             logger.debug(f"Matrix: resuming session {existing} for room {room_id}")
         else:
-            state = self._session_mgr.create_session("matrix", room_id)
+            state = self._session_mgr.create_session(
+                "matrix",
+                room_id,
+                budget=self._engine.config.agent.default_session_budget,
+            )
             self._room_sessions[room_id] = state.session_id
             logger.info(f"Matrix: created session {state.session_id} for room {room_id}")
         return self._room_sessions[room_id]
@@ -479,6 +483,8 @@ class MatrixChannel:
                     "- `/skills` — List available skills\n"
                     "- `/memory` — List memory files\n"
                     "- `/retitle` — Regenerate title, or `/retitle My title` to set it\n"
+                    "- `/budget` — Show current budgets; set with `/budget input N`, "
+                    "`/budget output N`, or `/budget cost N`\n"
                     "- `/usage` — Show token usage\n"
                     "- `/model` — View or switch agent, sentinel, and title models together\n"
                     "- `/model-agent` — View or switch the agent model only\n"
@@ -508,7 +514,11 @@ class MatrixChannel:
         if sub:
             self._engine.unsubscribe(old_session_id, sub)
         await self._sandbox_mgr.cleanup_session(old_session_id)
-        new_state = self._session_mgr.create_session("matrix", room_id)
+        new_state = self._session_mgr.create_session(
+            "matrix",
+            room_id,
+            budget=self._engine.config.agent.default_session_budget,
+        )
         self._room_sessions[room_id] = new_state.session_id
         # Clear any stale room-level pending approval
         self._room_pending.pop(room_id, None)

--- a/src/carapace/channels/matrix/formatting.py
+++ b/src/carapace/channels/matrix/formatting.py
@@ -91,11 +91,12 @@ def format_command_result_text(result: CommandResult) -> str:
             categories: dict[str, dict] = data.get("categories", {})
             costs: dict[str, str] = data.get("costs", {})
             category_costs: dict[str, str] = data.get("category_costs", {})
+            budget_gauges: list[dict] = data.get("budget_gauges", [])
             total_input = data.get("total_input", 0)
             total_output = data.get("total_output", 0)
             total_cost = float(costs.get("total", 0))
 
-            if not models and not categories:
+            if not models and not categories and not budget_gauges:
                 return "No token usage recorded yet."
 
             has_cache = any(
@@ -142,6 +143,28 @@ def format_command_result_text(result: CommandResult) -> str:
             parts.append(
                 f"**Total:** {total_tokens:,} tokens ({total_input:,} in + {total_output:,} out){cost_str}",
             )
+            if budget_gauges:
+                lines = [
+                    "**Session Budgets**\n",
+                    "| Metric | Current | Limit | Remaining | Used |",
+                    "|---|---:|---:|---:|---:|",
+                ]
+                for gauge in budget_gauges:
+                    used = "blocked" if gauge.get("unavailable_reason") else f"{float(gauge.get('fill_pct', 0)):.1f}%"
+                    lines.append(
+                        "| "
+                        + " | ".join(
+                            [
+                                str(gauge.get("label", "?")),
+                                str(gauge.get("current_value", "-")),
+                                str(gauge.get("limit_value", "-")),
+                                str(gauge.get("remaining_value") or "—"),
+                                used,
+                            ]
+                        )
+                        + " |"
+                    )
+                parts.append("\n".join(lines))
             if models:
                 parts.append(_table("By Model", models, show_cost=True))
             if categories:
@@ -201,6 +224,46 @@ def format_command_result_text(result: CommandResult) -> str:
                 parts.append("\n".join(lines))
 
             return "\n\n".join(parts)
+
+        case "budget":
+            if data.get("error"):
+                return f"Error: {data['error']}"
+            gauges: list[dict] = data.get("gauges", [])
+            message = data.get("message")
+            usage_hint = data.get("usage_hint")
+            if not gauges:
+                parts = [message or "No session budgets configured."]
+                if usage_hint:
+                    parts.append(usage_hint)
+                return "\n".join(parts)
+            lines = []
+            if message:
+                lines.append(message)
+            if usage_hint:
+                lines.append(usage_hint)
+            lines.extend(
+                [
+                    "**Session Budgets**\n",
+                    "| Metric | Current | Limit | Remaining | Used |",
+                    "|---|---:|---:|---:|---:|",
+                ]
+            )
+            for gauge in gauges:
+                used = "blocked" if gauge.get("unavailable_reason") else f"{float(gauge.get('fill_pct', 0)):.1f}%"
+                lines.append(
+                    "| "
+                    + " | ".join(
+                        [
+                            str(gauge.get("label", "?")),
+                            str(gauge.get("current_value", "-")),
+                            str(gauge.get("limit_value", "-")),
+                            str(gauge.get("remaining_value") or "—"),
+                            used,
+                        ]
+                    )
+                    + " |"
+                )
+            return "\n".join(lines)
 
         case "models":
             if "models" in data:

--- a/src/carapace/channels/matrix/subscriber.py
+++ b/src/carapace/channels/matrix/subscriber.py
@@ -221,7 +221,7 @@ class MatrixSubscriber:
             self._channel._pending_credential_approvals[event_id] = pending
             self._channel._room_pending[self._room_id] = pending
 
-    async def on_title_update(self, title: str) -> None:
+    async def on_title_update(self, title: str, usage: TurnUsage | None = None) -> None:
         pass  # Matrix rooms have their own titles
 
     async def on_domain_info(

--- a/src/carapace/cli.py
+++ b/src/carapace/cli.py
@@ -166,6 +166,9 @@ def _render_command_result(data: dict[str, Any]) -> None:
         case "usage":
             _render_usage(payload)
 
+        case "budget":
+            _render_budget(payload)
+
         case "models":
             if "models" in payload:
                 for model_type, info in payload["models"].items():
@@ -226,8 +229,9 @@ def _render_usage(payload: dict[str, Any]) -> None:
     categories: dict[str, dict[str, int]] = payload.get("categories", {})
     costs: dict[str, str] = payload.get("costs", {})
     category_costs: dict[str, str] = payload.get("category_costs", {})
+    budget_gauges: list[dict[str, Any]] = payload.get("budget_gauges", [])
 
-    if not models and not categories:
+    if not models and not categories and not budget_gauges:
         console.print("[dim]No token usage recorded yet.[/dim]")
         return
 
@@ -282,6 +286,9 @@ def _render_usage(payload: dict[str, Any]) -> None:
     cost_str = f" | {_styled_cost(total_cost)}" if total_cost != "0" else ""
     tokens_str = f"{total_in + total_out:,} tokens ({total_in:,} in + {total_out:,} out)"
     console.print(f"[bold]Total:[/bold] {tokens_str}{cost_str}")
+
+    if budget_gauges:
+        console.print(_make_budget_table(budget_gauges))
 
     if models:
         console.print(_make_table("Usage by Model", models, show_cost=True))
@@ -345,6 +352,43 @@ def _render_usage(payload: dict[str, Any]) -> None:
                 cells.append(_fmt_pct_cell(b.get("other")))
             lr.add_row(*cells)
         console.print(lr)
+
+
+def _make_budget_table(gauges: list[dict[str, Any]]) -> Table:
+    table = Table(title="Session Budgets")
+    table.add_column("Metric", style="bold")
+    table.add_column("Current", justify="right")
+    table.add_column("Limit", justify="right")
+    table.add_column("Remaining", justify="right")
+    table.add_column("Used", justify="right")
+    for gauge in gauges:
+        used = "blocked" if gauge.get("unavailable_reason") else f"{float(gauge.get('fill_pct', 0)):.1f}%"
+        style = "red" if gauge.get("reached") else "none"
+        table.add_row(
+            str(gauge.get("label", "?")),
+            str(gauge.get("current_value", "-")),
+            str(gauge.get("limit_value", "-")),
+            str(gauge.get("remaining_value") or "—"),
+            f"[{style}]{used}[/{style}]" if style != "none" else used,
+        )
+    return table
+
+
+def _render_budget(payload: dict[str, Any]) -> None:
+    if payload.get("error"):
+        console.print(f"[red]{payload['error']}[/red]")
+        return
+    gauges: list[dict[str, Any]] = payload.get("gauges", [])
+    usage_hint = payload.get("usage_hint")
+    if payload.get("message"):
+        console.print(f"[dim]{payload['message']}[/dim]")
+    if usage_hint:
+        console.print(f"[dim]{usage_hint}[/dim]")
+    if not gauges:
+        if not payload.get("message"):
+            console.print("[dim]No session budgets configured.[/dim]")
+        return
+    console.print(_make_budget_table(gauges))
 
 
 async def _render_escalation_request(data: dict[str, Any]) -> tuple[str, str | None]:

--- a/src/carapace/models.py
+++ b/src/carapace/models.py
@@ -4,6 +4,7 @@ import os
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from decimal import Decimal
 from pathlib import Path
 from typing import Annotated, Any, Literal, Protocol, runtime_checkable
 
@@ -40,6 +41,35 @@ class CredentialRegistryProtocol(Protocol):
 # --- Session State ---
 
 
+class SessionBudget(BaseModel):
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_cost_usd: Decimal | None = None
+
+    @model_validator(mode="after")
+    def _normalize_limits(self) -> SessionBudget:
+        if self.input_tokens is not None:
+            if self.input_tokens < 0:
+                raise ValueError("budget.input_tokens must be >= 0")
+            if self.input_tokens == 0:
+                self.input_tokens = None
+        if self.output_tokens is not None:
+            if self.output_tokens < 0:
+                raise ValueError("budget.output_tokens must be >= 0")
+            if self.output_tokens == 0:
+                self.output_tokens = None
+        if self.total_cost_usd is not None:
+            if self.total_cost_usd < 0:
+                raise ValueError("budget.total_cost_usd must be >= 0")
+            if self.total_cost_usd == 0:
+                self.total_cost_usd = None
+        return self
+
+    @property
+    def has_any_limit(self) -> bool:
+        return any(limit is not None for limit in (self.input_tokens, self.output_tokens, self.total_cost_usd))
+
+
 class SessionState(BaseModel):
     session_id: str
     channel_type: str = "cli"
@@ -48,6 +78,7 @@ class SessionState(BaseModel):
     approved_operations: list[str] = []
     activated_skills: list[str] = []
     context_grants: dict[str, ContextGrant] = {}
+    budget: SessionBudget = Field(default_factory=SessionBudget)
     created_at: datetime
     last_active: datetime
 
@@ -217,6 +248,7 @@ class AgentConfig(BaseModel):
     model: str = "anthropic:claude-sonnet-4-6"
     sentinel_model: str = "anthropic:claude-haiku-4-5"
     title_model: str = "anthropic:claude-haiku-4-5"
+    default_session_budget: SessionBudget = Field(default_factory=SessionBudget)
 
     available_models: list[AvailableModelEntry] = Field(default_factory=_default_agent_available_models)
 
@@ -471,4 +503,5 @@ class Deps(BaseModel):
     tool_result_callback: Callable[[ToolResult], None] | None = None
     append_session_events: Callable[[list[dict[str, Any]]], None] | None = None
     usage_tracker: UsageTracker
+    assert_llm_budget_available: Callable[[], None] | None = None
     credential_registry: CredentialRegistryProtocol

--- a/src/carapace/models.py
+++ b/src/carapace/models.py
@@ -44,7 +44,7 @@ class CredentialRegistryProtocol(Protocol):
 class SessionBudget(BaseModel):
     input_tokens: int | None = None
     output_tokens: int | None = None
-    total_cost_usd: Decimal | None = None
+    cost_usd: Decimal | None = None
 
     @model_validator(mode="after")
     def _normalize_limits(self) -> SessionBudget:
@@ -58,16 +58,16 @@ class SessionBudget(BaseModel):
                 raise ValueError("budget.output_tokens must be >= 0")
             if self.output_tokens == 0:
                 self.output_tokens = None
-        if self.total_cost_usd is not None:
-            if self.total_cost_usd < 0:
-                raise ValueError("budget.total_cost_usd must be >= 0")
-            if self.total_cost_usd == 0:
-                self.total_cost_usd = None
+        if self.cost_usd is not None:
+            if self.cost_usd < 0:
+                raise ValueError("budget.cost_usd must be >= 0")
+            if self.cost_usd == 0:
+                self.cost_usd = None
         return self
 
     @property
     def has_any_limit(self) -> bool:
-        return any(limit is not None for limit in (self.input_tokens, self.output_tokens, self.total_cost_usd))
+        return any(limit is not None for limit in (self.input_tokens, self.output_tokens, self.cost_usd))
 
 
 class SessionState(BaseModel):

--- a/src/carapace/security/__init__.py
+++ b/src/carapace/security/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -44,6 +45,7 @@ async def evaluate_with(
     args: dict[str, Any],
     *,
     usage_tracker: UsageTracker | None = None,
+    assert_llm_budget_available: Callable[[], None] | None = None,
     verbose: bool = True,
     tool_call_callback: Any = None,
 ) -> None:
@@ -79,6 +81,7 @@ async def evaluate_with(
         tool_name,
         args,
         usage_tracker=usage_tracker,
+        assert_llm_budget_available=assert_llm_budget_available,
     )
 
     decision_str = _verdict_to_decision(verdict)
@@ -148,6 +151,7 @@ async def evaluate_domain_with(
     command: str,
     *,
     usage_tracker: UsageTracker | None = None,
+    assert_llm_budget_available: Callable[[], None] | None = None,
 ) -> bool:
     """Evaluate a proxy domain request. Returns True to allow, False to deny.
 
@@ -159,6 +163,7 @@ async def evaluate_domain_with(
         domain,
         command,
         usage_tracker=usage_tracker,
+        assert_llm_budget_available=assert_llm_budget_available,
     )
 
     allowed: bool
@@ -215,6 +220,7 @@ async def evaluate_push_with(
     diff: str,
     *,
     usage_tracker: UsageTracker | None = None,
+    assert_llm_budget_available: Callable[[], None] | None = None,
 ) -> bool:
     """Evaluate a Git push. Returns True to allow, False to deny.
 
@@ -227,6 +233,7 @@ async def evaluate_push_with(
         commits,
         diff,
         usage_tracker=usage_tracker,
+        assert_llm_budget_available=assert_llm_budget_available,
     )
 
     decision = _verdict_to_decision(verdict)
@@ -307,6 +314,7 @@ async def evaluate_credential_with(
     trigger: str,
     *,
     usage_tracker: UsageTracker | None = None,
+    assert_llm_budget_available: Callable[[], None] | None = None,
 ) -> CredentialAccessEvaluation:
     """Evaluate a credential access request.
 
@@ -321,6 +329,7 @@ async def evaluate_credential_with(
         description,
         trigger,
         usage_tracker=usage_tracker,
+        assert_llm_budget_available=assert_llm_budget_available,
     )
 
     decision = _verdict_to_decision(verdict)

--- a/src/carapace/security/sentinel.py
+++ b/src/carapace/security/sentinel.py
@@ -198,6 +198,7 @@ class Sentinel:
         args: dict[str, Any],
         *,
         usage_tracker: UsageTracker | None = None,
+        assert_llm_budget_available: Callable[[], None] | None = None,
     ) -> SentinelVerdict:
         async with self._lock:
             if self._should_reset(session):
@@ -219,6 +220,8 @@ class Sentinel:
             prompt_parts.append(f"Last user message was {tool_calls_since_user} tool calls ago.")
 
             prompt = "\n".join(prompt_parts)
+            if assert_llm_budget_available is not None:
+                assert_llm_budget_available()
             result = await self._agent.run(
                 prompt,
                 deps=self._skills_dir,
@@ -239,6 +242,7 @@ class Sentinel:
         command: str,
         *,
         usage_tracker: UsageTracker | None = None,
+        assert_llm_budget_available: Callable[[], None] | None = None,
     ) -> SentinelVerdict:
         async with self._lock:
             if self._should_reset(session):
@@ -257,6 +261,8 @@ class Sentinel:
             prompt_parts.append(f"\nEVALUATE domain_access_request:\nDomain: {domain}\nTriggered by: {command}")
 
             prompt = "\n".join(prompt_parts)
+            if assert_llm_budget_available is not None:
+                assert_llm_budget_available()
             result = await self._agent.run(
                 prompt,
                 deps=self._skills_dir,
@@ -279,6 +285,7 @@ class Sentinel:
         trigger: str,
         *,
         usage_tracker: UsageTracker | None = None,
+        assert_llm_budget_available: Callable[[], None] | None = None,
     ) -> SentinelVerdict:
         async with self._lock:
             if self._should_reset(session):
@@ -300,6 +307,8 @@ class Sentinel:
             prompt_parts.append(f"Triggered by: {trigger}")
 
             prompt = "\n".join(prompt_parts)
+            if assert_llm_budget_available is not None:
+                assert_llm_budget_available()
             result = await self._agent.run(
                 prompt,
                 deps=self._skills_dir,
@@ -334,6 +343,7 @@ class Sentinel:
         diff: str,
         *,
         usage_tracker: UsageTracker | None = None,
+        assert_llm_budget_available: Callable[[], None] | None = None,
     ) -> SentinelVerdict:
         """Evaluate a Git push from the pre-receive hook."""
         async with self._lock:
@@ -360,6 +370,8 @@ class Sentinel:
             prompt_parts.append(f"Diff:\n{diff}")
 
             prompt = "\n".join(prompt_parts)
+            if assert_llm_budget_available is not None:
+                assert_llm_budget_available()
             result = await self._agent.run(
                 prompt,
                 deps=self._skills_dir,

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -46,7 +46,7 @@ from carapace.sandbox.runtime import ContainerRuntime
 from carapace.security.context import ApprovalSource, ApprovalVerdict
 from carapace.session import SessionEngine, SessionManager
 from carapace.skills import SkillRegistry
-from carapace.usage import gauge_breakdown_pct_dict, last_record_for_source
+from carapace.usage import SessionBudgetExceededError
 from carapace.ws_models import (
     SLASH_COMMANDS,
     ApprovalRequest,
@@ -68,7 +68,6 @@ from carapace.ws_models import (
     ToolCallInfo,
     ToolResultInfo,
     TurnUsage,
-    TurnUsageBreakdownPct,
     UserMessage,
     UserMessageNotification,
     parse_client_message,
@@ -416,7 +415,11 @@ async def create_session(
     _token: str = Depends(_verify_token),
 ) -> SessionInfo:
     body = body or SessionCreateRequest()
-    state = _engine.session_mgr.create_session(body.channel_type, body.channel_ref)
+    state = _engine.session_mgr.create_session(
+        body.channel_type,
+        body.channel_ref,
+        budget=_engine.config.agent.default_session_budget,
+    )
     return SessionInfo.from_state(state)
 
 
@@ -755,17 +758,7 @@ async def chat_ws(
 
     # Tell the client whether an agent turn is in progress.
     agent_running = active.agent_task is not None and not active.agent_task.done()
-    usage: TurnUsage | None = None
-    rec_agent = last_record_for_source(active.llm_request_log, "agent")
-    if rec_agent:
-        bd = gauge_breakdown_pct_dict(rec_agent)
-        usage = TurnUsage(
-            input_tokens=rec_agent.input_tokens,
-            output_tokens=rec_agent.output_tokens,
-            breakdown_pct=TurnUsageBreakdownPct.model_validate(bd) if bd else None,
-            model=_engine.agent_model_id_for_gauge(active),
-            context_cap_tokens=_engine.agent_context_cap_for_gauge(active),
-        )
+    usage = _engine._turn_usage_payload(active)
     with contextlib.suppress(Exception):
         await _send(websocket, StatusUpdate(agent_running=agent_running, usage=usage))
 
@@ -884,6 +877,14 @@ async def chat_ws(
                             {"role": "command", "command": result.command, "data": result.data},
                         ],
                     )
+                    if result.command == "budget":
+                        await _send(
+                            websocket,
+                            StatusUpdate(
+                                agent_running=active.agent_task is not None and not active.agent_task.done(),
+                                usage=_engine._turn_usage_payload(active),
+                            ),
+                        )
                     continue
 
                 await _send(websocket, ErrorMessage(detail=f"Unknown command: {user_input.split()[0]}"))
@@ -999,15 +1000,19 @@ async def evaluate_push(req: PushEvalRequest) -> dict[str, str]:
     from carapace.security import evaluate_push_with
 
     with _engine.llm_request_recording(active):
-        allowed = await evaluate_push_with(
-            active.security,
-            active.sentinel,
-            req.ref,
-            req.is_default_branch,
-            req.commits,
-            req.diff,
-            usage_tracker=active.usage_tracker,
-        )
+        try:
+            allowed = await evaluate_push_with(
+                active.security,
+                active.sentinel,
+                req.ref,
+                req.is_default_branch,
+                req.commits,
+                req.diff,
+                usage_tracker=active.usage_tracker,
+                assert_llm_budget_available=lambda: _engine._assert_llm_budget_available(active),
+            )
+        except SessionBudgetExceededError as exc:
+            return {"verdict": "deny", "reason": str(exc)}
     if allowed:
         return {"verdict": "allow"}
     return {"verdict": "deny", "reason": "Denied by sentinel"}
@@ -1149,15 +1154,19 @@ async def fetch_credential(request: Request, vault_path: str) -> Response:
         from carapace.security import evaluate_credential_with
 
         with _engine.llm_request_recording(active):
-            cred_eval = await evaluate_credential_with(
-                active.security,
-                active.sentinel,
-                vault_path,
-                meta.name,
-                meta.description,
-                f"Sandbox requested credential: {meta.name}",
-                usage_tracker=active.usage_tracker,
-            )
+            try:
+                cred_eval = await evaluate_credential_with(
+                    active.security,
+                    active.sentinel,
+                    vault_path,
+                    meta.name,
+                    meta.description,
+                    f"Sandbox requested credential: {meta.name}",
+                    usage_tracker=active.usage_tracker,
+                    assert_llm_budget_available=lambda: _engine._assert_llm_budget_available(active),
+                )
+            except SessionBudgetExceededError as exc:
+                return Response(status_code=403, content=str(exc))
         if not cred_eval.allowed:
             return Response(status_code=403, content="Credential access denied")
 

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -650,8 +650,8 @@ class WebSocketSubscriber:
             GitPushApprovalRequest(request_id=request_id, ref=ref, explanation=explanation, changed_files=changed_files)
         )
 
-    async def on_title_update(self, title: str) -> None:
-        await self._safe_send(SessionTitleUpdate(title=title))
+    async def on_title_update(self, title: str, usage: TurnUsage | None = None) -> None:
+        await self._safe_send(SessionTitleUpdate(title=title, usage=usage))
 
     async def on_domain_info(
         self,

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -1217,6 +1217,7 @@ class SessionEngine:
             logger.info(f"Session budget blocked LLM call for {session_id}: {exc}")
             self._session_mgr.save_usage(session_id, active.usage_tracker)
             self._session_mgr.save_llm_request_log(session_id, active.llm_request_log)
+            self._save_user_message_on_failure(session_id, user_input, latest_messages=latest_messages)
             await self._broadcast(active, "on_error", str(exc))
         except Exception:
             logger.exception("Agent error")

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -7,6 +7,7 @@ import traceback
 import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, Literal, Protocol, runtime_checkable
 
@@ -55,13 +56,17 @@ from carapace.session.manager import SessionManager
 from carapace.session.titler import generate_title
 from carapace.skills import SkillRegistry
 from carapace.usage import (
+    BudgetGauge,
     LlmRequestLog,
     LlmRequestRecord,
     LlmSource,
+    SessionBudgetExceededError,
     UsageTracker,
     gauge_breakdown_pct_dict,
     last_record_for_source,
     llm_request_sink_scope,
+    usage_budget_exceeded_error,
+    usage_budget_gauges,
     usage_last_request_row,
 )
 from carapace.ws_models import (
@@ -306,6 +311,126 @@ class SessionEngine:
         model_id = self.agent_model_id_for_gauge(active)
         return self._max_input_tokens_for_model_id(model_id) or _DEFAULT_CONTEXT_CAP_TOKENS
 
+    def _budget_gauges(self, active: ActiveSession) -> list[BudgetGauge]:
+        budget = active.state.budget
+        return usage_budget_gauges(
+            active.usage_tracker,
+            input_tokens_limit=budget.input_tokens,
+            output_tokens_limit=budget.output_tokens,
+            total_cost_limit=budget.total_cost_usd,
+        )
+
+    def _budget_exceeded_error(self, active: ActiveSession) -> SessionBudgetExceededError | None:
+        budget = active.state.budget
+        return usage_budget_exceeded_error(
+            active.usage_tracker,
+            input_tokens_limit=budget.input_tokens,
+            output_tokens_limit=budget.output_tokens,
+            total_cost_limit=budget.total_cost_usd,
+        )
+
+    def _assert_llm_budget_available(self, active: ActiveSession) -> None:
+        error = self._budget_exceeded_error(active)
+        if error is not None:
+            raise error
+
+    def _turn_usage_payload(self, active: ActiveSession) -> TurnUsage | None:
+        rec_agent = last_record_for_source(active.llm_request_log, "agent")
+        budget_gauges = self._budget_gauges(active)
+        if rec_agent is None and not budget_gauges:
+            return None
+        bd = gauge_breakdown_pct_dict(rec_agent)
+        return TurnUsage(
+            input_tokens=rec_agent.input_tokens if rec_agent else 0,
+            output_tokens=rec_agent.output_tokens if rec_agent else 0,
+            breakdown_pct=TurnUsageBreakdownPct.model_validate(bd) if bd else None,
+            model=self.agent_model_id_for_gauge(active),
+            context_cap_tokens=self.agent_context_cap_for_gauge(active),
+            budget_gauges=budget_gauges,
+        )
+
+    def _budget_command_payload(self, active: ActiveSession, *, message: str | None = None) -> dict[str, Any]:
+        gauges = self._budget_gauges(active)
+        usage_hint = "Set budgets with /budget input N, /budget output N, or /budget cost N. Use 0 to clear a limit."
+        payload: dict[str, Any] = {
+            "gauges": [g.model_dump(mode="json") for g in gauges],
+            "usage_hint": usage_hint,
+        }
+        if message is not None:
+            payload["message"] = message
+        if not gauges and message is None:
+            payload["message"] = "No session budgets configured."
+        return payload
+
+    def _parse_budget_limit_value(self, metric: Literal["input", "output", "cost"], raw: str) -> int | Decimal:
+        cleaned = raw.replace(",", "").replace("_", "")
+        if metric in ("input", "output"):
+            lowered = cleaned.lower()
+            multiplier = 1
+            if lowered.endswith("k"):
+                multiplier = 1_000
+                lowered = lowered[:-1]
+            elif lowered.endswith("m"):
+                multiplier = 1_000_000
+                lowered = lowered[:-1]
+
+            if not lowered:
+                raise ValueError(f"Invalid token budget: {raw}")
+
+            try:
+                scaled = Decimal(lowered) * multiplier
+            except InvalidOperation as exc:
+                raise ValueError(f"Invalid token budget: {raw}") from exc
+
+            if scaled != scaled.to_integral_value():
+                raise ValueError(f"Invalid token budget: {raw}")
+
+            value = int(scaled)
+            if value < 0:
+                raise ValueError("Budget value must be >= 0")
+            return value
+        try:
+            value = Decimal(cleaned)
+        except InvalidOperation as exc:
+            raise ValueError(f"Invalid cost budget: {raw}") from exc
+        if value < 0:
+            raise ValueError("Budget value must be >= 0")
+        return value
+
+    def _set_budget_metric(
+        self,
+        active: ActiveSession,
+        metric: Literal["input", "output", "cost"],
+        value: int | Decimal,
+    ) -> str:
+        budget = active.state.budget.model_copy(deep=True)
+        if metric == "input":
+            budget.input_tokens = int(value)
+            if budget.input_tokens == 0:
+                budget.input_tokens = None
+            active.state.budget = budget
+            self._session_mgr.save_state(active.state)
+            if budget.input_tokens is None:
+                return "Cleared input token budget."
+            return f"Set input token budget to {budget.input_tokens:,} tokens."
+        if metric == "output":
+            budget.output_tokens = int(value)
+            if budget.output_tokens == 0:
+                budget.output_tokens = None
+            active.state.budget = budget
+            self._session_mgr.save_state(active.state)
+            if budget.output_tokens is None:
+                return "Cleared output token budget."
+            return f"Set output token budget to {budget.output_tokens:,} tokens."
+        budget.total_cost_usd = Decimal(value)
+        if budget.total_cost_usd == 0:
+            budget.total_cost_usd = None
+        active.state.budget = budget
+        self._session_mgr.save_state(active.state)
+        if budget.total_cost_usd is None:
+            return "Cleared cost budget."
+        return f"Set cost budget to ${budget.total_cost_usd:.4f}."
+
     def _resolve_model(self, name: str) -> Model:
         """Create a Model from a name, using the model_factory if available."""
         return self._model_factory(name) if self._model_factory else infer_model(name)
@@ -499,6 +624,7 @@ class SessionEngine:
             tool_result_callback=tool_result_callback,
             append_session_events=_append_session_events,
             usage_tracker=active.usage_tracker,
+            assert_llm_budget_available=lambda: self._assert_llm_budget_available(active),
             sandbox=self._sandbox_mgr,
             activated_skills=[],
             credential_registry=self._credential_registry,
@@ -668,9 +794,38 @@ class SessionEngine:
                     "total_output": tracker.total_output,
                     "costs": {k: str(v) for k, v in costs.items()},
                     "category_costs": {k: str(v) for k, v in cat_costs.items()},
+                    "budget_gauges": [g.model_dump(mode="json") for g in self._budget_gauges(active)],
                     "last_llm_agent": self._usage_last_llm_payload_row(active, "agent"),
                     "last_llm_sentinel": self._usage_last_llm_payload_row(active, "sentinel"),
                 },
+            }
+
+        if cmd == "/budget":
+            if len(parts) == 1:
+                return {"command": "budget", "data": self._budget_command_payload(active)}
+
+            args = parts[1].strip().split(maxsplit=1)
+            if len(args) != 2 or args[0] not in ("input", "output", "cost"):
+                return {
+                    "command": "budget",
+                    "data": {
+                        **self._budget_command_payload(active),
+                        "error": "Usage: /budget, /budget input N, /budget output N, or /budget cost N",
+                    },
+                }
+
+            metric = args[0]
+            try:
+                value = self._parse_budget_limit_value(metric, args[1].strip())
+            except ValueError as exc:
+                return {
+                    "command": "budget",
+                    "data": {**self._budget_command_payload(active), "error": str(exc)},
+                }
+            message = self._set_budget_metric(active, metric, value)
+            return {
+                "command": "budget",
+                "data": self._budget_command_payload(active, message=message),
             }
 
         if cmd == "/pull":
@@ -1007,6 +1162,7 @@ class SessionEngine:
 
                 async with self._llm_semaphore:
                     with self.llm_request_recording(active):
+                        self._assert_llm_budget_available(active)
                         messages, output, thinking = await run_agent_turn(
                             user_input,
                             deps,
@@ -1016,6 +1172,7 @@ class SessionEngine:
                             on_token=_on_token,
                             on_thinking_token=_on_thinking_token,
                             on_messages_snapshot=lambda snapshot: _set_latest_messages(snapshot),
+                            before_llm_call=lambda: self._assert_llm_budget_available(active),
                         )
 
                 self._session_mgr.save_history(session_id, messages)
@@ -1031,19 +1188,12 @@ class SessionEngine:
                 if output.startswith("Unexpected agent output type:"):
                     await self._broadcast(active, "on_error", output)
                 else:
-                    rec_agent = last_record_for_source(active.llm_request_log, "agent")
-                    bd = gauge_breakdown_pct_dict(rec_agent)
+                    usage_payload = self._turn_usage_payload(active) or TurnUsage()
                     await self._broadcast(
                         active,
                         "on_done",
                         output,
-                        TurnUsage(
-                            input_tokens=rec_agent.input_tokens if rec_agent else 0,
-                            output_tokens=rec_agent.output_tokens if rec_agent else 0,
-                            breakdown_pct=TurnUsageBreakdownPct.model_validate(bd) if bd else None,
-                            model=self.agent_model_id_for_gauge(active),
-                            context_cap_tokens=self.agent_context_cap_for_gauge(active),
-                        ),
+                        usage_payload,
                         thinking=thinking or None,
                     )
 
@@ -1063,6 +1213,11 @@ class SessionEngine:
             self._session_mgr.save_llm_request_log(session_id, active.llm_request_log)
             self._save_user_message_on_failure(session_id, user_input, latest_messages=latest_messages)
             await self._broadcast(active, "on_cancelled")
+        except SessionBudgetExceededError as exc:
+            logger.info(f"Session budget blocked LLM call for {session_id}: {exc}")
+            self._session_mgr.save_usage(session_id, active.usage_tracker)
+            self._session_mgr.save_llm_request_log(session_id, active.llm_request_log)
+            await self._broadcast(active, "on_error", str(exc))
         except Exception:
             logger.exception("Agent error")
             self._save_user_message_on_failure(session_id, user_input, latest_messages=latest_messages)
@@ -1147,10 +1302,12 @@ class SessionEngine:
         session_id = active.state.session_id
         try:
             async with self._llm_semaphore:
+                self._assert_llm_budget_available(active)
                 title = await generate_title(
                     events,
                     model=active.title_model_name or self._config.agent.title_model,
                     usage_tracker=active.usage_tracker,
+                    before_llm_call=lambda: self._assert_llm_budget_available(active),
                     model_factory=self._model_factory,
                 )
             if title:
@@ -1489,12 +1646,17 @@ class SessionEngine:
 
         async def _eval(domain: str, command: str) -> bool:
             with self.llm_request_recording(active):
-                return await security_mod.evaluate_domain_with(
-                    security,
-                    sentinel,
-                    domain,
-                    command,
-                    usage_tracker=active.usage_tracker,
-                )
+                try:
+                    return await security_mod.evaluate_domain_with(
+                        security,
+                        sentinel,
+                        domain,
+                        command,
+                        usage_tracker=active.usage_tracker,
+                        assert_llm_budget_available=lambda: self._assert_llm_budget_available(active),
+                    )
+                except SessionBudgetExceededError as exc:
+                    logger.info(f"Session budget blocked domain evaluation for {active.state.session_id}: {exc}")
+                    return False
 
         return _eval

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -317,7 +317,7 @@ class SessionEngine:
             active.usage_tracker,
             input_tokens_limit=budget.input_tokens,
             output_tokens_limit=budget.output_tokens,
-            total_cost_limit=budget.total_cost_usd,
+            total_cost_limit=budget.cost_usd,
         )
 
     def _budget_exceeded_error(self, active: ActiveSession) -> SessionBudgetExceededError | None:
@@ -326,7 +326,7 @@ class SessionEngine:
             active.usage_tracker,
             input_tokens_limit=budget.input_tokens,
             output_tokens_limit=budget.output_tokens,
-            total_cost_limit=budget.total_cost_usd,
+            total_cost_limit=budget.cost_usd,
         )
 
     def _assert_llm_budget_available(self, active: ActiveSession) -> None:
@@ -422,14 +422,14 @@ class SessionEngine:
             if budget.output_tokens is None:
                 return "Cleared output token budget."
             return f"Set output token budget to {budget.output_tokens:,} tokens."
-        budget.total_cost_usd = Decimal(value)
-        if budget.total_cost_usd == 0:
-            budget.total_cost_usd = None
+        budget.cost_usd = Decimal(value)
+        if budget.cost_usd == 0:
+            budget.cost_usd = None
         active.state.budget = budget
         self._session_mgr.save_state(active.state)
-        if budget.total_cost_usd is None:
+        if budget.cost_usd is None:
             return "Cleared cost budget."
-        return f"Set cost budget to ${budget.total_cost_usd:.4f}."
+        return f"Set cost budget to ${budget.cost_usd:.4f}."
 
     def _resolve_model(self, name: str) -> Model:
         """Create a Model from a name, using the model_factory if available."""

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -124,7 +124,7 @@ class SessionSubscriber(Protocol):
     async def on_git_push_approval_request(
         self, request_id: str, ref: str, explanation: str, changed_files: list[str]
     ) -> None: ...
-    async def on_title_update(self, title: str) -> None: ...
+    async def on_title_update(self, title: str, usage: TurnUsage | None = None) -> None: ...
     async def on_domain_info(
         self,
         domain: str,
@@ -1313,7 +1313,8 @@ class SessionEngine:
             if title:
                 active.state.title = title
                 self._session_mgr.save_state(active.state)
-                await self._broadcast(active, "on_title_update", title)
+                self._session_mgr.save_usage(session_id, active.usage_tracker)
+                await self._broadcast(active, "on_title_update", title, self._turn_usage_payload(active))
                 return title
         except Exception as exc:
             logger.warning(f"Title generation failed for {session_id}: {exc}")

--- a/src/carapace/session/manager.py
+++ b/src/carapace/session/manager.py
@@ -12,7 +12,7 @@ from loguru import logger
 from pydantic import BaseModel
 from pydantic_ai import ModelMessage, ModelMessagesTypeAdapter
 
-from carapace.models import SessionState
+from carapace.models import SessionBudget, SessionState
 from carapace.usage import LlmRequestLog, UsageTracker
 
 
@@ -44,13 +44,19 @@ class SessionManager:
         self.sessions_dir = data_dir / "sessions"
         self.sessions_dir.mkdir(parents=True, exist_ok=True)
 
-    def create_session(self, channel_type: str = "cli", channel_ref: str = "") -> SessionState:
+    def create_session(
+        self,
+        channel_type: str = "cli",
+        channel_ref: str = "",
+        budget: SessionBudget | None = None,
+    ) -> SessionState:
         now = datetime.now(tz=UTC)
         session_id = f"{now:%Y-%m-%d-%H-%M}-{secrets.token_hex(4)}"
         state = SessionState(
             session_id=session_id,
             channel_type=channel_type,
             channel_ref=channel_ref or None,
+            budget=budget.model_copy(deep=True) if budget is not None else SessionBudget(),
             created_at=now,
             last_active=now,
         )

--- a/src/carapace/session/titler.py
+++ b/src/carapace/session/titler.py
@@ -24,6 +24,7 @@ async def generate_title(
     *,
     model: str,
     usage_tracker: UsageTracker | None = None,
+    before_llm_call: Callable[[], None] | None = None,
     model_factory: Callable[[str], Model] | None = None,
 ) -> str:
     """Build a short emoji-prefixed title from conversation events.
@@ -56,6 +57,8 @@ async def generate_title(
     resolved = model_factory(model) if model_factory is not None else infer_model(model)
     agent: Agent[None, str] = Agent(resolved, output_type=str, instructions=_SYSTEM_PROMPT, retries=1, output_retries=3)
     try:
+        if before_llm_call is not None:
+            before_llm_call()
         result = await agent.run(prompt)
         if usage_tracker:
             usage_tracker.record(model, "title", result.usage())

--- a/src/carapace/usage.py
+++ b/src/carapace/usage.py
@@ -176,16 +176,6 @@ def _format_usd(value: Decimal) -> str:
     return f"${value:.4f}"
 
 
-def usage_unknown_pricing_models(tracker: UsageTracker) -> list[str]:
-    unknown: list[str] = []
-    for model_key, usage in tracker.models.items():
-        if not _has_usage(usage):
-            continue
-        if _price_for_usage(model_key, usage) is None:
-            unknown.append(model_key)
-    return sorted(unknown)
-
-
 def usage_budget_gauges(
     tracker: UsageTracker,
     *,
@@ -230,37 +220,21 @@ def usage_budget_gauges(
         )
 
     if total_cost_limit is not None:
-        unknown_models = usage_unknown_pricing_models(tracker)
-        if unknown_models:
-            gauges.append(
-                BudgetGauge(
-                    key="cost",
-                    label="Cost",
-                    current_value="unknown",
-                    current_amount=None,
-                    limit_value=_format_usd(total_cost_limit),
-                    remaining_value=None,
-                    fill_pct=100.0,
-                    reached=True,
-                    unavailable_reason=("Pricing unavailable for: " + ", ".join(unknown_models)),
-                )
+        total_cost = tracker.estimated_cost().get("total", Decimal(0))
+        remaining = max(Decimal(0), total_cost_limit - total_cost)
+        fill_pct = min(100.0, float(Decimal(100) * total_cost / total_cost_limit)) if total_cost_limit > 0 else 0.0
+        gauges.append(
+            BudgetGauge(
+                key="cost",
+                label="Cost",
+                current_value=_format_usd(total_cost),
+                current_amount=float(total_cost),
+                limit_value=_format_usd(total_cost_limit),
+                remaining_value=_format_usd(remaining),
+                fill_pct=round(fill_pct, 1),
+                reached=total_cost >= total_cost_limit,
             )
-        else:
-            total_cost = tracker.estimated_cost().get("total", Decimal(0))
-            remaining = max(Decimal(0), total_cost_limit - total_cost)
-            fill_pct = min(100.0, float(Decimal(100) * total_cost / total_cost_limit)) if total_cost_limit > 0 else 0.0
-            gauges.append(
-                BudgetGauge(
-                    key="cost",
-                    label="Cost",
-                    current_value=_format_usd(total_cost),
-                    current_amount=float(total_cost),
-                    limit_value=_format_usd(total_cost_limit),
-                    remaining_value=_format_usd(remaining),
-                    fill_pct=round(fill_pct, 1),
-                    reached=total_cost >= total_cost_limit,
-                )
-            )
+        )
 
     return gauges
 

--- a/src/carapace/usage.py
+++ b/src/carapace/usage.py
@@ -148,22 +148,6 @@ class SessionBudgetExceededError(RuntimeError):
         self.gauges = gauges
 
 
-def _has_usage(u: ModelUsage) -> bool:
-    return any(
-        value > 0
-        for value in (
-            u.input_tokens,
-            u.output_tokens,
-            u.cache_read_tokens,
-            u.cache_write_tokens,
-            u.input_audio_tokens,
-            u.output_audio_tokens,
-            u.cache_audio_read_tokens,
-            u.requests,
-        )
-    )
-
-
 def _format_token_count(value: int) -> str:
     if value >= 1_000_000:
         return f"{value / 1_000_000:.1f}M tokens"

--- a/src/carapace/usage.py
+++ b/src/carapace/usage.py
@@ -130,6 +130,169 @@ class UsageTracker(BaseModel):
         return costs
 
 
+class BudgetGauge(BaseModel):
+    key: Literal["input", "output", "cost"]
+    label: str
+    current_value: str
+    current_amount: float | None = None
+    limit_value: str
+    remaining_value: str | None = None
+    fill_pct: float
+    reached: bool
+    unavailable_reason: str | None = None
+
+
+class SessionBudgetExceededError(RuntimeError):
+    def __init__(self, message: str, *, gauges: list[BudgetGauge]) -> None:
+        super().__init__(message)
+        self.gauges = gauges
+
+
+def _has_usage(u: ModelUsage) -> bool:
+    return any(
+        value > 0
+        for value in (
+            u.input_tokens,
+            u.output_tokens,
+            u.cache_read_tokens,
+            u.cache_write_tokens,
+            u.input_audio_tokens,
+            u.output_audio_tokens,
+            u.cache_audio_read_tokens,
+            u.requests,
+        )
+    )
+
+
+def _format_token_count(value: int) -> str:
+    if value >= 1_000_000:
+        return f"{value / 1_000_000:.1f}M tokens"
+    if value >= 1_000:
+        return f"{value / 1_000:.1f}k tokens"
+    return f"{value} tokens"
+
+
+def _format_usd(value: Decimal) -> str:
+    return f"${value:.4f}"
+
+
+def usage_unknown_pricing_models(tracker: UsageTracker) -> list[str]:
+    unknown: list[str] = []
+    for model_key, usage in tracker.models.items():
+        if not _has_usage(usage):
+            continue
+        if _price_for_usage(model_key, usage) is None:
+            unknown.append(model_key)
+    return sorted(unknown)
+
+
+def usage_budget_gauges(
+    tracker: UsageTracker,
+    *,
+    input_tokens_limit: int | None = None,
+    output_tokens_limit: int | None = None,
+    total_cost_limit: Decimal | None = None,
+) -> list[BudgetGauge]:
+    gauges: list[BudgetGauge] = []
+
+    if input_tokens_limit is not None:
+        current = tracker.total_input
+        remaining = max(0, input_tokens_limit - current)
+        fill_pct = min(100.0, (100.0 * current / input_tokens_limit)) if input_tokens_limit > 0 else 0.0
+        gauges.append(
+            BudgetGauge(
+                key="input",
+                label="Input",
+                current_value=_format_token_count(current),
+                current_amount=float(current),
+                limit_value=_format_token_count(input_tokens_limit),
+                remaining_value=_format_token_count(remaining),
+                fill_pct=round(fill_pct, 1),
+                reached=current >= input_tokens_limit,
+            )
+        )
+
+    if output_tokens_limit is not None:
+        current = tracker.total_output
+        remaining = max(0, output_tokens_limit - current)
+        fill_pct = min(100.0, (100.0 * current / output_tokens_limit)) if output_tokens_limit > 0 else 0.0
+        gauges.append(
+            BudgetGauge(
+                key="output",
+                label="Output",
+                current_value=_format_token_count(current),
+                current_amount=float(current),
+                limit_value=_format_token_count(output_tokens_limit),
+                remaining_value=_format_token_count(remaining),
+                fill_pct=round(fill_pct, 1),
+                reached=current >= output_tokens_limit,
+            )
+        )
+
+    if total_cost_limit is not None:
+        unknown_models = usage_unknown_pricing_models(tracker)
+        if unknown_models:
+            gauges.append(
+                BudgetGauge(
+                    key="cost",
+                    label="Cost",
+                    current_value="unknown",
+                    current_amount=None,
+                    limit_value=_format_usd(total_cost_limit),
+                    remaining_value=None,
+                    fill_pct=100.0,
+                    reached=True,
+                    unavailable_reason=("Pricing unavailable for: " + ", ".join(unknown_models)),
+                )
+            )
+        else:
+            total_cost = tracker.estimated_cost().get("total", Decimal(0))
+            remaining = max(Decimal(0), total_cost_limit - total_cost)
+            fill_pct = min(100.0, float(Decimal(100) * total_cost / total_cost_limit)) if total_cost_limit > 0 else 0.0
+            gauges.append(
+                BudgetGauge(
+                    key="cost",
+                    label="Cost",
+                    current_value=_format_usd(total_cost),
+                    current_amount=float(total_cost),
+                    limit_value=_format_usd(total_cost_limit),
+                    remaining_value=_format_usd(remaining),
+                    fill_pct=round(fill_pct, 1),
+                    reached=total_cost >= total_cost_limit,
+                )
+            )
+
+    return gauges
+
+
+def usage_budget_exceeded_error(
+    tracker: UsageTracker,
+    *,
+    input_tokens_limit: int | None = None,
+    output_tokens_limit: int | None = None,
+    total_cost_limit: Decimal | None = None,
+) -> SessionBudgetExceededError | None:
+    gauges = usage_budget_gauges(
+        tracker,
+        input_tokens_limit=input_tokens_limit,
+        output_tokens_limit=output_tokens_limit,
+        total_cost_limit=total_cost_limit,
+    )
+    offenders = [gauge for gauge in gauges if gauge.reached]
+    if not offenders:
+        return None
+    parts: list[str] = []
+    for gauge in offenders:
+        if gauge.unavailable_reason:
+            parts.append(f"{gauge.label.lower()}: {gauge.unavailable_reason}")
+        else:
+            parts.append(f"{gauge.label.lower()} {gauge.current_value} / {gauge.limit_value}")
+    return SessionBudgetExceededError(
+        "Session budget reached: " + "; ".join(parts),
+        gauges=gauges,
+    )
+
+
 LlmSource = Literal["agent", "sentinel"]
 
 _llm_request_sink: ContextVar[Callable[[LlmRequestRecord], None] | None] = ContextVar(

--- a/src/carapace/ws_models.py
+++ b/src/carapace/ws_models.py
@@ -5,6 +5,7 @@ from typing import Any, Literal
 from pydantic import BaseModel
 
 from carapace.security.context import ApprovalSource, ApprovalVerdict
+from carapace.usage import BudgetGauge
 
 SLASH_COMMANDS: list[dict[str, str]] = [
     {"command": "/security", "description": "Show security policy summary"},
@@ -26,6 +27,10 @@ SLASH_COMMANDS: list[dict[str, str]] = [
     {
         "command": "/model",
         "description": "View or switch agent, sentinel, and title models together (e.g. /model openai:gpt-4o)",
+    },
+    {
+        "command": "/budget",
+        "description": "Show current budgets. Set with /budget input N, /budget output N, or /budget cost N",
     },
     {"command": "/model-agent", "description": "View or switch the agent model only"},
     {"command": "/model-sentinel", "description": "View or switch the sentinel model"},
@@ -179,6 +184,7 @@ class TurnUsage(BaseModel):
     breakdown_pct: TurnUsageBreakdownPct | None = None
     model: str | None = None
     context_cap_tokens: int | None = None
+    budget_gauges: list[BudgetGauge] = []
 
 
 class Done(BaseModel):

--- a/src/carapace/ws_models.py
+++ b/src/carapace/ws_models.py
@@ -217,6 +217,7 @@ class SessionTitleUpdate(BaseModel):
 
     type: Literal["session_title"] = "session_title"
     title: str
+    usage: TurnUsage | None = None
 
 
 class StatusUpdate(BaseModel):

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -21,7 +21,7 @@ from carapace.channels.matrix import (
 )
 from carapace.channels.matrix.subscriber import MatrixSubscriber
 from carapace.config import load_config
-from carapace.models import MatrixChannelConfig, MatrixTokenFile, Secret
+from carapace.models import MatrixChannelConfig, MatrixTokenFile, Secret, SessionBudget
 from carapace.sandbox.manager import SandboxManager
 from carapace.session import SessionEngine, SessionManager
 from carapace.ws_models import ApprovalRequest, CommandResult
@@ -52,6 +52,7 @@ def _make_engine_mock() -> MagicMock:
     engine.subscribe = MagicMock()
     engine.unsubscribe = MagicMock()
     engine.deactivate = MagicMock()
+    engine.config.agent.default_session_budget = SessionBudget()
     return engine
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -37,17 +37,17 @@ def test_config_defaults():
 
 def test_session_budget_zero_values_normalize_to_unlimited() -> None:
     budget = SessionBudget.model_validate(
-        {"input_tokens": 0, "output_tokens": 0, "total_cost_usd": "0"},
+        {"input_tokens": 0, "output_tokens": 0, "cost_usd": "0"},
     )
     assert budget.input_tokens is None
     assert budget.output_tokens is None
-    assert budget.total_cost_usd is None
+    assert budget.cost_usd is None
     assert budget.has_any_limit is False
 
 
 def test_session_budget_accepts_decimal_cost() -> None:
-    budget = SessionBudget(total_cost_usd=Decimal("1.25"))
-    assert budget.total_cost_usd == Decimal("1.25")
+    budget = SessionBudget(cost_usd=Decimal("1.25"))
+    assert budget.cost_usd == Decimal("1.25")
 
 
 def test_available_model_entry_shorthand_string():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
 """Tests for pydantic models (no LLM tokens needed)."""
 
+from decimal import Decimal
 from unittest.mock import MagicMock
 
 import pytest
@@ -11,6 +12,7 @@ from carapace.models import (
     AgentConfig,
     AvailableModelEntry,
     Config,
+    SessionBudget,
     SessionState,
     agent_available_model_entries,
 )
@@ -26,10 +28,26 @@ def test_config_defaults():
     cfg = Config()
     assert cfg.carapace.log_level == "info"
     assert cfg.agent.model == "anthropic:claude-sonnet-4-6"
+    assert cfg.agent.default_session_budget.has_any_limit is False
     assert cfg.agent.tool_output_max_chars == 16_000
     assert cfg.sandbox.network_name == "carapace-sandbox"
     ids = {e.model_id for e in cfg.agent.available_models}
     assert ids == {"anthropic:claude-sonnet-4-6", "anthropic:claude-haiku-4-5"}
+
+
+def test_session_budget_zero_values_normalize_to_unlimited() -> None:
+    budget = SessionBudget.model_validate(
+        {"input_tokens": 0, "output_tokens": 0, "total_cost_usd": "0"},
+    )
+    assert budget.input_tokens is None
+    assert budget.output_tokens is None
+    assert budget.total_cost_usd is None
+    assert budget.has_any_limit is False
+
+
+def test_session_budget_accepts_decimal_cost() -> None:
+    budget = SessionBudget(total_cost_usd=Decimal("1.25"))
+    assert budget.total_cost_usd == Decimal("1.25")
 
 
 def test_available_model_entry_shorthand_string():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,7 +14,7 @@ from carapace.bootstrap import ensure_data_dir
 from carapace.config import load_config
 from carapace.credentials import CredentialRegistry
 from carapace.git.store import GitStore
-from carapace.models import CredentialMetadata
+from carapace.models import CredentialMetadata, SessionBudget
 from carapace.sandbox.manager import SandboxManager
 from carapace.security.context import CredentialAccessEntry
 from carapace.server import app, sandbox_app
@@ -215,6 +215,34 @@ def test_ws_session_command(client, auth_headers, bearer):
         assert msg["type"] == "command_result"
         assert msg["command"] == "session"
         assert msg["data"]["session_id"] == sid
+
+
+def test_ws_status_includes_budget_gauges_for_configured_defaults(client, auth_headers, bearer):
+    srv._engine.config.agent.default_session_budget = SessionBudget(input_tokens=1_000)
+    create_resp = client.post("/api/sessions", headers=auth_headers)
+    sid = create_resp.json()["session_id"]
+
+    with client.websocket_connect(f"/api/chat/{sid}?token={bearer}") as ws:
+        status = _consume_status(ws)
+        assert status["usage"]["budget_gauges"][0]["key"] == "input"
+        assert status["usage"]["budget_gauges"][0]["current_value"] == "0 tokens"
+
+
+def test_ws_budget_command_emits_status_refresh(client, auth_headers, bearer):
+    create_resp = client.post("/api/sessions", headers=auth_headers)
+    sid = create_resp.json()["session_id"]
+
+    with client.websocket_connect(f"/api/chat/{sid}?token={bearer}") as ws:
+        _consume_status(ws)
+        ws.send_json({"type": "message", "content": "/budget input 1000"})
+        echo = ws.receive_json()
+        assert echo["type"] == "user_message"
+        msg = ws.receive_json()
+        assert msg["type"] == "command_result"
+        assert msg["command"] == "budget"
+        status = ws.receive_json()
+        assert status["type"] == "status"
+        assert status["usage"]["budget_gauges"][0]["key"] == "input"
 
 
 def test_ws_skills_command(client, auth_headers, bearer):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from decimal import Decimal
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -15,7 +16,7 @@ from carapace.bootstrap import ensure_data_dir
 from carapace.config import load_config
 from carapace.credentials import CredentialRegistry
 from carapace.git.store import GitStore
-from carapace.models import ContextGrant, CredentialRegistryProtocol, SkillCredentialDecl, ToolResult
+from carapace.models import ContextGrant, CredentialRegistryProtocol, SessionBudget, SkillCredentialDecl, ToolResult
 from carapace.sandbox.manager import SandboxManager
 from carapace.security.context import UserEscalationDecision, format_denial_message, normalize_optional_message
 from carapace.security.sentinel import Sentinel
@@ -38,6 +39,17 @@ def test_create_session(tmp_path: Path):
     state = mgr.create_session()
     assert len(state.session_id) == 25  # 2026-03-08-10-22-abcd1234
     assert state.channel_type == "cli"
+
+
+def test_create_session_persists_budget(tmp_path: Path):
+    mgr = SessionManager(tmp_path)
+    budget = SessionBudget(input_tokens=1_000, total_cost_usd=Decimal("5.00"))
+    state = mgr.create_session(budget=budget)
+
+    resumed = mgr.resume_session(state.session_id)
+    assert resumed is not None
+    assert resumed.budget.input_tokens == 1_000
+    assert resumed.budget.total_cost_usd == Decimal("5.00")
 
 
 def test_resume_session(tmp_path: Path):
@@ -544,6 +556,129 @@ def test_handle_slash_command_retitle_regenerates(tmp_path: Path):
             assert "Cats chat" in result["data"]["message"]
             assert active.state.title == "📌 Cats chat"
 
+        asyncio.run(_run())
+
+
+def test_handle_slash_command_budget_sets_and_clears(tmp_path: Path):
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session()
+        sid = state.session_id
+        engine.get_or_activate(sid)
+
+        async def _run() -> None:
+            initial = await engine.handle_slash_command(sid, "/budget")
+            assert initial is not None
+            assert "usage_hint" in initial["data"]
+            assert "/budget input N" in initial["data"]["usage_hint"]
+
+            set_result = await engine.handle_slash_command(sid, "/budget input 1000")
+            assert set_result is not None
+            assert set_result["command"] == "budget"
+            assert set_result["data"]["message"] == "Set input token budget to 1,000 tokens."
+            assert set_result["data"]["gauges"][0]["key"] == "input"
+
+            cleared = await engine.handle_slash_command(sid, "/budget input 0")
+            assert cleared is not None
+            assert cleared["data"]["message"] == "Cleared input token budget."
+            assert cleared["data"]["gauges"] == []
+
+            reloaded = engine.session_mgr.load_state(sid)
+            assert reloaded is not None
+            assert reloaded.budget.input_tokens is None
+
+        asyncio.run(_run())
+
+
+def test_handle_slash_command_budget_accepts_k_and_m_suffixes(tmp_path: Path):
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session()
+        sid = state.session_id
+        engine.get_or_activate(sid)
+
+        async def _run() -> None:
+            input_result = await engine.handle_slash_command(sid, "/budget input 100k")
+            assert input_result is not None
+            assert input_result["data"]["message"] == "Set input token budget to 100,000 tokens."
+
+            output_result = await engine.handle_slash_command(sid, "/budget output 2M")
+            assert output_result is not None
+            assert output_result["data"]["message"] == "Set output token budget to 2,000,000 tokens."
+
+            reloaded = engine.session_mgr.load_state(sid)
+            assert reloaded is not None
+            assert reloaded.budget.input_tokens == 100_000
+            assert reloaded.budget.output_tokens == 2_000_000
+
+        asyncio.run(_run())
+
+
+def test_handle_slash_command_help_lists_budget(tmp_path: Path):
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session()
+        sid = state.session_id
+        engine.get_or_activate(sid)
+
+        async def _run() -> None:
+            result = await engine.handle_slash_command(sid, "/help")
+            assert result is not None
+            commands = result["data"]["commands"]
+            assert any(item["command"] == "/budget" for item in commands)
+
+        asyncio.run(_run())
+
+
+def test_turn_usage_payload_contains_budget_gauges_without_agent_usage(tmp_path: Path):
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session(budget=SessionBudget(input_tokens=1_000))
+        active = engine.get_or_activate(state.session_id)
+
+        payload = engine._turn_usage_payload(active)
+
+        assert payload is not None
+        assert payload.budget_gauges[0].key == "input"
+        assert payload.budget_gauges[0].current_value == "0 tokens"
+
+
+def test_submit_message_budget_exhausted_broadcasts_error(tmp_path: Path):
+    async def _run() -> None:
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session(budget=SessionBudget(input_tokens=100))
+        sid = state.session_id
+        sub = _FakeSubscriber()
+        engine.subscribe(sid, sub)
+        active = engine.get_active(sid)
+        assert active is not None
+        active.usage_tracker.models["test-model"] = ModelUsage(input_tokens=120)
+
+        with patch("carapace.session.engine.run_agent_turn", new=AsyncMock()) as mocked_turn:
+            await engine.submit_message(sid, "hello")
+            await asyncio.sleep(0.1)
+
+        mocked_turn.assert_not_awaited()
+        assert any("Session budget reached" in err for err in sub.errors)
+
+    with _patch_sentinel():
+        asyncio.run(_run())
+
+
+def test_generate_title_skips_when_budget_exhausted(tmp_path: Path):
+    async def _run() -> None:
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session(budget=SessionBudget(input_tokens=100))
+        active = engine.get_or_activate(state.session_id)
+        active.usage_tracker.models["test-model"] = ModelUsage(input_tokens=120)
+
+        with patch("carapace.session.engine.generate_title", new=AsyncMock(return_value="ignored")) as mocked:
+            title = await engine._generate_title(active, [{"role": "user", "content": "hello"}])
+
+        assert title == ""
+        mocked.assert_not_awaited()
+
+    with _patch_sentinel():
         asyncio.run(_run())
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -24,7 +24,7 @@ from carapace.security.sentinel import Sentinel
 from carapace.session import SessionEngine, SessionManager
 from carapace.session.engine import _non_slash_user_message_count
 from carapace.skills import SkillRegistry
-from carapace.usage import ModelUsage
+from carapace.usage import ModelUsage, SessionBudgetExceededError
 from carapace.ws_models import ApprovalRequest, TurnUsage
 
 
@@ -661,6 +661,34 @@ def test_submit_message_budget_exhausted_broadcasts_error(tmp_path: Path):
             await asyncio.sleep(0.1)
 
         mocked_turn.assert_not_awaited()
+        assert any("Session budget reached" in err for err in sub.errors)
+
+    with _patch_sentinel():
+        asyncio.run(_run())
+
+
+def test_submit_message_budget_exceeded_persists_history(tmp_path: Path):
+    async def _run() -> None:
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session(budget=SessionBudget(input_tokens=1_000))
+        sid = state.session_id
+        sub = _FakeSubscriber()
+        engine.subscribe(sid, sub)
+
+        async def _fail_run_agent_turn(*_args: Any, on_messages_snapshot=None, **_kwargs: Any):
+            snapshot = [ModelRequest(parts=[UserPromptPart(content="hello")])]
+            if on_messages_snapshot is not None:
+                on_messages_snapshot(snapshot)
+            raise SessionBudgetExceededError("Session budget reached: input 1.0k tokens / 1.0k tokens", gauges=[])
+
+        with patch("carapace.session.engine.run_agent_turn", new=_fail_run_agent_turn):
+            await engine.submit_message(sid, "hello")
+            await asyncio.sleep(0.1)
+
+        history = engine.session_mgr.load_history(sid)
+        assert history
+        assert isinstance(history[0], ModelRequest)
+        assert any(isinstance(part, UserPromptPart) and part.content == "hello" for part in history[0].parts)
         assert any("Session budget reached" in err for err in sub.errors)
 
     with _patch_sentinel():

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -43,13 +43,13 @@ def test_create_session(tmp_path: Path):
 
 def test_create_session_persists_budget(tmp_path: Path):
     mgr = SessionManager(tmp_path)
-    budget = SessionBudget(input_tokens=1_000, total_cost_usd=Decimal("5.00"))
+    budget = SessionBudget(input_tokens=1_000, cost_usd=Decimal("5.00"))
     state = mgr.create_session(budget=budget)
 
     resumed = mgr.resume_session(state.session_id)
     assert resumed is not None
     assert resumed.budget.input_tokens == 1_000
-    assert resumed.budget.total_cost_usd == Decimal("5.00")
+    assert resumed.budget.cost_usd == Decimal("5.00")
 
 
 def test_resume_session(tmp_path: Path):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, ToolCallPart, ToolReturnPart, UserPromptPart
 from pydantic_ai.models.test import TestModel
+from pydantic_ai.usage import RunUsage
 
 from carapace.bootstrap import ensure_data_dir
 from carapace.config import load_config
@@ -176,6 +177,7 @@ class _FakeSubscriber:
         self.user_messages: list[tuple[str, bool]] = []
         self.errors: list[str] = []
         self.cancelled: int = 0
+        self.title_updates: list[tuple[str, TurnUsage | None]] = []
 
     async def on_user_message(self, content: str, *, from_self: bool) -> None:
         self.user_messages.append((content, from_self))
@@ -201,8 +203,8 @@ class _FakeSubscriber:
     async def on_proxy_approval_request(self, request_id: str, domain: str, command: str) -> None:
         pass
 
-    async def on_title_update(self, title: str) -> None:
-        pass
+    async def on_title_update(self, title: str, usage: TurnUsage | None = None) -> None:
+        self.title_updates.append((title, usage))
 
     async def on_domain_info(self, domain: str, detail: str) -> None:
         pass
@@ -677,6 +679,38 @@ def test_generate_title_skips_when_budget_exhausted(tmp_path: Path):
 
         assert title == ""
         mocked.assert_not_awaited()
+
+    with _patch_sentinel():
+        asyncio.run(_run())
+
+
+def test_generate_title_persists_usage_and_broadcasts_usage(tmp_path: Path):
+    async def _run() -> None:
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session(budget=SessionBudget(cost_usd=Decimal("5.00")))
+        sid = state.session_id
+        active = engine.get_or_activate(sid)
+        sub = _FakeSubscriber()
+        engine.subscribe(sid, sub)
+
+        async def _fake_generate_title(*_args: Any, usage_tracker, **_kwargs: Any) -> str:
+            usage_tracker.record(
+                "anthropic:claude-haiku-4-5",
+                "title",
+                RunUsage(input_tokens=10, output_tokens=5, requests=1),
+            )
+            return "📌 hello"
+
+        with patch("carapace.session.engine.generate_title", new=AsyncMock(side_effect=_fake_generate_title)):
+            title = await engine._generate_title(active, [{"role": "user", "content": "hello"}])
+
+        assert title == "📌 hello"
+        stored_usage = engine.session_mgr.load_usage(sid)
+        assert stored_usage.categories["title"].input_tokens == 10
+        assert sub.title_updates
+        assert sub.title_updates[0][0] == "📌 hello"
+        assert sub.title_updates[0][1] is not None
+        assert sub.title_updates[0][1].budget_gauges[0].key == "cost"
 
     with _patch_sentinel():
         asyncio.run(_run())

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -82,7 +82,7 @@ def test_usage_budget_gauges_include_tokens_and_cost() -> None:
     assert gauges[2].current_amount is not None
 
 
-def test_usage_budget_exceeded_error_blocks_unknown_cost_pricing() -> None:
+def test_usage_budget_exceeded_error_treats_unknown_cost_pricing_as_zero() -> None:
     tracker = UsageTracker()
     tracker.record(
         "local:unknown-model",
@@ -95,6 +95,11 @@ def test_usage_budget_exceeded_error_blocks_unknown_cost_pricing() -> None:
         total_cost_limit=Decimal("5.00"),
     )
 
-    assert error is not None
-    assert "Pricing unavailable" in str(error)
-    assert error.gauges[0].unavailable_reason is not None
+    assert error is None
+
+    gauges = usage_budget_gauges(
+        tracker,
+        total_cost_limit=Decimal("5.00"),
+    )
+    assert gauges[0].current_value == "$0.0000"
+    assert gauges[0].current_amount == 0.0

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from decimal import Decimal
+
 from pydantic_ai.usage import RunUsage
 
-from carapace.usage import UsageTracker
+from carapace.usage import UsageTracker, usage_budget_exceeded_error, usage_budget_gauges
 
 
 def test_record_accumulates_tokens_across_events() -> None:
@@ -54,3 +56,45 @@ def test_estimated_category_cost_sums_to_model_costs_when_disjoint() -> None:
         return
     cats = t.estimated_category_cost()
     assert sum(cats.values()) == total
+
+
+def test_usage_budget_gauges_include_tokens_and_cost() -> None:
+    tracker = UsageTracker()
+    tracker.record(
+        "anthropic:claude-haiku-4-5",
+        "agent",
+        RunUsage(input_tokens=1_000, output_tokens=250, requests=1),
+    )
+
+    gauges = usage_budget_gauges(
+        tracker,
+        input_tokens_limit=2_000,
+        output_tokens_limit=500,
+        total_cost_limit=Decimal("1.00"),
+    )
+
+    assert [g.key for g in gauges] == ["input", "output", "cost"]
+    assert gauges[0].current_value == "1.0k tokens"
+    assert gauges[0].current_amount == 1_000.0
+    assert gauges[1].current_value == "250 tokens"
+    assert gauges[1].current_amount == 250.0
+    assert gauges[2].limit_value == "$1.0000"
+    assert gauges[2].current_amount is not None
+
+
+def test_usage_budget_exceeded_error_blocks_unknown_cost_pricing() -> None:
+    tracker = UsageTracker()
+    tracker.record(
+        "local:unknown-model",
+        "agent",
+        RunUsage(input_tokens=100, output_tokens=50, requests=1),
+    )
+
+    error = usage_budget_exceeded_error(
+        tracker,
+        total_cost_limit=Decimal("5.00"),
+    )
+
+    assert error is not None
+    assert "Pricing unavailable" in str(error)
+    assert error.gauges[0].unavailable_reason is not None


### PR DESCRIPTION
## Summary
Adds per-session budgets for input tokens, output tokens, and total cost, with backend enforcement, slash-command management, and UI visibility across web, CLI, and Matrix.

## What Changed
- add `SessionBudget` to session state and support `agent.default_session_budget` in `config.yaml` for new sessions
- enforce budgets before backend LLM calls across agent, sentinel, title generation, domain checks, push checks, and credential checks
- add `/budget` slash command support, help/discoverability updates, and `k`/`M` suffix parsing for token limits
- include budget gauges in usage payloads and render them in the web UI, CLI, and Matrix output
- hide inline budget bars until their current usage is greater than zero, while keeping `/budget` output visible for configured limits
- add regression coverage for config defaults, budget commands, websocket status updates, and budget gauge helpers

## Validation
- `uv run pytest tests/test_models.py tests/test_usage.py tests/test_session.py tests/test_server.py`
- `uvx ruff check src/ tests/`
- `cd frontend && pnpm lint`
- `uv run pytest tests/test_session.py -k budget`
- `uv run pytest tests/test_usage.py tests/test_session.py -k budget`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new per-session budget limits (tokens and cost) and enforces them across agent/sentinel/title and security evaluations, which can block requests and alter control flow. Risk is moderate due to new state persistence and multiple call-site integrations, but changes are bounded and covered by tests.
> 
> **Overview**
> Adds **per-session budgets** (`input_tokens`, `output_tokens`, `cost_usd`) to persisted session state, plus `agent.default_session_budget` config that is applied when creating new sessions (API + Matrix).
> 
> Enforces budgets before any LLM invocation (agent turns, approval-loop re-runs, sentinel evaluations for tools/domains/push/credentials, and title generation), returning user-visible errors or denials when limits are exceeded.
> 
> Introduces `/budget` management and reporting (including `k`/`m` token suffix parsing), plumbs `budget_gauges` into `TurnUsage`/`/usage` payloads, and renders budget tables/gauges across web UI (inline gauge stack), CLI, and Matrix formatting; also refreshes websocket `status` after budget updates and includes usage on title updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6063fafc9dbbee24acfa7427050aa183c914db38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->