### PR TITLE
✨ feat: Add sandbox start and scale-down controls

### DIFF
--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -46,8 +46,6 @@ function sandboxStorageLabel(snapshot: SessionSandboxSnapshot | null): string {
   const details: string[] = [];
   if (typeof snapshot.last_measured_used_bytes === "number") {
     details.push(`${formatBytes(snapshot.last_measured_used_bytes)} used`);
-  } else if (snapshot.storage_present) {
-    details.push("storage present");
   } else {
     details.push("no sandbox storage");
   }

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -46,7 +46,7 @@ function sandboxStorageLabel(snapshot: SessionSandboxSnapshot | null): string {
   const details: string[] = [];
   if (typeof snapshot.last_measured_used_bytes === "number") {
     details.push(`${formatBytes(snapshot.last_measured_used_bytes)} used`);
-  } else {
+  } else if (!snapshot.storage_present) {
     details.push("no sandbox storage");
   }
   if (

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -10,6 +10,8 @@ import {
   fetchSandbox,
   fetchModels,
   type SlashCommand,
+  startSandbox,
+  stopSandbox,
   wipeSandbox,
   wsUrl,
 } from "@/lib/api";
@@ -114,6 +116,14 @@ function shouldOptimisticallyShowPendingSandbox(
     return false;
   }
   return snapshot?.status !== "running" && snapshot?.status !== "pending";
+}
+
+function shouldShowStartSandbox(snapshot: SessionSandboxSnapshot | null): boolean {
+  if (!snapshot) return true;
+  return snapshot.status === "missing"
+    || snapshot.status === "scaled_down"
+    || snapshot.status === "stopped"
+    || snapshot.status === "error";
 }
 
 function argsMatch(
@@ -303,6 +313,7 @@ export function ChatView({
     initialSandbox ?? null,
   );
   const [sandboxLoading, setSandboxLoading] = useState(false);
+  const [sandboxPowerAction, setSandboxPowerAction] = useState<"starting" | "stopping" | null>(null);
   const [wipingSandbox, setWipingSandbox] = useState(false);
   const [deletingSession, setDeletingSession] = useState(false);
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -1058,7 +1069,7 @@ export function ChatView({
   }
 
   async function handleWipeSandbox() {
-    if (waiting || wipingSandbox || deletingSession) return;
+    if (waiting || sandboxPowerAction || wipingSandbox || deletingSession) return;
     if (!window.confirm("Wipe the sandbox and its storage for this session? Chat history will stay.")) {
       return;
     }
@@ -1074,8 +1085,36 @@ export function ChatView({
     }
   }
 
+  async function handleSandboxPowerAction() {
+    if (waiting || sandboxPowerAction || wipingSandbox || deletingSession) return;
+
+    const currentSandbox = sandboxRef.current;
+    const shouldStart = shouldShowStartSandbox(currentSandbox);
+    if (!shouldStart && !window.confirm("Scale down the sandbox for this session? Storage will be kept.")) {
+      return;
+    }
+
+    setSandboxPowerAction(shouldStart ? "starting" : "stopping");
+    try {
+      if (shouldStart) {
+        applySandboxSnapshot(optimisticPendingSandbox(currentSandbox));
+        const nextSandbox = await startSandbox(server, token, sessionId);
+        applySandboxSnapshot(nextSandbox);
+      } else {
+        const nextSandbox = await stopSandbox(server, token, sessionId);
+        applySandboxSnapshot(nextSandbox);
+      }
+    } catch (error) {
+      console.error(`Failed to ${shouldStart ? "start" : "scale down"} sandbox`, error);
+      setMessages((prev) => [...prev, { kind: "error", detail: errorDetail(error) }]);
+      void refreshSandbox();
+    } finally {
+      setSandboxPowerAction(null);
+    }
+  }
+
   async function handleDeleteSession() {
-    if (waiting || wipingSandbox || deletingSession || !onDeleteSession) return;
+    if (waiting || sandboxPowerAction || wipingSandbox || deletingSession || !onDeleteSession) return;
     if (!window.confirm("Delete this session? Chat history and sandbox state will be removed.")) {
       return;
     }
@@ -1183,6 +1222,22 @@ export function ChatView({
           ? "Generating..."
           : "Working..."
       : "Working...";
+    const showsStartSandbox = shouldShowStartSandbox(sandbox);
+    const sandboxActionDisabled = waiting
+      || sandboxLoading
+      || !!sandboxPowerAction
+      || wipingSandbox
+      || deletingSession
+      || sandbox?.status === "pending";
+    const sandboxPowerButtonLabel = sandboxPowerAction === "starting"
+      ? "Starting sandbox"
+      : sandboxPowerAction === "stopping"
+        ? "Scaling down sandbox"
+        : sandbox?.status === "pending"
+          ? "Starting sandbox"
+        : showsStartSandbox
+          ? "Start sandbox"
+          : "Scale down sandbox";
 
   return (
     <div className="flex flex-1 min-h-0 flex-col">
@@ -1221,8 +1276,18 @@ export function ChatView({
           </div>
           <div className="flex shrink-0 items-center gap-2">
             <button
+              onClick={() => void handleSandboxPowerAction()}
+              disabled={sandboxActionDisabled}
+              className="rounded-md border border-sky-300 bg-sky-50 px-3 py-1.5 text-xs font-medium text-sky-900 transition-colors hover:bg-sky-100 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <span className="inline-flex items-center gap-1.5">
+                {sandboxPowerAction ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+                {sandboxPowerButtonLabel}
+              </span>
+            </button>
+            <button
               onClick={() => void handleWipeSandbox()}
-              disabled={waiting || wipingSandbox || deletingSession}
+              disabled={waiting || !!sandboxPowerAction || wipingSandbox || deletingSession}
               className="rounded-md border border-amber-300 bg-amber-50 px-3 py-1.5 text-xs font-medium text-amber-900 transition-colors hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {wipingSandbox ? (
@@ -1239,7 +1304,7 @@ export function ChatView({
             </button>
             <button
               onClick={() => void handleDeleteSession()}
-              disabled={waiting || wipingSandbox || deletingSession || !onDeleteSession}
+              disabled={waiting || !!sandboxPowerAction || wipingSandbox || deletingSession || !onDeleteSession}
               title="Delete session"
               className="rounded-md p-1.5 text-destructive transition-colors hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-50"
             >

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -39,9 +39,6 @@ function sandboxSummaryLabel(sandbox: SessionSandboxSnapshot): string | null {
   if (typeof sandbox.last_measured_used_bytes === "number") {
     return formatBytes(sandbox.last_measured_used_bytes);
   }
-  if (sandbox.storage_present) {
-    return "storage";
-  }
   return null;
 }
 

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -88,6 +88,14 @@ export function Sidebar({
             (() => {
               const sandbox = sandboxSummary(s);
               const sandboxLabel = sandbox ? sandboxSummaryLabel(sandbox) : null;
+              const activityLabel = [
+                formatTime(s.last_active),
+                s.channel_type !== "web" && s.channel_type !== "cli"
+                  ? s.channel_type
+                  : null,
+              ]
+                .filter(Boolean)
+                .join(" · ");
               return (
             <div
               key={s.session_id}
@@ -114,9 +122,9 @@ export function Sidebar({
                       </span>
                     )}
                   </div>
-                  <div className="text-xs text-muted-foreground">
+                  <div className="mt-0.5 flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs text-muted-foreground">
                     {sandbox ? (
-                      <span className="mr-1 inline-flex items-center gap-1.5 align-middle">
+                      <span className="inline-flex items-center gap-1.5">
                         <span
                           title={sandboxStatusLabel(sandbox.status)}
                           className={cn(
@@ -124,22 +132,11 @@ export function Sidebar({
                             sandboxStatusIndicatorClass(sandbox.status),
                           )}
                         />
-                        {sandboxLabel ? (
-                          <>
-                            <span>{sandboxLabel}</span>
-                            <span aria-hidden="true">·</span>
-                          </>
-                        ) : null}
+                        {sandboxLabel ? <span>{sandboxLabel}</span> : null}
                       </span>
                     ) : null}
-                    {[
-                      formatTime(s.last_active),
-                      s.channel_type !== "web" && s.channel_type !== "cli"
-                        ? s.channel_type
-                        : null,
-                    ]
-                      .filter(Boolean)
-                      .join(" · ")}
+                    {sandbox && sandboxLabel ? <span aria-hidden="true">·</span> : null}
+                    <span>{activityLabel}</span>
                   </div>
                 </div>
               </button>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -59,6 +59,32 @@ export async function fetchSandbox(
   return res.json();
 }
 
+export async function startSandbox(
+  server: string,
+  token: string,
+  sessionId: string,
+): Promise<SessionSandboxSnapshot> {
+  const res = await fetch(`${server}/api/sessions/${sessionId}/sandbox/up`, {
+    method: "POST",
+    headers: headers(token),
+  });
+  if (!res.ok) throw new Error(`Failed to start sandbox: ${res.status}`);
+  return res.json();
+}
+
+export async function stopSandbox(
+  server: string,
+  token: string,
+  sessionId: string,
+): Promise<SessionSandboxSnapshot> {
+  const res = await fetch(`${server}/api/sessions/${sessionId}/sandbox/down`, {
+    method: "POST",
+    headers: headers(token),
+  });
+  if (!res.ok) throw new Error(`Failed to scale down sandbox: ${res.status}`);
+  return res.json();
+}
+
 export async function wipeSandbox(
   server: string,
   token: string,

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -470,6 +470,30 @@ async def get_session_sandbox(session_id: str, _token: str = Depends(_verify_tok
     return snapshot or SessionSandboxSnapshot()
 
 
+@router.post("/sessions/{session_id}/sandbox/up", response_model=SessionSandboxSnapshot)
+async def start_session_sandbox(session_id: str, _token: str = Depends(_verify_token)) -> SessionSandboxSnapshot:
+    state = _engine.session_mgr.load_state(session_id)
+    if state is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if _engine.is_agent_running(session_id):
+        raise HTTPException(status_code=409, detail="Cannot start sandbox while an agent turn is running")
+    await _engine.sandbox_mgr.ensure_session(session_id)
+    snapshot = _engine.session_mgr.load_sandbox_snapshot(session_id)
+    return snapshot or SessionSandboxSnapshot()
+
+
+@router.post("/sessions/{session_id}/sandbox/down", response_model=SessionSandboxSnapshot)
+async def stop_session_sandbox(session_id: str, _token: str = Depends(_verify_token)) -> SessionSandboxSnapshot:
+    state = _engine.session_mgr.load_state(session_id)
+    if state is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if _engine.is_agent_running(session_id):
+        raise HTTPException(status_code=409, detail="Cannot scale down sandbox while an agent turn is running")
+    await _engine.sandbox_mgr.cleanup_session(session_id)
+    snapshot = _engine.session_mgr.load_sandbox_snapshot(session_id)
+    return snapshot or SessionSandboxSnapshot()
+
+
 @router.post("/sessions/{session_id}/sandbox/wipe", response_model=SessionSandboxSnapshot)
 async def wipe_session_sandbox(session_id: str, _token: str = Depends(_verify_token)) -> SessionSandboxSnapshot:
     state = _engine.session_mgr.load_state(session_id)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -229,6 +229,93 @@ def test_get_session_sandbox_returns_default_snapshot_when_missing(client, auth_
     assert resp.json()["exists"] is False
 
 
+def test_start_session_sandbox_starts_when_idle(client, auth_headers):
+    create_resp = client.post("/api/sessions", headers=auth_headers)
+    sid = create_resp.json()["session_id"]
+
+    async def _ensure_session(session_id: str) -> tuple[MagicMock, bool]:
+        assert session_id == sid
+        srv._engine.session_mgr.save_sandbox_snapshot(
+            sid,
+            SessionSandboxSnapshot(
+                exists=True,
+                runtime="kubernetes",
+                status="running",
+                storage_present=True,
+                updated_at=datetime.now(tz=UTC),
+            ),
+        )
+        return MagicMock(), True
+
+    srv._engine.sandbox_mgr.ensure_session = AsyncMock(side_effect=_ensure_session)
+
+    resp = client.post(f"/api/sessions/{sid}/sandbox/up", headers=auth_headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "running"
+    srv._engine.sandbox_mgr.ensure_session.assert_awaited_once_with(sid)
+
+
+def test_start_session_sandbox_rejects_running_agent(client, auth_headers):
+    create_resp = client.post("/api/sessions", headers=auth_headers)
+    sid = create_resp.json()["session_id"]
+    active = srv._engine.get_or_activate(sid)
+    active.agent_task = MagicMock()
+    active.agent_task.done.return_value = False
+
+    resp = client.post(f"/api/sessions/{sid}/sandbox/up", headers=auth_headers)
+
+    assert resp.status_code == 409
+
+
+def test_stop_session_sandbox_scales_down_when_idle(client, auth_headers):
+    create_resp = client.post("/api/sessions", headers=auth_headers)
+    sid = create_resp.json()["session_id"]
+    srv._engine.session_mgr.save_sandbox_snapshot(
+        sid,
+        SessionSandboxSnapshot(
+            exists=True,
+            runtime="kubernetes",
+            status="running",
+            storage_present=True,
+            updated_at=datetime.now(tz=UTC),
+        ),
+    )
+
+    async def _cleanup_session(session_id: str) -> None:
+        assert session_id == sid
+        srv._engine.session_mgr.save_sandbox_snapshot(
+            sid,
+            SessionSandboxSnapshot(
+                exists=True,
+                runtime="kubernetes",
+                status="scaled_down",
+                storage_present=True,
+                updated_at=datetime.now(tz=UTC),
+            ),
+        )
+
+    srv._engine.sandbox_mgr.cleanup_session = AsyncMock(side_effect=_cleanup_session)
+
+    resp = client.post(f"/api/sessions/{sid}/sandbox/down", headers=auth_headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "scaled_down"
+    srv._engine.sandbox_mgr.cleanup_session.assert_awaited_once_with(sid)
+
+
+def test_stop_session_sandbox_rejects_running_agent(client, auth_headers):
+    create_resp = client.post("/api/sessions", headers=auth_headers)
+    sid = create_resp.json()["session_id"]
+    active = srv._engine.get_or_activate(sid)
+    active.agent_task = MagicMock()
+    active.agent_task.done.return_value = False
+
+    resp = client.post(f"/api/sessions/{sid}/sandbox/down", headers=auth_headers)
+
+    assert resp.status_code == 409
+
+
 def test_wipe_session_sandbox_resets_when_idle(client, auth_headers):
     create_resp = client.post("/api/sessions", headers=auth_headers)
     sid = create_resp.json()["session_id"]


### PR DESCRIPTION
## Summary
Add explicit sandbox start and scale-down controls to the chat UI.

## What changed
- add `POST /api/sessions/{session_id}/sandbox/up` to start or create a sandbox
- add `POST /api/sessions/{session_id}/sandbox/down` to scale down an existing sandbox while keeping storage
- add frontend API helpers for the new sandbox lifecycle actions
- add a context-aware sandbox power button in the chat header that starts missing or scaled-down sandboxes and scales down running ones
- keep the existing reset sandbox action intact
- add focused server tests for the new start/stop routes and running-agent guards

## Validation
- `uv run pytest tests/test_server.py -k 'start_session_sandbox or stop_session_sandbox or wipe_session_sandbox'`
- `uvx ruff check src/carapace/server.py tests/test_server.py`
- `pnpm exec eslint src/components/chat-view.tsx src/lib/api.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new sandbox lifecycle endpoints and UI actions that change when sandboxes are provisioned/cleaned up; mistakes could impact session resources or user expectations, though actions are guarded (e.g., 409 when an agent is running).
> 
> **Overview**
> Adds `POST /api/sessions/{session_id}/sandbox/up` and `/sandbox/down` to explicitly start or scale down a session sandbox, with server-side guards returning `409` if an agent turn is currently running.
> 
> Updates the frontend API client and `ChatView` header to include a context-aware **Start/Scale down sandbox** button with optimistic `pending` state, action-specific loading, and disabled states coordinated with wipe/delete actions. Also tweaks sandbox storage labels (don’t show generic “storage present”) and slightly refines sidebar session metadata display.
> 
> Adds focused server tests covering the new up/down routes and their running-agent rejection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7686e533dcf2f7fed3c3d97706c566e8d3b8fc05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->