### PR TITLE
✨Add exec-scoped network tunnels for skill contexts

### DIFF
--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -42,17 +42,17 @@ When a session container is created, the following mounts are configured:
 
 ### Docker mode
 
-| Host source | Container path | Mode | Purpose |
-| --- | --- | --- | --- |
-| `sessions/{sid}/workspace/` | `/workspace/` | read-write | Persistent session workspace |
+| Host source                 | Container path | Mode       | Purpose                      |
+| --------------------------- | -------------- | ---------- | ---------------------------- |
+| `sessions/{sid}/workspace/` | `/workspace/`  | read-write | Persistent session workspace |
 
 ### Kubernetes mode (StatefulSet)
 
 Each session gets its own PVC via the StatefulSet's `volumeClaimTemplates`:
 
-| Volume | Container path | Mode | Purpose |
-| --- | --- | --- | --- |
-| `session-data` (per-session PVC) | `/workspace/` | read-write | Persistent session workspace |
+| Volume                           | Container path | Mode       | Purpose                      |
+| -------------------------------- | -------------- | ---------- | ---------------------------- |
+| `session-data` (per-session PVC) | `/workspace/`  | read-write | Persistent session workspace |
 
 No shared PVC access — the server's data PVC is `ReadWriteOnce`.
 
@@ -75,6 +75,24 @@ Each session maintains a domain allowlist. Domains are added when:
 3. **Proxy bypass**: During trusted automatic setup providers (`uv sync --locked`, `npm ci`, `pnpm install --frozen-lockfile`, and `setup.sh`), the proxy is temporarily bypassed. This is intentional: these providers are restored from the pushed upstream revision before execution, and `setup.sh` is treated as the most intentional, reviewable local setup hook rather than something less trustworthy than third-party package install scripts.
 
 The proxy supports exact domain matching (`example.com`) and wildcard matching (`*.example.com`).
+
+### Exec-scoped TCP tunnels
+
+Skills may also declare `network.tunnels` in `carapace.yaml`. These are not long-running session daemons. Instead, Carapace manages them around a single `exec` call:
+
+1. Before the command runs, Carapace temporarily shadows the declared hostnames inside the sandbox.
+2. It starts trusted TCP forwarders inside the sandbox that use the existing HTTP CONNECT proxy to reach the remote `host:remote_port` endpoints.
+3. The user command runs.
+4. In `finally`, Carapace stops the forwarders and restores the original host resolution.
+
+Important semantics:
+
+- Tunnels are exec-scoped, not session-scoped.
+- Tunnel hosts must be exact hostnames; wildcards are not allowed.
+- The client should keep using the original hostname so TLS validation and SNI continue to work.
+- `network.domains` and `network.tunnels` may overlap on the same hostname.
+- Proxy-aware HTTP and HTTPS to the same hostname still work through the normal proxy path.
+- Direct socket connections to the tunneled hostname are shadowed for the duration of that exec, even on other ports.
 
 ## Container lifecycle
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -71,13 +71,18 @@ Summarize the top results for the user.
 
 ## carapace.yaml (Carapace extension)
 
-Optional file that declares network domains the skill needs and credentials it uses.
+Optional file that declares network domains, exec-scoped TCP tunnels, and credentials the skill needs.
 
 ```yaml
 network:
   domains:
     - "api.searxng.example.com"
     - "*.search.example.com"
+  tunnels:
+    - host: imap.zoho.eu
+      remote_port: 993
+      local_port: 1993
+      description: Zoho IMAP over the Carapace CONNECT proxy
 
 credentials:
   - vault_path: "dev/searxng-url"
@@ -91,6 +96,17 @@ credentials:
 ### Fields
 
 **`network.domains`** — list of domains the skill needs to access. These are registered as a **context grant** when the skill is activated. The domains are only allowed during commands that explicitly request the skill's context (see [Context-scoped access](#context-scoped-access) below). Supports wildcard matching (`*.example.com`).
+
+**`network.tunnels`** — list of exec-scoped TCP tunnels the skill needs. Each tunnel declaration has:
+
+- `host` — exact remote hostname. Wildcards, IP literals, loopback names, Docker special hostnames, and Kubernetes/internal service names (`*.svc`, `*.cluster.local`, etc.) are not allowed.
+- `remote_port` — target port on the remote host.
+- `local_port` — unprivileged local port inside the sandbox used for the duration of the exec.
+- `description` — optional human-readable explanation for approvals and docs.
+
+Carapace manages these tunnels itself during `exec(..., contexts=[...])`. Skills do not start background processes. Tunnel setup is temporary and is re-established if the sandbox has to be recreated before the command retry.
+
+`network.domains` and `network.tunnels` may refer to the same hostname. That is intentional: HTTP and HTTPS through the proxy still work normally, while direct socket connections to the tunneled hostname are shadowed during that exec.
 
 **`credentials`** — list of credentials the skill needs. Each entry has:
 
@@ -111,6 +127,7 @@ Skill-declared domains and credentials are **not globally available** in the ses
 1. **Activation** creates a context grant: `use_skill("moneydb")` registers the skill's declared domains and credential vault paths as a grant keyed by `"moneydb"`.
 2. **Exec requests contexts**: The agent passes `contexts=["moneydb"]` when running commands that need the skill's resources.
 3. **Per-exec injection**: Domains are temporarily allowed in the proxy. Credential values are injected as env vars or written as files for the duration of that single exec. File-based credentials are deleted immediately after the command completes.
+   Tunnel declarations are also applied here: Carapace temporarily shadows the declared hostnames inside the sandbox, starts trusted CONNECT-backed tunnel helpers, and tears them down again after the exec.
 4. **No context = no access**: An exec without `contexts` (or with unrelated contexts) does not get the skill's domains or credentials. The sentinel evaluates any credential access without a matching context.
 
 ### Matching semantics

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -355,8 +355,10 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
 
         carapace_cfg = registry.get_carapace_config(skill_name)
         declared_domains = carapace_cfg.network.domains if carapace_cfg else []
+        declared_tunnels = carapace_cfg.network.tunnels if carapace_cfg else []
         declared_creds = carapace_cfg.credentials if carapace_cfg else []
         declared_creds_payload = [decl.model_dump(mode="json") for decl in declared_creds]
+        declared_tunnels_payload = [decl.model_dump(mode="json") for decl in declared_tunnels]
 
         # Resolve human-readable names from the vault for UI display
         cred_registry = ctx.deps.credential_registry
@@ -373,6 +375,7 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
                 "skill_name": skill_name,
                 "declared_creds": declared_creds_payload,
                 "declared_domains": declared_domains,
+                "declared_tunnels": declared_tunnels_payload,
             }
 
             if denied := await _gate(ctx, "use_skill", gate_args):
@@ -388,6 +391,7 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
         grant = ContextGrant(
             skill_name=skill_name,
             domains=set(declared_domains),
+            tunnels=list(declared_tunnels),
             credential_decls=list(declared_creds),
         )
         ctx.deps.session_state.context_grants[skill_name] = grant
@@ -395,6 +399,7 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
             ContextGrantEntry(
                 skill_name=skill_name,
                 domains=declared_domains,
+                tunnels=[tunnel.display for tunnel in declared_tunnels],
                 vault_paths=[c.vault_path for c in declared_creds],
             ),
         )
@@ -423,6 +428,7 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
                 skill_name=skill_name,
                 description=skill_info.description if skill_info else "",
                 declared_domains=declared_domains,
+                declared_tunnels=[tunnel.display for tunnel in declared_tunnels],
             ),
         )
 
@@ -433,6 +439,10 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
             status_lines.append(f"Skill '{skill_name}' activated.")
         if declared_domains:
             status_lines.append(f"Network access granted for: {', '.join(declared_domains)}")
+        if declared_tunnels:
+            status_lines.append(
+                "Network tunnels available for: " + ", ".join(tunnel.display for tunnel in declared_tunnels)
+            )
         if cred_msg:
             status_lines.extend(cred_msg.splitlines())
 
@@ -604,12 +614,15 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
         # Build per-exec injection data from matching context grants
         extra_env: dict[str, str] = {}
         context_domains: set[str] = set()
+        context_tunnels = []
         context_file_creds: list[tuple[str, str, str]] = []  # (skill_name, file_path, value)
         missing_cached: list[tuple[str, str]] = []
         injected_creds: list[tuple[str, str]] = []  # (ctx_name, vault_path)
         for ctx_name in contexts:
             grant = grants[ctx_name]
             context_domains.update(grant.domains)
+            context_tunnels.extend(grant.tunnels)
+            context_domains.update(tunnel.host for tunnel in grant.tunnels)
             for decl in grant.credential_decls:
                 if not (decl.env_var or decl.file):
                     continue
@@ -654,6 +667,7 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
                 contexts=contexts,
                 extra_env=extra_env or None,
                 context_domains=context_domains or None,
+                context_tunnels=context_tunnels or None,
                 context_file_creds=context_file_creds or None,
                 after_exec_credential_notify=_notify_injected_skill_creds if injected_creds else None,
             )

--- a/src/carapace/assets/skills/create-skill/SKILL.md
+++ b/src/carapace/assets/skills/create-skill/SKILL.md
@@ -88,16 +88,17 @@ See [the API reference](references/api.md) for endpoint details.
 
 ## Carapace-specific carapace.yaml
 
-Optional. If present, Carapace reads `skills/<name>/carapace.yaml` when the agent calls `use_skill("<name>")`. It declares **which hostnames the sandbox proxy may reach** and **which vault credentials to inject** (after user approval). Omit the file if the skill needs neither.
+Optional. If present, Carapace reads `skills/<name>/carapace.yaml` when the agent calls `use_skill("<name>")`. It declares **which hostnames the sandbox proxy may reach**, **which exec-scoped TCP tunnels Carapace should manage**, and **which vault credentials to inject** (after user approval). Omit the file if the skill needs none of these.
 
 **Top-level keys** (all optional):
 
-| Key               | Type            | Purpose                                                                                               |
-| ----------------- | --------------- | ----------------------------------------------------------------------------------------------------- |
-| `network`         | object          | Must contain `domains` — not a bare list under `network`.                                             |
-| `network.domains` | list of strings | Hostnames added to the session allowlist (wildcards like `*.cdn.example.com` allowed).                |
+| Key               | Type            | Purpose                                                                                                                                                   |
+| ----------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `network`         | object          | Container for `domains` and/or `tunnels` — not a bare list under `network`.                                                                               |
+| `network.domains` | list of strings | Hostnames added to the proxy allowlist (wildcards like `*.cdn.example.com` allowed).                                                                      |
+| `network.tunnels` | list of objects | Exec-scoped TCP tunnels managed by Carapace. Each entry needs `host`, `remote_port`, and `local_port`; optional `description`.                            |
 | `credentials`     | list of objects | Each entry: `vault_path` (required), `description`, and either `env_var` and/or `file` for injection. Optional `base64: true` to decode before injection. |
-| `hints`           | string map      | Extra metadata for tooling (does not replace `network` / `credentials`).                              |
+| `hints`           | string map      | Extra metadata for tooling (does not replace `network` / `credentials`).                                                                                  |
 
 **Valid example** (shape matters):
 
@@ -106,6 +107,11 @@ network:
   domains:
     - api.example.com
     - "*.cdn.example.com"
+  tunnels:
+    - host: imap.zoho.eu
+      remote_port: 993
+      local_port: 1993
+      description: Zoho IMAP over the Carapace CONNECT proxy
 
 credentials:
   - vault_path: my-backend/some-secret-id
@@ -129,6 +135,12 @@ That parses as a list assigned to `network`, Pydantic validation fails, and **th
 **Rules:**
 
 - Paths are resolved from the skill directory next to `SKILL.md` in the knowledge repo (under `skills/<name>/carapace.yaml`).
+- `network.tunnels[].host` must be an exact hostname. Wildcards are not allowed for tunnels.
+- `network.tunnels[].host` must not be an IP literal, loopback target, Docker special hostname, or Kubernetes/internal service name such as `*.svc` / `*.cluster.local`.
+- `network.tunnels[].local_port` must be an unprivileged local port (`1024-65535`) and must be unique within the skill.
+- `network.tunnels` are exec-scoped. Carapace starts them only for commands that request the matching skill via `contexts=[...]`, then tears them down afterwards.
+- `network.domains` and `network.tunnels` may mention the same hostname. That is valid: proxy-aware HTTP/HTTPS still works through the normal proxy path, while direct socket connections to the tunneled hostname are shadowed for that exec.
+- Tunnels preserve TLS only if the client keeps using the original hostname. Do not configure IMAP/SMTP clients against `localhost`; use the real hostname together with the declared `local_port`.
 - Credential values are never echoed to the user; env vars and files are set inside the sandbox after approval.
 - For full detail, see bundled `credentials` skill and project `docs/skills.md`.
 
@@ -351,6 +363,6 @@ description: <What it does and when to use it.>
 <Things to watch out for.>
 ```
 
