### PR TITLE
✨ feat: thinking budget tokens + enforce usage limits better + limit sentinel turns to 5

### DIFF
--- a/src/carapace/agent/loop.py
+++ b/src/carapace/agent/loop.py
@@ -25,6 +25,7 @@ from pydantic_ai.messages import (
     ThinkingPart,
     ThinkingPartDelta,
 )
+from pydantic_ai.usage import UsageLimits
 
 from carapace.agent.tools import create_agent
 from carapace.models import Deps
@@ -48,6 +49,7 @@ async def run_agent_turn(
     on_thinking_token: Callable[[str], Awaitable[None]] | None = None,
     on_messages_snapshot: Callable[[list[Any]], None] | None = None,
     before_llm_call: Callable[[], None] | None = None,
+    get_usage_limits: Callable[[], UsageLimits | None] | None = None,
 ) -> tuple[list[Any], str, str]:
     """Run one full agent turn, handling approval loops.
 
@@ -86,11 +88,13 @@ async def run_agent_turn(
     if before_llm_call is not None:
         before_llm_call()
     current_thinking_parts.clear()
+    usage_limits = get_usage_limits() if get_usage_limits is not None else None
     result = await agent.run(
         user_input,
         deps=deps,
         message_history=message_history or None,
         event_stream_handler=_stream_handler,
+        usage_limits=usage_limits,
     )
     last_thinking = "".join(current_thinking_parts)
     deps.usage_tracker.record(usage_model_key, "agent", result.usage())
@@ -148,11 +152,13 @@ async def run_agent_turn(
         if before_llm_call is not None:
             before_llm_call()
         current_thinking_parts.clear()
+        usage_limits = get_usage_limits() if get_usage_limits is not None else None
         result = await agent.run(
             deps=deps,
             message_history=messages,
             deferred_tool_results=deferred_results,
             event_stream_handler=_stream_handler,
+            usage_limits=usage_limits,
         )
         last_thinking = "".join(current_thinking_parts)
         deps.usage_tracker.record(usage_model_key, "agent", result.usage())

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -11,10 +11,10 @@ import httpx
 from loguru import logger
 from pydantic import Field
 from pydantic_ai import Agent, DeferredToolRequests, RunContext, ToolDenied
-from pydantic_ai.capabilities import Thinking
 
 import carapace.security as security
 from carapace.config import load_workspace_file
+from carapace.llm import model_settings_for_config
 from carapace.models import (
     ContextGrant,
     CredentialMetadata,
@@ -205,6 +205,7 @@ async def _gate(ctx: RunContext[Deps], tool_name: str, args: dict[str, Any]) -> 
             args,
             usage_tracker=ctx.deps.usage_tracker,
             assert_llm_budget_available=ctx.deps.assert_llm_budget_available,
+            usage_limits=ctx.deps.llm_usage_limits() if ctx.deps.llm_usage_limits is not None else None,
             verbose=ctx.deps.verbose,
             tool_call_callback=ctx.deps.tool_call_callback,
         )
@@ -441,21 +442,13 @@ def build_system_prompt(deps: Deps) -> str:
 def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
     system_prompt = build_system_prompt(deps)
 
-    capabilities: list[Any] = [LlmRequestLogCapability(source="agent")]
-    model_entry = next(
-        (e for e in deps.config.agent.available_models if e.model_id == deps.agent_model_id),
-        None,
-    )
-    thinking = model_entry.thinking if model_entry and model_entry.thinking is not None else True
-    if thinking is not False:
-        capabilities.append(Thinking(effort=thinking))
-
     agent: Agent[Deps, str | DeferredToolRequests] = Agent(
         deps.agent_model,
         deps_type=Deps,
         output_type=[str, DeferredToolRequests],  # type: ignore[arg-type]
         instructions=system_prompt,
-        capabilities=capabilities,
+        capabilities=[LlmRequestLogCapability(source="agent")],
+        model_settings=model_settings_for_config(deps.config, deps.agent_model_id, default_thinking=True),
         retries=1,
         output_retries=3,
     )

--- a/src/carapace/llm.py
+++ b/src/carapace/llm.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Callable
+from typing import Literal, cast
 
 from httpx import AsyncClient, HTTPStatusError, Timeout
 from pydantic_ai.models import Model, infer_model
@@ -12,9 +13,12 @@ from pydantic_ai.providers import Provider, infer_provider, infer_provider_class
 from pydantic_ai.providers.google import GoogleProvider
 from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic_ai.retries import AsyncTenacityTransport, RetryConfig, wait_retry_after
+from pydantic_ai.settings import ModelSettings
 from tenacity import retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from carapace.models import Config, agent_available_model_entries
+
+ThinkingSetting = bool | Literal["minimal", "low", "medium", "high", "xhigh"]
 
 
 def retry_http_client() -> AsyncClient:
@@ -47,14 +51,43 @@ def infer_model_with_retry_transport(model_name: str) -> Model:
     return infer_model(model_name, provider_factory=_provider_factory)
 
 
+def resolve_available_model_entry(config: Config, model_name: str):
+    entries = {e.model_id: e for e in agent_available_model_entries(config.agent)}
+    entry = entries.get(model_name)
+    if entry is None:
+        raise ValueError(f"Model {model_name!r} is not registered in agent.available_models")
+    return entry
+
+
+def model_settings_for_entry(
+    entry,
+    *,
+    default_thinking: ThinkingSetting | None = None,
+) -> ModelSettings | None:
+    settings: dict[str, object] = {}
+    thinking = entry.thinking if entry.thinking is not None else default_thinking
+    if thinking is not None:
+        settings["thinking"] = thinking
+    if entry.thinking_budget_tokens is not None:
+        settings["extra_body"] = {"thinking_budget_tokens": entry.thinking_budget_tokens}
+    return cast(ModelSettings, settings) if settings else None
+
+
+def model_settings_for_config(
+    config: Config,
+    model_name: str,
+    *,
+    default_thinking: ThinkingSetting | None = None,
+) -> ModelSettings | None:
+    entry = resolve_available_model_entry(config, model_name)
+    return model_settings_for_entry(entry, default_thinking=default_thinking)
+
+
 def make_model_factory(config: Config) -> Callable[[str], Model]:
     """Resolve registered model ids; OpenAI-compatible overrides use ``OpenAIProvider``."""
-    entries = {e.model_id: e for e in agent_available_model_entries(config.agent)}
 
     def factory(model_name: str) -> Model:
-        entry = entries.get(model_name)
-        if entry is None:
-            raise ValueError(f"Model {model_name!r} is not registered in agent.available_models")
+        entry = resolve_available_model_entry(config, model_name)
         resolved_model_name = f"{entry.provider}:{entry.name}"
         if entry.provider in ("openai", "openai-chat"):
             api_key: str | None = None

--- a/src/carapace/models.py
+++ b/src/carapace/models.py
@@ -11,6 +11,7 @@ from typing import Annotated, Any, Literal, Protocol, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_serializer, model_validator
 from pydantic_ai.models import Model
+from pydantic_ai.usage import UsageLimits
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from carapace.git.store import GitStore
@@ -210,6 +211,11 @@ class AvailableModelEntry(BaseModel):
         default=None,
         description="Enable model thinking/reasoning. true/false to toggle, or an effort level.",
     )
+    thinking_budget_tokens: int | None = Field(
+        default=None,
+        ge=0,
+        description="Optional llama.cpp reasoning budget for OpenAI-compatible rows.",
+    )
     base_url: str | None = Field(
         default=None,
         description="OpenAI-compatible API base URL (openai / openai-chat rows only).",
@@ -229,10 +235,12 @@ class AvailableModelEntry(BaseModel):
 
     @model_validator(mode="after")
     def _validate_openai_compatible_fields(self) -> AvailableModelEntry:
-        if self.base_url is None and self.api_key is None:
+        if self.base_url is None and self.api_key is None and self.thinking_budget_tokens is None:
             return self
         if self.provider not in ("openai", "openai-chat"):
-            raise ValueError("base_url/api_key are only supported for provider 'openai' or 'openai-chat'")
+            raise ValueError(
+                "base_url/api_key/thinking_budget_tokens are only supported for provider 'openai' or 'openai-chat'"
+            )
         return self
 
     @property
@@ -596,4 +604,5 @@ class Deps(BaseModel):
     append_session_events: Callable[[list[dict[str, Any]]], None] | None = None
     usage_tracker: UsageTracker
     assert_llm_budget_available: Callable[[], None] | None = None
+    llm_usage_limits: Callable[[], UsageLimits | None] | None = None
     credential_registry: CredentialRegistryProtocol

--- a/src/carapace/security/__init__.py
+++ b/src/carapace/security/__init__.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 from pydantic_ai import ApprovalRequired
+from pydantic_ai.usage import UsageLimits
 
 from carapace.security.context import (
     ActionLogEntry as ActionLogEntry,
@@ -46,6 +47,7 @@ async def evaluate_with(
     *,
     usage_tracker: UsageTracker | None = None,
     assert_llm_budget_available: Callable[[], None] | None = None,
+    usage_limits: UsageLimits | None = None,
     verbose: bool = True,
     tool_call_callback: Any = None,
 ) -> None:
@@ -91,6 +93,7 @@ async def evaluate_with(
         args,
         usage_tracker=usage_tracker,
         assert_llm_budget_available=assert_llm_budget_available,
+        usage_limits=usage_limits,
     )
 
     decision_str = _verdict_to_decision(verdict)
@@ -161,6 +164,7 @@ async def evaluate_domain_with(
     *,
     usage_tracker: UsageTracker | None = None,
     assert_llm_budget_available: Callable[[], None] | None = None,
+    usage_limits: UsageLimits | None = None,
 ) -> bool:
     """Evaluate a proxy domain request. Returns True to allow, False to deny.
 
