### PR TITLE
✨ feat: Track persisted LLM activity timing

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,5 +51,4 @@
 ## Workspace Files
 
 - [ ] **`HEARTBEAT.md` support** — cron reads this for periodic task definitions
-- [ ] **Gated workspace writes** — writes to `SOUL.md`, `USER.md`, etc. go through the pending-write approval mechanism
 - [ ] **`TOOLS.md` read gating** — optionally treat reading tool definitions as a security-sensitive operation

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -982,14 +982,15 @@ export function ChatView({
   }
 
   const connected = status === "connected";
-  const waitingLabel =
-    waiting && llmActivity?.source === "agent"
+  const waitingLabel = !waiting
+    ? null
+    : llmActivity?.source === "agent"
       ? llmActivity.phase === "processing_prompt"
         ? "Processing Prompt..."
         : llmActivity.phase === "generating"
           ? "Generating..."
-          : null
-      : null;
+          : "Working..."
+      : "Working...";
 
   return (
     <div className="flex flex-1 min-h-0 flex-col">

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -15,6 +15,7 @@ import type {
   ChatMessage,
   ClientMessage,
   EscalationDecision,
+  LlmActivity,
   ServerMessage,
   TurnUsage,
 } from "@/lib/types";
@@ -26,6 +27,23 @@ interface ChatViewProps {
   token: string;
   sessionId: string;
   onTitleUpdate?: (title: string) => void;
+}
+
+function thinkingUsageMeta(usage?: TurnUsage | null): {
+  reasoningDurationMs?: number;
+  reasoningTokens?: number;
+} {
+  const meta: {
+    reasoningDurationMs?: number;
+    reasoningTokens?: number;
+  } = {};
+  if (typeof usage?.reasoning_duration_ms === "number") {
+    meta.reasoningDurationMs = usage.reasoning_duration_ms;
+  }
+  if (typeof usage?.reasoning_tokens === "number") {
+    meta.reasoningTokens = usage.reasoning_tokens;
+  }
+  return meta;
 }
 
 function normalizedDecisionMessage(message?: string | null): string | undefined {
@@ -208,6 +226,7 @@ export function ChatView({
   const [waiting, setWaiting] = useState(false);
   const [queuedMessage, setQueuedMessage] = useState<string | null>(null);
   const [usage, setUsage] = useState<TurnUsage | null>(null);
+  const [llmActivity, setLlmActivity] = useState<LlmActivity | null>(null);
   const [loadingHistory, setLoadingHistory] = useState(true);
   const [commands, setCommands] = useState<SlashCommand[]>([]);
   const [availableModelEntries, setAvailableModelEntries] = useState<
@@ -216,6 +235,7 @@ export function ChatView({
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const isAtBottomRef = useRef(true);
+  const lastThinkingStartedAtRef = useRef<string | null>(null);
   const queueRef = useRef<string | null>(null);
   const sendRef = useRef<(msg: ClientMessage) => void>(() => {});
 
@@ -522,17 +542,29 @@ export function ChatView({
     }
   }, [clearToolLoading]);
 
+  const snapshotThinkingDurationMs = useCallback((): number | undefined => {
+    const startedAt = lastThinkingStartedAtRef.current;
+    if (!startedAt) return undefined;
+    const parsed = Date.parse(startedAt);
+    if (Number.isNaN(parsed)) return undefined;
+    return Math.max(0, Date.now() - parsed);
+  }, []);
+
   const finalizeThinkingMessages = useCallback((messages: ChatMessage[]): ChatMessage[] => {
     const updated = [...messages];
     const thinkIdx = updated.findIndex((m) => m.kind === "thinking_streaming");
     if (thinkIdx !== -1) {
+      const thinking = updated[thinkIdx] as Extract<ChatMessage, { kind: "thinking_streaming" }>;
       updated[thinkIdx] = {
         kind: "thinking",
-        content: (updated[thinkIdx] as { content: string }).content,
+        content: thinking.content,
+        reasoningDurationMs:
+          thinking.reasoningDurationMs ?? snapshotThinkingDurationMs(),
+        reasoningTokens: thinking.reasoningTokens,
       };
     }
     return updated;
-  }, []);
+  }, [snapshotThinkingDurationMs]);
 
   const onMessage = useCallback(
     (msg: ServerMessage) => {
@@ -540,20 +572,22 @@ export function ChatView({
         case "done":
           setMessages((prev) => {
             const updated = [...prev];
+            const thinkingMeta = thinkingUsageMeta(msg.usage);
             // Finalize thinking: update thinking_streaming or existing thinking with authoritative content
             const thinkStreamIdx = updated.findIndex((m) => m.kind === "thinking_streaming");
             if (thinkStreamIdx !== -1) {
               updated[thinkStreamIdx] = {
                 kind: "thinking",
                 content: msg.thinking ?? (updated[thinkStreamIdx] as { content: string }).content,
+                ...thinkingMeta,
               };
             } else if (msg.thinking) {
               // Update already-finalized thinking with authoritative content, or insert if missing
               const thinkIdx = updated.findLastIndex((m) => m.kind === "thinking");
               if (thinkIdx !== -1) {
-                updated[thinkIdx] = { kind: "thinking", content: msg.thinking };
+                updated[thinkIdx] = { kind: "thinking", content: msg.thinking, ...thinkingMeta };
               } else {
-                updated.push({ kind: "thinking", content: msg.thinking });
+                updated.push({ kind: "thinking", content: msg.thinking, ...thinkingMeta });
               }
             }
             // Replace streaming message with the final content
@@ -566,6 +600,8 @@ export function ChatView({
             return updated;
           });
           if (msg.usage) setUsage(msg.usage);
+          setLlmActivity(null);
+          lastThinkingStartedAtRef.current = null;
           finishWaiting();
           break;
         case "tool_call": {
@@ -717,6 +753,8 @@ export function ChatView({
             ...prev,
             { kind: "command", command: msg.command, data: msg.data },
           ]);
+          setLlmActivity(null);
+          lastThinkingStartedAtRef.current = null;
           finishWaiting();
           break;
         case "error":
@@ -724,6 +762,8 @@ export function ChatView({
             ...prev,
             { kind: "error", detail: msg.detail },
           ]);
+          setLlmActivity(null);
+          lastThinkingStartedAtRef.current = null;
           finishWaiting();
           break;
         case "cancelled":
@@ -731,7 +771,17 @@ export function ChatView({
             ...prev,
             { kind: "error", detail: msg.detail },
           ]);
+          setLlmActivity(null);
+          lastThinkingStartedAtRef.current = null;
           finishWaiting();
+          break;
+        case "llm_activity":
+          setLlmActivity(msg.activity ?? null);
+          if (typeof msg.activity?.first_thinking_at === "string") {
+            lastThinkingStartedAtRef.current = msg.activity.first_thinking_at;
+          } else if (msg.activity?.phase === "processing_prompt") {
+            lastThinkingStartedAtRef.current = null;
+          }
           break;
         case "session_title":
           onTitleUpdate?.(msg.title);
@@ -740,6 +790,12 @@ export function ChatView({
         case "status":
           if (msg.agent_running) setWaiting(true);
           if (msg.usage) setUsage(msg.usage);
+          setLlmActivity(msg.llm_activity ?? null);
+          if (typeof msg.llm_activity?.first_thinking_at === "string") {
+            lastThinkingStartedAtRef.current = msg.llm_activity.first_thinking_at;
+          } else if (msg.llm_activity?.phase === "processing_prompt") {
+            lastThinkingStartedAtRef.current = null;
+          }
           break;
         case "user_message":
           // Slash commands end with command_result (no agent); echo must not re-arm waiting
@@ -775,10 +831,17 @@ export function ChatView({
               const last = prev[prev.length - 1] as {
                 kind: "thinking_streaming";
                 content: string;
+                reasoningDurationMs?: number;
+                reasoningTokens?: number;
               };
               return [
                 ...prev.slice(0, -1),
-                { kind: "thinking_streaming", content: last.content + msg.content },
+                {
+                  kind: "thinking_streaming",
+                  content: last.content + msg.content,
+                  reasoningDurationMs: last.reasoningDurationMs,
+                  reasoningTokens: last.reasoningTokens,
+                },
               ];
             }
             return [...prev, { kind: "thinking_streaming", content: msg.content }];
@@ -791,6 +854,7 @@ export function ChatView({
 
   const onWsDisconnect = useCallback(() => {
     queueRef.current = null;
+    lastThinkingStartedAtRef.current = null;
     setQueuedMessage(null);
     clearToolLoading();
     setWaiting(false);
@@ -821,6 +885,7 @@ export function ChatView({
       queueRef.current = content;
       setQueuedMessage(content);
     } else {
+      lastThinkingStartedAtRef.current = null;
       send({ type: "message", content });
       setWaiting(true);
     }
@@ -917,6 +982,14 @@ export function ChatView({
   }
 
   const connected = status === "connected";
+  const waitingLabel =
+    waiting && llmActivity?.source === "agent"
+      ? llmActivity.phase === "processing_prompt"
+        ? "Processing Prompt..."
+        : llmActivity.phase === "generating"
+          ? "Generating..."
+          : null
+      : null;
 
   return (
     <div className="flex flex-1 min-h-0 flex-col">
@@ -956,15 +1029,16 @@ export function ChatView({
             <Message
               key={i}
               message={msg}
+              activeLlmActivity={llmActivity}
               onApproval={handleApproval}
               onEscalation={handleEscalation}
               onCredentialApproval={handleCredentialEscalation}
             />
           ))}
-          {waiting && (
+          {waitingLabel && (
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              <span>Working…</span>
+              <span>{waitingLabel}</span>
             </div>
           )}
           <div ref={bottomRef} />

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -987,6 +987,8 @@ export function ChatView({
     : llmActivity?.source === "agent"
       ? llmActivity.phase === "processing_prompt"
         ? "Processing Prompt..."
+        : llmActivity.phase === "thinking"
+          ? "Thinking..."
         : llmActivity.phase === "generating"
           ? "Generating..."
           : "Working..."

--- a/frontend/src/components/message.tsx
+++ b/frontend/src/components/message.tsx
@@ -3,7 +3,7 @@
 import { Brain, Check, ChevronRight, Copy, Loader2 } from "lucide-react";
 import { useCallback, useState } from "react";
 
-import type { ChatMessage, EscalationDecision } from "@/lib/types";
+import type { ChatMessage, EscalationDecision, LlmActivity } from "@/lib/types";
 import { MarkdownContent } from "./markdown-content";
 import { ToolCallBadge } from "./tool-call-badge";
 import { ApprovalCard } from "./approval-card";
@@ -12,6 +12,12 @@ import { DomainAccessApprovalCard } from "./domain-access-approval-card";
 import { GitPushApprovalCard } from "./git-push-approval-card";
 import { CommandResultView } from "./command-result";
 import { cn } from "@/lib/utils";
+
+function formatDuration(ms: number): string {
+  if (ms < 1_000) return `${ms}ms`;
+  if (ms < 10_000) return `${(ms / 1_000).toFixed(1)}s`;
+  return `${Math.round(ms / 1_000)}s`;
+}
 
 function MessageCopyButton({
   text,
@@ -57,12 +63,32 @@ function MessageCopyButton({
 function ThinkingBadge({
   content,
   streaming,
+  reasoningDurationMs,
+  reasoningTokens,
+  activeLlmActivity,
 }: {
   content: string;
   streaming: boolean;
+  reasoningDurationMs?: number;
+  reasoningTokens?: number;
+  activeLlmActivity?: LlmActivity | null;
 }) {
   const [manualOpen, setManualOpen] = useState(false);
   const open = streaming || manualOpen;
+  const liveReasoningDurationMs =
+    streaming &&
+    activeLlmActivity?.phase === "thinking" &&
+    typeof activeLlmActivity.first_thinking_at === "string"
+      ? Math.max(0, Date.now() - Date.parse(activeLlmActivity.first_thinking_at))
+      : undefined;
+  const shownDurationMs = liveReasoningDurationMs ?? reasoningDurationMs;
+  const meta: string[] = [];
+  if (typeof shownDurationMs === "number") {
+    meta.push(`for ${formatDuration(shownDurationMs)}`);
+  }
+  if (typeof reasoningTokens === "number" && reasoningTokens > 0) {
+    meta.push(`${reasoningTokens.toLocaleString()} reasoning`);
+  }
 
   return (
     <div className="my-1 w-full min-w-0">
@@ -87,11 +113,11 @@ function ThinkingBadge({
           <Brain className="h-3 w-3 shrink-0 text-muted-foreground" />
         )}
         <span className="shrink-0 font-mono font-medium text-foreground/80">
-          {streaming ? "thinking…" : "thought"}
+          {streaming ? "thinking" : "thought"}
         </span>
-        {!streaming && content.length > 0 && (
+        {meta.length > 0 && (
           <span className="min-w-0 truncate font-mono text-[11px] text-foreground/65 dark:text-foreground/70">
-            {content.length.toLocaleString()} chars
+            {meta.join(", ")}
           </span>
         )}
       </button>
@@ -107,6 +133,7 @@ function ThinkingBadge({
 
 interface MessageProps {
   message: ChatMessage;
+  activeLlmActivity?: LlmActivity | null;
   onApproval?: (toolCallId: string, approved: boolean, message?: string) => void;
   onEscalation?: (
     requestId: string,
@@ -122,6 +149,7 @@ interface MessageProps {
 
 export function Message({
   message,
+  activeLlmActivity,
   onApproval,
   onEscalation,
   onCredentialApproval,
@@ -162,10 +190,25 @@ export function Message({
       );
 
     case "thinking":
-      return <ThinkingBadge content={message.content} streaming={false} />;
+      return (
+        <ThinkingBadge
+          content={message.content}
+          streaming={false}
+          reasoningDurationMs={message.reasoningDurationMs}
+          reasoningTokens={message.reasoningTokens}
+        />
+      );
 
     case "thinking_streaming":
-      return <ThinkingBadge content={message.content} streaming />;
+      return (
+        <ThinkingBadge
+          content={message.content}
+          streaming
+          reasoningDurationMs={message.reasoningDurationMs}
+          reasoningTokens={message.reasoningTokens}
+          activeLlmActivity={activeLlmActivity}
+        />
+      );
 
     case "tool_call":
       return (

--- a/frontend/src/components/message.tsx
+++ b/frontend/src/components/message.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Brain, Check, ChevronRight, Copy, Loader2 } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import type { ChatMessage, EscalationDecision, LlmActivity } from "@/lib/types";
 import { MarkdownContent } from "./markdown-content";
@@ -74,14 +74,47 @@ function ThinkingBadge({
   activeLlmActivity?: LlmActivity | null;
 }) {
   const [manualOpen, setManualOpen] = useState(false);
+  const [liveReasoningDuration, setLiveReasoningDuration] = useState<{
+    startedAt: string;
+    durationMs: number;
+  } | null>(null);
   const open = streaming || manualOpen;
-  const liveReasoningDurationMs =
+  const liveThinkingStartedAt =
     streaming &&
     activeLlmActivity?.phase === "thinking" &&
     typeof activeLlmActivity.first_thinking_at === "string"
-      ? Math.max(0, Date.now() - Date.parse(activeLlmActivity.first_thinking_at))
-      : undefined;
-  const shownDurationMs = liveReasoningDurationMs ?? reasoningDurationMs;
+      ? activeLlmActivity.first_thinking_at
+      : null;
+
+  useEffect(() => {
+    if (!liveThinkingStartedAt) {
+      return;
+    }
+
+    const startedAt = Date.parse(liveThinkingStartedAt);
+    if (Number.isNaN(startedAt)) {
+      return;
+    }
+
+    const updateDuration = () => {
+      setLiveReasoningDuration({
+        startedAt: liveThinkingStartedAt,
+        durationMs: Math.max(0, Date.now() - startedAt),
+      });
+    };
+
+    const timeoutId = window.setTimeout(updateDuration, 0);
+    const intervalId = window.setInterval(updateDuration, 100);
+    return () => {
+      window.clearTimeout(timeoutId);
+      window.clearInterval(intervalId);
+    };
+  }, [liveThinkingStartedAt]);
+
+  const shownDurationMs =
+    liveThinkingStartedAt && liveReasoningDuration?.startedAt === liveThinkingStartedAt
+      ? liveReasoningDuration.durationMs
+      : reasoningDurationMs;
   const meta: string[] = [];
   if (typeof shownDurationMs === "number") {
     meta.push(`for ${formatDuration(shownDurationMs)}`);

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -68,6 +68,24 @@ export interface ThinkingChunk {
   content: string;
 }
 
+export type LlmActivityPhase = "processing_prompt" | "thinking" | "generating";
+
+export interface LlmActivity {
+  request_id: string;
+  source: "agent" | "sentinel";
+  model?: string | null;
+  phase: LlmActivityPhase;
+  started_at: string;
+  first_thinking_at?: string | null;
+  last_thinking_at?: string | null;
+  first_text_at?: string | null;
+}
+
+export interface LlmActivityUpdate {
+  type: "llm_activity";
+  activity?: LlmActivity | null;
+}
+
 export interface ToolCallInfo {
   type: "tool_call";
   tool: string;
@@ -159,6 +177,15 @@ export interface TurnUsage {
   model?: string | null;
   /** Backend-resolved context window for this usage row. */
   context_cap_tokens?: number | null;
+  ttft_ms?: number | null;
+  total_duration_ms?: number | null;
+  reasoning_duration_ms?: number | null;
+  reasoning_tokens?: number | null;
+  started_at?: string | null;
+  first_thinking_at?: string | null;
+  last_thinking_at?: string | null;
+  first_text_at?: string | null;
+  completed_at?: string | null;
   /** Session budget gauges rendered below the context gauge. */
   budget_gauges?: BudgetGauge[];
 }
@@ -196,6 +223,7 @@ export interface StatusUpdate {
   type: "status";
   agent_running: boolean;
   usage?: TurnUsage;
+  llm_activity?: LlmActivity | null;
 }
 
 export interface UserMessageNotification {
@@ -217,6 +245,7 @@ export type ServerMessage =
   | ErrorMessage
   | Cancelled
   | SessionTitleUpdate
+  | LlmActivityUpdate
   | StatusUpdate
   | UserMessageNotification;
 
@@ -259,8 +288,18 @@ export type ChatMessage =
   | { kind: "user"; content: string }
   | { kind: "assistant"; content: string }
   | { kind: "streaming"; content: string }
-  | { kind: "thinking"; content: string }
-  | { kind: "thinking_streaming"; content: string }
+  | {
+      kind: "thinking";
+      content: string;
+      reasoningDurationMs?: number;
+      reasoningTokens?: number;
+    }
+  | {
+      kind: "thinking_streaming";
+      content: string;
+      reasoningDurationMs?: number;
+      reasoningTokens?: number;
+    }
   | {
       kind: "tool_call";
       tool: string;

--- a/src/carapace/channels/matrix/subscriber.py
+++ b/src/carapace/channels/matrix/subscriber.py
@@ -16,6 +16,7 @@ from carapace.channels.matrix.approval import (
 )
 from carapace.channels.matrix.formatting import format_approval_request, format_domain_escalation
 from carapace.models import ToolResult
+from carapace.usage import LlmRequestState
 from carapace.ws_models import ApprovalRequest, TurnUsage
 
 if TYPE_CHECKING:
@@ -109,6 +110,9 @@ class MatrixSubscriber:
 
     async def on_thinking_token(self, content: str) -> None:
         pass  # Thinking content not displayed in Matrix
+
+    async def on_llm_activity(self, activity: LlmRequestState | None) -> None:
+        pass
 
     async def on_done(self, content: str, usage: TurnUsage, *, thinking: str | None = None) -> None:
         if self._stream_event_id is not None:

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -46,7 +46,7 @@ from carapace.sandbox.runtime import ContainerRuntime
 from carapace.security.context import ApprovalSource, ApprovalVerdict
 from carapace.session import SessionEngine, SessionManager
 from carapace.skills import SkillRegistry
-from carapace.usage import SessionBudgetExceededError
+from carapace.usage import LlmRequestState, SessionBudgetExceededError
 from carapace.ws_models import (
     SLASH_COMMANDS,
     ApprovalRequest,
@@ -60,6 +60,8 @@ from carapace.ws_models import (
     ErrorMessage,
     EscalationResponse,
     GitPushApprovalRequest,
+    LlmActivity,
+    LlmActivityUpdate,
     ServerEnvelope,
     SessionTitleUpdate,
     StatusUpdate,
@@ -564,7 +566,22 @@ def _history_from_messages(session_id: str) -> list[HistoryMessage]:
 
 
 async def _send(ws: WebSocket, msg: ServerEnvelope) -> None:
-    await ws.send_json(msg.model_dump())
+    await ws.send_json(msg.model_dump(mode="json"))
+
+
+def _llm_activity_payload(activity: LlmRequestState | None) -> LlmActivity | None:
+    if activity is None:
+        return None
+    return LlmActivity(
+        request_id=activity.request_id,
+        source=activity.source,
+        model=activity.model_name,
+        phase=activity.phase,
+        started_at=activity.started_at,
+        first_thinking_at=activity.first_thinking_at,
+        last_thinking_at=activity.last_thinking_at,
+        first_text_at=activity.first_text_at,
+    )
 
 
 @router.get("/commands")
@@ -634,6 +651,9 @@ class WebSocketSubscriber:
 
     async def on_thinking_token(self, content: str) -> None:
         await self._safe_send(ThinkingChunk(content=content))
+
+    async def on_llm_activity(self, activity: LlmRequestState | None) -> None:
+        await self._safe_send(LlmActivityUpdate(activity=_llm_activity_payload(activity)))
 
     async def on_done(self, content: str, usage: TurnUsage, *, thinking: str | None = None) -> None:
         await self._safe_send(Done(content=content, thinking=thinking, usage=usage))
@@ -773,7 +793,14 @@ async def chat_ws(
     agent_running = active.agent_task is not None and not active.agent_task.done()
     usage = _engine._turn_usage_payload(active)
     with contextlib.suppress(Exception):
-        await _send(websocket, StatusUpdate(agent_running=agent_running, usage=usage))
+        await _send(
+            websocket,
+            StatusUpdate(
+                agent_running=agent_running,
+                usage=usage,
+                llm_activity=_llm_activity_payload(active.llm_request_state if agent_running else None),
+            ),
+        )
 
     # If agent is already running (e.g. reconnect), the subscriber will
     # start receiving events immediately.  If there are pending approvals,
@@ -896,6 +923,7 @@ async def chat_ws(
                             StatusUpdate(
                                 agent_running=active.agent_task is not None and not active.agent_task.done(),
                                 usage=_engine._turn_usage_payload(active),
+                                llm_activity=_llm_activity_payload(active.llm_request_state),
                             ),
                         )
                     continue

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -63,12 +63,15 @@ from carapace.usage import (
     BudgetGauge,
     LlmRequestLog,
     LlmRequestRecord,
+    LlmRequestState,
     LlmSource,
     SessionBudgetExceededError,
     UsageTracker,
     gauge_breakdown_pct_dict,
     last_record_for_source,
     llm_request_sink_scope,
+    note_llm_request_text,
+    note_llm_request_thinking,
     usage_budget_exceeded_error,
     usage_budget_gauges,
     usage_last_request_row,
@@ -151,6 +154,7 @@ class SessionSubscriber(Protocol):
     async def on_tool_result(self, result: ToolResult) -> None: ...
     async def on_token(self, content: str) -> None: ...
     async def on_thinking_token(self, content: str) -> None: ...
+    async def on_llm_activity(self, activity: LlmRequestState | None) -> None: ...
     async def on_done(self, content: str, usage: TurnUsage, *, thinking: str | None = None) -> None: ...
     async def on_error(self, detail: str) -> None: ...
     async def on_cancelled(self) -> None: ...
@@ -220,6 +224,7 @@ class ActiveSession:
     escalation_queue: asyncio.Queue[EscalationResponse | None] = field(default_factory=asyncio.Queue)
     usage_tracker: UsageTracker = field(default_factory=UsageTracker)
     llm_request_log: LlmRequestLog = field(default_factory=LlmRequestLog)
+    llm_request_state: LlmRequestState | None = None
     verbose: bool = True
     agent_model: Model | None = None
     agent_model_name: str | None = None
@@ -377,6 +382,7 @@ class SessionEngine:
         budget_gauges = self._budget_gauges(active)
         if rec_agent is None and not budget_gauges:
             return None
+        row = usage_last_request_row(rec_agent) if rec_agent else None
         bd = gauge_breakdown_pct_dict(rec_agent)
         return TurnUsage(
             input_tokens=rec_agent.input_tokens if rec_agent else 0,
@@ -384,8 +390,38 @@ class SessionEngine:
             breakdown_pct=TurnUsageBreakdownPct.model_validate(bd) if bd else None,
             model=self.agent_model_id_for_gauge(active),
             context_cap_tokens=self.agent_context_cap_for_gauge(active),
+            ttft_ms=row["ttft_ms"] if row else None,
+            total_duration_ms=row["total_duration_ms"] if row else None,
+            reasoning_duration_ms=row["reasoning_duration_ms"] if row else None,
+            reasoning_tokens=row["reasoning_tokens"] if row else None,
+            started_at=rec_agent.started_at if rec_agent else None,
+            first_thinking_at=rec_agent.first_thinking_at if rec_agent else None,
+            last_thinking_at=rec_agent.last_thinking_at if rec_agent else None,
+            first_text_at=rec_agent.first_text_at if rec_agent else None,
+            completed_at=rec_agent.completed_at if rec_agent else None,
             budget_gauges=budget_gauges,
         )
+
+    async def _set_llm_request_state(self, active: ActiveSession, state: LlmRequestState) -> None:
+        active.llm_request_state = state.model_copy(deep=True)
+        self._session_mgr.save_llm_request_state(active.state.session_id, active.llm_request_state)
+        await self._broadcast(active, "on_llm_activity", active.llm_request_state.model_copy(deep=True))
+
+    async def _clear_llm_request_state(self, active: ActiveSession) -> None:
+        if active.llm_request_state is None:
+            self._session_mgr.clear_llm_request_state(active.state.session_id)
+            return
+        active.llm_request_state = None
+        self._session_mgr.clear_llm_request_state(active.state.session_id)
+        await self._broadcast(active, "on_llm_activity", None)
+
+    async def _maybe_promote_llm_request_state(self, active: ActiveSession, state: LlmRequestState | None) -> None:
+        if state is None:
+            return
+        current = active.llm_request_state
+        if current is not None and current.phase == state.phase and current.first_text_at == state.first_text_at:
+            return
+        await self._set_llm_request_state(active, state)
 
     def _budget_command_payload(self, active: ActiveSession, *, message: str | None = None) -> dict[str, Any]:
         gauges = self._budget_gauges(active)
@@ -494,6 +530,10 @@ class SessionEngine:
         )
         usage_tracker = self._session_mgr.load_usage(session_id)
         llm_log = self._session_mgr.load_llm_request_log(session_id)
+        stale_llm_state = self._session_mgr.load_llm_request_state(session_id)
+        if stale_llm_state is not None:
+            logger.warning(f"Clearing stale in-flight LLM activity for session {session_id}")
+            self._session_mgr.clear_llm_request_state(session_id)
 
         active = ActiveSession(
             state=state,
@@ -607,13 +647,19 @@ class SessionEngine:
 
     @contextlib.contextmanager
     def llm_request_recording(self, active: ActiveSession):
+        engine = self
         session_id = active.state.session_id
 
-        def sink(rec: LlmRequestRecord) -> None:
-            active.llm_request_log.records.append(rec)
-            self._session_mgr.save_llm_request_log(session_id, active.llm_request_log)
+        class Sink:
+            async def on_request_started(self, state: LlmRequestState) -> None:
+                await engine._set_llm_request_state(active, state)
 
-        with llm_request_sink_scope(sink):
+            async def on_request_completed(self, rec: LlmRequestRecord) -> None:
+                active.llm_request_log.records.append(rec)
+                engine._session_mgr.save_llm_request_log(session_id, active.llm_request_log)
+                await engine._clear_llm_request_state(active)
+
+        with llm_request_sink_scope(Sink()):
             yield
 
     def unsubscribe(self, session_id: str, sub: SessionSubscriber) -> None:
@@ -627,6 +673,8 @@ class SessionEngine:
             if not active.subscribers and (active.agent_task is None or active.agent_task.done()):
                 self._session_mgr.save_usage(session_id, active.usage_tracker)
                 self._session_mgr.save_llm_request_log(session_id, active.llm_request_log)
+                if active.llm_request_state is not None:
+                    self._session_mgr.save_llm_request_state(session_id, active.llm_request_state)
 
     # -- broadcasting helpers --
 
@@ -1281,9 +1329,11 @@ class SessionEngine:
                     return results
 
                 async def _on_token(chunk: str) -> None:
+                    await self._maybe_promote_llm_request_state(active, note_llm_request_text())
                     await self._broadcast(active, "on_token", chunk)
 
                 async def _on_thinking_token(chunk: str) -> None:
+                    await self._maybe_promote_llm_request_state(active, note_llm_request_thinking())
                     await self._broadcast(active, "on_thinking_token", chunk)
 
                 async with self._llm_semaphore:
@@ -1343,6 +1393,7 @@ class SessionEngine:
             logger.info(f"Agent turn cancelled for session {session_id}")
             self._session_mgr.save_usage(session_id, active.usage_tracker)
             self._session_mgr.save_llm_request_log(session_id, active.llm_request_log)
+            await self._clear_llm_request_state(active)
             self._save_user_message_on_failure(
                 session_id,
                 user_input,
@@ -1354,6 +1405,7 @@ class SessionEngine:
             logger.info(f"Session budget blocked LLM call for {session_id}: {exc}")
             self._session_mgr.save_usage(session_id, active.usage_tracker)
             self._session_mgr.save_llm_request_log(session_id, active.llm_request_log)
+            await self._clear_llm_request_state(active)
             self._save_user_message_on_failure(
                 session_id,
                 user_input,
@@ -1368,6 +1420,7 @@ class SessionEngine:
                 + f"llm_requests={len(active.llm_request_log.records)} "
                 + f"sentinel_evals={sentinel_evals} prompt={_truncate_for_log(user_input)}"
             )
+            await self._clear_llm_request_state(active)
             self._save_user_message_on_failure(
                 session_id,
                 user_input,
@@ -1377,6 +1430,7 @@ class SessionEngine:
             await self._broadcast(active, "on_error", str(exc))
         except Exception:
             logger.exception(f"Agent error session={session_id} prompt={_truncate_for_log(user_input)}")
+            await self._clear_llm_request_state(active)
             self._save_user_message_on_failure(
                 session_id,
                 user_input,

--- a/src/carapace/session/manager.py
+++ b/src/carapace/session/manager.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 from pydantic_ai import ModelMessage, ModelMessagesTypeAdapter
 
 from carapace.models import SessionBudget, SessionState
-from carapace.usage import LlmRequestLog, UsageTracker
+from carapace.usage import LlmRequestLog, LlmRequestState, UsageTracker
 
 
 def _to_yaml_safe(value: Any) -> Any:
@@ -183,6 +183,29 @@ class SessionManager:
         path = session_dir / "llm_requests.yaml"
         with open(path, "w") as f:
             yaml.dump(log.model_dump(mode="json"), f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+    # --- In-flight LLM request activity ---
+
+    def load_llm_request_state(self, session_id: str) -> LlmRequestState | None:
+        path = self.sessions_dir / session_id / "llm_activity.yaml"
+        if not path.exists():
+            return None
+        with open(path) as f:
+            raw = yaml.safe_load(f)
+        if not raw:
+            return None
+        return LlmRequestState.model_validate(raw)
+
+    def save_llm_request_state(self, session_id: str, state: LlmRequestState) -> None:
+        session_dir = self.sessions_dir / session_id
+        session_dir.mkdir(parents=True, exist_ok=True)
+        path = session_dir / "llm_activity.yaml"
+        with open(path, "w") as f:
+            yaml.dump(state.model_dump(mode="json"), f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+    def clear_llm_request_state(self, session_id: str) -> None:
+        path = self.sessions_dir / session_id / "llm_activity.yaml"
+        path.unlink(missing_ok=True)
 
     # --- Event log (ordered display history including slash commands) ---
 

--- a/src/carapace/usage.py
+++ b/src/carapace/usage.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Callable
+import secrets
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import Any, Literal, TypedDict, assert_never
+from typing import Any, Literal, Protocol, TypedDict, assert_never
 
 import tiktoken
 from genai_prices import Usage as PriceUsage
@@ -252,20 +252,65 @@ def usage_budget_exceeded_error(
 
 
 LlmSource = Literal["agent", "sentinel"]
+LlmRequestPhase = Literal["processing_prompt", "thinking", "generating"]
 
-_llm_request_sink: ContextVar[Callable[[LlmRequestRecord], None] | None] = ContextVar(
+_llm_request_sink: ContextVar[LlmRequestObserver | None] = ContextVar(
     "llm_request_sink",
+    default=None,
+)
+_current_llm_request_state: ContextVar[LlmRequestState | None] = ContextVar(
+    "current_llm_request_state",
     default=None,
 )
 
 
+class LlmRequestState(BaseModel):
+    request_id: str
+    source: LlmSource
+    model_name: str | None = None
+    started_at: datetime
+    phase: LlmRequestPhase = "processing_prompt"
+    first_thinking_at: datetime | None = None
+    last_thinking_at: datetime | None = None
+    first_text_at: datetime | None = None
+
+
+class LlmRequestObserver(Protocol):
+    async def on_request_started(self, state: LlmRequestState) -> None: ...
+
+    async def on_request_completed(self, record: LlmRequestRecord) -> None: ...
+
+
 @contextmanager
-def llm_request_sink_scope(sink: Callable[[LlmRequestRecord], None] | None) -> Any:
+def llm_request_sink_scope(sink: LlmRequestObserver | None) -> Any:
     token = _llm_request_sink.set(sink)
     try:
         yield
     finally:
         _llm_request_sink.reset(token)
+
+
+def note_llm_request_thinking(ts: datetime | None = None) -> LlmRequestState | None:
+    state = _current_llm_request_state.get()
+    if state is None:
+        return None
+    when = ts or datetime.now(tz=UTC)
+    if state.first_thinking_at is None:
+        state.first_thinking_at = when
+    state.last_thinking_at = when
+    state.phase = "thinking"
+    return state
+
+
+def note_llm_request_text(ts: datetime | None = None) -> LlmRequestState | None:
+    state = _current_llm_request_state.get()
+    if state is None:
+        return None
+    when = ts or datetime.now(tz=UTC)
+    if state.first_text_at is None:
+        state.first_text_at = when
+    state.phase = "generating"
+    return state
 
 
 class InputShapeRatios(BaseModel):
@@ -285,6 +330,12 @@ class LlmRequestRecord(BaseModel):
     model_name: str | None = None
     input_tokens: int = 0
     output_tokens: int = 0
+    started_at: datetime | None = None
+    first_thinking_at: datetime | None = None
+    last_thinking_at: datetime | None = None
+    first_text_at: datetime | None = None
+    completed_at: datetime | None = None
+    reasoning_tokens: int | None = None
     usage_details: dict[str, int] = Field(default_factory=dict)
     input_shape: InputShapeRatios | None = None
 
@@ -316,7 +367,31 @@ class UsageLastRequestRow(TypedDict):
     input_tokens: int
     output_tokens: int
     context_size: int
+    ttft_ms: int | None
+    total_duration_ms: int | None
+    reasoning_duration_ms: int | None
+    reasoning_tokens: int | None
     breakdown_pct: _BreakdownPct
+
+
+def _duration_ms(start: datetime | None, end: datetime | None) -> int | None:
+    if start is None or end is None:
+        return None
+    return max(0, int((end - start).total_seconds() * 1000))
+
+
+def _normalize_reasoning_tokens(details: dict[str, int]) -> int | None:
+    exact = details.get("reasoning_tokens")
+    if isinstance(exact, int):
+        return exact
+    for key in sorted(details):
+        value = details[key]
+        if not isinstance(value, int):
+            continue
+        normalized = key.lower().replace(".", "_")
+        if "reasoning" in normalized and "token" in normalized:
+            return value
+    return None
 
 
 def usage_last_request_row(rec: LlmRequestRecord | None) -> UsageLastRequestRow | None:
@@ -348,6 +423,10 @@ def usage_last_request_row(rec: LlmRequestRecord | None) -> UsageLastRequestRow 
         "input_tokens": inp,
         "output_tokens": out,
         "context_size": inp + out,
+        "ttft_ms": _duration_ms(rec.started_at, rec.first_text_at),
+        "total_duration_ms": _duration_ms(rec.started_at, rec.completed_at),
+        "reasoning_duration_ms": _duration_ms(rec.first_thinking_at, rec.first_text_at),
+        "reasoning_tokens": rec.reasoning_tokens,
         "breakdown_pct": breakdown_pct,
     }
 
@@ -466,17 +545,34 @@ class LlmRequestLogCapability(AbstractCapability[AgentDepsT]):
 
     source: LlmSource
 
+    async def before_model_request(
+        self,
+        ctx: RunContext[AgentDepsT],
+        request_context: ModelRequestContext,
+    ) -> ModelRequestContext:
+        sink = _llm_request_sink.get()
+        api_model_name = request_context.model.model_name
+        carapace_id = getattr(ctx.deps, "agent_model_id", None)
+        stored_model_name = carapace_id if isinstance(carapace_id, str) and carapace_id else api_model_name
+        state = LlmRequestState(
+            request_id=secrets.token_hex(8),
+            source=self.source,
+            model_name=stored_model_name,
+            started_at=datetime.now(tz=UTC),
+        )
+        _current_llm_request_state.set(state)
+        if sink is not None:
+            await sink.on_request_started(state.model_copy(deep=True))
+        return request_context
+
     async def after_model_request(
         self,
         ctx: RunContext[AgentDepsT],
-        *,
         request_context: ModelRequestContext,
         response: ModelResponse,
     ) -> ModelResponse:
         sink = _llm_request_sink.get()
-        if sink is None:
-            return response
-
+        state = _current_llm_request_state.get()
         usage = response.usage
         details = {k: int(v) for k, v in (usage.details or {}).items() if isinstance(v, int)}
         api_model_name = response.model_name or request_context.model.model_name
@@ -486,14 +582,30 @@ class LlmRequestLogCapability(AbstractCapability[AgentDepsT]):
         )
         carapace_id = getattr(ctx.deps, "agent_model_id", None)
         stored_model_name = carapace_id if isinstance(carapace_id, str) and carapace_id else api_model_name
+        completed_at = datetime.now(tz=UTC)
+        if state is None:
+            state = LlmRequestState(
+                request_id=secrets.token_hex(8),
+                source=self.source,
+                model_name=stored_model_name,
+                started_at=completed_at,
+            )
         record = LlmRequestRecord(
-            ts=datetime.now(tz=UTC),
+            ts=completed_at,
             source=self.source,
-            model_name=stored_model_name,
+            model_name=state.model_name or stored_model_name,
             input_tokens=usage.input_tokens or 0,
             output_tokens=usage.output_tokens or 0,
+            started_at=state.started_at,
+            first_thinking_at=state.first_thinking_at,
+            last_thinking_at=state.last_thinking_at,
+            first_text_at=state.first_text_at,
+            completed_at=completed_at,
+            reasoning_tokens=_normalize_reasoning_tokens(details),
             usage_details=details,
             input_shape=shape,
         )
-        sink(record)
+        _current_llm_request_state.set(None)
+        if sink is not None:
+            await sink.on_request_completed(record)
         return response

--- a/src/carapace/ws_models.py
+++ b/src/carapace/ws_models.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel
 
 from carapace.security.context import ApprovalSource, ApprovalVerdict
-from carapace.usage import BudgetGauge
+from carapace.usage import BudgetGauge, LlmRequestPhase, LlmSource
 
 SLASH_COMMANDS: list[dict[str, str]] = [
     {"command": "/security", "description": "Show security policy summary"},
@@ -177,6 +178,17 @@ class TurnUsageBreakdownPct(BaseModel):
     other: float
 
 
+class LlmActivity(BaseModel):
+    request_id: str
+    source: LlmSource
+    model: str | None = None
+    phase: LlmRequestPhase
+    started_at: datetime
+    first_thinking_at: datetime | None = None
+    last_thinking_at: datetime | None = None
+    first_text_at: datetime | None = None
+
+
 class TurnUsage(BaseModel):
     """Token counts from the last LLM request of a turn."""
 
@@ -185,6 +197,15 @@ class TurnUsage(BaseModel):
     breakdown_pct: TurnUsageBreakdownPct | None = None
     model: str | None = None
     context_cap_tokens: int | None = None
+    ttft_ms: int | None = None
+    total_duration_ms: int | None = None
+    reasoning_duration_ms: int | None = None
+    reasoning_tokens: int | None = None
+    started_at: datetime | None = None
+    first_thinking_at: datetime | None = None
+    last_thinking_at: datetime | None = None
+    first_text_at: datetime | None = None
+    completed_at: datetime | None = None
     budget_gauges: list[BudgetGauge] = []
 
 
@@ -221,12 +242,20 @@ class SessionTitleUpdate(BaseModel):
     usage: TurnUsage | None = None
 
 
+class LlmActivityUpdate(BaseModel):
+    """Server → Client: current in-flight LLM activity changed."""
+
+    type: Literal["llm_activity"] = "llm_activity"
+    activity: LlmActivity | None = None
+
+
 class StatusUpdate(BaseModel):
     """Server → Client: session status on connect (includes last agent-turn usage for the context bar)."""
 
     type: Literal["status"] = "status"
     agent_running: bool
     usage: TurnUsage | None = None
+    llm_activity: LlmActivity | None = None
 
 
 class UserMessageNotification(BaseModel):
@@ -250,6 +279,7 @@ ServerEnvelope = (
     | ErrorMessage
     | Cancelled
     | SessionTitleUpdate
+    | LlmActivityUpdate
     | StatusUpdate
     | UserMessageNotification
 )

--- a/tests/test_llm_request_log.py
+++ b/tests/test_llm_request_log.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from pydantic_ai import ModelMessage
 from pydantic_ai.messages import ModelRequest, ModelResponse, SystemPromptPart, TextPart, UserPromptPart
@@ -100,6 +100,61 @@ def test_usage_last_request_row_tiktoken_pct_independent_of_api_output() -> None
     assert bp["assistant"] == 0.0
     total_pct = sum(v for v in bp.values() if isinstance(v, float))
     assert abs(total_pct - 100.0) < 1e-6
+
+
+def test_usage_last_request_row_includes_timing_and_reasoning_tokens() -> None:
+    started_at = datetime.now(tz=UTC)
+    rec = LlmRequestRecord(
+        ts=started_at,
+        source="agent",
+        input_tokens=100,
+        output_tokens=50,
+        started_at=started_at,
+        first_thinking_at=started_at + timedelta(seconds=1),
+        last_thinking_at=started_at + timedelta(seconds=2),
+        first_text_at=started_at + timedelta(seconds=3),
+        completed_at=started_at + timedelta(seconds=4),
+        reasoning_tokens=64,
+        input_shape=InputShapeRatios(
+            system=0.5,
+            user=0.5,
+            assistant=0,
+            tool_calls=0,
+            tool_returns=0,
+            other=0,
+        ),
+    )
+    row = usage_last_request_row(rec)
+    assert row is not None
+    assert row["reasoning_tokens"] == 64
+    assert row["ttft_ms"] == 3000
+
+
+def test_usage_last_request_row_calculates_durations() -> None:
+    started_at = datetime.now(tz=UTC)
+    rec = LlmRequestRecord(
+        ts=started_at,
+        source="agent",
+        input_tokens=100,
+        output_tokens=50,
+        started_at=started_at,
+        first_thinking_at=started_at + timedelta(seconds=1),
+        first_text_at=started_at + timedelta(seconds=3),
+        completed_at=started_at + timedelta(seconds=5),
+        input_shape=InputShapeRatios(
+            system=0.5,
+            user=0.5,
+            assistant=0,
+            tool_calls=0,
+            tool_returns=0,
+            other=0,
+        ),
+    )
+    row = usage_last_request_row(rec)
+    assert row is not None
+    assert row["ttft_ms"] == 3000
+    assert row["reasoning_duration_ms"] == 2000
+    assert row["total_duration_ms"] == 5000
 
 
 def test_gauge_breakdown_pct_dict_none_without_shape() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -20,6 +21,7 @@ from carapace.security.context import CredentialAccessEntry
 from carapace.server import app, sandbox_app
 from carapace.session import SessionEngine, SessionManager
 from carapace.skills import SkillRegistry
+from carapace.usage import LlmRequestState
 
 _TEST_TOKEN = "test-bearer-token-for-server-tests"
 
@@ -226,6 +228,27 @@ def test_ws_status_includes_budget_gauges_for_configured_defaults(client, auth_h
         status = _consume_status(ws)
         assert status["usage"]["budget_gauges"][0]["key"] == "input"
         assert status["usage"]["budget_gauges"][0]["current_value"] == "0 tokens"
+
+
+def test_ws_status_includes_live_llm_activity_when_running(client, auth_headers, bearer):
+    create_resp = client.post("/api/sessions", headers=auth_headers)
+    sid = create_resp.json()["session_id"]
+    active = srv._engine.get_or_activate(sid)
+    active.llm_request_state = LlmRequestState(
+        request_id="req-1",
+        source="agent",
+        model_name="anthropic:claude-haiku-4-5",
+        started_at=datetime.now(tz=UTC),
+        phase="thinking",
+    )
+    active.agent_task = MagicMock()
+    active.agent_task.done.return_value = False
+
+    with client.websocket_connect(f"/api/chat/{sid}?token={bearer}") as ws:
+        status = _consume_status(ws)
+        assert status["llm_activity"]["request_id"] == "req-1"
+        assert status["llm_activity"]["phase"] == "thinking"
+        assert status["llm_activity"]["source"] == "agent"
 
 
 def test_ws_budget_command_emits_status_refresh(client, auth_headers, bearer):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from pathlib import Path
 from typing import Any
@@ -24,7 +25,7 @@ from carapace.security.sentinel import Sentinel
 from carapace.session import SessionEngine, SessionManager
 from carapace.session.engine import _non_slash_user_message_count
 from carapace.skills import SkillRegistry
-from carapace.usage import ModelUsage, SessionBudgetExceededError
+from carapace.usage import LlmRequestRecord, LlmRequestState, ModelUsage, SessionBudgetExceededError
 from carapace.ws_models import ApprovalRequest, TurnUsage
 
 
@@ -91,6 +92,28 @@ def test_save_and_resume_state(tmp_path: Path):
     assert resumed is not None
     assert "my-skill" in resumed.context_grants
     assert "dev/test" in resumed.context_grants["my-skill"].vault_paths
+
+
+def test_save_and_load_llm_request_state(tmp_path: Path) -> None:
+    mgr = SessionManager(tmp_path)
+    state = mgr.create_session()
+    activity = LlmRequestState(
+        request_id="req-1",
+        source="agent",
+        model_name="anthropic:claude-haiku-4-5",
+        started_at=datetime.now(tz=UTC),
+        phase="processing_prompt",
+    )
+
+    mgr.save_llm_request_state(state.session_id, activity)
+
+    reloaded = mgr.load_llm_request_state(state.session_id)
+    assert reloaded is not None
+    assert reloaded.request_id == "req-1"
+    assert reloaded.phase == "processing_prompt"
+
+    mgr.clear_llm_request_state(state.session_id)
+    assert mgr.load_llm_request_state(state.session_id) is None
 
 
 def test_normalize_optional_message_strips_blank_values() -> None:
@@ -197,6 +220,7 @@ class _FakeSubscriber:
         self.errors: list[str] = []
         self.cancelled: int = 0
         self.title_updates: list[tuple[str, TurnUsage | None]] = []
+        self.llm_activity_updates: list[LlmRequestState | None] = []
 
     async def on_user_message(self, content: str, *, from_self: bool) -> None:
         self.user_messages.append((content, from_self))
@@ -224,6 +248,9 @@ class _FakeSubscriber:
 
     async def on_title_update(self, title: str, usage: TurnUsage | None = None) -> None:
         self.title_updates.append((title, usage))
+
+    async def on_llm_activity(self, activity: LlmRequestState | None) -> None:
+        self.llm_activity_updates.append(activity)
 
     async def on_domain_info(self, domain: str, detail: str) -> None:
         pass
@@ -820,6 +847,58 @@ def test_turn_usage_payload_contains_budget_gauges_without_agent_usage(tmp_path:
         assert payload is not None
         assert payload.budget_gauges[0].key == "input"
         assert payload.budget_gauges[0].current_value == "0 tokens"
+
+
+def test_turn_usage_payload_includes_reasoning_metrics(tmp_path: Path) -> None:
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session()
+        active = engine.get_or_activate(state.session_id)
+        started_at = datetime.now(tz=UTC)
+        active.llm_request_log.records.append(
+            LlmRequestRecord(
+                ts=started_at + timedelta(seconds=5),
+                source="agent",
+                model_name="anthropic:claude-haiku-4-5",
+                input_tokens=100,
+                output_tokens=20,
+                started_at=started_at,
+                first_thinking_at=started_at + timedelta(seconds=1),
+                last_thinking_at=started_at + timedelta(seconds=2),
+                first_text_at=started_at + timedelta(seconds=3),
+                completed_at=started_at + timedelta(seconds=5),
+                reasoning_tokens=42,
+            )
+        )
+
+        payload = engine._turn_usage_payload(active)
+
+        assert payload is not None
+        assert payload.ttft_ms == 3000
+        assert payload.reasoning_duration_ms == 2000
+        assert payload.total_duration_ms == 5000
+        assert payload.reasoning_tokens == 42
+
+
+def test_activate_clears_stale_llm_request_state(tmp_path: Path) -> None:
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session()
+        engine.session_mgr.save_llm_request_state(
+            state.session_id,
+            LlmRequestState(
+                request_id="stale",
+                source="agent",
+                model_name="anthropic:claude-haiku-4-5",
+                started_at=datetime.now(tz=UTC),
+                phase="thinking",
+            ),
+        )
+
+        active = engine.get_or_activate(state.session_id)
+
+        assert active.llm_request_state is None
+        assert engine.session_mgr.load_llm_request_state(state.session_id) is None
 
 
 def test_submit_message_budget_exhausted_broadcasts_error(tmp_path: Path):


### PR DESCRIPTION
## Summary
Add persisted live LLM activity tracking so the UI can show prompt-processing, thinking, and generation phases with timing data, including across reconnects.

## What Changed
- add in-flight LLM activity models and persisted session storage on the backend
- broadcast live LLM activity over WebSocket status and incremental updates
- include request timing and reasoning metadata in turn usage payloads
- update the chat UI to render phase-aware activity, preserve thought timing across tool calls, and simplify the thought badge copy
- add backend coverage for request timing, persisted activity state, and WebSocket status payloads

## Validation
- uv run pytest tests/test_llm_request_log.py tests/test_session.py tests/test_server.py
- uv run ruff check src/carapace/usage.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core session/WS plumbing and usage tracking with new persisted state and real-time updates; failures could cause incorrect UI status or stale in-flight markers across reconnects, but changes are additive and covered by tests.
> 
> **Overview**
> Adds **live, persisted LLM request activity tracking** (prompt processing → thinking → generating) on the backend, including saving/clearing per-session in-flight state and broadcasting changes via new WebSocket messages (`status.llm_activity` on connect and incremental `llm_activity` updates).
> 
> Extends usage accounting to include **timing and reasoning metadata** (e.g. TTFT, total duration, reasoning duration/tokens) and threads those fields through `TurnUsage`/`Done`, plus UI updates to render phase-specific “Working…” labels and show thinking duration/reasoning tokens (including live-updating during streaming and preserving timing across tool calls/reconnects). Tests are updated/added to cover the new timing calculations, persisted activity state, and WebSocket status payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69667eb852f6c2d9222a1c7cadffeff2ca274d70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->