### PR TITLE
✨ Improve tool-call feedback during sentinel review

### DIFF
--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -522,6 +522,18 @@ export function ChatView({
     }
   }, [clearToolLoading]);
 
+  const finalizeThinkingMessages = useCallback((messages: ChatMessage[]): ChatMessage[] => {
+    const updated = [...messages];
+    const thinkIdx = updated.findIndex((m) => m.kind === "thinking_streaming");
+    if (thinkIdx !== -1) {
+      updated[thinkIdx] = {
+        kind: "thinking",
+        content: (updated[thinkIdx] as { content: string }).content,
+      };
+    }
+    return updated;
+  }, []);
+
   const onMessage = useCallback(
     (msg: ServerMessage) => {
       switch (msg.type) {
@@ -590,7 +602,7 @@ export function ChatView({
           ) {
             setMessages((prev) =>
               applyApprovedApprovalToMessages(
-                prev,
+                finalizeThinkingMessages(prev),
                 { tool: msg.tool, args: msg.args },
                 isLoading,
               ),
@@ -599,17 +611,18 @@ export function ChatView({
           }
           if (msg.tool_id) {
             setMessages((prev) => {
-              const updated = updateToolCallMessageById(prev, msg.tool_id!, (entry) => ({
+              const withThinkingFinalized = finalizeThinkingMessages(prev);
+              const updated = updateToolCallMessageById(withThinkingFinalized, msg.tool_id!, (entry) => ({
                 ...entry,
                 ...newMsg,
               }));
               if (updated.found) return updated.messages;
 
               if (msg.parent_tool_id) {
-                for (let i = prev.length - 1; i >= 0; i--) {
-                  const m = prev[i];
+                for (let i = withThinkingFinalized.length - 1; i >= 0; i--) {
+                  const m = withThinkingFinalized[i];
                   if (m.kind === "tool_call" && m.toolId === msg.parent_tool_id) {
-                    const next = [...prev];
+                    const next = [...withThinkingFinalized];
                     next[i] = {
                       ...m,
                       children: [...(m.children ?? []), newMsg],
@@ -619,7 +632,7 @@ export function ChatView({
                 }
               }
 
-              return [...prev, newMsg];
+              return [...withThinkingFinalized, newMsg];
             });
             if (isGitPush) finishWaiting();
             break;
@@ -627,7 +640,7 @@ export function ChatView({
           if (msg.parent_tool_id) {
             // Attach to parent tool call
             setMessages((prev) => {
-              const updated = [...prev];
+              const updated = finalizeThinkingMessages(prev);
               for (let i = updated.length - 1; i >= 0; i--) {
                 const m = updated[i];
                 if (m.kind === "tool_call" && m.toolId === msg.parent_tool_id) {
@@ -639,10 +652,10 @@ export function ChatView({
                 }
               }
               // Parent not found — render top-level
-              return [...prev, newMsg];
+              return [...updated, newMsg];
             });
           } else {
-            setMessages((prev) => [...prev, newMsg]);
+            setMessages((prev) => [...finalizeThinkingMessages(prev), newMsg]);
           }
           if (isGitPush) finishWaiting();
           break;
@@ -742,15 +755,7 @@ export function ChatView({
         case "token":
           setWaiting(true);
           setMessages((prev) => {
-            const updated = [...prev];
-            // Finalize any open thinking_streaming → thinking when text tokens arrive
-            const thinkIdx = updated.findIndex((m) => m.kind === "thinking_streaming");
-            if (thinkIdx !== -1) {
-              updated[thinkIdx] = {
-                kind: "thinking",
-                content: (updated[thinkIdx] as { content: string }).content,
-              };
-            }
+            const updated = finalizeThinkingMessages(prev);
             const lastIdx = updated.length - 1;
             if (lastIdx >= 0 && updated[lastIdx].kind === "streaming") {
               updated[lastIdx] = {
@@ -781,7 +786,7 @@ export function ChatView({
           break;
       }
     },
-    [finishWaiting, onTitleUpdate],
+    [finalizeThinkingMessages, finishWaiting, onTitleUpdate],
   );
 
   const onWsDisconnect = useCallback(() => {

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -323,6 +323,7 @@ export function ChatView({
                 ...toolCall,
                 result: h.result,
                 exitCode: h.exit_code,
+                loading: false,
               };
             }
             if (queue && queue.length === 0) {

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -125,6 +125,79 @@ function isUserApprovedReplay(
   );
 }
 
+type ToolCallMessage = Extract<ChatMessage, { kind: "tool_call" }>;
+type ToolCallChildMessage = NonNullable<ToolCallMessage["children"]>[number];
+
+function isToolCallLoading(
+  tool: string,
+  approvalSource?:
+    | "safe-list"
+    | "sentinel"
+    | "user"
+    | "skill"
+    | "bypass"
+    | "unknown",
+  approvalVerdict?: "allow" | "deny" | "escalate",
+): boolean {
+  const isGitPush = tool === "git_push";
+  if (
+    tool === "proxy_domain" ||
+    tool === "credential_access" ||
+    isGitPush
+  ) {
+    return false;
+  }
+  if (approvalSource === "sentinel" && approvalVerdict == null) {
+    return true;
+  }
+  return approvalVerdict === "allow";
+}
+
+function updateToolCallMessageById(
+  messages: ChatMessage[],
+  toolId: string,
+  updater: (message: ToolCallMessage | ToolCallChildMessage) =>
+    | ToolCallMessage
+    | ToolCallChildMessage,
+): { messages: ChatMessage[]; found: boolean } {
+  let found = false;
+  const updated = messages.map((entry) => {
+    if (entry.kind !== "tool_call") return entry;
+
+    if (entry.toolId === toolId) {
+      found = true;
+      return updater(entry) as ToolCallMessage;
+    }
+
+    if (!entry.children?.length) return entry;
+
+    let childChanged = false;
+    const children = entry.children.map((child) => {
+      if (child.toolId !== toolId) return child;
+      found = true;
+      childChanged = true;
+      return updater(child) as ToolCallChildMessage;
+    });
+
+    return childChanged ? { ...entry, children } : entry;
+  });
+
+  return { messages: found ? updated : messages, found };
+}
+
+function updateToolResultById(
+  messages: ChatMessage[],
+  toolId: string,
+  result: { result: string; exitCode?: number },
+): { messages: ChatMessage[]; found: boolean } {
+  return updateToolCallMessageById(messages, toolId, (entry) => ({
+    ...entry,
+    result: result.result,
+    exitCode: result.exitCode,
+    loading: false,
+  }));
+}
+
 export function ChatView({
   server,
   token,
@@ -182,6 +255,11 @@ export function ChatView({
             msgs.push({ kind: "user", content: h.content });
           } else if (h.role === "tool_call") {
             const rawContexts = h.contexts ?? h.args?.contexts;
+            const isLoading = isToolCallLoading(
+              h.tool ?? "",
+              h.approval_source,
+              h.approval_verdict,
+            );
             if (
               isUserApprovedReplay(
                 h.tool ?? "",
@@ -196,6 +274,7 @@ export function ChatView({
                   tool: h.tool ?? "",
                   args: (h.args ?? {}) as Record<string, unknown>,
                 },
+                isLoading,
               );
               msgs.length = 0;
               msgs.push(...patched);
@@ -212,6 +291,7 @@ export function ChatView({
               approvalSource: h.approval_source,
               approvalVerdict: h.approval_verdict,
               approvalExplanation: h.approval_explanation,
+              loading: isLoading,
               toolId: h.tool_id as string | undefined,
               parentToolId: h.parent_tool_id as string | undefined,
             });
@@ -221,6 +301,19 @@ export function ChatView({
             queue.push(idx);
             pendingToolCallIndices.set(toolName, queue);
           } else if (h.role === "tool_result") {
+            const toolResultId = h.tool_id as string | undefined;
+            if (toolResultId) {
+              const updated = updateToolResultById(msgs, toolResultId, {
+                result: h.result ?? "",
+                exitCode: h.exit_code,
+              });
+              if (updated.found) {
+                msgs.length = 0;
+                msgs.push(...updated.messages);
+                continue;
+              }
+            }
+
             const toolName = h.tool ?? "";
             const queue = pendingToolCallIndices.get(toolName);
             const idx = queue?.shift();
@@ -465,12 +558,11 @@ export function ChatView({
         case "tool_call": {
           const isGitPush = msg.tool === "git_push";
           if (!isGitPush) setWaiting(true); // agent is active (may restore after reconnect)
-          const verdict = msg.approval_verdict;
-          const isLoading =
-            msg.tool !== "proxy_domain" &&
-            msg.tool !== "credential_access" &&
-            !isGitPush &&
-            verdict === "allow";
+          const isLoading = isToolCallLoading(
+            msg.tool,
+            msg.approval_source,
+            msg.approval_verdict,
+          );
           const rawContexts = msg.contexts ?? msg.args?.contexts;
           const newMsg: ChatMessage = {
             kind: "tool_call",
@@ -504,6 +596,33 @@ export function ChatView({
             );
             break;
           }
+          if (msg.tool_id) {
+            setMessages((prev) => {
+              const updated = updateToolCallMessageById(prev, msg.tool_id!, (entry) => ({
+                ...entry,
+                ...newMsg,
+              }));
+              if (updated.found) return updated.messages;
+
+              if (msg.parent_tool_id) {
+                for (let i = prev.length - 1; i >= 0; i--) {
+                  const m = prev[i];
+                  if (m.kind === "tool_call" && m.toolId === msg.parent_tool_id) {
+                    const next = [...prev];
+                    next[i] = {
+                      ...m,
+                      children: [...(m.children ?? []), newMsg],
+                    };
+                    return next;
+                  }
+                }
+              }
+
+              return [...prev, newMsg];
+            });
+            if (isGitPush) finishWaiting();
+            break;
+          }
           if (msg.parent_tool_id) {
             // Attach to parent tool call
             setMessages((prev) => {
@@ -530,6 +649,14 @@ export function ChatView({
         case "tool_result":
           setWaiting(true);
           setMessages((prev) => {
+            if (msg.tool_id) {
+              const updatedById = updateToolResultById(prev, msg.tool_id, {
+                result: msg.result,
+                exitCode: msg.exit_code,
+              });
+              if (updatedById.found) return updatedById.messages;
+            }
+
             const updated = [...prev];
             for (let i = updated.length - 1; i >= 0; i--) {
               const m = updated[i];

--- a/frontend/src/components/tool-call-badge.tsx
+++ b/frontend/src/components/tool-call-badge.tsx
@@ -262,7 +262,7 @@ function ApprovalBadge({
   tooltip,
 }: {
   source: ApprovalSource;
-  verdict: ApprovalVerdict;
+  verdict?: ApprovalVerdict;
   tooltip?: string;
 }) {
   if (source === "safe-list") {
@@ -275,6 +275,17 @@ function ApprovalBadge({
   }
 
   if (source === "sentinel") {
+    if (verdict == null) {
+      return (
+        <span
+          className="inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[10px] font-medium bg-slate-500/10 text-slate-600 dark:text-slate-400"
+          title={tooltip || undefined}
+        >
+          <Loader2 className="h-2.5 w-2.5 animate-spin" />
+          review
+        </span>
+      );
+    }
     const colorClass =
       verdict === "allow"
         ? "bg-green-500/10 text-green-600 dark:text-green-400"
@@ -365,17 +376,21 @@ export function ToolCallBadge({
   const [skillInstructionsOpen, setSkillInstructionsOpen] = useState(false);
   void _detail;
   const source = approvalSource;
-  const verdict = approvalVerdict ?? "allow";
+  const verdict = approvalVerdict;
   const explanation = approvalExplanation ?? "";
   const hasExplicitDecisionMessage = decisionMessage !== undefined;
+  const isSentinelReviewPending = source === "sentinel" && verdict == null;
   const sentinelExplanation =
-    source === "sentinel" || hasExplicitDecisionMessage ? explanation : "";
+    ((source === "sentinel" && verdict != null) || hasExplicitDecisionMessage)
+      ? explanation
+      : "";
   const finalDecisionMessage = hasExplicitDecisionMessage
     ? decisionMessage ?? ""
     : source === "user"
       ? explanation
       : "";
-  const showUserDecision = source === "user" && (verdict === "deny" || finalDecisionMessage.length > 0);
+  const showUserDecision =
+    source === "user" && (verdict === "deny" || finalDecisionMessage.length > 0);
   const isError = exitCode != null && exitCode !== 0;
   const isExecTool = tool === "exec";
   const isUseSkillTool = tool === "use_skill";
@@ -581,6 +596,16 @@ export function ToolCallBadge({
                 {useSkillName}
               </span>{" "}
               skill.
+            </div>
+          )}
+
+          {isSentinelReviewPending && (
+            <div className="text-[11px] text-muted-foreground leading-relaxed">
+              <span className="font-medium text-foreground/70">
+                <Loader2 className="inline h-3 w-3 -translate-y-px mr-1 animate-spin" />
+                Sentinel:
+              </span>
+              Reviewing this tool call.
             </div>
           )}
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -92,6 +92,7 @@ export interface ToolResultInfo {
   tool: string;
   result: string;
   exit_code?: number;
+  tool_id?: string;
 }
 
 export interface ApprovalRequest {

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -112,7 +112,14 @@ def _notify_approved_start(ctx: RunContext[Deps], tool_name: str, args: dict[str
 
 def _notify_result(ctx: RunContext[Deps], tool_name: str, result: str, exit_code: int = 0) -> None:
     if ctx.deps.tool_result_callback:
-        ctx.deps.tool_result_callback(ToolResult(tool=tool_name, output=result, exit_code=exit_code))
+        ctx.deps.tool_result_callback(
+            ToolResult(
+                tool=tool_name,
+                output=result,
+                exit_code=exit_code,
+                tool_id=ctx.deps.security.current_parent_tool_id,
+            )
+        )
 
 
 def truncate_tool_output(text: str, max_chars: int) -> str:

--- a/src/carapace/channels/matrix/subscriber.py
+++ b/src/carapace/channels/matrix/subscriber.py
@@ -185,6 +185,7 @@ class MatrixSubscriber:
         approval_source: str | None = None,
         approval_verdict: str | None = None,
         approval_explanation: str | None = None,
+        tool_id: str | None = None,
         parent_tool_id: str | None = None,
     ) -> None:
         logger.debug(f"Matrix [{self._room_id}] credential: {vault_path} {detail}")
@@ -231,6 +232,7 @@ class MatrixSubscriber:
         approval_source: str | None = None,
         approval_verdict: str | None = None,
         approval_explanation: str | None = None,
+        tool_id: str | None = None,
         parent_tool_id: str | None = None,
     ) -> None:
         logger.debug(f"Matrix [{self._room_id}] domain: {domain} {detail}")
@@ -246,6 +248,7 @@ class MatrixSubscriber:
         approval_source: str | None = None,
         approval_verdict: str | None = None,
         approval_explanation: str | None = None,
+        tool_id: str | None = None,
         parent_tool_id: str | None = None,
     ) -> None:
         logger.debug(f"Matrix [{self._room_id}] git_push: {ref} {decision} {detail}")

--- a/src/carapace/models.py
+++ b/src/carapace/models.py
@@ -407,6 +407,7 @@ class ToolResult:
     tool: str
     output: str
     exit_code: int = 0
+    tool_id: str | None = None
 
 
 class SkillCredentialDecl(BaseModel):

--- a/src/carapace/security/__init__.py
+++ b/src/carapace/security/__init__.py
@@ -76,6 +76,15 @@ async def evaluate_with(
             )
         return
 
+    if verbose:
+        _log_tool_call(
+            tool_name,
+            args,
+            "[sentinel] reviewing",
+            tool_call_callback,
+            approval_source="sentinel",
+        )
+
     verdict = await sentinel.evaluate_tool_call(
         session,
         tool_name,
@@ -158,6 +167,8 @@ async def evaluate_domain_with(
     If the sentinel escalates, delegates to the session's user escalation callback.
     """
 
+    session.notify_domain_decision(domain, "[sentinel] reviewing", approval_source="sentinel")
+
     verdict = await sentinel.evaluate_domain_access(
         session,
         domain,
@@ -226,6 +237,8 @@ async def evaluate_push_with(
 
     If the sentinel escalates, delegates to the session's user escalation callback.
     """
+    await session.notify_push_decision(ref, "reviewing", "[sentinel] reviewing", approval_source="sentinel")
+
     verdict = await sentinel.evaluate_push(
         session,
         ref,
@@ -322,6 +335,8 @@ async def evaluate_credential_with(
     ``user_was_prompted`` is False when the sentinel allowed or denied without escalation
     (the engine's escalation callback already persists UI events when escalation runs).
     """
+    session.notify_credential_review(vault_path, "[sentinel] reviewing", name=name, approval_source="sentinel")
+
     verdict = await sentinel.evaluate_credential_access(
         session,
         vault_path,

--- a/src/carapace/security/__init__.py
+++ b/src/carapace/security/__init__.py
@@ -383,6 +383,7 @@ async def evaluate_credential_with(
 
     session.record_credential_access(
         vault_paths=[vault_path],
+        names=[name],
         decision=cred_decision,
         explanation=verdict.explanation,
         ui_label=detail,

--- a/src/carapace/security/context.py
+++ b/src/carapace/security/context.py
@@ -366,6 +366,26 @@ class SessionSecurity:
             approval_explanation=approval_explanation,
         )
 
+    def notify_credential_review(
+        self,
+        vault_path: str,
+        detail: str,
+        *,
+        name: str = "",
+        approval_source: ApprovalSource | None = None,
+        approval_verdict: ApprovalVerdict | None = None,
+        approval_explanation: str | None = None,
+    ) -> None:
+        """Emit a provisional credential UI event without triggering duplicate suppression."""
+        self._emit_credential_ui(
+            vault_path,
+            detail,
+            name=name,
+            approval_source=approval_source,
+            approval_verdict=approval_verdict,
+            approval_explanation=approval_explanation,
+        )
+
     def record_credential_access(
         self,
         *,

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -620,7 +620,14 @@ class WebSocketSubscriber:
         )
 
     async def on_tool_result(self, result: ToolResult) -> None:
-        await self._safe_send(ToolResultInfo(tool=result.tool, result=result.output, exit_code=result.exit_code))
+        await self._safe_send(
+            ToolResultInfo(
+                tool=result.tool,
+                result=result.output,
+                exit_code=result.exit_code,
+                tool_id=result.tool_id,
+            )
+        )
 
     async def on_token(self, content: str) -> None:
         await self._safe_send(TokenChunk(content=content))
@@ -660,6 +667,7 @@ class WebSocketSubscriber:
         approval_source: ApprovalSource | None = None,
         approval_verdict: ApprovalVerdict | None = None,
         approval_explanation: str | None = None,
+        tool_id: str | None = None,
         parent_tool_id: str | None = None,
     ) -> None:
         await self._safe_send(
@@ -670,6 +678,7 @@ class WebSocketSubscriber:
                 approval_source=approval_source,
                 approval_verdict=approval_verdict,
                 approval_explanation=approval_explanation,
+                tool_id=tool_id,
                 parent_tool_id=parent_tool_id,
             )
         )
@@ -682,6 +691,7 @@ class WebSocketSubscriber:
         approval_source: ApprovalSource | None = None,
         approval_verdict: ApprovalVerdict | None = None,
         approval_explanation: str | None = None,
+        tool_id: str | None = None,
         parent_tool_id: str | None = None,
     ) -> None:
         await self._safe_send(
@@ -692,6 +702,7 @@ class WebSocketSubscriber:
                 approval_source=approval_source,
                 approval_verdict=approval_verdict,
                 approval_explanation=approval_explanation,
+                tool_id=tool_id,
                 parent_tool_id=parent_tool_id,
             )
         )
@@ -704,6 +715,7 @@ class WebSocketSubscriber:
         approval_source: ApprovalSource | None = None,
         approval_verdict: ApprovalVerdict | None = None,
         approval_explanation: str | None = None,
+        tool_id: str | None = None,
         parent_tool_id: str | None = None,
     ) -> None:
         await self._safe_send(
@@ -714,6 +726,7 @@ class WebSocketSubscriber:
                 approval_source=approval_source,
                 approval_verdict=approval_verdict,
                 approval_explanation=approval_explanation,
+                tool_id=tool_id,
                 parent_tool_id=parent_tool_id,
             )
         )

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -167,6 +167,7 @@ class SessionSubscriber(Protocol):
         approval_source: ApprovalSource | None = None,
         approval_verdict: ApprovalVerdict | None = None,
         approval_explanation: str | None = None,
+        tool_id: str | None = None,
         parent_tool_id: str | None = None,
     ) -> None: ...
     async def on_git_push_info(
@@ -177,6 +178,7 @@ class SessionSubscriber(Protocol):
         approval_source: ApprovalSource | None = None,
         approval_verdict: ApprovalVerdict | None = None,
         approval_explanation: str | None = None,
+        tool_id: str | None = None,
         parent_tool_id: str | None = None,
     ) -> None: ...
     async def on_credential_info(
@@ -187,6 +189,7 @@ class SessionSubscriber(Protocol):
         approval_source: ApprovalSource | None = None,
         approval_verdict: ApprovalVerdict | None = None,
         approval_explanation: str | None = None,
+        tool_id: str | None = None,
         parent_tool_id: str | None = None,
     ) -> None: ...
     async def on_credential_approval_request(
@@ -1057,6 +1060,56 @@ class SessionEngine:
         if events:
             await self._generate_title(active, events)
 
+    def _record_tool_call_event(
+        self,
+        session_id: str,
+        *,
+        tool: str,
+        args: dict[str, Any],
+        detail: str,
+        approval_source: ApprovalSource | None = None,
+        approval_verdict: ApprovalVerdict | None = None,
+        approval_explanation: str | None = None,
+        parent_tool_id: str | None = None,
+    ) -> str:
+        contexts_raw = args.get("contexts")
+        event: dict[str, Any] = {
+            "role": "tool_call",
+            "tool": tool,
+            "args": args,
+            "detail": detail,
+            "approval_source": approval_source,
+            "approval_verdict": approval_verdict,
+            "approval_explanation": approval_explanation,
+        }
+        if parent_tool_id is not None:
+            event["parent_tool_id"] = parent_tool_id
+        if isinstance(contexts_raw, list):
+            event["contexts"] = list(contexts_raw)
+
+        should_update_pending = approval_source == "sentinel" and approval_verdict is not None
+        if should_update_pending:
+            events = self._session_mgr.load_events(session_id)
+            for index in range(len(events) - 1, -1, -1):
+                existing = events[index]
+                if existing.get("role") != "tool_call":
+                    continue
+                if existing.get("tool") != tool or existing.get("args") != args:
+                    continue
+                if existing.get("parent_tool_id") != parent_tool_id:
+                    continue
+                if existing.get("approval_source") != "sentinel" or existing.get("approval_verdict") is not None:
+                    continue
+
+                tool_id = str(existing.get("tool_id") or uuid.uuid4())
+                events[index] = {**existing, **event, "tool_id": tool_id}
+                self._session_mgr.save_events(session_id, events)
+                return tool_id
+
+        tool_id = str(uuid.uuid4())
+        self._session_mgr.append_events(session_id, [{**event, "tool_id": tool_id}])
+        return tool_id
+
     # -- internal turn runner --
 
     async def _run_turn(
@@ -1082,23 +1135,17 @@ class SessionEngine:
             approval_verdict: ApprovalVerdict | None = None,
             approval_explanation: str | None = None,
         ) -> None:
-            tool_id = str(uuid.uuid4())
+            tool_id = self._record_tool_call_event(
+                session_id,
+                tool=tool,
+                args=args,
+                detail=detail,
+                approval_source=approval_source,
+                approval_verdict=approval_verdict,
+                approval_explanation=approval_explanation,
+            )
             if active.security:
                 active.security.current_parent_tool_id = tool_id
-            event: dict[str, Any] = {
-                "role": "tool_call",
-                "tool": tool,
-                "args": args,
-                "detail": detail,
-                "approval_source": approval_source,
-                "approval_verdict": approval_verdict,
-                "approval_explanation": approval_explanation,
-                "tool_id": tool_id,
-            }
-            contexts_raw = args.get("contexts")
-            if isinstance(contexts_raw, list):
-                event["contexts"] = list(contexts_raw)
-            self._session_mgr.append_events(session_id, [event])
             logger.info(
                 f"Tool call session={session_id} tool={tool} "
                 + f"approval={approval_source or '-'}:{approval_verdict or '-'} "
@@ -1123,7 +1170,15 @@ class SessionEngine:
         def _tool_result_cb(tr: ToolResult) -> None:
             self._session_mgr.append_events(
                 session_id,
-                [{"role": "tool_result", "tool": tr.tool, "result": tr.output, "exit_code": tr.exit_code}],
+                [
+                    {
+                        "role": "tool_result",
+                        "tool": tr.tool,
+                        "result": tr.output,
+                        "exit_code": tr.exit_code,
+                        "tool_id": tr.tool_id,
+                    }
+                ],
             )
             logger.info(
                 f"Tool result session={session_id} tool={tr.tool} exit_code={tr.exit_code} "
@@ -1587,22 +1642,15 @@ class SessionEngine:
             approval_explanation: str | None = None,
         ) -> None:
             parent_id = active.security.current_parent_tool_id if active.security else None
-            tool_id = str(uuid.uuid4())
-            self._session_mgr.append_events(
+            tool_id = self._record_tool_call_event(
                 session_id,
-                [
-                    {
-                        "role": "tool_call",
-                        "tool": "proxy_domain",
-                        "args": {"domain": domain},
-                        "detail": detail,
-                        "approval_source": approval_source,
-                        "approval_verdict": approval_verdict,
-                        "approval_explanation": approval_explanation,
-                        "tool_id": tool_id,
-                        "parent_tool_id": parent_id,
-                    }
-                ],
+                tool="proxy_domain",
+                args={"domain": domain},
+                detail=detail,
+                approval_source=approval_source,
+                approval_verdict=approval_verdict,
+                approval_explanation=approval_explanation,
+                parent_tool_id=parent_id,
             )
             task = asyncio.ensure_future(
                 self._broadcast(
@@ -1613,6 +1661,7 @@ class SessionEngine:
                     approval_source,
                     approval_verdict,
                     approval_explanation,
+                    tool_id,
                     parent_id,
                 )
             )
@@ -1647,22 +1696,15 @@ class SessionEngine:
             approval_explanation: str | None = None,
         ) -> None:
             parent_id = active.security.current_parent_tool_id if active.security else None
-            tool_id = str(uuid.uuid4())
-            self._session_mgr.append_events(
+            tool_id = self._record_tool_call_event(
                 session_id,
-                [
-                    {
-                        "role": "git_push",
-                        "ref": ref,
-                        "decision": decision,
-                        "detail": detail,
-                        "approval_source": approval_source,
-                        "approval_verdict": approval_verdict,
-                        "approval_explanation": approval_explanation,
-                        "tool_id": tool_id,
-                        "parent_tool_id": parent_id,
-                    }
-                ],
+                tool="git_push",
+                args={"ref": ref, "decision": decision},
+                detail=detail,
+                approval_source=approval_source,
+                approval_verdict=approval_verdict,
+                approval_explanation=approval_explanation,
+                parent_tool_id=parent_id,
             )
             await self._broadcast(
                 active,
@@ -1673,6 +1715,7 @@ class SessionEngine:
                 approval_source,
                 approval_verdict,
                 approval_explanation,
+                tool_id,
                 parent_id,
             )
 
@@ -1704,22 +1747,15 @@ class SessionEngine:
             approval_explanation: str | None = None,
         ) -> None:
             parent_id = active.security.current_parent_tool_id if active.security else None
-            tool_id = str(uuid.uuid4())
-            self._session_mgr.append_events(
+            tool_id = self._record_tool_call_event(
                 session_id,
-                [
-                    {
-                        "role": "tool_call",
-                        "tool": "credential_access",
-                        "args": {"vault_path": vault_path, "name": name},
-                        "detail": detail,
-                        "approval_source": approval_source,
-                        "approval_verdict": approval_verdict,
-                        "approval_explanation": approval_explanation,
-                        "tool_id": tool_id,
-                        "parent_tool_id": parent_id,
-                    }
-                ],
+                tool="credential_access",
+                args={"vault_path": vault_path, "name": name},
+                detail=detail,
+                approval_source=approval_source,
+                approval_verdict=approval_verdict,
+                approval_explanation=approval_explanation,
+                parent_tool_id=parent_id,
             )
             task = asyncio.ensure_future(
                 self._broadcast(
@@ -1731,6 +1767,7 @@ class SessionEngine:
                     approval_source,
                     approval_verdict,
                     approval_explanation,
+                    tool_id,
                     parent_id,
                 )
             )

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -1089,33 +1089,37 @@ class SessionEngine:
         if isinstance(contexts_raw, list):
             event["contexts"] = list(contexts_raw)
 
-        should_update_pending = approval_source == "sentinel" and approval_verdict is not None
-        if should_update_pending:
-            events = self._session_mgr.load_events(session_id)
-            for index in range(len(events) - 1, -1, -1):
-                existing = events[index]
-                if existing.get("role") != "tool_call":
-                    continue
-                if existing.get("tool") != tool:
-                    continue
-                if existing.get("parent_tool_id") != parent_tool_id:
-                    continue
-                if existing.get("approval_source") != "sentinel" or existing.get("approval_verdict") is not None:
-                    continue
-                existing_args = existing.get("args")
-                if not isinstance(existing_args, dict):
-                    continue
-                if any(existing_args.get(key) != value for key, value in matching_args.items()):
-                    continue
+        should_update_existing = approval_verdict is not None and approval_source in {"sentinel", "user"}
 
-                tool_id = str(existing.get("tool_id") or uuid.uuid4())
-                events[index] = {**existing, **event, "tool_id": tool_id}
-                self._session_mgr.save_events(session_id, events)
-                return tool_id
+        def _mutate(events: list[dict[str, Any]]) -> str:
+            if should_update_existing:
+                for index in range(len(events) - 1, -1, -1):
+                    existing = events[index]
+                    if existing.get("role") != "tool_call":
+                        continue
+                    if existing.get("tool") != tool:
+                        continue
+                    if existing.get("parent_tool_id") != parent_tool_id:
+                        continue
+                    if existing.get("approval_source") != "sentinel":
+                        continue
+                    if existing.get("approval_verdict") not in (None, "escalate"):
+                        continue
+                    existing_args = existing.get("args")
+                    if not isinstance(existing_args, dict):
+                        continue
+                    if any(existing_args.get(key) != value for key, value in matching_args.items()):
+                        continue
 
-        tool_id = str(uuid.uuid4())
-        self._session_mgr.append_events(session_id, [{**event, "tool_id": tool_id}])
-        return tool_id
+                    tool_id = str(existing.get("tool_id") or uuid.uuid4())
+                    events[index] = {**existing, **event, "tool_id": tool_id}
+                    return tool_id
+
+            tool_id = str(uuid.uuid4())
+            events.append({**event, "tool_id": tool_id})
+            return tool_id
+
+        return self._session_mgr.update_events(session_id, _mutate)
 
     # -- internal turn runner --
 

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -1071,8 +1071,10 @@ class SessionEngine:
         approval_verdict: ApprovalVerdict | None = None,
         approval_explanation: str | None = None,
         parent_tool_id: str | None = None,
+        match_args: dict[str, Any] | None = None,
     ) -> str:
         contexts_raw = args.get("contexts")
+        matching_args = match_args if match_args is not None else args
         event: dict[str, Any] = {
             "role": "tool_call",
             "tool": tool,
@@ -1094,11 +1096,16 @@ class SessionEngine:
                 existing = events[index]
                 if existing.get("role") != "tool_call":
                     continue
-                if existing.get("tool") != tool or existing.get("args") != args:
+                if existing.get("tool") != tool:
                     continue
                 if existing.get("parent_tool_id") != parent_tool_id:
                     continue
                 if existing.get("approval_source") != "sentinel" or existing.get("approval_verdict") is not None:
+                    continue
+                existing_args = existing.get("args")
+                if not isinstance(existing_args, dict):
+                    continue
+                if any(existing_args.get(key) != value for key, value in matching_args.items()):
                     continue
 
                 tool_id = str(existing.get("tool_id") or uuid.uuid4())
@@ -1705,6 +1712,7 @@ class SessionEngine:
                 approval_verdict=approval_verdict,
                 approval_explanation=approval_explanation,
                 parent_tool_id=parent_id,
+                match_args={"ref": ref},
             )
             await self._broadcast(
                 active,
@@ -1756,6 +1764,7 @@ class SessionEngine:
                 approval_verdict=approval_verdict,
                 approval_explanation=approval_explanation,
                 parent_tool_id=parent_id,
+                match_args={"vault_path": vault_path},
             )
             task = asyncio.ensure_future(
                 self._broadcast(

--- a/src/carapace/session/manager.py
+++ b/src/carapace/session/manager.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import json
 import secrets
 import shutil
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
+from threading import RLock
 from typing import Any
 
 import yaml
@@ -43,6 +45,7 @@ class SessionManager:
     def __init__(self, data_dir: Path):
         self.sessions_dir = data_dir / "sessions"
         self.sessions_dir.mkdir(parents=True, exist_ok=True)
+        self._events_lock = RLock()
 
     def create_session(
         self,
@@ -183,7 +186,7 @@ class SessionManager:
 
     # --- Event log (ordered display history including slash commands) ---
 
-    def load_events(self, session_id: str) -> list[dict[str, Any]]:
+    def _load_events_unlocked(self, session_id: str) -> list[dict[str, Any]]:
         events_path = self.sessions_dir / session_id / "events.yaml"
         if not events_path.exists():
             # fallback to legacy JSON
@@ -214,7 +217,11 @@ class SessionManager:
                     logger.warning(f"Skipped {skipped_docs} invalid event document(s) in session {session_id}")
         return result
 
-    def append_events(self, session_id: str, events: list[dict[str, Any]]) -> None:
+    def load_events(self, session_id: str) -> list[dict[str, Any]]:
+        with self._events_lock:
+            return self._load_events_unlocked(session_id)
+
+    def _append_events_unlocked(self, session_id: str, events: list[dict[str, Any]]) -> None:
         session_dir = self.sessions_dir / session_id
         session_dir.mkdir(parents=True, exist_ok=True)
         events_path = session_dir / "events.yaml"
@@ -223,7 +230,11 @@ class SessionManager:
                 f.write("---\n")
                 yaml.dump(_to_yaml_safe(event), f, default_flow_style=False, allow_unicode=True, sort_keys=False)
 
-    def save_events(self, session_id: str, events: list[dict[str, Any]]) -> None:
+    def append_events(self, session_id: str, events: list[dict[str, Any]]) -> None:
+        with self._events_lock:
+            self._append_events_unlocked(session_id, events)
+
+    def _save_events_unlocked(self, session_id: str, events: list[dict[str, Any]]) -> None:
         session_dir = self.sessions_dir / session_id
         session_dir.mkdir(parents=True, exist_ok=True)
         events_path = session_dir / "events.yaml"
@@ -231,3 +242,18 @@ class SessionManager:
             for event in events:
                 f.write("---\n")
                 yaml.dump(_to_yaml_safe(event), f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+    def save_events(self, session_id: str, events: list[dict[str, Any]]) -> None:
+        with self._events_lock:
+            self._save_events_unlocked(session_id, events)
+
+    def update_events(
+        self,
+        session_id: str,
+        updater: Callable[[list[dict[str, Any]]], Any],
+    ) -> Any:
+        with self._events_lock:
+            events = self._load_events_unlocked(session_id)
+            result = updater(events)
+            self._save_events_unlocked(session_id, events)
+            return result

--- a/src/carapace/ws_models.py
+++ b/src/carapace/ws_models.py
@@ -123,6 +123,7 @@ class ToolResultInfo(BaseModel):
     tool: str
     result: str
     exit_code: int = 0
+    tool_id: str | None = None
 
 
 class ApprovalRequest(BaseModel):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -251,6 +251,123 @@ def _make_engine(tmp_path: Path) -> SessionEngine:
     )
 
 
+def test_record_tool_call_event_reuses_sentinel_row_for_user_decision(tmp_path: Path) -> None:
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path)
+
+    sid = engine.session_mgr.create_session().session_id
+
+    initial_tool_id = engine._record_tool_call_event(
+        sid,
+        tool="proxy_domain",
+        args={"domain": "example.com", "command": "curl https://example.com"},
+        detail="[sentinel] reviewing",
+        approval_source="sentinel",
+    )
+    updated_tool_id = engine._record_tool_call_event(
+        sid,
+        tool="proxy_domain",
+        args={"domain": "example.com", "command": "curl https://example.com"},
+        detail="[user: allow]",
+        approval_source="user",
+        approval_verdict="allow",
+    )
+
+    assert updated_tool_id == initial_tool_id
+    assert engine.session_mgr.load_events(sid) == [
+        {
+            "role": "tool_call",
+            "tool": "proxy_domain",
+            "args": {"domain": "example.com", "command": "curl https://example.com"},
+            "detail": "[user: allow]",
+            "approval_source": "user",
+            "approval_verdict": "allow",
+            "approval_explanation": None,
+            "tool_id": initial_tool_id,
+        }
+    ]
+
+
+def test_truncate_incomplete_events_keeps_completed_user_approved_exec(tmp_path: Path) -> None:
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path)
+
+    sid = engine.session_mgr.create_session().session_id
+
+    reviewing_tool_id = engine._record_tool_call_event(
+        sid,
+        tool="exec",
+        args={"command": "ls"},
+        detail="[sentinel] reviewing",
+        approval_source="sentinel",
+    )
+    escalated_tool_id = engine._record_tool_call_event(
+        sid,
+        tool="exec",
+        args={"command": "ls"},
+        detail="[sentinel: escalate] needs approval",
+        approval_source="sentinel",
+        approval_verdict="escalate",
+        approval_explanation="needs approval",
+    )
+    approved_tool_id = engine._record_tool_call_event(
+        sid,
+        tool="exec",
+        args={"command": "ls"},
+        detail="[user approved]",
+        approval_source="user",
+        approval_verdict="allow",
+        approval_explanation="user approved",
+    )
+
+    assert reviewing_tool_id == escalated_tool_id == approved_tool_id
+
+    engine.session_mgr.append_events(
+        sid,
+        [
+            {
+                "role": "tool_result",
+                "tool": "exec",
+                "result": "ok",
+                "exit_code": 0,
+                "tool_id": approved_tool_id,
+            },
+            {
+                "role": "tool_call",
+                "tool": "exec",
+                "args": {"command": "pwd"},
+                "detail": "[safe-list] auto-allowed",
+                "approval_source": "safe-list",
+                "approval_verdict": "allow",
+                "approval_explanation": "auto-allowed",
+                "tool_id": "later-exec",
+            },
+        ],
+    )
+
+    truncated = engine._truncate_incomplete_events(engine.session_mgr.load_events(sid))
+
+    assert truncated == [
+        {
+            "role": "tool_call",
+            "tool": "exec",
+            "args": {"command": "ls"},
+            "detail": "[user approved]",
+            "approval_source": "user",
+            "approval_verdict": "allow",
+            "approval_explanation": "user approved",
+            "tool_id": approved_tool_id,
+        },
+        {
+            "role": "tool_result",
+            "tool": "exec",
+            "result": "ok",
+            "exit_code": 0,
+            "tool_id": approved_tool_id,
+        },
+    ]
+
+
 def test_available_model_entries_override_default_with_metadata(tmp_path: Path):
     """``available_models`` lists every selectable model; duplicate id in YAML keeps last row metadata."""
     (tmp_path / "config.yaml").write_text(


### PR DESCRIPTION
## Summary
Show tool activity in the UI before the sentinel finishes reviewing it, and fix tool result matching so parallel tool calls do not leave stale spinners behind.

## What changed
- emit provisional tool-call rows as soon as sentinel review starts
- update those rows in place when sentinel decisions arrive, including proxy-domain, credential-access, and git-push flows
- thread `tool_id` through tool results so the frontend can match results to the correct in-flight tool call
- keep a fallback path for older history entries that do not yet have result ids

## Verification
- VS Code diagnostics are clean for the changed files
- full browser verification was not run because the frontend dev server is currently blocked by the existing Turbopack root configuration error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the tool-call event lifecycle and WebSocket payloads to emit/update provisional sentinel-review rows and to correlate `tool_result` messages by `tool_id`, which could affect ordering/rendering of tool activity across reconnects and parallel calls.
> 
> **Overview**
> **Improves tool-call UX during sentinel review and fixes stale spinners for parallel tools.** The backend now emits provisional `sentinel` tool-call events (no verdict yet) as soon as review starts, then updates the same persisted event when the final verdict/user decision arrives (including `proxy_domain`, `credential_access`, and `git_push`).
> 
> Tool results now carry `tool_id` end-to-end (`ToolResult`/WS `ToolResultInfo`/history), and the frontend prefers ID-based updates (including for nested child tool calls) with a fallback to the older tool-name queue matching. The UI also renders an explicit “Sentinel reviewing” state/badge when `approval_source=sentinel` and `approval_verdict` is unset, and centralizes thinking-stream finalization to avoid interleaving issues when tool events arrive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89911a2fa5d73f5f02eee297331e1bfccf4c27c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->