@@ -175,6 +179,7 @@ async def evaluate_domain_with(
         command,
         usage_tracker=usage_tracker,
         assert_llm_budget_available=assert_llm_budget_available,
+        usage_limits=usage_limits,
     )
 
     allowed: bool
@@ -232,6 +237,7 @@ async def evaluate_push_with(
     *,
     usage_tracker: UsageTracker | None = None,
     assert_llm_budget_available: Callable[[], None] | None = None,
+    usage_limits: UsageLimits | None = None,
 ) -> bool:
     """Evaluate a Git push. Returns True to allow, False to deny.
 
@@ -247,6 +253,7 @@ async def evaluate_push_with(
         diff,
         usage_tracker=usage_tracker,
         assert_llm_budget_available=assert_llm_budget_available,
+        usage_limits=usage_limits,
     )
 
     decision = _verdict_to_decision(verdict)
@@ -328,6 +335,7 @@ async def evaluate_credential_with(
     *,
     usage_tracker: UsageTracker | None = None,
     assert_llm_budget_available: Callable[[], None] | None = None,
+    usage_limits: UsageLimits | None = None,
 ) -> CredentialAccessEvaluation:
     """Evaluate a credential access request.
 
@@ -345,6 +353,7 @@ async def evaluate_credential_with(
         trigger,
         usage_tracker=usage_tracker,
         assert_llm_budget_available=assert_llm_budget_available,
+        usage_limits=usage_limits,
     )
 
     decision = _verdict_to_decision(verdict)

