### PR TITLE
✨ feat: Add skill command aliases for activated skills

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,6 @@
 - [ ] "daily" session that is recreated every day and that should persist some of its memories during the night
 - [ ] should the chat histories become a part of the knowledge repo automatically? at least by pressing a "save" button for the session?
 - [ ] instead of carapace.yaml, use the Skill.md frontmatter metadata field, that's how openclaw does it
-- [ ] skills could register commands (e.g. uv run shortcuts) in carapace yaml, and if the agent tries to use those without the context (although the skill is active) automatically add the context and then warn the agent that this happened
 
 ## Knowledge Repo Handling
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,6 +11,7 @@
 - [ ] "daily" session that is recreated every day and that should persist some of its memories during the night
 - [ ] should the chat histories become a part of the knowledge repo automatically? at least by pressing a "save" button for the session?
 - [ ] instead of carapace.yaml, use the Skill.md frontmatter metadata field, that's how openclaw does it
+- [ ] skills could register commands (e.g. uv run shortcuts) in carapace yaml, and if the agent tries to use those without the context (although the skill is active) automatically add the context and then warn the agent that this happened
 
 ## Knowledge Repo Handling
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -8,7 +8,7 @@ A skill is a directory with a `SKILL.md` file (Markdown instructions with YAML f
 
 Carapace extends the format with optional files:
 
-- **`carapace.yaml`** — security metadata: network domain declarations, credential needs
+- **`carapace.yaml`** — security metadata: network domain declarations, credential needs, and optional command aliases
 - **`pyproject.toml`** + **`uv.lock`** — Python dependencies installed via `uv sync --locked`
 - **`package.json`** + **`package-lock.json`** or **`pnpm-lock.yaml`** — Node dependencies installed with the matching package manager
 - **`setup.sh`** — optional post-activation setup script for local config generation or other derived artifacts
@@ -71,7 +71,7 @@ Summarize the top results for the user.
 
 ## carapace.yaml (Carapace extension)
 
-Optional file that declares network domains, exec-scoped TCP tunnels, and credentials the skill needs.
+Optional file that declares network domains, exec-scoped TCP tunnels, credentials, and command aliases the skill needs.
 
 ```yaml
 network:
@@ -91,6 +91,10 @@ credentials:
   - vault_path: "dev/searxng-cert"
     description: Optional client certificate
     file: "~/.config/searxng/client.pem"
+
+commands:
+  - name: web-search
+    command: uv run --directory /workspace/skills/web-search scripts/search.py
 ```
 
 ### Fields
@@ -118,6 +122,26 @@ Carapace manages these tunnels itself during `exec(..., contexts=[...])`. Skills
 
 > **Note**: Credential declarations are implemented. See [credentials.md](credentials.md) for approval flow, backend config, and `ccred` usage.
 
+**`commands`** — optional list of command aliases the skill exposes. Each entry has:
+
+- `name` — the exact alias token, for example `web-search`
+- `command` — a single-line shell command to run for that alias
+
+When the skill is activated, Carapace writes a generated wrapper script for each alias into `/root/.carapace/bin/` and marks it executable. The wrapper looks like this conceptually:
+
+```sh
+#!/bin/sh
+exec <configured command> "$@"
+```
+
+Notes:
+
+- The wrapper preserves the caller's working directory. Do not rely on it changing cwd to the skill directory.
+- Extra arguments are forwarded with `"$@"`.
+- The wrapper uses shell `exec` so the launcher shell is replaced by the real command.
+- `command` must be a single non-empty line.
+- Alias names must be unique across active skills. If an active skill already owns an alias, activating another skill with the same alias fails.
+
 ## Context-scoped access
 
 Skill-declared domains and credentials are **not globally available** in the session. Instead, they're scoped to individual `exec` calls via the `contexts` parameter.
@@ -129,6 +153,8 @@ Skill-declared domains and credentials are **not globally available** in the ses
 3. **Per-exec injection**: Domains are temporarily allowed in the proxy. Credential values are injected as env vars or written as files for the duration of that single exec. File-based credentials are deleted immediately after the command completes.
    Tunnel declarations are also applied here: Carapace temporarily shadows the declared hostnames inside the sandbox, starts trusted CONNECT-backed tunnel helpers, and tears them down again after the exec.
 4. **No context = no access**: An exec without `contexts` (or with unrelated contexts) does not get the skill's domains or credentials. The sentinel evaluates any credential access without a matching context.
+
+For command aliases declared in `carapace.yaml`, Carapace also recognizes the alias at the start of an `exec` command. If the owning skill is already active but missing from `contexts`, Carapace adds that context automatically, rewrites the command to the generated wrapper path, and warns the agent to pass the context explicitly next time.
 
 ### Matching semantics
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -127,7 +127,7 @@ Carapace manages these tunnels itself during `exec(..., contexts=[...])`. Skills
 - `name` — the exact alias token, for example `web-search`
 - `command` — a single-line shell command to run for that alias
 
-When the skill is activated, Carapace writes a generated wrapper script for each alias into `/root/.carapace/bin/` and marks it executable. The wrapper looks like this conceptually:
+When the skill is activated, Carapace writes a generated wrapper script for each alias into `/root/.carapace/bin/`, marks it executable, and exposes that directory on `PATH`. Agents should invoke the plain alias token such as `web-search`, not the absolute shim path. The wrapper looks like this conceptually:
 
 ```sh
 #!/bin/sh
@@ -154,7 +154,7 @@ Skill-declared domains and credentials are **not globally available** in the ses
    Tunnel declarations are also applied here: Carapace temporarily shadows the declared hostnames inside the sandbox, starts trusted CONNECT-backed tunnel helpers, and tears them down again after the exec.
 4. **No context = no access**: An exec without `contexts` (or with unrelated contexts) does not get the skill's domains or credentials. The sentinel evaluates any credential access without a matching context.
 
-For command aliases declared in `carapace.yaml`, Carapace also recognizes the alias at the start of an `exec` command. If the owning skill is already active but missing from `contexts`, Carapace adds that context automatically, rewrites the command to the generated wrapper path, and warns the agent to pass the context explicitly next time.
+For command aliases declared in `carapace.yaml`, Carapace also recognizes the alias at the start of an `exec` command. If the owning skill is already active but missing from `contexts`, Carapace adds that context automatically, resolves the command through the generated shim on `PATH`, and warns the agent to pass the context explicitly next time while continuing to use the plain alias.
 
 ### Matching semantics
 

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
 
 COPY --from=ghcr.io/astral-sh/uv@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a /uv /usr/local/bin/uv
 
-ENV PATH="/root/.local/bin:${PATH}" \
+ENV PATH="/root/.carapace/bin:/root/.local/bin:${PATH}" \
    NODE_USE_ENV_PROXY=1
 RUN uv python install 3.14 --default --preview-features python-install-default
 RUN corepack enable
@@ -27,7 +27,7 @@ RUN chmod +x /usr/local/bin/setup-proxy.sh
 COPY ccred /usr/local/bin/ccred
 RUN chmod +x /usr/local/bin/ccred
 
-RUN mkdir -p /workspace \
+RUN mkdir -p /root/.carapace/bin /workspace \
    && git config --global --add safe.directory /workspace
 
 WORKDIR /workspace

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -19,11 +19,13 @@ from carapace.models import (
     ContextGrant,
     CredentialMetadata,
     Deps,
+    SkillCarapaceConfig,
     SkillCredentialDecl,
     ToolResult,
 )
 from carapace.sandbox.manager import READ_TOOL_MAX_LINE_WINDOW
 from carapace.sandbox.runtime import SkillActivationError
+from carapace.sandbox.skill_activation import SKILL_COMMAND_SHIM_DIR
 from carapace.security.context import (
     ContextGrantEntry,
     CredentialAccessEntry,
@@ -115,6 +117,84 @@ def _exec_skill_access_warning(
     return "Warning: this command references skill directories without the matching skill context:\n" + "\n".join(
         warnings
     )
+
+
+def _active_skill_command_aliases(knowledge_dir: Path, activated_skills: list[str]) -> dict[str, str]:
+    registry = SkillRegistry(knowledge_dir / "skills")
+    alias_to_skill: dict[str, str] = {}
+    for skill_name in activated_skills:
+        cfg: SkillCarapaceConfig | None = registry.get_carapace_config(skill_name)
+        if not cfg:
+            continue
+        for declared_command in cfg.commands:
+            alias_to_skill.setdefault(declared_command.name, skill_name)
+    return alias_to_skill
+
+
+def _skill_command_alias_conflict(skill_name: str, knowledge_dir: Path, activated_skills: list[str]) -> str | None:
+    registry = SkillRegistry(knowledge_dir / "skills")
+    cfg = registry.get_carapace_config(skill_name)
+    if not cfg or not cfg.commands:
+        return None
+
+    alias_to_skill = _active_skill_command_aliases(
+        knowledge_dir,
+        [active_skill for active_skill in activated_skills if active_skill != skill_name],
+    )
+    conflicts = [
+        (declared_command.name, alias_to_skill[declared_command.name])
+        for declared_command in cfg.commands
+        if declared_command.name in alias_to_skill
+    ]
+    if not conflicts:
+        return None
+
+    details = ", ".join(f"{alias!r} (already registered by {owner!r})" for alias, owner in conflicts)
+    return f"Cannot activate skill '{skill_name}' because these command aliases conflict with active skills: {details}."
+
+
+def _extract_leading_command_token(command: str) -> tuple[str, int, int] | None:
+    match = re.match(
+        r"^\s*(?P<token>(?:" + re.escape(SKILL_COMMAND_SHIM_DIR) + r"/)?[A-Za-z0-9][A-Za-z0-9._-]*)", command
+    )
+    if match is None:
+        return None
+    start, end = match.span("token")
+    return match.group("token"), start, end
+
+
+def _resolve_exec_command_alias(
+    command: str,
+    knowledge_dir: Path,
+    activated_skills: list[str],
+    contexts: list[str],
+) -> tuple[str, list[str], str | None]:
+    token_info = _extract_leading_command_token(command)
+    if token_info is None:
+        return command, contexts, None
+
+    token, start, end = token_info
+    alias_to_skill = _active_skill_command_aliases(knowledge_dir, activated_skills)
+    alias = token.removeprefix(f"{SKILL_COMMAND_SHIM_DIR}/")
+    owning_skill = alias_to_skill.get(alias)
+    if owning_skill is None:
+        return command, contexts, None
+
+    resolved_contexts = list(dict.fromkeys(contexts))
+    warning: str | None = None
+    if owning_skill not in resolved_contexts:
+        resolved_contexts.append(owning_skill)
+        warning = (
+            "Warning: adding skill context automatically because this command starts with "
+            f"the registered alias `{alias}` from skill `{owning_skill}`. "
+            + f"Include `contexts=['{owning_skill}']` next time."
+        )
+
+    if token.startswith(f"{SKILL_COMMAND_SHIM_DIR}/"):
+        return command, resolved_contexts, warning
+
+    rewritten = command[:start] + f"{SKILL_COMMAND_SHIM_DIR}/{alias}" + command[end:]
+    return rewritten, resolved_contexts, warning
 
 
 async def _gate(ctx: RunContext[Deps], tool_name: str, args: dict[str, Any]) -> ToolDenied | None:
@@ -410,8 +490,17 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
         declared_domains = carapace_cfg.network.domains if carapace_cfg else []
         declared_tunnels = carapace_cfg.network.tunnels if carapace_cfg else []
         declared_creds = carapace_cfg.credentials if carapace_cfg else []
+        declared_commands = carapace_cfg.commands if carapace_cfg else []
         declared_creds_payload = [decl.model_dump(mode="json") for decl in declared_creds]
         declared_tunnels_payload = [decl.model_dump(mode="json") for decl in declared_tunnels]
+        declared_commands_payload = [decl.model_dump(mode="json") for decl in declared_commands]
+
+        if conflict_message := _skill_command_alias_conflict(
+            skill_name,
+            ctx.deps.knowledge_dir,
+            ctx.deps.session_state.activated_skills,
+        ):
+            return conflict_message
 
         # Resolve human-readable names from the vault for UI display
         cred_registry = ctx.deps.credential_registry
@@ -429,6 +518,7 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
                 "declared_creds": declared_creds_payload,
                 "declared_domains": declared_domains,
                 "declared_tunnels": declared_tunnels_payload,
+                "declared_commands": declared_commands_payload,
             }
 
             if denied := await _gate(ctx, "use_skill", gate_args):
@@ -643,9 +733,16 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
                 an activated skill; unknown names are rejected.
                 Always set this to the list of skills that are needed for the command.
         """
+        original_command = command
         contexts = contexts or []
-        skill_warning = _exec_skill_access_warning(
+        command, contexts, alias_warning = _resolve_exec_command_alias(
             command,
+            ctx.deps.knowledge_dir,
+            ctx.deps.session_state.activated_skills,
+            contexts,
+        )
+        skill_warning = _exec_skill_access_warning(
+            original_command,
             ctx.deps.knowledge_dir,
             ctx.deps.session_state.activated_skills,
             contexts,
@@ -745,8 +842,10 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
                 f"{lines}\n\n"
             ) + result
 
-        if skill_warning:
-            result = f"{result}\n\n{skill_warning}" if result else skill_warning
+        warnings = [warning for warning in [alias_warning, skill_warning] if warning]
+        if warnings:
+            warning_block = "\n\n".join(warnings)
+            result = f"{result}\n\n{warning_block}" if result else warning_block
 
         ctx.deps.security.append(
             ToolResultEntry(tool="exec", status="error" if exit_code != 0 else "success"),

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -734,18 +734,18 @@ def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
                 Always set this to the list of skills that are needed for the command.
         """
         original_command = command
-        contexts = contexts or []
+        requested_contexts = list(contexts or [])
         command, contexts, alias_warning = _resolve_exec_command_alias(
             command,
             ctx.deps.knowledge_dir,
             ctx.deps.session_state.activated_skills,
-            contexts,
+            requested_contexts,
         )
         skill_warning = _exec_skill_access_warning(
             original_command,
             ctx.deps.knowledge_dir,
             ctx.deps.session_state.activated_skills,
-            contexts,
+            requested_contexts,
         )
 
         # Validate contexts against activated skills

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -188,9 +188,6 @@ def _resolve_exec_command_alias(
             + f"Include `contexts=['{owning_skill}']` next time."
         )
 
-    if token.startswith(f"{SKILL_COMMAND_SHIM_DIR}/"):
-        return command, resolved_contexts, warning
-
     return command, resolved_contexts, warning
 
 

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -153,14 +153,13 @@ def _skill_command_alias_conflict(skill_name: str, knowledge_dir: Path, activate
     return f"Cannot activate skill '{skill_name}' because these command aliases conflict with active skills: {details}."
 
 
-def _extract_leading_command_token(command: str) -> tuple[str, int, int] | None:
+def _extract_leading_command_token(command: str) -> str | None:
     match = re.match(
         r"^\s*(?P<token>(?:" + re.escape(SKILL_COMMAND_SHIM_DIR) + r"/)?[A-Za-z0-9][A-Za-z0-9._-]*)", command
     )
     if match is None:
         return None
-    start, end = match.span("token")
-    return match.group("token"), start, end
+    return match.group("token")
 
 
 def _resolve_exec_command_alias(
@@ -169,11 +168,10 @@ def _resolve_exec_command_alias(
     activated_skills: list[str],
     contexts: list[str],
 ) -> tuple[str, list[str], str | None]:
-    token_info = _extract_leading_command_token(command)
-    if token_info is None:
+    token = _extract_leading_command_token(command)
+    if token is None:
         return command, contexts, None
 
-    token, start, end = token_info
     alias_to_skill = _active_skill_command_aliases(knowledge_dir, activated_skills)
     alias = token.removeprefix(f"{SKILL_COMMAND_SHIM_DIR}/")
     owning_skill = alias_to_skill.get(alias)
@@ -193,8 +191,7 @@ def _resolve_exec_command_alias(
     if token.startswith(f"{SKILL_COMMAND_SHIM_DIR}/"):
         return command, resolved_contexts, warning
 
-    rewritten = command[:start] + f"{SKILL_COMMAND_SHIM_DIR}/{alias}" + command[end:]
-    return rewritten, resolved_contexts, warning
+    return command, resolved_contexts, warning
 
 
 async def _gate(ctx: RunContext[Deps], tool_name: str, args: dict[str, Any]) -> ToolDenied | None:

--- a/src/carapace/assets/skills/create-skill/REFERENCE.md
+++ b/src/carapace/assets/skills/create-skill/REFERENCE.md
@@ -214,7 +214,7 @@ network:
 
 When credentials are declared here, activation handles approval and injection automatically. Keep those details out of `SKILL.md` unless the runtime behavior itself depends on them.
 
-When command aliases are declared here, activation generates executable wrappers in `/root/.carapace/bin/`. Authors should think of `command` as the base command line for that wrapper, not as a multi-line shell script.
+When command aliases are declared here, activation generates executable wrappers in `/root/.carapace/bin/` and exposes that directory on `PATH`. Runtime agents should call the plain alias token, not the absolute shim path. Authors should think of `command` as the base command line for that wrapper, not as a multi-line shell script.
 
 Each command entry has:
 

--- a/src/carapace/assets/skills/create-skill/REFERENCE.md
+++ b/src/carapace/assets/skills/create-skill/REFERENCE.md
@@ -23,10 +23,11 @@ Use this checklist when writing or reviewing a skill:
 4. Keep domain facts in `SKILL.md` when the agent needs them to act correctly, even if they are user-specific.
 5. Move schemas, dependency setup, auth internals, wrapper internals, and maintainer troubleshooting into sidecar docs.
 6. Link any sidecar docs from `SKILL.md` when the runtime agent may need to know they exist.
-7. If the skill exposes commands, show the real entrypoints the agent should run.
-8. If the skill performs risky actions, add explicit safety rules near the top of `SKILL.md`.
-9. If activation handles credentials or setup automatically, say that briefly in `SKILL.md` and stop there.
-10. If `carapace.yaml` injects a credential into a local file, add that generated file path to the skill-local `.gitignore`.
+7. If the skill exposes commands, add a short `Exposed Commands` list near the top of `SKILL.md` and show the real aliases there.
+8. Do not put exposed commands into frontmatter; keep them in the body where the runtime agent will read them naturally.
+9. If the skill performs risky actions, add explicit safety rules near the top of `SKILL.md`.
+10. If activation handles credentials or setup automatically, say that briefly in `SKILL.md` and stop there.
+11. If `carapace.yaml` injects a credential into a local file, add that generated file path to the skill-local `.gitignore`.
 
 ## What Good `SKILL.md` Files Usually Contain
 
@@ -35,6 +36,7 @@ Most good skills in this repo converge on the same shape:
 - a precise `description` with task keywords
 - one short opening paragraph that sets scope
 - a `When To Use` or equivalent section
+- an `Exposed Commands` section near the top when the skill ships command aliases
 - the normal workflow or command entrypoints
 - enough CLI usage detail to run the skill without guessing
 - user-specific domain maps that prevent mistakes, such as folder names, project IDs, label names, account conventions, or preferred filters
@@ -57,6 +59,7 @@ Move content into a sidecar doc when it is mainly about:
 Keep content in `SKILL.md` when it is mainly about:
 
 - how to invoke the skill's CLI correctly
+- which exposed command aliases the agent should prefer during normal use
 - common commands the agent should use often
 - user-specific categories, folders, projects, labels, accounts, or IDs needed for correct action
 - safety rules and syntax traps that prevent accidental side effects
@@ -227,6 +230,17 @@ Guidelines for command aliases:
 - Do not use multi-line commands; validation rejects them.
 
 The usual sentence in `SKILL.md` is enough: setup or credential injection happens automatically on activation.
+
+If the skill exposes commands, it is customary to list them near the top of `SKILL.md` in a short section such as:
+
+```markdown
+## Exposed Commands
+
+- `example-search`: Search the Example service.
+- `example-sync`: Run the Example sync flow.
+```
+
+Keep this in the body, not in frontmatter.
 
 If a credential is materialized into a local file, treat that path as generated secret state and ignore it in the skill-local `.gitignore`.
 

--- a/src/carapace/assets/skills/create-skill/REFERENCE.md
+++ b/src/carapace/assets/skills/create-skill/REFERENCE.md
@@ -167,7 +167,7 @@ As a rule of thumb, if a runtime agent can succeed without reading a section eve
 
 ## `carapace.yaml`
 
-`carapace.yaml` is optional. Use it when the skill needs outbound domains, tunnels, hints, or auto-injected credentials.
+`carapace.yaml` is optional. Use it when the skill needs outbound domains, tunnels, hints, auto-injected credentials, or command aliases.
 
 Top-level keys:
 
@@ -176,6 +176,7 @@ Top-level keys:
 | `network`         | object          | Network configuration for allowed domains or tunnels    |
 | `network.domains` | list of strings | Hostnames added to the session allowlist                |
 | `credentials`     | list of objects | Vault-backed credentials to inject as env vars or files |
+| `commands`        | list of objects | Command aliases registered on skill activation          |
 | `hints`           | map             | Extra metadata for tooling                              |
 
 Valid example:
@@ -193,6 +194,10 @@ credentials:
   - vault_path: my-backend/deploy-key
     description: SSH private key for deploys
     file: ~/.ssh/id_example_deploy
+
+commands:
+  - name: example-search
+    command: uv run --directory /workspace/skills/example scripts/search.py
 ```
 
 Common mistake:
@@ -205,6 +210,21 @@ network:
 `network` must be an object with a `domains` key. If the shape is wrong, validation fails and the file may be ignored.
 
 When credentials are declared here, activation handles approval and injection automatically. Keep those details out of `SKILL.md` unless the runtime behavior itself depends on them.
+
+When command aliases are declared here, activation generates executable wrappers in `/root/.carapace/bin/`. Authors should think of `command` as the base command line for that wrapper, not as a multi-line shell script.
+
+Each command entry has:
+
+- `name`: the alias token the agent will invoke
+- `command`: a single non-empty line that becomes `exec <command> "$@"` inside the generated `#!/bin/sh` wrapper
+
+Guidelines for command aliases:
+
+- Preserve the caller's current working directory. Do not depend on an implicit `cd` into the skill directory.
+- Use absolute paths if the command needs files under `/workspace/skills/<name>/`.
+- Assume extra arguments are forwarded with `"$@"`.
+- Keep aliases unique. If another active skill already owns the same alias, activation fails.
+- Do not use multi-line commands; validation rejects them.
 
 The usual sentence in `SKILL.md` is enough: setup or credential injection happens automatically on activation.
 

--- a/src/carapace/assets/skills/create-skill/SKILL.md
+++ b/src/carapace/assets/skills/create-skill/SKILL.md
@@ -20,6 +20,7 @@ Produce a skill that is easy for another agent to activate and follow.
 Keep the information an activated agent should know before acting:
 
 - what the skill does and when to use it
+- a short list of exposed commands near the top of the body when the skill ships command aliases
 - hard constraints and safety rules
 - the normal workflow or command entrypoints
 - how the skill CLI is supposed to be invoked
@@ -56,9 +57,10 @@ Good filenames are `REFERENCE.md`, `CONFIG.md`, or `references/*.md`.
    - `name` matches the folder name exactly.
    - `description` says what the skill does and when to use it.
 5. Write the body for the agent who will use the skill, including the operational facts needed for safe normal use.
-6. If the skill needs network access, credentials, code, or setup hooks, add the supporting files next to it and summarize the activation behavior in `SKILL.md`.
-7. If setup, implementation, or reference material is not needed for normal use, add a sidecar markdown file and link it from `SKILL.md`.
-8. Tell the user the skill will show up in `/skills` and be available in new sessions.
+6. If the skill exposes command aliases, add an `Exposed Commands` section near the top of `SKILL.md`. List the real aliases there in the body, not in frontmatter.
+7. If the skill needs network access, credentials, code, or setup hooks, add the supporting files next to it and summarize the activation behavior in `SKILL.md`.
+8. If setup, implementation, or reference material is not needed for normal use, add a sidecar markdown file and link it from `SKILL.md`.
+9. Tell the user the skill will show up in `/skills` and be available in new sessions.
 
 ## Setup Guidance
 
@@ -80,6 +82,11 @@ One short paragraph describing the skill.
 
 - <Concrete trigger or task>
 - <Concrete trigger or task>
+
+## Exposed Commands
+
+- `<command-alias>`: <What it does>
+- `<command-alias>`: <What it does>
 
 ## Workflow
 

--- a/src/carapace/assets/skills/example/REFERENCE.md
+++ b/src/carapace/assets/skills/example/REFERENCE.md
@@ -8,7 +8,7 @@ This file documents the maintainer-facing details for the example skill. Runtime
 skills/example/
   SKILL.md              # metadata and runtime instructions for the agent
   REFERENCE.md          # this maintainer reference
-  carapace.yaml         # network allowlist, tunnel declarations, and credential declarations
+  carapace.yaml         # network declarations and command aliases for the demo entrypoints
   pyproject.toml        # Python project with dependencies and CLI entrypoints
   uv.lock               # locked dependency versions
   package.json          # Node project manifest using the pnpm workflow
@@ -22,8 +22,8 @@ skills/example/
 
 ## Key Files
 
-- `SKILL.md`: YAML frontmatter plus the instructions the agent follows after activation.
-- `carapace.yaml`: declares the exec-scoped tunnel to `imap.gmail.com:993`; no credentials are required for this demo.
+- `SKILL.md`: YAML frontmatter plus the instructions the agent follows after activation, including the exposed command list near the top.
+- `carapace.yaml`: declares the exec-scoped tunnel to `imap.gmail.com:993` and the `example-hello` / `example-node` command aliases; no credentials are required for this demo.
 - `pyproject.toml`: declares Python dependencies, CLI entrypoints, and build config.
 - `uv.lock`: lock file for reproducible Python installs.
 - `package.json`: declares the Node-side entrypoint.
@@ -41,8 +41,9 @@ When adapting this example:
 1. Keep `SKILL.md` focused on runtime behavior.
 2. Move provider and file-layout explanations into sidecar docs.
 3. Keep lockfiles committed alongside provider manifests.
-4. Use entrypoint commands through `uv run --directory /workspace/skills/<name> <command>` or `pnpm --dir /workspace/skills/<name> run <script>`.
-5. Keep setup hooks deterministic and avoid printing secrets.
+4. If the skill exposes command aliases, list them near the top of `SKILL.md` and prefer those aliases in the runtime instructions.
+5. Keep the underlying raw `uv run --directory ...` or `pnpm --dir ... run ...` commands in `carapace.yaml`, not in frontmatter.
+6. Keep setup hooks deterministic and avoid printing secrets.
 
 ## Activation Flow
 

--- a/src/carapace/assets/skills/example/SKILL.md
+++ b/src/carapace/assets/skills/example/SKILL.md
@@ -9,13 +9,18 @@ This is a template skill that demonstrates the [AgentSkills](https://agentskills
 with a Python package, a pnpm-managed Node entrypoint, provider-based activation, post-activation setup,
 and an exec-scoped TCP tunnel declared in `carapace.yaml`.
 
+## Exposed Commands
+
+- `example-hello`: Run the Python demo command that probes IMAP `CAPABILITY` through the Carapace-managed tunnel.
+- `example-node`: Run the Node demo command from the pnpm-managed entrypoint.
+
 ## Instructions
 
-When this skill is activated, run the example commands to verify the sandbox environment and tunnel support:
+When this skill is activated, run the exposed commands to verify the sandbox environment and tunnel support:
 
 ```text
-uv run --directory /workspace/skills/example hello
-pnpm --dir /workspace/skills/example run hello:node
+example-hello
+example-node
 ```
 
 The Python command performs an unauthenticated IMAP `CAPABILITY` request against `imap.gmail.com`

--- a/src/carapace/assets/skills/example/carapace.yaml
+++ b/src/carapace/assets/skills/example/carapace.yaml
@@ -4,3 +4,9 @@ network:
       remote_port: 993
       local_port: 1993
       description: Unauthenticated IMAP CAPABILITY probe over a Carapace-managed tunnel
+
+commands:
+  - name: example-hello
+    command: uv run --directory /workspace/skills/example hello
+  - name: example-node
+    command: pnpm --dir /workspace/skills/example run hello:node

--- a/src/carapace/models.py
+++ b/src/carapace/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -476,12 +477,49 @@ class SkillNetworkConfig(BaseModel):
         return self
 
 
+_SKILL_COMMAND_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+class SkillCommandDecl(BaseModel):
+    """A command alias declared in a skill's ``carapace.yaml``."""
+
+    name: str
+    command: str
+
+    @model_validator(mode="after")
+    def _validate(self) -> SkillCommandDecl:
+        if not _SKILL_COMMAND_NAME_RE.match(self.name):
+            raise ValueError(
+                "skill command name must start with an alphanumeric character and contain only letters, "
+                "numbers, dots, underscores, or hyphens"
+            )
+
+        command = self.command.strip()
+        if not command:
+            raise ValueError("skill command must not be empty")
+        if "\n" in command or "\r" in command:
+            raise ValueError("skill command must be a single line")
+
+        self.command = command
+        return self
+
+
 class SkillCarapaceConfig(BaseModel):
     """Parsed contents of a skill's ``carapace.yaml``."""
 
     network: SkillNetworkConfig = SkillNetworkConfig()
     credentials: list[SkillCredentialDecl] = []
+    commands: list[SkillCommandDecl] = []
     hints: dict[str, str] = {}
+
+    @model_validator(mode="after")
+    def _validate_commands(self) -> SkillCarapaceConfig:
+        seen_names: set[str] = set()
+        for command in self.commands:
+            if command.name in seen_names:
+                raise ValueError(f"duplicate skill command name {command.name!r} is not allowed")
+            seen_names.add(command.name)
+        return self
 
 
 class ContextGrant(BaseModel):

--- a/src/carapace/sandbox/manager.py
+++ b/src/carapace/sandbox/manager.py
@@ -230,6 +230,7 @@ class SandboxManager:
         self._exec_notified_credentials: dict[str, set[str]] = {}  # dedupe credential UI notifications
         self._get_activated_skills_cb: Callable[[str], list[str]] | None = None
         self._skill_activation_inputs_cb: Callable[[str, str], Awaitable[SkillActivationInputs]] | None = None
+        self._skill_command_aliases_cb: Callable[[str], list[tuple[str, str]]] | None = None
         self._session_lifecycle = SandboxSessionLifecycle(
             runtime=runtime,
             state=SandboxSessionLifecycleState(
@@ -305,10 +306,19 @@ class SandboxManager:
         """Register a callback to retrieve activation inputs for a skill."""
         self._skill_activation_inputs_cb = cb
 
+    def set_skill_command_aliases_callback(self, cb: Callable[[str], list[tuple[str, str]]]) -> None:
+        """Register a callback to retrieve command aliases for a skill."""
+        self._skill_command_aliases_cb = cb
+
     async def _get_skill_activation_inputs(self, session_id: str, skill_name: str) -> SkillActivationInputs:
         if self._skill_activation_inputs_cb is None:
             return SkillActivationInputs()
         return await self._skill_activation_inputs_cb(session_id, skill_name)
+
+    def _get_skill_command_aliases(self, skill_name: str) -> list[tuple[str, str]]:
+        if self._skill_command_aliases_cb is None:
+            return []
+        return self._skill_command_aliases_cb(skill_name)
 
     def _get_or_create_token(self, session_id: str) -> str:
         return self._session_lifecycle.get_or_create_token(session_id)
@@ -585,12 +595,15 @@ class SandboxManager:
             logger.warning(f"Skill '{skill_name}' not found for session {session_id}")
             return f"Skill '{skill_name}' not found."
 
+        command_aliases = self._get_skill_command_aliases(skill_name)
+
         activation_msg = ""
         try:
             activation_lines = await self._skill_activation_runner.restore_and_run_detected_providers(
                 sc,
                 skill_name,
                 master_skill_dir,
+                command_aliases=command_aliases,
                 run_session_id=session_id,
             )
             activation_msg = "\n".join(activation_lines)
@@ -655,7 +668,13 @@ class SandboxManager:
     async def _rerun_skill_setup(self, sc: SessionContainer, skill_name: str) -> str:
         """Restore trusted skill files from git and rerun automatic setup providers."""
         master = self._knowledge_dir / "skills" / skill_name
-        lines = await self._skill_activation_runner.restore_and_run_detected_providers(sc, skill_name, master)
+        command_aliases = self._get_skill_command_aliases(skill_name)
+        lines = await self._skill_activation_runner.restore_and_run_detected_providers(
+            sc,
+            skill_name,
+            master,
+            command_aliases=command_aliases,
+        )
         return "\n".join(lines)
 
     async def rerun_skill_setup(self, session_id: str, activated_skills: list[str]) -> None:

--- a/src/carapace/sandbox/skill_activation.py
+++ b/src/carapace/sandbox/skill_activation.py
@@ -188,6 +188,9 @@ class SkillActivationRunner:
         session_id: str | None = None,
         sc: SessionContainerLike | None = None,
     ) -> list[str]:
+        if not command_aliases:
+            return []
+
         if (session_id is None) == (sc is None):
             raise ValueError("Exactly one of session_id and sc must be set")
 
@@ -223,8 +226,6 @@ class SkillActivationRunner:
         if result.exit_code != 0:
             raise SkillActivationError(f"command alias registration exit {result.exit_code}: {result.output[:500]}")
 
-        if not command_aliases:
-            return []
         names = ", ".join(alias for alias, _command in command_aliases)
         return [f"Command aliases registered: {names}."]
 

--- a/src/carapace/sandbox/skill_activation.py
+++ b/src/carapace/sandbox/skill_activation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import shlex
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -9,6 +10,8 @@ from loguru import logger
 
 from carapace.sandbox.file_ops import ContextFileCredential, SessionContainerLike, WrittenContextFile
 from carapace.sandbox.runtime import ExecResult, SkillActivationError, SkillActivationInputs
+
+SKILL_COMMAND_SHIM_DIR = "/root/.carapace/bin"
 
 
 @dataclass(frozen=True)
@@ -135,10 +138,11 @@ class SkillActivationRunner:
         skill_name: str,
         skill_dir: Path,
         *,
+        command_aliases: list[tuple[str, str]] | None = None,
         run_session_id: str | None = None,
     ) -> list[str]:
         providers = self.matching_providers(skill_dir)
-        if not providers:
+        if not providers and not command_aliases:
             return []
 
         trusted_files = self.trusted_files_for(providers)
@@ -151,14 +155,78 @@ class SkillActivationRunner:
 
         activation_inputs = await self._get_activation_inputs(run_session_id or sc.session_id, skill_name)
         if run_session_id is not None:
-            return await self.run_providers(
+            status_lines = await self.run_providers(
                 skill_name,
                 providers,
                 activation_inputs,
                 session_id=run_session_id,
             )
+            if command_aliases:
+                status_lines.extend(
+                    await self.register_command_aliases(
+                        command_aliases,
+                        session_id=run_session_id,
+                    )
+                )
+            return status_lines
 
-        return await self.run_providers(skill_name, providers, activation_inputs, sc=sc)
+        status_lines = await self.run_providers(skill_name, providers, activation_inputs, sc=sc)
+        if command_aliases:
+            status_lines.extend(await self.register_command_aliases(command_aliases, sc=sc))
+        return status_lines
+
+    def _command_shim_path(self, alias: str) -> str:
+        return f"{SKILL_COMMAND_SHIM_DIR}/{alias}"
+
+    def _command_wrapper_content(self, command: str) -> str:
+        return f'#!/bin/sh\nexec {command} "$@"\n'
+
+    async def register_command_aliases(
+        self,
+        command_aliases: list[tuple[str, str]],
+        *,
+        session_id: str | None = None,
+        sc: SessionContainerLike | None = None,
+    ) -> list[str]:
+        if (session_id is None) == (sc is None):
+            raise ValueError("Exactly one of session_id and sc must be set")
+
+        shell_commands = [f"mkdir -p {shlex.quote(SKILL_COMMAND_SHIM_DIR)}"]
+
+        for alias, command in command_aliases:
+            wrapper = self._command_wrapper_content(command)
+            wrapper_b64 = base64.b64encode(wrapper.encode()).decode()
+            shell_commands.append(
+                f"printf %s {shlex.quote(wrapper_b64)} | base64 -d > {shlex.quote(self._command_shim_path(alias))}"
+            )
+            shell_commands.append(f"chmod +x {shlex.quote(self._command_shim_path(alias))}")
+
+        command = " && ".join(shell_commands)
+        if session_id is not None:
+            result = await self._exec_in_session(
+                session_id,
+                command,
+                timeout=30,
+                bypass_proxy=True,
+                workdir=self._knowledge_workdir,
+            )
+        else:
+            assert sc is not None
+            result = await self._exec_in_container(
+                sc,
+                command,
+                timeout=30,
+                bypass_proxy=True,
+                workdir=self._knowledge_workdir,
+            )
+
+        if result.exit_code != 0:
+            raise SkillActivationError(f"command alias registration exit {result.exit_code}: {result.output[:500]}")
+
+        if not command_aliases:
+            return []
+        names = ", ".join(alias for alias, _command in command_aliases)
+        return [f"Command aliases registered: {names}."]
 
     def _activation_file_credentials(
         self,

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -281,6 +281,7 @@ class SessionEngine:
         # Let SandboxManager retrieve activated skills so automatic setup can rerun on recreation
         sandbox_mgr.set_activated_skills_callback(self._get_activated_skills)
         sandbox_mgr.set_skill_activation_inputs_callback(self._skill_activation_inputs)
+        sandbox_mgr.set_skill_command_aliases_callback(self._skill_command_aliases)
 
     # -- public access to file I/O manager --
 
@@ -612,6 +613,14 @@ class SessionEngine:
             if decl.file:
                 file_credentials.append(SkillFileCredential(path=decl.file, value=value))
         return SkillActivationInputs(environment=env, file_credentials=file_credentials)
+
+    def _skill_command_aliases(self, skill_name: str) -> list[tuple[str, str]]:
+        """Return validated command aliases declared by a skill."""
+        registry = SkillRegistry(self._knowledge_dir / "skills")
+        carapace_cfg = registry.get_carapace_config(skill_name)
+        if not carapace_cfg:
+            return []
+        return [(command.name, command.command) for command in carapace_cfg.commands]
 
     def _credential_vault_paths_for_skill(self, session_id: str, skill_name: str) -> set[str]:
         """Vault paths allowed for file re-injection: that skill's context grant (from ``use_skill``)."""

--- a/tests/test_agent_read_skill_policy.py
+++ b/tests/test_agent_read_skill_policy.py
@@ -188,3 +188,34 @@ def test_resolves_exec_alias_without_warning_when_context_present(tmp_path: Path
     assert command == f"{SKILL_COMMAND_SHIM_DIR}/web search docs/skills.md"
     assert contexts == ["web"]
     assert warning is None
+
+
+def test_alias_auto_add_keeps_skill_directory_warning_on_original_contexts(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "skills" / "web"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text("# Web")
+    (skill_dir / "carapace.yaml").write_text("commands:\n  - name: web\n    command: uv run web\n")
+
+    original_command = "web search /workspace/skills/web/data.json"
+    requested_contexts: list[str] = []
+
+    _resolved_command, resolved_contexts, alias_warning = _resolve_exec_command_alias(
+        original_command,
+        tmp_path,
+        activated_skills=["web"],
+        contexts=requested_contexts,
+    )
+    skill_warning = _exec_skill_access_warning(
+        original_command,
+        tmp_path,
+        activated_skills=["web"],
+        contexts=requested_contexts,
+    )
+
+    assert resolved_contexts == ["web"]
+    assert alias_warning is not None
+    assert skill_warning == (
+        "Warning: this command references skill directories without the matching skill context:\n"
+        "- `web` is referenced in this command but missing from `contexts`. Rerun `exec` with "
+        "`contexts=['web']` if you need that skill's injected credentials, tunnels, or domains."
+    )

--- a/tests/test_agent_read_skill_policy.py
+++ b/tests/test_agent_read_skill_policy.py
@@ -167,7 +167,7 @@ def test_resolves_exec_alias_and_auto_adds_context(tmp_path: Path) -> None:
     assert command == f"{SKILL_COMMAND_SHIM_DIR}/web search docs/skills.md"
     assert contexts == ["web"]
     assert warning == (
-        "Warning: Carapace added a skill context automatically because this command starts with the registered "
+        "Warning: adding skill context automatically because this command starts with the registered "
         "alias `web` from skill `web`. Include `contexts=['web']` next time."
     )
 

--- a/tests/test_agent_read_skill_policy.py
+++ b/tests/test_agent_read_skill_policy.py
@@ -4,7 +4,13 @@ from pathlib import Path
 
 import pytest
 
-from carapace.agent.tools import _exec_skill_access_warning, _read_skill_access_denial
+from carapace.agent.tools import (
+    _exec_skill_access_warning,
+    _read_skill_access_denial,
+    _resolve_exec_command_alias,
+    _skill_command_alias_conflict,
+)
+from carapace.sandbox.skill_activation import SKILL_COMMAND_SHIM_DIR
 
 
 def test_denies_read_for_backend_existing_skill_file_when_not_activated(tmp_path: Path) -> None:
@@ -124,3 +130,61 @@ def test_ignores_non_backend_skill_path_mentions(tmp_path: Path) -> None:
     )
 
     assert result is None
+
+
+def test_detects_command_alias_conflict_with_active_skill(tmp_path: Path) -> None:
+    active_skill_dir = tmp_path / "skills" / "web"
+    active_skill_dir.mkdir(parents=True, exist_ok=True)
+    (active_skill_dir / "SKILL.md").write_text("# Web")
+    (active_skill_dir / "carapace.yaml").write_text("commands:\n  - name: web\n    command: uv run web\n")
+
+    new_skill_dir = tmp_path / "skills" / "web-plus"
+    new_skill_dir.mkdir(parents=True, exist_ok=True)
+    (new_skill_dir / "SKILL.md").write_text("# Web Plus")
+    (new_skill_dir / "carapace.yaml").write_text("commands:\n  - name: web\n    command: uv run web-plus\n")
+
+    result = _skill_command_alias_conflict("web-plus", tmp_path, activated_skills=["web"])
+
+    assert result == (
+        "Cannot activate skill 'web-plus' because these command aliases conflict with active skills: "
+        "'web' (already registered by 'web')."
+    )
+
+
+def test_resolves_exec_alias_and_auto_adds_context(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "skills" / "web"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text("# Web")
+    (skill_dir / "carapace.yaml").write_text("commands:\n  - name: web\n    command: uv run web\n")
+
+    command, contexts, warning = _resolve_exec_command_alias(
+        "web search docs/skills.md",
+        tmp_path,
+        activated_skills=["web"],
+        contexts=[],
+    )
+
+    assert command == f"{SKILL_COMMAND_SHIM_DIR}/web search docs/skills.md"
+    assert contexts == ["web"]
+    assert warning == (
+        "Warning: Carapace added a skill context automatically because this command starts with the registered "
+        "alias `web` from skill `web`. Include `contexts=['web']` next time."
+    )
+
+
+def test_resolves_exec_alias_without_warning_when_context_present(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "skills" / "web"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text("# Web")
+    (skill_dir / "carapace.yaml").write_text("commands:\n  - name: web\n    command: uv run web\n")
+
+    command, contexts, warning = _resolve_exec_command_alias(
+        f"{SKILL_COMMAND_SHIM_DIR}/web search docs/skills.md",
+        tmp_path,
+        activated_skills=["web"],
+        contexts=["web"],
+    )
+
+    assert command == f"{SKILL_COMMAND_SHIM_DIR}/web search docs/skills.md"
+    assert contexts == ["web"]
+    assert warning is None

--- a/tests/test_agent_read_skill_policy.py
+++ b/tests/test_agent_read_skill_policy.py
@@ -164,7 +164,7 @@ def test_resolves_exec_alias_and_auto_adds_context(tmp_path: Path) -> None:
         contexts=[],
     )
 
-    assert command == f"{SKILL_COMMAND_SHIM_DIR}/web search docs/skills.md"
+    assert command == "web search docs/skills.md"
     assert contexts == ["web"]
     assert warning == (
         "Warning: adding skill context automatically because this command starts with the registered "

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -468,6 +468,7 @@ async def test_activate_skill_prefers_pnpm_when_package_and_pnpm_lockfiles_exist
 
     result = await mgr.activate_skill("sess-1", "multi-node-lock")
     commands = [call.args[1] for call in runtime.exec.call_args_list]
+
     result_lines = result.splitlines()
 
     assert "pnpm dependencies installed." in result_lines
@@ -477,6 +478,44 @@ async def test_activate_skill_prefers_pnpm_when_package_and_pnpm_lockfiles_exist
     assert not any(
         command.startswith("git checkout @{upstream} --") and "package-lock.json" in command for command in commands
     )
+
+
+@pytest.mark.anyio
+async def test_activate_skill_registers_command_aliases_in_image_shim_dir(tmp_path: Path):
+    runtime = make_runtime_mock()
+    runtime.get_host_ip = AsyncMock(return_value="172.18.0.1")
+    runtime.create_sandbox = AsyncMock(return_value="container-1")
+    runtime.get_ip = AsyncMock(return_value="172.18.0.22")
+    runtime.logs = AsyncMock(return_value="carapace sandbox ready")
+    runtime.exec = AsyncMock(
+        side_effect=[
+            ExecResult(exit_code=0, output=""),  # _clone_knowledge_repo probe after create
+            ExecResult(exit_code=0, output=""),  # git checkout carapace.yaml
+            ExecResult(exit_code=0, output=""),  # command alias registration
+        ]
+    )
+
+    skill_dir = tmp_path / "skills" / "web"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: web\n---\nBody.\n")
+
+    mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+    mgr.set_skill_command_aliases_callback(
+        lambda skill_name: (
+            [("web", "uv run --directory /workspace/skills/web web-search")] if skill_name == "web" else []
+        )
+    )
+
+    result = await mgr.activate_skill("sess-1", "web")
+
+    assert "Command aliases registered: web." in result
+    assert "PATH" not in mgr.get_session_env("sess-1")
+
+    register_call = runtime.exec.call_args_list[2]
+    shell_cmd = register_call.args[1]
+    wrapper = '#!/bin/sh\nexec uv run --directory /workspace/skills/web web-search "$@"\n'
+    assert "/root/.carapace/bin/web" in shell_cmd
+    assert base64.b64encode(wrapper.encode()).decode() in shell_cmd
 
 
 # ── carapace.yaml parsing ───────────────────────────────────────────
@@ -590,6 +629,7 @@ class TestCarapaceYamlParsing:
                     "tunnels": [{"host": "imap.a.com", "remote_port": 993, "local_port": 1993}],
                 },
                 "credentials": [{"vault_path": "x/y", "description": "Test cred", "env_var": "FOO"}],
+                "commands": [{"name": "demo", "command": "uv run demo"}],
             }
         )
         assert cfg.network.domains == ["a.com"]
@@ -597,6 +637,28 @@ class TestCarapaceYamlParsing:
         assert len(cfg.credentials) == 1
         assert cfg.credentials[0].vault_path == "x/y"
         assert cfg.credentials[0].env_var == "FOO"
+        assert len(cfg.commands) == 1
+        assert cfg.commands[0].name == "demo"
+        assert cfg.commands[0].command == "uv run demo"
+
+    def test_model_validation_rejects_multiline_command(self):
+        with pytest.raises(ValueError, match="single line"):
+            SkillCarapaceConfig.model_validate(
+                {
+                    "commands": [{"name": "demo", "command": "uv run demo\necho nope"}],
+                }
+            )
+
+    def test_model_validation_rejects_duplicate_command_names(self):
+        with pytest.raises(ValueError, match="duplicate skill command name"):
+            SkillCarapaceConfig.model_validate(
+                {
+                    "commands": [
+                        {"name": "demo", "command": "uv run demo"},
+                        {"name": "demo", "command": "uv run demo --help"},
+                    ]
+                }
+            )
 
     def test_model_validation_rejects_duplicate_local_ports(self):
         with pytest.raises(ValueError, match="local_port 1993"):


### PR DESCRIPTION
## Summary
Add command aliases to `carapace.yaml` so active skills can expose executable shortcuts inside the sandbox.

## What changed
- add `commands` to the skill config schema with validation for alias names, duplicate names, and single-line commands
- register command shims during skill activation and sandbox recreation in a static image-level shim directory
- detect alias conflicts across active skills before activation
- auto-add the owning skill context when `exec` starts with a registered alias and warn the agent to pass the context explicitly next time
- document the new manifest field and authoring rules for skill command aliases
- add focused tests for schema validation, activation-time shim registration, alias conflicts, and exec alias resolution

## Validation
- `/Users/tgerken/Privat/Projekte/carapace/.venv/bin/python -m pytest tests/test_agent_read_skill_policy.py tests/test_proxy.py::test_activate_skill_prefers_pnpm_when_package_and_pnpm_lockfiles_exist tests/test_proxy.py::test_activate_skill_registers_command_aliases_in_image_shim_dir tests/test_proxy.py::TestCarapaceYamlParsing::test_model_validation tests/test_proxy.py::TestCarapaceYamlParsing::test_model_validation_rejects_multiline_command tests/test_proxy.py::TestCarapaceYamlParsing::test_model_validation_rejects_duplicate_command_names`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new execution entrypoints (generated shell shims) and context auto-injection behavior, which can affect how commands run and what resources are implicitly granted during `exec`.
> 
> **Overview**
> Adds a new `commands` field to `carapace.yaml` so activated skills can expose validated command aliases, with activation failing on alias conflicts across active skills.
> 
> During skill activation (and sandbox recreation), Carapace now generates executable wrapper shims under `/root/.carapace/bin` (added to the sandbox `PATH`) and, when `exec` starts with a registered alias, automatically appends the owning skill to `contexts` while emitting a warning to pass it explicitly next time.
> 
> Updates the bundled example and authoring docs to describe alias usage, and adds tests covering schema validation, shim registration, conflict detection, and exec-time alias resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69b2d8bfd19382a30011ae70818aa22ce0f1ebee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->