-If the skill needs outbound HTTP or credentials, add `carapace.yaml` with `network.domains` and/or `credentials` as in the section above.
+If the skill needs outbound HTTP, TCP tunnels, or credentials, add `carapace.yaml` with `network.domains`, `network.tunnels`, and/or `credentials` as in the section above.
 
 If the skill needs Python code, structure it as a package with `[project.scripts]` entrypoints — see the **Python projects** section above for the full layout and `pyproject.toml` template.

--- a/src/carapace/assets/skills/example/SKILL.md
+++ b/src/carapace/assets/skills/example/SKILL.md
@@ -1,31 +1,38 @@
 ---
 name: example
-description: A template skill showing the AgentSkills format with provider-based activation, Python and Node entrypoints, and post-activation setup.
+description: A template skill showing provider-based activation, a Python entrypoint, a Node entrypoint, post-activation setup, and an exec-scoped TCP tunnel.
 ---
 
 # Example Skill
 
 This is a template skill that demonstrates the [AgentSkills](https://agentskills.io/) format
-with a Python package, a pnpm-managed Node entrypoint, provider-based activation, and post-activation setup.
+with a Python package, a pnpm-managed Node entrypoint, provider-based activation, post-activation setup,
+and an exec-scoped TCP tunnel declared in `carapace.yaml`.
 
 ## Instructions
 
-When this skill is activated, run the example commands to verify the sandbox environment:
+When this skill is activated, run the example commands to verify the sandbox environment and tunnel support:
 
 ```text
 uv run --directory /workspace/skills/example hello
 pnpm --dir /workspace/skills/example run hello:node
 ```
 
-`setup.sh` is intentionally minimal in this template and just prints `hello world` during
-activation to show where post-activation hooks run.
+The Python command performs an unauthenticated IMAP `CAPABILITY` request against `imap.gmail.com`
+through a Carapace-managed tunnel. That demonstrates the important path for non-HTTP protocols:
+
+- `carapace.yaml` declares `network.tunnels`
+- `setup.sh` materializes a tiny local config file consumed by the Python command
+- `hello` connects to the real hostname on the declared local port so TLS/SNI still work
+
+No mailbox credentials are required for this demo because `CAPABILITY` works before login.
 
 ## Skill Structure
 
 ```text
 skills/example/
   SKILL.md              # This file — metadata + instructions for the agent
-  carapace.yaml         # Optional — network allowlist + credential declarations for Carapace
+  carapace.yaml         # Optional — network allowlist, tunnel declarations, + credential declarations
   pyproject.toml        # Python project with dependencies and CLI entrypoints
   uv.lock               # Locked dependency versions
   package.json          # Node project manifest using the pnpm workflow
@@ -41,18 +48,19 @@ skills/example/
 
 - **`SKILL.md`** — YAML frontmatter provides `name` and `description` for the catalog.
   The body contains instructions the agent follows when the skill is activated.
-- **`carapace.yaml`** — Optional. Declares outbound domains under `network.domains` and
+- **`carapace.yaml`** — Optional. Declares outbound domains, exec-scoped tunnels, and
   vault-backed credentials for auto-injection when the skill is activated (`use_skill`).
-  This repo copy uses a fictional credential path and `httpbin.org` so `hello` can
-  reach https://httpbin.org/get after approval; replace with your real entries.
+  This repo copy uses a tunnel to `imap.gmail.com:993` and no credentials so the example
+  stays runnable in a fresh sandbox.
 - **`pyproject.toml`** — Declares dependencies, CLI entrypoints (`[project.scripts]`),
   and build config. When present with `uv.lock`, `use_skill` runs `uv sync --locked` automatically.
 - **`uv.lock`** — Lock file for reproducible installs. Always commit alongside `pyproject.toml`.
 - **`package.json`** — Declares the Node-side entrypoint. When present with `pnpm-lock.yaml`,
   `use_skill` runs `pnpm install --frozen-lockfile` automatically.
 - **`pnpm-lock.yaml`** — Lock file for reproducible pnpm installs. Always commit it with `package.json`.
-- **`setup.sh`** — Runs after dependency installation. This example keeps it intentionally minimal
-  and just prints `hello world` so the hook remains easy to understand. Only the pushed upstream copy is executed automatically.
+- **`setup.sh`** — Runs after dependency installation. This example writes a small local JSON
+  config file that tells the Python entrypoint which hostname and local tunnel port to use.
+  Only the pushed upstream copy is executed automatically.
 - **`scripts/hello-node.mjs`** — Simple Node entrypoint invoked via `pnpm run hello:node`.
 - **`src/example_skill/`** — Python package. Modules with `main()` functions are
   wired as CLI commands via `[project.scripts]` in `pyproject.toml`.

--- a/src/carapace/assets/skills/example/carapace.yaml
+++ b/src/carapace/assets/skills/example/carapace.yaml
@@ -1,10 +1,6 @@
-# Illustrative Carapace extension — replace with real vault paths and domains for your skill.
-# Parsed on use_skill(); invalid YAML or wrong shapes cause the whole file to be ignored.
 network:
-  domains:
-    - httpbin.org
-
-credentials:
-  - vault_path: example/illustrative-api-token
-    description: Made-up credential for documentation (the example commands do not use it)
-    env_var: EXAMPLE_ILLUSTRATIVE_API_KEY
+  tunnels:
+    - host: imap.gmail.com
+      remote_port: 993
+      local_port: 1993
+      description: Unauthenticated IMAP CAPABILITY probe over a Carapace-managed tunnel

--- a/src/carapace/assets/skills/example/setup.sh
+++ b/src/carapace/assets/skills/example/setup.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
 set -eu
 
-echo "hello world"
+mkdir -p .example-skill
+cat > .example-skill/imap-demo.json <<'EOF'
+{
+	"host": "imap.gmail.com",
+	"port": 1993
+}
+EOF
+
+echo "prepared example IMAP tunnel config"

--- a/src/carapace/assets/skills/example/src/example_skill/hello.py
+++ b/src/carapace/assets/skills/example/src/example_skill/hello.py
@@ -1,16 +1,16 @@
-"""Example skill demonstrating the sandbox environment.
+"""Example skill demonstrating provider setup and exec-scoped tunnel usage.
 
-Run with:  uv run --directory /workspace/skills/example hello
+Run with: uv run --directory /workspace/skills/example hello
 """
 
+import imaplib
 import json
 import os
 import sys
 from pathlib import Path
 
-import httpx
-
 WORKSPACE = Path("/workspace")
+CONFIG_PATH = WORKSPACE / "skills" / "example" / ".example-skill" / "imap-demo.json"
 
 
 def main() -> None:
@@ -30,19 +30,32 @@ def main() -> None:
         files = list(memory.rglob("*"))
         print(f"  /workspace/memory/: {len(files)} file(s)")
 
-    # HTTP request (tests network access and httpx dependency)
-    print("\nFetching https://httpbin.org/get ...")
+    print(f"\nReading tunnel config from {CONFIG_PATH} ...")
     try:
-        resp = httpx.get("https://httpbin.org/get", timeout=10)
-        print(f"  Status: {resp.status_code}")
-        print(f"  Origin: {resp.json().get('origin', 'unknown')}")
-    except httpx.HTTPError as exc:
-        print(f"  Request failed: {exc}")
+        config = json.loads(CONFIG_PATH.read_text())
+    except OSError as exc:
+        print(f"  Could not read config: {exc}")
+        return
+
+    host = str(config.get("host", "imap.gmail.com"))
+    port = int(config.get("port", 1993))
+    print(f"  Connecting to {host}:{port} via Carapace-managed tunnel ...")
+
+    try:
+        client = imaplib.IMAP4_SSL(host=host, port=port)
+        _tag, capabilities = client.capability()
+        client.logout()
+    except OSError as exc:
+        print(f"  IMAP capability probe failed: {exc}")
+    else:
+        capability_text = " ".join(part.decode("utf-8", errors="replace") for part in capabilities)
+        print("  CAPABILITY succeeded")
+        print(f"  {capability_text}")
 
     # Writable scratch space
     tmp = WORKSPACE / "tmp"
     tmp.mkdir(parents=True, exist_ok=True)
-    result = {"message": "Hello from example skill", "python": sys.version}
+    result = {"message": "Hello from example skill", "python": sys.version, "imap_host": host, "imap_port": port}
     output_file = tmp / "example-output.json"
     output_file.write_text(json.dumps(result, indent=2))
     print(f"\nWrote result to {output_file}")

--- a/src/carapace/models.py
+++ b/src/carapace/models.py
@@ -14,6 +14,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from carapace.git.store import GitStore
 from carapace.sandbox.manager import SandboxManager
+from carapace.sandbox.runtime import NetworkTunnel
 from carapace.security.context import ApprovalSource, ApprovalVerdict, SessionSecurity
 from carapace.security.sentinel import Sentinel
 from carapace.usage import UsageTracker
@@ -422,6 +423,23 @@ class SkillCredentialDecl(BaseModel):
 
 class SkillNetworkConfig(BaseModel):
     domains: list[str] = []
+    tunnels: list[NetworkTunnel] = []
+
+    @model_validator(mode="after")
+    def _validate_tunnels(self) -> SkillNetworkConfig:
+        seen_local_ports: set[int] = set()
+        seen_endpoints: set[tuple[str, int]] = set()
+        for tunnel in self.tunnels:
+            if tunnel.local_port in seen_local_ports:
+                raise ValueError(f"network.tunnels local_port {tunnel.local_port} must be unique within a skill")
+            endpoint = (tunnel.host, tunnel.remote_port)
+            if endpoint in seen_endpoints:
+                raise ValueError(
+                    f"network.tunnels duplicate endpoint {tunnel.host}:{tunnel.remote_port} is not allowed"
+                )
+            seen_local_ports.add(tunnel.local_port)
+            seen_endpoints.add(endpoint)
+        return self
 
 
 class SkillCarapaceConfig(BaseModel):
@@ -433,7 +451,7 @@ class SkillCarapaceConfig(BaseModel):
 
 
 class ContextGrant(BaseModel):
-    """Context-scoped grant for a skill's declared domains and credentials.
+    """Context-scoped grant for a skill's declared domains, tunnels, and credentials.
 
     Registered at ``use_skill`` time, keyed by skill name.  The agent must pass
     matching ``contexts`` on ``exec`` for these grants to take effect.
@@ -441,6 +459,7 @@ class ContextGrant(BaseModel):
 
     skill_name: str
     domains: set[str] = set()
+    tunnels: list[NetworkTunnel] = []
     credential_decls: list[SkillCredentialDecl] = []
     credential_names: dict[str, str] = {}  # vault_path → human-readable name
 
@@ -460,6 +479,7 @@ def context_grants_session_summary(
         cached = sum(1 for vp in grant.vault_paths if get_cached_credential(session_id, vp) is not None)
         summary[skill] = {
             "domains": sorted(grant.domains),
+            "tunnels": [tunnel.display for tunnel in grant.tunnels],
             "vault_paths": sorted(grant.vault_paths),
             "cached_credentials": cached,
         }

--- a/src/carapace/sandbox/exec_flow.py
+++ b/src/carapace/sandbox/exec_flow.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from loguru import logger
 
 from carapace.sandbox.file_ops import ContextFileCredential, WrittenContextFile
-from carapace.sandbox.runtime import ContainerGoneError, ContainerRuntime, ExecResult
+from carapace.sandbox.runtime import ContainerGoneError, ContainerRuntime, ExecResult, NetworkTunnel
 from carapace.sandbox.session_lifecycle import SessionContainer
 from carapace.security.context import ApprovalSource, ApprovalVerdict
 
@@ -20,6 +20,8 @@ type RerunSkillSetupCallback = Callable[[str], Awaitable[None]]
 type LogContainerTailCallback = Callable[[str, str], Awaitable[None]]
 type PrepareSessionRecreateCallback = Callable[[str], None]
 type ExecInContainerCallback = Callable[..., Awaitable[ExecResult]]
+type PrepareContextTunnelsCallback = Callable[[SessionContainer, list[NetworkTunnel]], Awaitable[None]]
+type CleanupContextTunnelsCallback = Callable[[SessionContainer, list[NetworkTunnel]], Awaitable[None]]
 type WriteContextFileCredentialsCallback = Callable[
     [SessionContainer, list[ContextFileCredential]],
     Awaitable[list[WrittenContextFile]],
@@ -94,6 +96,8 @@ class SandboxExecCoordinator:
         log_container_tail: LogContainerTailCallback,
         prepare_session_recreate: PrepareSessionRecreateCallback,
         exec_in_container: ExecInContainerCallback,
+        prepare_context_tunnels: PrepareContextTunnelsCallback,
+        cleanup_context_tunnels: CleanupContextTunnelsCallback,
         write_context_file_credentials: WriteContextFileCredentialsCallback,
         delete_context_file_credentials: DeleteContextFileCredentialsCallback,
         bypass_proxy: bool = False,
@@ -101,12 +105,15 @@ class SandboxExecCoordinator:
         contexts: list[str] | None = None,
         extra_env: dict[str, str] | None = None,
         context_domains: set[str] | None = None,
+        context_tunnels: list[NetworkTunnel] | None = None,
         context_file_creds: list[ContextFileCredential] | None = None,
         after_exec_credential_notify: AfterExecCredentialNotify | None = None,
     ) -> ExecResult:
         """Run a command in the sandbox and return the raw ExecResult."""
         contexts = contexts or []
         written_files: list[WrittenContextFile] = []
+        sc: SessionContainer | None = None
+        tunnels_prepared = False
 
         async with self.get_exec_lock(session_id):
             if bypass_proxy:
@@ -131,6 +138,9 @@ class SandboxExecCoordinator:
                     self._state.exec_context_skill_domains[session_id].update(context_domains)
 
                 try:
+                    if context_tunnels:
+                        await prepare_context_tunnels(sc, context_tunnels)
+                        tunnels_prepared = True
                     if context_file_creds:
                         written_files = await write_context_file_credentials(sc, context_file_creds)
                     exec_result = await exec_in_container(
@@ -143,12 +153,16 @@ class SandboxExecCoordinator:
                     )
                 except ContainerGoneError:
                     logger.warning(f"Container gone for session {session_id}, recreating sandbox")
+                    tunnels_prepared = False
                     await log_container_tail(sc.container_id, session_id)
                     prepare_session_recreate(session_id)
                     sc, _ = await ensure_session(session_id)
                     await rerun_skill_setup(session_id)
 
                     written_files.clear()
+                    if context_tunnels:
+                        await prepare_context_tunnels(sc, context_tunnels)
+                        tunnels_prepared = True
                     if context_file_creds:
                         written_files = await write_context_file_credentials(sc, context_file_creds)
                     exec_result = await exec_in_container(
@@ -173,6 +187,9 @@ class SandboxExecCoordinator:
                 self._state.exec_context_skill_domains.pop(session_id, None)
                 self._state.exec_notified_domains.pop(session_id, None)
                 self._state.exec_notified_credentials.pop(session_id, None)
+
+                if sc is not None and tunnels_prepared and context_tunnels:
+                    await cleanup_context_tunnels(sc, context_tunnels)
 
                 if written_files:
                     await delete_context_file_credentials(session_id, written_files)

--- a/src/carapace/sandbox/exec_flow.py
+++ b/src/carapace/sandbox/exec_flow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -178,6 +179,8 @@ class SandboxExecCoordinator:
                     after_exec_credential_notify()
                 return exec_result
             finally:
+                original_exc = sys.exc_info()[1]
+                cleanup_exc: Exception | None = None
                 if bypass_proxy:
                     self._state.proxy_bypass_sessions.discard(session_id)
                     logger.info(f"Proxy bypass DISABLED for session {session_id}")
@@ -189,10 +192,19 @@ class SandboxExecCoordinator:
                 self._state.exec_notified_credentials.pop(session_id, None)
 
                 if sc is not None and tunnels_prepared and context_tunnels:
-                    await cleanup_context_tunnels(sc, context_tunnels)
+                    try:
+                        await cleanup_context_tunnels(sc, context_tunnels)
+                    except Exception as exc:
+                        cleanup_exc = exc
+                        logger.opt(exception=True).warning(
+                            f"Failed to clean up context tunnels for session {session_id}"
+                        )
 
                 if written_files:
                     await delete_context_file_credentials(session_id, written_files)
+
+                if cleanup_exc is not None and original_exc is None:
+                    raise cleanup_exc
 
     def allow_domains(self, session_id: str, domains: set[str]) -> None:
         existing = self._state.allowed_domains.setdefault(session_id, set())

--- a/src/carapace/sandbox/manager.py
+++ b/src/carapace/sandbox/manager.py
@@ -94,11 +94,11 @@ async def _open_proxy_tunnel(
         if len(response) > 65536:
             raise RuntimeError("proxy CONNECT response too large")
 
-    status_line, remainder = response.split(b"\r\n", 1)
+    header_block, prebuffer = response.split(b"\r\n\r\n", 1)
+    status_line = header_block.split(b"\r\n", 1)[0]
     status = status_line.decode("latin-1", errors="replace")
     if not status.startswith("HTTP/1.1 200") and not status.startswith("HTTP/1.0 200"):
         raise RuntimeError(f"proxy CONNECT failed: {status}")
-    prebuffer = remainder.split(b"\r\n\r\n", 1)[1]
     return prebuffer, reader, writer
 
 
@@ -579,7 +579,7 @@ class SandboxManager:
         unique: dict[tuple[str, int, int], NetworkTunnel] = {}
         for tunnel in tunnels:
             existing = by_local_port.get(tunnel.local_port)
-            if existing is not None and existing.model_dump(mode="json") != tunnel.model_dump(mode="json"):
+            if existing is not None and (existing.host, existing.remote_port) != (tunnel.host, tunnel.remote_port):
                 raise ValueError(
                     "Conflicting network.tunnels declarations for local_port "
                     + f"{tunnel.local_port}: {existing.display} vs {tunnel.display}"

--- a/src/carapace/sandbox/manager.py
+++ b/src/carapace/sandbox/manager.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import re
+import shlex
 from asyncio.locks import Lock
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from pathlib import Path
 
 from loguru import logger
@@ -13,6 +15,7 @@ from carapace.sandbox.file_ops import SandboxFileOps
 from carapace.sandbox.runtime import (
     ContainerRuntime,
     ExecResult,
+    NetworkTunnel,
     SkillActivationError,
     SkillActivationInputs,
 )
@@ -29,6 +32,134 @@ FILE_READ_SCRIPT = file_ops.FILE_READ_SCRIPT
 MAX_READ_OUTPUT_CHARS = file_ops.MAX_READ_OUTPUT_CHARS
 SANDBOX_READ_BODY_SEPARATOR = file_ops.SANDBOX_READ_BODY_SEPARATOR
 READ_TOOL_MAX_LINE_WINDOW = file_ops.READ_TOOL_MAX_LINE_WINDOW
+
+_CONTEXT_TUNNEL_HELPER = """#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import sys
+from urllib.parse import unquote, urlsplit
+
+
+async def _close_writer(writer: asyncio.StreamWriter) -> None:
+    writer.close()
+    try:
+        await writer.wait_closed()
+    except Exception:
+        pass
+
+
+async def _pipe(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    try:
+        while True:
+            chunk = await reader.read(65536)
+            if not chunk:
+                break
+            writer.write(chunk)
+            await writer.drain()
+    except (BrokenPipeError, ConnectionResetError):
+        pass
+    finally:
+        await _close_writer(writer)
+
+
+async def _open_proxy_tunnel(
+    proxy_url: str,
+    target_host: str,
+    target_port: int,
+) -> tuple[bytes, asyncio.StreamReader, asyncio.StreamWriter]:
+    parsed = urlsplit(proxy_url)
+    if not parsed.hostname:
+        raise RuntimeError("HTTP_PROXY does not include a hostname")
+    proxy_port = parsed.port or 80
+    reader, writer = await asyncio.open_connection(parsed.hostname, proxy_port)
+
+    headers = [f"CONNECT {target_host}:{target_port} HTTP/1.1", f"Host: {target_host}:{target_port}"]
+    if parsed.username or parsed.password:
+        creds = f"{unquote(parsed.username or '')}:{unquote(parsed.password or '')}"
+        encoded = base64.b64encode(creds.encode()).decode()
+        headers.append(f"Proxy-Authorization: Basic {encoded}")
+    request = "\r\n".join(headers) + "\r\n\r\n"
+    writer.write(request.encode("latin-1"))
+    await writer.drain()
+
+    response = b""
+    while b"\r\n\r\n" not in response:
+        chunk = await reader.read(4096)
+        if not chunk:
+            raise RuntimeError("proxy closed CONNECT response early")
+        response += chunk
+        if len(response) > 65536:
+            raise RuntimeError("proxy CONNECT response too large")
+
+    status_line, remainder = response.split(b"\r\n", 1)
+    status = status_line.decode("latin-1", errors="replace")
+    if not status.startswith("HTTP/1.1 200") and not status.startswith("HTTP/1.0 200"):
+        raise RuntimeError(f"proxy CONNECT failed: {status}")
+    prebuffer = remainder.split(b"\r\n\r\n", 1)[1]
+    return prebuffer, reader, writer
+
+
+async def _handle_client(
+    client_reader: asyncio.StreamReader,
+    client_writer: asyncio.StreamWriter,
+    proxy_url: str,
+    target_host: str,
+    target_port: int,
+) -> None:
+    upstream_reader: asyncio.StreamReader | None = None
+    upstream_writer: asyncio.StreamWriter | None = None
+    try:
+        prebuffer, upstream_reader, upstream_writer = await _open_proxy_tunnel(proxy_url, target_host, target_port)
+        if prebuffer:
+            client_writer.write(prebuffer)
+            await client_writer.drain()
+        await asyncio.gather(
+            _pipe(client_reader, upstream_writer),
+            _pipe(upstream_reader, client_writer),
+        )
+    except Exception as exc:
+        print(f"tunnel error for {target_host}:{target_port}: {exc}", file=sys.stderr)
+        await _close_writer(client_writer)
+        if upstream_writer is not None:
+            await _close_writer(upstream_writer)
+
+
+async def _run() -> None:
+    parser = argparse.ArgumentParser(description="Carapace CONNECT tunnel helper")
+    parser.add_argument("--listen-host", default="127.0.0.1")
+    parser.add_argument("--listen-port", type=int, required=True)
+    parser.add_argument("--target-host", required=True)
+    parser.add_argument("--target-port", type=int, required=True)
+    parser.add_argument("--proxy", default="")
+    args = parser.parse_args()
+
+    proxy_url = args.proxy or ""
+    if not proxy_url:
+        raise RuntimeError("HTTP_PROXY is required for the tunnel helper")
+
+    server = await asyncio.start_server(
+        lambda r, w: _handle_client(r, w, proxy_url, args.target_host, args.target_port),
+        args.listen_host,
+        args.listen_port,
+    )
+    async with server:
+        await server.serve_forever()
+
+
+if __name__ == "__main__":
+    asyncio.run(_run())
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class _TunnelPaths:
+    helper_path: str
+    hosts_backup_path: str
+    pid_path: str
+    log_path: str
 
 
 def _validate_skill_name(skill_name: str) -> str | None:
@@ -213,6 +344,7 @@ class SandboxManager:
         contexts: list[str] | None = None,
         extra_env: dict[str, str] | None = None,
         context_domains: set[str] | None = None,
+        context_tunnels: list[NetworkTunnel] | None = None,
         context_file_creds: list[tuple[str, str, str]] | None = None,
         after_exec_credential_notify: Callable[[], None] | None = None,
     ) -> ExecResult:
@@ -230,6 +362,8 @@ class SandboxManager:
                 timeout=cmd_timeout,
                 **kwargs,
             ),
+            prepare_context_tunnels=lambda sc, tunnels: self._prepare_context_tunnels(sc, tunnels),
+            cleanup_context_tunnels=lambda sc, tunnels: self._cleanup_context_tunnels(sc, tunnels),
             write_context_file_credentials=lambda sc, creds: self._write_context_file_credentials(sc, creds),
             delete_context_file_credentials=lambda sid, written: self._delete_context_file_credentials(sid, written),
             bypass_proxy=bypass_proxy,
@@ -237,6 +371,7 @@ class SandboxManager:
             contexts=contexts,
             extra_env=extra_env,
             context_domains=context_domains,
+            context_tunnels=context_tunnels,
             context_file_creds=context_file_creds,
             after_exec_credential_notify=after_exec_credential_notify,
         )
@@ -252,6 +387,7 @@ class SandboxManager:
         contexts: list[str] | None = None,
         extra_env: dict[str, str] | None = None,
         context_domains: set[str] | None = None,
+        context_tunnels: list[NetworkTunnel] | None = None,
         context_file_creds: list[tuple[str, str, str]] | None = None,
         after_exec_credential_notify: Callable[[], None] | None = None,
     ) -> ExecResult:
@@ -260,6 +396,7 @@ class SandboxManager:
         *contexts*: activated skill names active for this exec.
         *extra_env*: per-exec env vars (credential values) — merged on top of session env.
         *context_domains*: domains to add to exec-scoped temp allowlist.
+        *context_tunnels*: declarative exec-scoped TCP tunnels to establish for this command.
         *context_file_creds*: ``(skill_name, file_path, value)`` tuples for file-based
             credentials to be written before exec and deleted after.
         *after_exec_credential_notify*: passed through to `_exec` (see there).
@@ -272,6 +409,7 @@ class SandboxManager:
             contexts=contexts,
             extra_env=extra_env,
             context_domains=context_domains,
+            context_tunnels=context_tunnels,
             context_file_creds=context_file_creds,
             after_exec_credential_notify=after_exec_credential_notify,
         )
@@ -435,6 +573,103 @@ class SandboxManager:
         activated = self._get_activated_skills_cb(session_id)
         if activated:
             await self.rerun_skill_setup(session_id, activated)
+
+    def _normalize_context_tunnels(self, tunnels: list[NetworkTunnel]) -> list[NetworkTunnel]:
+        by_local_port: dict[int, NetworkTunnel] = {}
+        unique: dict[tuple[str, int, int], NetworkTunnel] = {}
+        for tunnel in tunnels:
+            existing = by_local_port.get(tunnel.local_port)
+            if existing is not None and existing.model_dump(mode="json") != tunnel.model_dump(mode="json"):
+                raise ValueError(
+                    "Conflicting network.tunnels declarations for local_port "
+                    + f"{tunnel.local_port}: {existing.display} vs {tunnel.display}"
+                )
+            by_local_port[tunnel.local_port] = tunnel
+            unique[(tunnel.host, tunnel.remote_port, tunnel.local_port)] = tunnel
+        return sorted(unique.values(), key=lambda tunnel: (tunnel.local_port, tunnel.host, tunnel.remote_port))
+
+    def _context_tunnel_paths(self, session_id: str, tunnel: NetworkTunnel) -> _TunnelPaths:
+        return _TunnelPaths(
+            helper_path=f"/tmp/carapace-tunnel-helper-{session_id}.py",
+            hosts_backup_path=f"/tmp/carapace-tunnel-hosts-{session_id}.bak",
+            pid_path=f"/tmp/carapace-tunnel-{session_id}-{tunnel.local_port}.pid",
+            log_path=f"/tmp/carapace-tunnel-{session_id}-{tunnel.local_port}.log",
+        )
+
+    async def _prepare_context_tunnels(self, sc: SessionContainer, tunnels: list[NetworkTunnel]) -> None:
+        normalized = self._normalize_context_tunnels(tunnels)
+        if not normalized:
+            return
+
+        await self._cleanup_context_tunnels(sc, normalized)
+
+        helper_path = self._context_tunnel_paths(sc.session_id, normalized[0]).helper_path
+        write_result = await self._file_write_in_container(
+            sc,
+            helper_path,
+            _CONTEXT_TUNNEL_HELPER,
+            mode=0o700,
+            workdir=self._KNOWLEDGE_WORKDIR,
+        )
+        if write_result.exit_code != 0:
+            raise RuntimeError(f"Failed to materialize tunnel helper: {write_result.output}")
+
+        hosts_backup = self._context_tunnel_paths(sc.session_id, normalized[0]).hosts_backup_path
+        host_lines = "\n".join(f"127.0.0.1 {host}" for host in sorted({tunnel.host for tunnel in normalized}))
+        hosts_cmd = f"cp /etc/hosts {shlex.quote(hosts_backup)} && cat <<'EOF' >> /etc/hosts\n{host_lines}\nEOF"
+        hosts_result = await self._exec_in_container(sc, hosts_cmd, timeout=10)
+        if hosts_result.exit_code != 0:
+            await self._cleanup_context_tunnels(sc, normalized)
+            raise RuntimeError(f"Failed to install temporary tunnel hosts: {hosts_result.output}")
+
+        for tunnel in normalized:
+            paths = self._context_tunnel_paths(sc.session_id, tunnel)
+            start_cmd = (
+                f"rm -f {shlex.quote(paths.pid_path)} {shlex.quote(paths.log_path)} && "
+                f"nohup python3 {shlex.quote(paths.helper_path)} "
+                "--listen-host 127.0.0.1 "
+                f"--listen-port {tunnel.local_port} "
+                f"--target-host {shlex.quote(tunnel.host)} "
+                f"--target-port {tunnel.remote_port} "
+                '--proxy "$HTTP_PROXY" '
+                f">{shlex.quote(paths.log_path)} 2>&1 & "
+                f"echo $! > {shlex.quote(paths.pid_path)} && "
+                f'kill -0 "$(cat {shlex.quote(paths.pid_path)})"'
+            )
+            start_result = await self._exec_in_container(sc, start_cmd, timeout=10)
+            if start_result.exit_code != 0:
+                await self._cleanup_context_tunnels(sc, normalized)
+                raise RuntimeError(f"Failed to start tunnel {tunnel.display}: {start_result.output}")
+
+    async def _cleanup_context_tunnels(self, sc: SessionContainer, tunnels: list[NetworkTunnel]) -> None:
+        if not tunnels:
+            return
+
+        pid_paths = [self._context_tunnel_paths(sc.session_id, tunnel).pid_path for tunnel in tunnels]
+        log_paths = [self._context_tunnel_paths(sc.session_id, tunnel).log_path for tunnel in tunnels]
+        helper_path = self._context_tunnel_paths(sc.session_id, tunnels[0]).helper_path
+        hosts_backup = self._context_tunnel_paths(sc.session_id, tunnels[0]).hosts_backup_path
+
+        pid_cleanup = []
+        for pid_path in sorted(set(pid_paths)):
+            quoted = shlex.quote(pid_path)
+            pid_cleanup.append(
+                f'if [ -f {quoted} ]; then kill "$(cat {quoted})" 2>/dev/null || true; rm -f {quoted}; fi'
+            )
+        quoted_hosts_backup = shlex.quote(hosts_backup)
+        restore_hosts_cmd = (
+            f"if [ -f {quoted_hosts_backup} ]; then "
+            + f"cp {quoted_hosts_backup} /etc/hosts && rm -f {quoted_hosts_backup}; fi"
+        )
+        cleanup_parts = [
+            *pid_cleanup,
+            restore_hosts_cmd,
+            "rm -f " + " ".join(shlex.quote(path) for path in sorted(set([helper_path, *log_paths]))),
+        ]
+        cleanup_cmd = " && ".join(cleanup_parts)
+        result = await self._exec_in_container(sc, cleanup_cmd, timeout=10)
+        if result.exit_code != 0:
+            logger.warning(f"Failed to clean up context tunnels for session {sc.session_id}: {result.output}")
 
     async def cleanup_session(self, session_id: str) -> None:
         await self._session_lifecycle.cleanup_session(session_id)

--- a/src/carapace/sandbox/manager.py
+++ b/src/carapace/sandbox/manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import shlex
+import textwrap
 from asyncio.locks import Lock
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -39,6 +40,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import base64
+from pathlib import Path
 import sys
 from urllib.parse import unquote, urlsplit
 
@@ -134,6 +136,7 @@ async def _run() -> None:
     parser.add_argument("--target-host", required=True)
     parser.add_argument("--target-port", type=int, required=True)
     parser.add_argument("--proxy", default="")
+    parser.add_argument("--ready-file", default="")
     args = parser.parse_args()
 
     proxy_url = args.proxy or ""
@@ -145,6 +148,8 @@ async def _run() -> None:
         args.listen_host,
         args.listen_port,
     )
+    if args.ready_file:
+        Path(args.ready_file).write_text("ready\n")
     async with server:
         await server.serve_forever()
 
@@ -160,6 +165,7 @@ class _TunnelPaths:
     hosts_backup_path: str
     pid_path: str
     log_path: str
+    ready_path: str
 
 
 def _validate_skill_name(skill_name: str) -> str | None:
@@ -594,6 +600,7 @@ class SandboxManager:
             hosts_backup_path=f"/tmp/carapace-tunnel-hosts-{session_id}.bak",
             pid_path=f"/tmp/carapace-tunnel-{session_id}-{tunnel.local_port}.pid",
             log_path=f"/tmp/carapace-tunnel-{session_id}-{tunnel.local_port}.log",
+            ready_path=f"/tmp/carapace-tunnel-{session_id}-{tunnel.local_port}.ready",
         )
 
     async def _prepare_context_tunnels(self, sc: SessionContainer, tunnels: list[NetworkTunnel]) -> None:
@@ -624,8 +631,25 @@ class SandboxManager:
 
         for tunnel in normalized:
             paths = self._context_tunnel_paths(sc.session_id, tunnel)
+            wait_cmd = (
+                textwrap.dedent(
+                    f"""
+                i=0
+                while [ ! -f {shlex.quote(paths.ready_path)} ]; do
+                    i=$((i+1))
+                    if [ "$i" -ge 10 ]; then
+                        exit 1
+                    fi
+                    kill -0 "$(cat {shlex.quote(paths.pid_path)})" 2>/dev/null || exit 1
+                    sleep 1
+                done
+                """
+                )
+                .strip()
+                .replace("\n", "; ")
+            )
             start_cmd = (
-                f"rm -f {shlex.quote(paths.pid_path)} {shlex.quote(paths.log_path)} && "
+                f"rm -f {shlex.quote(paths.pid_path)} {shlex.quote(paths.log_path)} {shlex.quote(paths.ready_path)} && "
                 "{ "
                 f"nohup python3 {shlex.quote(paths.helper_path)} "
                 "--listen-host 127.0.0.1 "
@@ -633,10 +657,12 @@ class SandboxManager:
                 f"--target-host {shlex.quote(tunnel.host)} "
                 f"--target-port {tunnel.remote_port} "
                 '--proxy "$HTTP_PROXY" '
+                f"--ready-file {shlex.quote(paths.ready_path)} "
                 f">{shlex.quote(paths.log_path)} 2>&1 & "
                 f"echo $! > {shlex.quote(paths.pid_path)}; "
                 "} && "
-                f'kill -0 "$(cat {shlex.quote(paths.pid_path)})"'
+                f'kill -0 "$(cat {shlex.quote(paths.pid_path)})" && '
+                f"{wait_cmd}"
             )
             start_result = await self._exec_in_container(sc, start_cmd, timeout=10)
             if start_result.exit_code != 0:
@@ -649,6 +675,7 @@ class SandboxManager:
 
         pid_paths = [self._context_tunnel_paths(sc.session_id, tunnel).pid_path for tunnel in tunnels]
         log_paths = [self._context_tunnel_paths(sc.session_id, tunnel).log_path for tunnel in tunnels]
+        ready_paths = [self._context_tunnel_paths(sc.session_id, tunnel).ready_path for tunnel in tunnels]
         helper_path = self._context_tunnel_paths(sc.session_id, tunnels[0]).helper_path
         hosts_backup = self._context_tunnel_paths(sc.session_id, tunnels[0]).hosts_backup_path
 
@@ -666,7 +693,7 @@ class SandboxManager:
         cleanup_parts = [
             *pid_cleanup,
             restore_hosts_cmd,
-            "rm -f " + " ".join(shlex.quote(path) for path in sorted(set([helper_path, *log_paths]))),
+            "rm -f " + " ".join(shlex.quote(path) for path in sorted(set([helper_path, *log_paths, *ready_paths]))),
         ]
         cleanup_cmd = " && ".join(cleanup_parts)
         result = await self._exec_in_container(sc, cleanup_cmd, timeout=10)

--- a/src/carapace/sandbox/manager.py
+++ b/src/carapace/sandbox/manager.py
@@ -626,6 +626,7 @@ class SandboxManager:
             paths = self._context_tunnel_paths(sc.session_id, tunnel)
             start_cmd = (
                 f"rm -f {shlex.quote(paths.pid_path)} {shlex.quote(paths.log_path)} && "
+                "{ "
                 f"nohup python3 {shlex.quote(paths.helper_path)} "
                 "--listen-host 127.0.0.1 "
                 f"--listen-port {tunnel.local_port} "
@@ -633,7 +634,8 @@ class SandboxManager:
                 f"--target-port {tunnel.remote_port} "
                 '--proxy "$HTTP_PROXY" '
                 f">{shlex.quote(paths.log_path)} 2>&1 & "
-                f"echo $! > {shlex.quote(paths.pid_path)} && "
+                f"echo $! > {shlex.quote(paths.pid_path)}; "
+                "} && "
                 f'kill -0 "$(cat {shlex.quote(paths.pid_path)})"'
             )
             start_result = await self._exec_in_container(sc, start_cmd, timeout=10)

--- a/src/carapace/sandbox/manager.py
+++ b/src/carapace/sandbox/manager.py
@@ -33,7 +33,7 @@ MAX_READ_OUTPUT_CHARS = file_ops.MAX_READ_OUTPUT_CHARS
 SANDBOX_READ_BODY_SEPARATOR = file_ops.SANDBOX_READ_BODY_SEPARATOR
 READ_TOOL_MAX_LINE_WINDOW = file_ops.READ_TOOL_MAX_LINE_WINDOW
 
-_CONTEXT_TUNNEL_HELPER = """#!/usr/bin/env python3
+_CONTEXT_TUNNEL_HELPER = r"""#!/usr/bin/env python3
 from __future__ import annotations
 
 import argparse

--- a/src/carapace/sandbox/runtime.py
+++ b/src/carapace/sandbox/runtime.py
@@ -50,7 +50,7 @@ class NetworkTunnel(BaseModel):
     @field_validator("host")
     @classmethod
     def _validate_host(cls, value: str) -> str:
-        host = value.strip().lower()
+        host = value.strip().lower().rstrip(".")
         if not host:
             raise ValueError("network tunnel host must not be empty")
         if "*" in host:

--- a/src/carapace/sandbox/runtime.py
+++ b/src/carapace/sandbox/runtime.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Protocol
+import ipaddress
+from typing import ClassVar, Protocol
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
 
 
 class ContainerGoneError(Exception):
@@ -21,6 +22,60 @@ class SkillFileCredential(BaseModel):
 class SkillActivationInputs(BaseModel):
     environment: dict[str, str] = {}
     file_credentials: list[SkillFileCredential] = []
+
+
+class NetworkTunnel(BaseModel):
+    host: str
+    remote_port: int = Field(ge=1, le=65535)
+    local_port: int = Field(ge=1024, le=65535)
+    description: str = ""
+
+    _BLOCKED_HOSTS: ClassVar[set[str]] = {
+        "localhost",
+        "host.docker.internal",
+        "gateway.docker.internal",
+        "kubernetes.default.svc",
+        "kubernetes.default.svc.cluster.local",
+    }
+    _BLOCKED_SUFFIXES: ClassVar[tuple[str, ...]] = (
+        ".localhost",
+        ".local",
+        ".internal",
+        ".home.arpa",
+        ".localdomain",
+        ".svc",
+        ".cluster.local",
+    )
+
+    @field_validator("host")
+    @classmethod
+    def _validate_host(cls, value: str) -> str:
+        host = value.strip().lower()
+        if not host:
+            raise ValueError("network tunnel host must not be empty")
+        if "*" in host:
+            raise ValueError("network tunnel host must be exact; wildcards are not allowed")
+        if any(ch in host for ch in ("/", ":", " ", "\t", "\n", "\r")):
+            raise ValueError("network tunnel host must be a plain hostname")
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+            pass
+        else:
+            raise ValueError("network tunnel host must not be an IP literal")
+        if host in cls._BLOCKED_HOSTS or host in {"127.0.0.1", "::1", "0.0.0.0"}:
+            raise ValueError("network tunnel host must not target loopback or wildcard addresses")
+        if any(host.endswith(suffix) for suffix in cls._BLOCKED_SUFFIXES):
+            raise ValueError("network tunnel host must not target internal-only service names")
+        return host
+
+    @property
+    def endpoint(self) -> str:
+        return f"{self.host}:{self.remote_port}"
+
+    @property
+    def display(self) -> str:
+        return f"{self.host}:{self.remote_port} via :{self.local_port}"
 
 
 class Mount(BaseModel):

--- a/src/carapace/security/context.py
+++ b/src/carapace/security/context.py
@@ -76,6 +76,7 @@ class SkillActivatedEntry(BaseModel):
     skill_name: str
     description: str = ""
     declared_domains: list[str] = []
+    declared_tunnels: list[str] = []
 
 
 class UserVouchedEntry(BaseModel):
@@ -100,6 +101,7 @@ class ContextGrantEntry(BaseModel):
     type: Literal["context_grant"] = "context_grant"
     skill_name: str
     domains: list[str] = []
+    tunnels: list[str] = []
     vault_paths: list[str] = []
 
 

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -20,6 +20,7 @@ from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
     ModelResponse,
+    TextPart,
     ToolCallPart,
     ToolReturnPart,
     UserPromptPart,
@@ -1225,17 +1226,32 @@ class SessionEngine:
             logger.info(f"Agent turn cancelled for session {session_id}")
             self._session_mgr.save_usage(session_id, active.usage_tracker)
             self._session_mgr.save_llm_request_log(session_id, active.llm_request_log)
-            self._save_user_message_on_failure(session_id, user_input, latest_messages=latest_messages)
+            self._save_user_message_on_failure(
+                session_id,
+                user_input,
+                latest_messages=latest_messages,
+                terminal_message="The previous turn was interrupted before completion.",
+            )
             await self._broadcast(active, "on_cancelled")
         except SessionBudgetExceededError as exc:
             logger.info(f"Session budget blocked LLM call for {session_id}: {exc}")
             self._session_mgr.save_usage(session_id, active.usage_tracker)
             self._session_mgr.save_llm_request_log(session_id, active.llm_request_log)
-            self._save_user_message_on_failure(session_id, user_input, latest_messages=latest_messages)
+            self._save_user_message_on_failure(
+                session_id,
+                user_input,
+                latest_messages=latest_messages,
+                terminal_message=str(exc),
+            )
             await self._broadcast(active, "on_error", str(exc))
         except Exception:
             logger.exception("Agent error")
-            self._save_user_message_on_failure(session_id, user_input, latest_messages=latest_messages)
+            self._save_user_message_on_failure(
+                session_id,
+                user_input,
+                latest_messages=latest_messages,
+                terminal_message="The previous turn failed before completion.",
+            )
             await self._broadcast(active, "on_error", traceback.format_exc())
         finally:
             active.agent_task = None
@@ -1246,6 +1262,7 @@ class SessionEngine:
         user_input: str,
         *,
         latest_messages: list[ModelMessage] | None = None,
+        terminal_message: str | None = None,
     ) -> None:
         """Persist the user message to history even when the agent turn fails.
 
@@ -1257,10 +1274,15 @@ class SessionEngine:
         else:
             history = self._session_mgr.load_history(session_id)
             history.append(ModelRequest(parts=[UserPromptPart(content=user_input)]))
-        self._session_mgr.save_history(session_id, self._truncate_incomplete_model_history(history))
-        self._session_mgr.save_events(
-            session_id, self._truncate_incomplete_events(self._session_mgr.load_events(session_id))
-        )
+        history = self._truncate_incomplete_model_history(history)
+        if terminal_message:
+            history.append(ModelResponse(parts=[TextPart(content=terminal_message)]))
+        self._session_mgr.save_history(session_id, history)
+
+        events = self._truncate_incomplete_events(self._session_mgr.load_events(session_id))
+        if terminal_message:
+            events.append({"role": "assistant", "content": terminal_message})
+        self._session_mgr.save_events(session_id, events)
 
     def _truncate_incomplete_model_history(self, messages: list[ModelMessage]) -> list[ModelMessage]:
         pending_tool_calls: set[str] = set()

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -15,6 +15,7 @@ from carapace.sandbox.runtime import (
     ContainerGoneError,
     ContainerRuntime,
     ExecResult,
+    NetworkTunnel,
     SkillActivationInputs,
     SkillFileCredential,
 )
@@ -396,6 +397,20 @@ class TestCarapaceYamlParsing:
         assert cfg is not None
         assert cfg.network.domains == ["api.example.com", "*.cdn.example.com"]
 
+    def test_parse_network_tunnels(self, tmp_path: Path):
+        skill_dir = tmp_path / "zoho-mail"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("---\nname: zoho-mail\n---\nBody.\n")
+        (skill_dir / "carapace.yaml").write_text(
+            "network:\n  tunnels:\n    - host: imap.zoho.eu\n      remote_port: 993\n      local_port: 1993\n"
+        )
+
+        registry = SkillRegistry(tmp_path)
+        cfg = registry.get_carapace_config("zoho-mail")
+        assert cfg is not None
+        assert len(cfg.network.tunnels) == 1
+        assert cfg.network.tunnels[0].display == "imap.zoho.eu:993 via :1993"
+
     def test_no_carapace_yaml(self, tmp_path: Path):
         skill_dir = tmp_path / "plain"
         skill_dir.mkdir()
@@ -413,6 +428,39 @@ class TestCarapaceYamlParsing:
         registry = SkillRegistry(tmp_path)
         assert registry.get_carapace_config("bad") is None
 
+    def test_invalid_tunnel_host_rejects_config(self, tmp_path: Path):
+        skill_dir = tmp_path / "bad-tunnel"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("Body.\n")
+        (skill_dir / "carapace.yaml").write_text(
+            "network:\n  tunnels:\n    - host: '*.zoho.eu'\n      remote_port: 993\n      local_port: 1993\n"
+        )
+
+        registry = SkillRegistry(tmp_path)
+        assert registry.get_carapace_config("bad-tunnel") is None
+
+    def test_invalid_tunnel_ip_literal_rejects_config(self, tmp_path: Path):
+        skill_dir = tmp_path / "bad-tunnel-ip"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("Body.\n")
+        (skill_dir / "carapace.yaml").write_text(
+            "network:\n  tunnels:\n    - host: 10.0.0.1\n      remote_port: 993\n      local_port: 1993\n"
+        )
+
+        registry = SkillRegistry(tmp_path)
+        assert registry.get_carapace_config("bad-tunnel-ip") is None
+
+    def test_invalid_tunnel_internal_service_rejects_config(self, tmp_path: Path):
+        skill_dir = tmp_path / "bad-tunnel-svc"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("Body.\n")
+        (skill_dir / "carapace.yaml").write_text(
+            "network:\n  tunnels:\n    - host: kubernetes.default.svc\n      remote_port: 443\n      local_port: 1443\n"
+        )
+
+        registry = SkillRegistry(tmp_path)
+        assert registry.get_carapace_config("bad-tunnel-svc") is None
+
     def test_empty_network_section(self, tmp_path: Path):
         skill_dir = tmp_path / "minimal"
         skill_dir.mkdir()
@@ -427,14 +475,161 @@ class TestCarapaceYamlParsing:
     def test_model_validation(self):
         cfg = SkillCarapaceConfig.model_validate(
             {
-                "network": {"domains": ["a.com"]},
+                "network": {
+                    "domains": ["a.com"],
+                    "tunnels": [{"host": "imap.a.com", "remote_port": 993, "local_port": 1993}],
+                },
                 "credentials": [{"vault_path": "x/y", "description": "Test cred", "env_var": "FOO"}],
             }
         )
         assert cfg.network.domains == ["a.com"]
+        assert cfg.network.tunnels[0].display == "imap.a.com:993 via :1993"
         assert len(cfg.credentials) == 1
         assert cfg.credentials[0].vault_path == "x/y"
         assert cfg.credentials[0].env_var == "FOO"
+
+    def test_model_validation_rejects_duplicate_local_ports(self):
+        with pytest.raises(ValueError, match="local_port 1993"):
+            SkillCarapaceConfig.model_validate(
+                {
+                    "network": {
+                        "tunnels": [
+                            {"host": "imap.a.com", "remote_port": 993, "local_port": 1993},
+                            {"host": "imap.b.com", "remote_port": 993, "local_port": 1993},
+                        ]
+                    }
+                }
+            )
+
+
+@pytest.mark.anyio
+async def test_exec_command_sets_up_and_cleans_up_tunnels(tmp_path: Path):
+    runtime = MagicMock(spec=ContainerRuntime)
+    runtime.get_host_ip = AsyncMock(return_value="172.18.0.1")
+    runtime.create_sandbox = AsyncMock(return_value="container-1")
+    runtime.get_ip = AsyncMock(return_value="172.18.0.22")
+    runtime.logs = AsyncMock(return_value="carapace sandbox ready")
+    runtime.exec = AsyncMock(return_value=ExecResult(exit_code=0, output="ok"))
+
+    mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+
+    result = await mgr.exec_command(
+        "sess-1",
+        "run-mail-sync",
+        context_tunnels=[NetworkTunnel(host="imap.zoho.eu", remote_port=993, local_port=1993)],
+    )
+
+    assert result.output == "ok"
+
+    commands = [call.args[1] for call in runtime.exec.call_args_list]
+    assert any("carapace-tunnel-helper-sess-1.py" in command for command in commands)
+    assert any("cp /etc/hosts /tmp/carapace-tunnel-hosts-sess-1.bak" in command for command in commands)
+    assert any("nohup python3 /tmp/carapace-tunnel-helper-sess-1.py" in command for command in commands)
+    assert any("--listen-port 1993" in command and "--target-port 993" in command for command in commands)
+    assert any(command == "run-mail-sync" for command in commands)
+    assert any('kill "$(cat /tmp/carapace-tunnel-sess-1-1993.pid)"' in command for command in commands)
+
+
+@pytest.mark.anyio
+async def test_exec_command_rejects_conflicting_tunnel_local_ports(tmp_path: Path):
+    runtime = MagicMock(spec=ContainerRuntime)
+    runtime.get_host_ip = AsyncMock(return_value="172.18.0.1")
+    runtime.create_sandbox = AsyncMock(return_value="container-1")
+    runtime.get_ip = AsyncMock(return_value="172.18.0.22")
+    runtime.logs = AsyncMock(return_value="carapace sandbox ready")
+    runtime.exec = AsyncMock(return_value=ExecResult(exit_code=0, output="ok"))
+
+    mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+
+    with pytest.raises(ValueError, match=r"Conflicting network\.tunnels declarations"):
+        await mgr.exec_command(
+            "sess-1",
+            "run-mail-sync",
+            context_tunnels=[
+                NetworkTunnel(host="imap.zoho.eu", remote_port=993, local_port=1993),
+                NetworkTunnel(host="smtp.zoho.eu", remote_port=465, local_port=1993),
+            ],
+        )
+
+
+@pytest.mark.anyio
+async def test_exec_command_recreates_tunnels_before_retry(tmp_path: Path):
+    runtime = MagicMock(spec=ContainerRuntime)
+    runtime.get_host_ip = AsyncMock(return_value="172.18.0.1")
+    runtime.sandbox_exists = AsyncMock(return_value=None)
+    runtime.create_sandbox = AsyncMock(side_effect=["container-1", "container-2"])
+    runtime.get_ip = AsyncMock(return_value="172.18.0.22")
+    runtime.logs = AsyncMock(return_value="carapace sandbox ready")
+
+    _ok = ExecResult(exit_code=0, output="")
+    runtime.exec = AsyncMock(
+        side_effect=[
+            _ok,
+            _ok,
+            _ok,
+            _ok,
+            _ok,
+            ContainerGoneError(),
+            _ok,
+            _ok,
+            _ok,
+            _ok,
+            _ok,
+            ExecResult(exit_code=0, output="ok"),
+            _ok,
+        ]
+    )
+
+    mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+
+    result = await mgr.exec_command(
+        "sess-1",
+        "run-mail-sync",
+        context_tunnels=[NetworkTunnel(host="imap.zoho.eu", remote_port=993, local_port=1993)],
+    )
+
+    assert result.output == "ok"
+    assert runtime.create_sandbox.await_count == 2
+
+    commands = [call.args[1] for call in runtime.exec.call_args_list]
+    assert sum("carapace-tunnel-helper-sess-1.py" in command for command in commands) >= 2
+    assert sum("--listen-port 1993" in command and "--target-port 993" in command for command in commands) == 2
+
+
+@pytest.mark.anyio
+async def test_exec_command_cleans_up_tunnels_after_command_failure(tmp_path: Path):
+    runtime = MagicMock(spec=ContainerRuntime)
+    runtime.get_host_ip = AsyncMock(return_value="172.18.0.1")
+    runtime.create_sandbox = AsyncMock(return_value="container-1")
+    runtime.get_ip = AsyncMock(return_value="172.18.0.22")
+    runtime.logs = AsyncMock(return_value="carapace sandbox ready")
+    runtime.exec = AsyncMock(
+        side_effect=[
+            ExecResult(exit_code=0, output=""),
+            ExecResult(exit_code=0, output=""),
+            ExecResult(exit_code=0, output=""),
+            ExecResult(exit_code=0, output=""),
+            ExecResult(exit_code=0, output=""),
+            ExecResult(exit_code=5, output="mail failed"),
+            ExecResult(exit_code=0, output=""),
+        ]
+    )
+
+    mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+
+    result = await mgr.exec_command(
+        "sess-1",
+        "run-mail-sync",
+        context_tunnels=[NetworkTunnel(host="imap.zoho.eu", remote_port=993, local_port=1993)],
+    )
+
+    assert result.exit_code == 5
+    assert "mail failed" in result.output
+    assert "[exit code: 5]" in result.output
+
+    cleanup_command = runtime.exec.call_args_list[-1].args[1]
+    assert 'kill "$(cat /tmp/carapace-tunnel-sess-1-1993.pid)"' in cleanup_command
+    assert "cp /tmp/carapace-tunnel-hosts-sess-1.bak /etc/hosts" in cleanup_command
 
 
 # ── Proxy token extraction ───────────────────────────────────────────

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import base64
-import re
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
@@ -11,8 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from carapace.models import SkillCarapaceConfig
-from carapace.sandbox import manager as sandbox_manager
-from carapace.sandbox.manager import SandboxManager
+from carapace.sandbox.manager import _CONTEXT_TUNNEL_HELPER, SandboxManager
 from carapace.sandbox.proxy import ProxyServer, domain_matches
 from carapace.sandbox.runtime import (
     ContainerGoneError,
@@ -506,15 +504,9 @@ class TestCarapaceYamlParsing:
 
     @pytest.mark.anyio
     async def test_context_tunnel_helper_accepts_minimal_connect_response(self):
-        helper_source_match = re.search(
-            r'_CONTEXT_TUNNEL_HELPER = """(.*?)"""',
-            Path(sandbox_manager.__file__).read_text(),
-            re.DOTALL,
-        )
-        assert helper_source_match is not None
-
         namespace: dict[str, Any] = {"__name__": "test_context_tunnel_helper"}
-        exec(helper_source_match.group(1), namespace)
+        compile(_CONTEXT_TUNNEL_HELPER, "carapace_tunnel_helper.py", "exec")
+        exec(_CONTEXT_TUNNEL_HELPER, namespace)
         open_proxy_tunnel = cast(Any, namespace["_open_proxy_tunnel"])
         helper_asyncio = cast(Any, namespace["asyncio"])
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -578,8 +578,10 @@ async def test_exec_command_sets_up_and_cleans_up_tunnels(tmp_path: Path):
     assert any("cp /etc/hosts /tmp/carapace-tunnel-hosts-sess-1.bak" in command for command in commands)
     assert any("{ nohup python3 /tmp/carapace-tunnel-helper-sess-1.py" in command for command in commands)
     assert any("--listen-port 1993" in command and "--target-port 993" in command for command in commands)
+    assert any("--ready-file /tmp/carapace-tunnel-sess-1-1993.ready" in command for command in commands)
     assert any(command == "run-mail-sync" for command in commands)
     assert any("echo $! > /tmp/carapace-tunnel-sess-1-1993.pid; } && kill -0" in command for command in commands)
+    assert any("while [ ! -f /tmp/carapace-tunnel-sess-1-1993.ready ]" in command for command in commands)
     assert any('kill "$(cat /tmp/carapace-tunnel-sess-1-1993.pid)"' in command for command in commands)
 
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -584,9 +584,10 @@ async def test_exec_command_sets_up_and_cleans_up_tunnels(tmp_path: Path):
     commands = [call.args[1] for call in runtime.exec.call_args_list]
     assert any("carapace-tunnel-helper-sess-1.py" in command for command in commands)
     assert any("cp /etc/hosts /tmp/carapace-tunnel-hosts-sess-1.bak" in command for command in commands)
-    assert any("nohup python3 /tmp/carapace-tunnel-helper-sess-1.py" in command for command in commands)
+    assert any("{ nohup python3 /tmp/carapace-tunnel-helper-sess-1.py" in command for command in commands)
     assert any("--listen-port 1993" in command and "--target-port 993" in command for command in commands)
     assert any(command == "run-mail-sync" for command in commands)
+    assert any("echo $! > /tmp/carapace-tunnel-sess-1-1993.pid; } && kill -0" in command for command in commands)
     assert any('kill "$(cat /tmp/carapace-tunnel-sess-1-1993.pid)"' in command for command in commands)
 
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from carapace.models import SkillCarapaceConfig
+from carapace.sandbox.exec_flow import SandboxExecCoordinator, SandboxExecState
 from carapace.sandbox.manager import _CONTEXT_TUNNEL_HELPER, SandboxManager
 from carapace.sandbox.proxy import ProxyServer, domain_matches
 from carapace.sandbox.runtime import (
@@ -20,6 +21,7 @@ from carapace.sandbox.runtime import (
     SkillActivationInputs,
     SkillFileCredential,
 )
+from carapace.sandbox.session_lifecycle import SessionContainer
 from carapace.skills import SkillRegistry
 
 # ── domain_matches ──────────────────────────────────────────────────
@@ -462,6 +464,17 @@ class TestCarapaceYamlParsing:
         registry = SkillRegistry(tmp_path)
         assert registry.get_carapace_config("bad-tunnel-svc") is None
 
+    def test_invalid_tunnel_trailing_dot_blocked_host_rejects_config(self, tmp_path: Path):
+        skill_dir = tmp_path / "bad-tunnel-dot"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("Body.\n")
+        (skill_dir / "carapace.yaml").write_text(
+            "network:\n  tunnels:\n    - host: localhost.\n      remote_port: 443\n      local_port: 1443\n"
+        )
+
+        registry = SkillRegistry(tmp_path)
+        assert registry.get_carapace_config("bad-tunnel-dot") is None
+
     def test_empty_network_section(self, tmp_path: Path):
         skill_dir = tmp_path / "minimal"
         skill_dir.mkdir()
@@ -721,6 +734,58 @@ async def test_exec_command_cleans_up_tunnels_after_command_failure(tmp_path: Pa
     cleanup_command = runtime.exec.call_args_list[-1].args[1]
     assert 'kill "$(cat /tmp/carapace-tunnel-sess-1-1993.pid)"' in cleanup_command
     assert "cp /tmp/carapace-tunnel-hosts-sess-1.bak /etc/hosts" in cleanup_command
+
+
+@pytest.mark.anyio
+async def test_exec_cleanup_tunnel_error_does_not_mask_command_error_or_skip_credential_cleanup():
+    runtime = MagicMock(spec=ContainerRuntime)
+    state = SandboxExecState(
+        sessions={},
+        allowed_domains={},
+        exec_temp_domains={},
+        exec_context_skill_domains={},
+        session_current_command={},
+        domain_approval_cbs={},
+        domain_notify_cbs={},
+        exec_locks={},
+        proxy_bypass_sessions=set(),
+        session_current_contexts={},
+        exec_notified_domains={},
+        exec_notified_credentials={},
+    )
+    coordinator = SandboxExecCoordinator(runtime=runtime, state=state)
+    sc1 = SessionContainer(container_id="container-1", session_id="sess-1", created_at=0, last_used=0)
+    sc2 = SessionContainer(container_id="container-2", session_id="sess-1", created_at=0, last_used=0)
+    written_files = [("example", "/workspace/skills/example/.secrets/token.txt")]
+
+    ensure_session = AsyncMock(side_effect=[(sc1, False), (sc2, False)])
+    rerun_skill_setup = AsyncMock()
+    log_container_tail = AsyncMock()
+    prepare_session_recreate = MagicMock()
+    exec_in_container = AsyncMock(side_effect=[ContainerGoneError("gone"), RuntimeError("command failed")])
+    prepare_context_tunnels = AsyncMock()
+    cleanup_context_tunnels = AsyncMock(side_effect=ContainerGoneError("cleanup failed"))
+    write_context_file_credentials = AsyncMock(side_effect=[list(written_files), list(written_files)])
+    delete_context_file_credentials = AsyncMock()
+
+    with pytest.raises(RuntimeError, match="command failed"):
+        await coordinator.exec(
+            "sess-1",
+            "run-mail-sync",
+            ensure_session=ensure_session,
+            rerun_skill_setup=rerun_skill_setup,
+            log_container_tail=log_container_tail,
+            prepare_session_recreate=prepare_session_recreate,
+            exec_in_container=exec_in_container,
+            prepare_context_tunnels=prepare_context_tunnels,
+            cleanup_context_tunnels=cleanup_context_tunnels,
+            write_context_file_credentials=write_context_file_credentials,
+            delete_context_file_credentials=delete_context_file_credentials,
+            context_tunnels=[NetworkTunnel(host="imap.zoho.eu", remote_port=993, local_port=1993)],
+            context_file_creds=[("example", ".secrets/token.txt", "secret")],
+        )
+
+    delete_context_file_credentials.assert_awaited_once_with("sess-1", written_files)
 
 
 # ── Proxy token extraction ───────────────────────────────────────────

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import base64
+import re
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from carapace.models import SkillCarapaceConfig
+from carapace.sandbox import manager as sandbox_manager
 from carapace.sandbox.manager import SandboxManager
 from carapace.sandbox.proxy import ProxyServer, domain_matches
 from carapace.sandbox.runtime import (
@@ -501,6 +504,63 @@ class TestCarapaceYamlParsing:
                 }
             )
 
+    @pytest.mark.anyio
+    async def test_context_tunnel_helper_accepts_minimal_connect_response(self):
+        helper_source_match = re.search(
+            r'_CONTEXT_TUNNEL_HELPER = """(.*?)"""',
+            Path(sandbox_manager.__file__).read_text(),
+            re.DOTALL,
+        )
+        assert helper_source_match is not None
+
+        namespace: dict[str, Any] = {"__name__": "test_context_tunnel_helper"}
+        exec(helper_source_match.group(1), namespace)
+        open_proxy_tunnel = cast(Any, namespace["_open_proxy_tunnel"])
+        helper_asyncio = cast(Any, namespace["asyncio"])
+
+        class FakeReader:
+            def __init__(self, chunks: list[bytes]):
+                self._chunks = list(chunks)
+
+            async def read(self, _size: int) -> bytes:
+                if self._chunks:
+                    return self._chunks.pop(0)
+                return b""
+
+        class FakeWriter:
+            def __init__(self):
+                self.writes: list[bytes] = []
+
+            def write(self, data: bytes) -> None:
+                self.writes.append(data)
+
+            async def drain(self) -> None:
+                return None
+
+        reader = FakeReader([b"HTTP/1.1 200 Connection Established\r\n\r\n"])
+        writer = FakeWriter()
+
+        async def fake_open_connection(host: str, port: int):
+            assert host == "proxy.internal"
+            assert port == 8080
+            return reader, writer
+
+        original_open_connection = helper_asyncio.open_connection
+        helper_asyncio.open_connection = fake_open_connection
+        try:
+            prebuffer, upstream_reader, upstream_writer = await open_proxy_tunnel(
+                "http://proxy.internal:8080",
+                "imap.zoho.eu",
+                993,
+            )
+        finally:
+            helper_asyncio.open_connection = original_open_connection
+
+        assert prebuffer == b""
+        assert upstream_reader is reader
+        assert upstream_writer is writer
+        assert writer.writes == [b"CONNECT imap.zoho.eu:993 HTTP/1.1\r\nHost: imap.zoho.eu:993\r\n\r\n"]
+
 
 @pytest.mark.anyio
 async def test_exec_command_sets_up_and_cleans_up_tunnels(tmp_path: Path):
@@ -550,6 +610,42 @@ async def test_exec_command_rejects_conflicting_tunnel_local_ports(tmp_path: Pat
                 NetworkTunnel(host="smtp.zoho.eu", remote_port=465, local_port=1993),
             ],
         )
+
+
+@pytest.mark.anyio
+async def test_exec_command_allows_duplicate_tunnel_with_different_descriptions(tmp_path: Path):
+    runtime = MagicMock(spec=ContainerRuntime)
+    runtime.get_host_ip = AsyncMock(return_value="172.18.0.1")
+    runtime.create_sandbox = AsyncMock(return_value="container-1")
+    runtime.get_ip = AsyncMock(return_value="172.18.0.22")
+    runtime.logs = AsyncMock(return_value="carapace sandbox ready")
+    runtime.exec = AsyncMock(return_value=ExecResult(exit_code=0, output="ok"))
+
+    mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+
+    result = await mgr.exec_command(
+        "sess-1",
+        "run-mail-sync",
+        context_tunnels=[
+            NetworkTunnel(
+                host="imap.zoho.eu",
+                remote_port=993,
+                local_port=1993,
+                description="Primary IMAP tunnel",
+            ),
+            NetworkTunnel(
+                host="imap.zoho.eu",
+                remote_port=993,
+                local_port=1993,
+                description="Same tunnel from another skill",
+            ),
+        ],
+    )
+
+    assert result.output == "ok"
+
+    commands = [call.args[1] for call in runtime.exec.call_args_list]
+    assert sum("nohup python3 /tmp/carapace-tunnel-helper-sess-1.py" in command for command in commands) == 1
 
 
 @pytest.mark.anyio

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -495,6 +495,47 @@ def test_submit_cancel_stops_task(tmp_path: Path):
         asyncio.run(_run())
 
 
+def test_submit_cancel_persists_interruption_marker(tmp_path: Path):
+    """Cancelled turns are persisted with a terminal assistant message."""
+
+    async def _run() -> None:
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session()
+        sid = state.session_id
+
+        sub = _FakeSubscriber()
+        engine.subscribe(sid, sub)
+
+        async def _hanging_turn(*_args: Any, **_kwargs: Any) -> str:
+            await asyncio.sleep(999)
+            return "unreachable"
+
+        with patch("carapace.session.engine.run_agent_turn", new=_hanging_turn):
+            await engine.submit_message(sid, "hello")
+            await asyncio.sleep(0.05)
+            await engine.submit_cancel(sid)
+
+        history = engine.session_mgr.load_history(sid)
+        assert len(history) == 2
+        assert isinstance(history[0], ModelRequest)
+        assert any(isinstance(part, UserPromptPart) and part.content == "hello" for part in history[0].parts)
+        assert isinstance(history[1], ModelResponse)
+        assert any(
+            isinstance(part, TextPart) and part.content == "The previous turn was interrupted before completion."
+            for part in history[1].parts
+        )
+
+        events = engine.session_mgr.load_events(sid)
+        assert events[-2:] == [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "The previous turn was interrupted before completion."},
+        ]
+        assert sub.cancelled == 1
+
+    with _patch_sentinel():
+        asyncio.run(_run())
+
+
 def test_submit_cancel_noop_when_inactive(tmp_path: Path):
     """submit_cancel is a no-op when session is not active."""
 
@@ -708,6 +749,17 @@ def test_submit_message_budget_exceeded_persists_history(tmp_path: Path):
         assert history
         assert isinstance(history[0], ModelRequest)
         assert any(isinstance(part, UserPromptPart) and part.content == "hello" for part in history[0].parts)
+        assert isinstance(history[-1], ModelResponse)
+        assert any(
+            isinstance(part, TextPart) and part.content == "Session budget reached: input 1.0k tokens / 1.0k tokens"
+            for part in history[-1].parts
+        )
+
+        events = engine.session_mgr.load_events(sid)
+        assert events[-1] == {
+            "role": "assistant",
+            "content": "Session budget reached: input 1.0k tokens / 1.0k tokens",
+        }
         assert any("Session budget reached" in err for err in sub.errors)
 
     with _patch_sentinel():


### PR DESCRIPTION
## Summary
- add declarative `network.tunnels` support to skill configs and context grants
- establish exec-scoped CONNECT-backed TCP tunnels in the sandbox with host validation, cleanup, and recreate handling
- document the new tunnel model and update the example skill to demonstrate IMAP connectivity
- extend proxy tests to cover parsing, validation, conflicts, cleanup, and sandbox recreation

## Testing
- `uv run pytest tests/test_proxy.py`
- `prek run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new exec-time networking behavior (hostname shadowing + CONNECT-backed TCP forwarders) and touches sandbox exec lifecycle/cleanup, so regressions could impact connectivity or container stability. Host/port validation and expanded tests reduce but don’t eliminate the risk.
> 
> **Overview**
> Adds declarative `network.tunnels` to skill `carapace.yaml` and propagates tunnels through `use_skill` → context grants → `exec` so commands can get **exec-scoped TCP tunnels** in addition to domain allowlisting.
> 
> Implements tunnel setup/teardown in the sandbox exec flow: Carapace temporarily shadows tunneled hostnames via `/etc/hosts`, starts a trusted in-sandbox CONNECT forwarder per tunnel, recreates tunnels on container recreation, and ensures cleanup runs in `finally` without masking command errors.
> 
> Updates docs and the bundled `example` skill to demonstrate IMAP connectivity via a tunnel, extends security/audit metadata to record declared tunnels, and expands tests to cover parsing/validation, conflict handling, lifecycle cleanup, and failure/cancel persistence behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a76ebc510be6d2b688158cd4cb12233a05760127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->