--- a/src/carapace/security/__init__.py
+++ b/src/carapace/security/__init__.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 from pydantic_ai import ApprovalRequired
+from pydantic_ai.exceptions import UsageLimitExceeded
 from pydantic_ai.usage import UsageLimits
 
 from carapace.security.context import (
@@ -87,14 +88,24 @@ async def evaluate_with(
             approval_source="sentinel",
         )
 
-    verdict = await sentinel.evaluate_tool_call(
-        session,
-        tool_name,
-        args,
-        usage_tracker=usage_tracker,
-        assert_llm_budget_available=assert_llm_budget_available,
-        usage_limits=usage_limits,
-    )
+    try:
+        verdict = await sentinel.evaluate_tool_call(
+            session,
+            tool_name,
+            args,
+            usage_tracker=usage_tracker,
+            assert_llm_budget_available=assert_llm_budget_available,
+            usage_limits=usage_limits,
+        )
+    except UsageLimitExceeded:
+        verdict = SentinelVerdict(
+            decision="escalate",
+            explanation=(
+                "Automatic sentinel review hit its internal request limit and could not finish. "
+                "Please approve or deny this tool call manually."
+            ),
+            risk_level="high",
+        )
 
     decision_str = _verdict_to_decision(verdict)
 

--- a/src/carapace/security/sentinel.py
+++ b/src/carapace/security/sentinel.py
@@ -9,6 +9,8 @@ from typing import Any
 from loguru import logger
 from pydantic_ai import Agent, RunContext, ToolOutput
 from pydantic_ai.models import Model, infer_model
+from pydantic_ai.settings import ModelSettings
+from pydantic_ai.usage import UsageLimits
 
 from carapace.security.context import (
     ActionLogEntry,
@@ -135,12 +137,14 @@ class Sentinel:
         skills_dir: Path,
         reset_threshold: int = _RESET_THRESHOLD_DEFAULT,
         model_factory: Callable[[str], Model] | None = None,
+        model_settings_resolver: Callable[[str], ModelSettings | None] | None = None,
     ) -> None:
         self._model = model
         self._knowledge_dir = knowledge_dir
         self._skills_dir = skills_dir
         self._reset_threshold = reset_threshold
         self._model_factory = model_factory
+        self._model_settings_resolver = model_settings_resolver
         self._agent = self._create_agent()
         self._message_history: list[Any] = []
         self._skill_file_cache: dict[tuple[str, str], tuple[int, int, str]] = {}
@@ -296,6 +300,7 @@ class Sentinel:
         new_entries_count: int,
         usage_tracker: UsageTracker | None = None,
         assert_llm_budget_available: Callable[[], None] | None = None,
+        usage_limits: UsageLimits | None = None,
     ) -> SentinelVerdict:
         eval_no = session.sentinel_eval_count + 1
         logger.info(
@@ -311,6 +316,7 @@ class Sentinel:
                 prompt,
                 deps=self._skills_dir,
                 message_history=self._message_history or None,
+                usage_limits=usage_limits,
             )
         except Exception as exc:
             stats = self._end_eval_logging()
@@ -338,13 +344,17 @@ class Sentinel:
 
     def _create_agent(self) -> Agent[Path, SentinelVerdict]:
         resolved = self._model_factory(self._model) if self._model_factory is not None else infer_model(self._model)
+        model_settings = (
+            self._model_settings_resolver(self._model) if self._model_settings_resolver is not None else None
+        )
         agent: Agent[Path, SentinelVerdict] = Agent(
             resolved,
             deps_type=Path,
             output_type=ToolOutput(SentinelVerdict, name="judge"),
             instructions=self._load_system_prompt,
             capabilities=[LlmRequestLogCapability(source="sentinel")],
-            output_retries=3,
+            model_settings=model_settings,
+            output_retries=2,
             retries=1,
         )
 
@@ -401,6 +411,7 @@ class Sentinel:
         *,
         usage_tracker: UsageTracker | None = None,
         assert_llm_budget_available: Callable[[], None] | None = None,
+        usage_limits: UsageLimits | None = None,
     ) -> SentinelVerdict:
         async with self._lock:
             if self._should_reset(session):
@@ -430,6 +441,7 @@ class Sentinel:
                 new_entries_count=len(new_entries),
                 usage_tracker=usage_tracker,
                 assert_llm_budget_available=assert_llm_budget_available,
+                usage_limits=usage_limits,
             )
 
     async def evaluate_domain_access(
@@ -440,6 +452,7 @@ class Sentinel:
         *,
         usage_tracker: UsageTracker | None = None,
         assert_llm_budget_available: Callable[[], None] | None = None,
+        usage_limits: UsageLimits | None = None,
     ) -> SentinelVerdict:
         async with self._lock:
             if self._should_reset(session):
@@ -466,6 +479,7 @@ class Sentinel:
                 new_entries_count=len(new_entries),
                 usage_tracker=usage_tracker,
                 assert_llm_budget_available=assert_llm_budget_available,
+                usage_limits=usage_limits,
             )
 
     async def evaluate_credential_access(
@@ -478,6 +492,7 @@ class Sentinel:
         *,
         usage_tracker: UsageTracker | None = None,
         assert_llm_budget_available: Callable[[], None] | None = None,
+        usage_limits: UsageLimits | None = None,
     ) -> SentinelVerdict:
         async with self._lock:
             if self._should_reset(session):
@@ -507,6 +522,7 @@ class Sentinel:
                 new_entries_count=len(new_entries),
                 usage_tracker=usage_tracker,
                 assert_llm_budget_available=assert_llm_budget_available,
+                usage_limits=usage_limits,
             )
 
     def _should_reset(self, session: SessionSecurity) -> bool:
@@ -533,6 +549,7 @@ class Sentinel:
         *,
         usage_tracker: UsageTracker | None = None,
         assert_llm_budget_available: Callable[[], None] | None = None,
+        usage_limits: UsageLimits | None = None,
     ) -> SentinelVerdict:
         """Evaluate a Git push from the pre-receive hook."""
         async with self._lock:
@@ -567,4 +584,5 @@ class Sentinel:
                 new_entries_count=len(new_entries),
                 usage_tracker=usage_tracker,
                 assert_llm_budget_available=assert_llm_budget_available,
+                usage_limits=usage_limits,
             )

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -32,6 +32,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from genai_prices import UpdatePrices
 from loguru import logger
 from pydantic import BaseModel, model_validator
+from pydantic_ai.exceptions import UsageLimitExceeded
 
 from carapace.auth import get_token
 from carapace.bootstrap import ensure_data_dir, ensure_knowledge_dir
@@ -1279,8 +1280,11 @@ async def evaluate_push(req: PushEvalRequest) -> dict[str, str]:
                 req.diff,
                 usage_tracker=active.usage_tracker,
                 assert_llm_budget_available=lambda: _engine._assert_llm_budget_available(active),
+                usage_limits=_engine._remaining_aux_usage_limits(active),
             )
         except SessionBudgetExceededError as exc:
+            return {"verdict": "deny", "reason": str(exc)}
+        except UsageLimitExceeded as exc:
             return {"verdict": "deny", "reason": str(exc)}
     if allowed:
         return {"verdict": "allow"}
@@ -1433,8 +1437,11 @@ async def fetch_credential(request: Request, vault_path: str) -> Response:
                     f"Sandbox requested credential: {meta.name}",
                     usage_tracker=active.usage_tracker,
                     assert_llm_budget_available=lambda: _engine._assert_llm_budget_available(active),
+                    usage_limits=_engine._remaining_aux_usage_limits(active),
                 )
             except SessionBudgetExceededError as exc:
+                return Response(status_code=403, content=str(exc))
+            except UsageLimitExceeded as exc:
                 return Response(status_code=403, content=str(exc))
         if not cred_eval.allowed:
             return Response(status_code=403, content="Credential access denied")

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -394,7 +394,7 @@ class SessionEngine:
         return usage_limits_for_remaining_budget(
             active.usage_tracker,
             output_tokens_limit=active.state.budget.output_tokens,
-            request_limit=5,
+            request_limit=10,
         )
 
     def _turn_usage_payload(self, active: ActiveSession) -> TurnUsage | None:

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -1605,18 +1605,19 @@ class SessionEngine:
         session_id = active.state.session_id
         try:
             async with self._llm_semaphore:
-                self._assert_llm_budget_available(active)
-                title = await generate_title(
-                    events,
-                    model=active.title_model_name or self._config.agent.title_model,
-                    usage_tracker=active.usage_tracker,
-                    before_llm_call=lambda: self._assert_llm_budget_available(active),
-                    model_factory=self._model_factory,
-                    model_settings=self._resolve_model_settings(
-                        active.title_model_name or self._config.agent.title_model
-                    ),
-                    usage_limits=self._remaining_aux_usage_limits(active),
-                )
+                with self.llm_request_recording(active):
+                    self._assert_llm_budget_available(active)
+                    title = await generate_title(
+                        events,
+                        model=active.title_model_name or self._config.agent.title_model,
+                        usage_tracker=active.usage_tracker,
+                        before_llm_call=lambda: self._assert_llm_budget_available(active),
+                        model_factory=self._model_factory,
+                        model_settings=self._resolve_model_settings(
+                            active.title_model_name or self._config.agent.title_model
+                        ),
+                        usage_limits=self._remaining_aux_usage_limits(active),
+                    )
             if title:
                 active.state.title = title
                 self._session_mgr.save_state(active.state)

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -28,10 +28,13 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 from pydantic_ai.models import Model, infer_model
+from pydantic_ai.settings import ModelSettings
+from pydantic_ai.usage import UsageLimits
 
 import carapace.security as security_mod
 from carapace.agent.loop import run_agent_turn
 from carapace.git.store import GitStore
+from carapace.llm import model_settings_for_config
 from carapace.memory import MemoryStore
 from carapace.models import (
     AvailableModelEntry,
@@ -76,6 +79,7 @@ from carapace.usage import (
     usage_budget_exceeded_error,
     usage_budget_gauges,
     usage_last_request_row,
+    usage_limits_for_remaining_budget,
 )
 from carapace.ws_models import (
     SLASH_COMMANDS,
@@ -380,6 +384,19 @@ class SessionEngine:
         if error is not None:
             raise error
 
+    def _remaining_usage_limits(self, active: ActiveSession) -> UsageLimits | None:
+        return usage_limits_for_remaining_budget(
+            active.usage_tracker,
+            output_tokens_limit=active.state.budget.output_tokens,
+        )
+
+    def _remaining_aux_usage_limits(self, active: ActiveSession) -> UsageLimits | None:
+        return usage_limits_for_remaining_budget(
+            active.usage_tracker,
+            output_tokens_limit=active.state.budget.output_tokens,
+            request_limit=5,
+        )
+
     def _turn_usage_payload(self, active: ActiveSession) -> TurnUsage | None:
         rec_agent = last_record_for_source(active.llm_request_log, "agent")
         budget_gauges = self._budget_gauges(active)
@@ -512,6 +529,10 @@ class SessionEngine:
         """Create a Model from a name, using the model_factory if available."""
         return self._model_factory(name) if self._model_factory else infer_model(name)
 
+    def _resolve_model_settings(self, name: str) -> ModelSettings | None:
+        """Build per-model request settings from the configured catalog."""
+        return model_settings_for_config(self._config, name, default_thinking=True)
+
     # -- session lifecycle --
 
     def _ensure_active(self, session_id: str) -> ActiveSession:
@@ -530,6 +551,7 @@ class SessionEngine:
             knowledge_dir=self._knowledge_dir,
             skills_dir=self._knowledge_dir / "skills",
             model_factory=self._model_factory,
+            model_settings_resolver=self._resolve_model_settings,
         )
         usage_tracker = self._session_mgr.load_usage(session_id)
         llm_log = self._session_mgr.load_llm_request_log(session_id)
@@ -762,6 +784,7 @@ class SessionEngine:
             append_session_events=_append_session_events,
             usage_tracker=active.usage_tracker,
             assert_llm_budget_available=lambda: self._assert_llm_budget_available(active),
+            llm_usage_limits=lambda: self._remaining_aux_usage_limits(active),
             sandbox=self._sandbox_mgr,
             activated_skills=[],
             credential_registry=self._credential_registry,
@@ -1393,6 +1416,7 @@ class SessionEngine:
                             on_thinking_token=_on_thinking_token,
                             on_messages_snapshot=lambda snapshot: _set_latest_messages(snapshot),
                             before_llm_call=lambda: self._assert_llm_budget_available(active),
+                            get_usage_limits=lambda: self._remaining_usage_limits(active),
                         )
 
                 self._session_mgr.save_history(session_id, messages)
@@ -1588,6 +1612,10 @@ class SessionEngine:
                     usage_tracker=active.usage_tracker,
                     before_llm_call=lambda: self._assert_llm_budget_available(active),
                     model_factory=self._model_factory,
+                    model_settings=self._resolve_model_settings(
+                        active.title_model_name or self._config.agent.title_model
+                    ),
+                    usage_limits=self._remaining_aux_usage_limits(active),
                 )
             if title:
                 active.state.title = title
@@ -1918,9 +1946,13 @@ class SessionEngine:
                         command,
                         usage_tracker=active.usage_tracker,
                         assert_llm_budget_available=lambda: self._assert_llm_budget_available(active),
+                        usage_limits=self._remaining_aux_usage_limits(active),
                     )
                 except SessionBudgetExceededError as exc:
                     logger.info(f"Session budget blocked domain evaluation for {active.state.session_id}: {exc}")
+                    return False
+                except UsageLimitExceeded as exc:
+                    logger.info(f"Usage limits blocked domain evaluation for {active.state.session_id}: {exc}")
                     return False
 
         return _eval

--- a/src/carapace/session/titler.py
+++ b/src/carapace/session/titler.py
@@ -8,8 +8,10 @@ from typing import Any
 from loguru import logger
 from pydantic_ai import Agent
 from pydantic_ai.models import Model, infer_model
+from pydantic_ai.settings import ModelSettings
+from pydantic_ai.usage import UsageLimits
 
-from carapace.usage import UsageTracker
+from carapace.usage import LlmRequestLogCapability, UsageTracker
 
 _SYSTEM_PROMPT = """\
 Generate a very short title (3-8 words) for a chat conversation.
@@ -26,6 +28,8 @@ async def generate_title(
     usage_tracker: UsageTracker | None = None,
     before_llm_call: Callable[[], None] | None = None,
     model_factory: Callable[[str], Model] | None = None,
+    model_settings: ModelSettings | None = None,
+    usage_limits: UsageLimits | None = None,
 ) -> str:
     """Build a short emoji-prefixed title from conversation events.
 
@@ -55,11 +59,19 @@ async def generate_title(
     prompt = "\n".join(lines)[:2000]
 
     resolved = model_factory(model) if model_factory is not None else infer_model(model)
-    agent: Agent[None, str] = Agent(resolved, output_type=str, instructions=_SYSTEM_PROMPT, retries=1, output_retries=3)
+    agent: Agent[None, str] = Agent(
+        resolved,
+        output_type=str,
+        instructions=_SYSTEM_PROMPT,
+        model_settings=model_settings,
+        capabilities=[LlmRequestLogCapability(source="titler")],
+        retries=1,
+        output_retries=2,
+    )
     try:
         if before_llm_call is not None:
             before_llm_call()
-        result = await agent.run(prompt)
+        result = await agent.run(prompt, usage_limits=usage_limits)
         if usage_tracker:
             usage_tracker.record(model, "title", result.usage())
         return result.output.strip()

--- a/src/carapace/usage.py
+++ b/src/carapace/usage.py
@@ -34,7 +34,7 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models import ModelRequestContext
 from pydantic_ai.tools import AgentDepsT, RunContext
-from pydantic_ai.usage import RunUsage
+from pydantic_ai.usage import RunUsage, UsageLimits
 
 
 class ModelUsage(BaseModel):
@@ -251,7 +251,22 @@ def usage_budget_exceeded_error(
     )
 
 
-LlmSource = Literal["agent", "sentinel"]
+def usage_limits_for_remaining_budget(
+    tracker: UsageTracker,
+    *,
+    output_tokens_limit: int | None = None,
+    request_limit: int | None = None,
+) -> UsageLimits | None:
+    """Translate the remaining session output budget into PydanticAI usage limits."""
+
+    if output_tokens_limit is None and request_limit is None:
+        return None
+
+    remaining_output = None if output_tokens_limit is None else max(0, output_tokens_limit - tracker.total_output)
+    return UsageLimits(output_tokens_limit=remaining_output, request_limit=request_limit)
+
+
+LlmSource = Literal["agent", "sentinel", "titler"]
 LlmRequestPhase = Literal["processing_prompt", "thinking", "generating"]
 
 _llm_request_sink: ContextVar[LlmRequestObserver | None] = ContextVar(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -263,6 +263,31 @@ def test_model_settings_for_config_defaults_thinking_when_unset():
     assert settings == {"thinking": True}
 
 
+def test_model_settings_for_config_preserves_explicit_thinking_false():
+    cfg = Config.model_validate(
+        {
+            "agent": {
+                "model": "local:qwen",
+                "sentinel_model": "local:qwen",
+                "title_model": "local:qwen",
+                "available_models": [
+                    {
+                        "provider": "openai",
+                        "name": "qwen/qwen3-32b",
+                        "id": "local:qwen",
+                        "base_url": "http://llm/v1",
+                        "thinking": False,
+                    }
+                ],
+            }
+        }
+    )
+
+    settings = model_settings_for_config(cfg, "local:qwen", default_thinking=True)
+
+    assert settings == {"thinking": False}
+
+
 def test_agent_config_mixed_available_models():
     ac = AgentConfig.model_validate(
         {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,7 +7,7 @@ import pytest
 from pydantic import ValidationError
 from pydantic_ai.models.openai import OpenAIChatModel
 
-from carapace.llm import make_model_factory
+from carapace.llm import make_model_factory, model_settings_for_config
 from carapace.models import (
     AgentConfig,
     AvailableModelEntry,
@@ -100,6 +100,13 @@ def test_available_model_entry_rejects_api_key_for_non_openai_provider():
     with pytest.raises(ValidationError):
         AvailableModelEntry.model_validate(
             {"provider": "google-gla", "name": "gemini-2.5-pro", "api_key": {"raw": "secret"}}
+        )
+
+
+def test_available_model_entry_rejects_thinking_budget_tokens_for_non_openai_provider():
+    with pytest.raises(ValidationError):
+        AvailableModelEntry.model_validate(
+            {"provider": "anthropic", "name": "claude-opus-4-6", "thinking_budget_tokens": 2048}
         )
 
 
@@ -201,6 +208,59 @@ def test_make_model_factory_resolves_registered_alias(monkeypatch: pytest.Monkey
     factory = make_model_factory(cfg)
     _ = factory("alias:opus")
     assert seen == ["anthropic:claude-opus-4-6"]
+
+
+def test_model_settings_for_config_uses_thinking_and_budget():
+    cfg = Config.model_validate(
+        {
+            "agent": {
+                "model": "local:qwen",
+                "sentinel_model": "local:qwen",
+                "title_model": "local:qwen",
+                "available_models": [
+                    {
+                        "provider": "openai",
+                        "name": "qwen/qwen3-32b",
+                        "id": "local:qwen",
+                        "base_url": "http://llm/v1",
+                        "thinking": "low",
+                        "thinking_budget_tokens": 2048,
+                    }
+                ],
+            }
+        }
+    )
+
+    settings = model_settings_for_config(cfg, "local:qwen", default_thinking=True)
+
+    assert settings == {
+        "thinking": "low",
+        "extra_body": {"thinking_budget_tokens": 2048},
+    }
+
+
+def test_model_settings_for_config_defaults_thinking_when_unset():
+    cfg = Config.model_validate(
+        {
+            "agent": {
+                "model": "local:qwen",
+                "sentinel_model": "local:qwen",
+                "title_model": "local:qwen",
+                "available_models": [
+                    {
+                        "provider": "openai",
+                        "name": "qwen/qwen3-32b",
+                        "id": "local:qwen",
+                        "base_url": "http://llm/v1",
+                    }
+                ],
+            }
+        }
+    )
+
+    settings = model_settings_for_config(cfg, "local:qwen", default_thinking=True)
+
+    assert settings == {"thinking": True}
 
 
 def test_agent_config_mixed_available_models():

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -10,10 +10,13 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic_ai import ApprovalRequired
+from pydantic_ai.exceptions import UsageLimitExceeded
 from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, ToolCallPart, ToolReturnPart, UserPromptPart
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.usage import RunUsage
 
+import carapace.security as security_mod
 import carapace.usage as usage_mod
 from carapace.bootstrap import ensure_data_dir
 from carapace.config import load_config
@@ -28,7 +31,14 @@ from carapace.models import (
 )
 from carapace.sandbox.manager import SandboxManager
 from carapace.sandbox.state import SessionSandboxSnapshot
-from carapace.security.context import UserEscalationDecision, format_denial_message, normalize_optional_message
+from carapace.security.context import (
+    SentinelVerdict,
+    SessionSecurity,
+    ToolCallEntry,
+    UserEscalationDecision,
+    format_denial_message,
+    normalize_optional_message,
+)
 from carapace.security.sentinel import Sentinel
 from carapace.session import SessionEngine, SessionManager
 from carapace.session.engine import _non_slash_user_message_count
@@ -1176,6 +1186,40 @@ def test_submit_message_budget_exceeded_persists_history(tmp_path: Path):
 
     with _patch_sentinel():
         asyncio.run(_run())
+
+
+def test_evaluate_with_usage_limit_exceeded_escalates_to_user(tmp_path: Path):
+    async def _run() -> None:
+        session = SessionSecurity("test-session", audit_dir=tmp_path)
+        sentinel = MagicMock(spec=Sentinel)
+        sentinel.evaluate_tool_call = AsyncMock(
+            side_effect=UsageLimitExceeded("The next request would exceed the request_limit of 5")
+        )
+
+        with pytest.raises(ApprovalRequired) as exc_info:
+            await security_mod.evaluate_with(
+                session,
+                sentinel,
+                "use_skill",
+                {"skill_name": "paperless"},
+            )
+
+        metadata = exc_info.value.metadata
+        assert metadata["tool"] == "use_skill"
+        assert metadata["args"] == {"skill_name": "paperless"}
+        assert metadata["risk_level"] == "high"
+        assert isinstance(metadata["sentinel_verdict"], SentinelVerdict)
+        assert metadata["sentinel_verdict"].decision == "escalate"
+        assert "request limit" in metadata["explanation"].lower()
+
+        entry = session.action_log[-1]
+        assert isinstance(entry, ToolCallEntry)
+        assert entry.decision == "escalated"
+        assert entry.tool == "use_skill"
+        assert entry.explanation is not None
+        assert "request limit" in entry.explanation.lower()
+
+    asyncio.run(_run())
 
 
 def test_generate_title_skips_when_budget_exhausted(tmp_path: Path):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1227,6 +1227,52 @@ def test_generate_title_persists_usage_and_broadcasts_usage(tmp_path: Path):
         asyncio.run(_run())
 
 
+def test_generate_title_records_titler_request_log(tmp_path: Path):
+    async def _run() -> None:
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session()
+        sid = state.session_id
+        active = engine.get_or_activate(sid)
+        started_at = datetime.now(tz=UTC)
+
+        async def _fake_generate_title(*_args: Any, **_kwargs: Any) -> str:
+            observer = usage_mod._llm_request_sink.get()
+            assert observer is not None
+
+            request_state = LlmRequestState(
+                request_id="req-title",
+                source="titler",
+                model_name="anthropic:claude-haiku-4-5",
+                started_at=started_at,
+            )
+            record = LlmRequestRecord(
+                ts=started_at + timedelta(seconds=1),
+                request_id="req-title",
+                source="titler",
+                model_name="anthropic:claude-haiku-4-5",
+                started_at=started_at,
+                completed_at=started_at + timedelta(seconds=1),
+            )
+
+            await observer.on_request_started(request_state)
+            await observer.on_request_completed(record)
+            return "📌 hello"
+
+        with patch("carapace.session.engine.generate_title", new=AsyncMock(side_effect=_fake_generate_title)):
+            title = await engine._generate_title(active, [{"role": "user", "content": "hello"}])
+
+        assert title == "📌 hello"
+        assert active.llm_request_log.records[-1].request_id == "req-title"
+        assert active.llm_request_log.records[-1].source == "titler"
+
+        stored_log = engine.session_mgr.load_llm_request_log(sid)
+        assert stored_log.records[-1].request_id == "req-title"
+        assert stored_log.records[-1].source == "titler"
+
+    with _patch_sentinel():
+        asyncio.run(_run())
+
+
 def test_handle_slash_command_inactive_session(tmp_path: Path):
     """handle_slash_command returns None for a session that isn't active."""
     engine = _make_engine(tmp_path)

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -4,7 +4,12 @@ from decimal import Decimal
 
 from pydantic_ai.usage import RunUsage
 
-from carapace.usage import UsageTracker, usage_budget_exceeded_error, usage_budget_gauges
+from carapace.usage import (
+    UsageTracker,
+    usage_budget_exceeded_error,
+    usage_budget_gauges,
+    usage_limits_for_remaining_budget,
+)
 
 
 def test_record_accumulates_tokens_across_events() -> None:
@@ -103,3 +108,50 @@ def test_usage_budget_exceeded_error_treats_unknown_cost_pricing_as_zero() -> No
     )
     assert gauges[0].current_value == "$0.0000"
     assert gauges[0].current_amount == 0.0
+
+
+def test_usage_limits_for_remaining_budget_uses_remaining_output_tokens() -> None:
+    tracker = UsageTracker()
+    tracker.record(
+        "anthropic:claude-haiku-4-5",
+        "agent",
+        RunUsage(input_tokens=100, output_tokens=250, requests=1),
+    )
+
+    limits = usage_limits_for_remaining_budget(tracker, output_tokens_limit=500)
+
+    assert limits is not None
+    assert limits.output_tokens_limit == 250
+
+
+def test_usage_limits_for_remaining_budget_can_include_request_limit() -> None:
+    tracker = UsageTracker()
+
+    limits = usage_limits_for_remaining_budget(tracker, request_limit=5)
+
+    assert limits is not None
+    assert limits.request_limit == 5
+    assert limits.output_tokens_limit is None
+
+
+def test_usage_limits_for_remaining_budget_combines_output_and_request_limits() -> None:
+    tracker = UsageTracker()
+    tracker.record(
+        "anthropic:claude-haiku-4-5",
+        "agent",
+        RunUsage(input_tokens=100, output_tokens=250, requests=1),
+    )
+
+    limits = usage_limits_for_remaining_budget(tracker, output_tokens_limit=500, request_limit=5)
+
+    assert limits is not None
+    assert limits.output_tokens_limit == 250
+    assert limits.request_limit == 5
+
+
+def test_usage_limits_for_remaining_budget_returns_none_without_output_limit() -> None:
+    tracker = UsageTracker()
+
+    limits = usage_limits_for_remaining_budget(tracker)
+
+    assert limits is None


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches request configuration and enforcement paths for the agent, sentinel, and sandbox-facing security checks, which could change when/why tool calls and evaluations are blocked or escalated. Failures here may manifest as unexpected denials/escalations or incomplete sentinel reviews under tight budgets.
> 
> **Overview**
> Adds config-driven `ModelSettings` resolution (including new `thinking_budget_tokens`) and wires it into agent, sentinel, and title-generation LLM calls so per-model *thinking* behavior is consistently applied.
> 
> Introduces PydanticAI `UsageLimits` plumbing end-to-end: remaining session budget is translated into per-call limits, enforced during `agent.run()` and sentinel evaluations, and auxiliary calls (sentinel, titler, credential/push/domain checks) are capped with a request limit to prevent runaway sentinel loops.
> 
> Improves resilience when limits are hit: sentinel `UsageLimitExceeded` now escalates tool calls for manual approval, and server endpoints return explicit deny/403 responses on usage-limit failures; LLM request logging also now records `titler` activity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be7a2dd2102ca9756108cc3b35a7ca52759287a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->