### PR TITLE
✨ feat: retry+reset for chat history

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@
 - [ ] image input ([plan](docs/plans/images.md))
 - [ ] image output — agent tools producing images (screenshots, charts, renders)
 - [ ] custom sentinel instructions for skills, e.g. moneydb: make sure that the agent only does mutations based on user approval
-- [ ] conversation history niceties (retry message, fork session, ...)
+- [ ] conversation history: fork session
 - [ ] "daily" session that is recreated every day and that should persist some of its memories during the night
 
 ## Knowledge Repo Handling

--- a/docs/websocket-session.md
+++ b/docs/websocket-session.md
@@ -63,7 +63,7 @@ Each message is one JSON object with a `type` field.
 | `git_push_approval_request`      | Sentinel escalated **git push**                     | `request_id`, `ref`, `explanation`, `changed_files`                                              |
 | `credential_approval_request`    | Sentinel escalated **credential** access            | `request_id`, `vault_paths`, `names`, `descriptions`, optional `skill_name`, `explanation`       |
 | `done`                           | Agent turn finished                                 | `content` (final assistant text), optional `usage`                                               |
-| `command_result`                 | Slash command or `/verbose` handled                 | `command`, `data` (arbitrary)                                                                    |
+| `command_result`                 | Slash command, `/verbose`, or reset ack handled     | `command`, `data` (arbitrary)                                                                    |
 | `error`                          | Parse error, unknown command, busy agent, etc.      | `detail`                                                                                         |
 | `cancelled`                      | Turn cancelled after `cancel`                       | `detail` (default explains cancellation)                                                         |
 | `session_title`                  | Title changed                                       | `title`                                                                                          |

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -674,6 +674,7 @@ export function ChatView({
   const isAtBottomRef = useRef(true);
   const lastThinkingStartedAtRef = useRef<string | null>(null);
   const queueRef = useRef<string | null>(null);
+  const resetRollbackRef = useRef<ChatMessage[] | null>(null);
   const sendRef = useRef<(msg: ClientMessage) => void>(() => {});
   const onSandboxUpdateRef = useRef(onSandboxUpdate);
   const sandboxRef = useRef(sandbox);
@@ -832,6 +833,7 @@ export function ChatView({
     (msg: ServerMessage) => {
       switch (msg.type) {
         case "done":
+          resetRollbackRef.current = null;
           setMessages((prev) => {
             const updated = [...prev];
             const thinkingMeta = thinkingUsageMeta(msg.usage);
@@ -1030,6 +1032,7 @@ export function ChatView({
           ]);
           break;
         case "command_result":
+          resetRollbackRef.current = null;
           setMessages((prev) => [
             ...prev,
             { kind: "command", command: msg.command, data: msg.data },
@@ -1039,15 +1042,26 @@ export function ChatView({
           finishWaiting();
           break;
         case "error":
-          setMessages((prev) => [
-            ...prev,
-            { kind: "error", detail: msg.detail, turnTerminal: msg.turn_terminal === true },
-          ]);
+          setMessages((prev) => {
+            const rollback = resetRollbackRef.current;
+            resetRollbackRef.current = null;
+            if (rollback !== null) {
+              return [
+                ...rollback,
+                { kind: "error", detail: msg.detail, turnTerminal: msg.turn_terminal === true },
+              ];
+            }
+            return [
+              ...prev,
+              { kind: "error", detail: msg.detail, turnTerminal: msg.turn_terminal === true },
+            ];
+          });
           setLlmActivity(null);
           lastThinkingStartedAtRef.current = null;
           finishWaiting();
           break;
         case "cancelled":
+          resetRollbackRef.current = null;
           setMessages((prev) => [
             ...prev,
             { kind: "error", detail: msg.detail, turnTerminal: true },
@@ -1079,6 +1093,7 @@ export function ChatView({
           }
           break;
         case "user_message":
+          resetRollbackRef.current = null;
           // Slash commands end with command_result (no agent); echo must not re-arm waiting
           // after command_result cleared it (message order / batching).
           if (!msg.content.startsWith("/")) {
@@ -1168,6 +1183,7 @@ export function ChatView({
   }, []);
 
   function handleSend(content: string) {
+    resetRollbackRef.current = null;
     if (waiting) {
       queueRef.current = content;
       setQueuedMessage(content);
@@ -1180,6 +1196,7 @@ export function ChatView({
   }
 
   function handleInterrupt(content: string) {
+    resetRollbackRef.current = null;
     queueRef.current = content;
     setQueuedMessage(content);
     send({ type: "cancel" });
@@ -1187,11 +1204,15 @@ export function ChatView({
 
   function handleRetry() {
     if (waiting || status !== "connected") return;
+    const startIndex = latestCompletedTurnStartMessageIndex(messages);
+    if (startIndex >= messages.length) return;
+
+    resetRollbackRef.current = null;
     queueRef.current = null;
     setQueuedMessage(null);
     lastThinkingStartedAtRef.current = null;
     setLlmActivity(null);
-    setMessages((prev) => prev.slice(0, latestCompletedTurnStartMessageIndex(prev)));
+    setMessages((prev) => prev.slice(0, startIndex));
     setWaiting(true);
     send({ type: "retry_latest_turn" });
   }
@@ -1226,6 +1247,7 @@ export function ChatView({
         return;
       }
 
+      resetRollbackRef.current = currentMessages;
       send({ type: "reset_to_turn", event_index: targetEventIndex });
       setMessages((prev) => prev.slice(0, messageIndex + 1));
     } finally {

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -1034,7 +1034,7 @@ export function ChatView({
         case "error":
           setMessages((prev) => [
             ...prev,
-            { kind: "error", detail: msg.detail, turnTerminal: true },
+            { kind: "error", detail: msg.detail, turnTerminal: msg.turn_terminal === true },
           ]);
           setLlmActivity(null);
           lastThinkingStartedAtRef.current = null;

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -1033,6 +1033,9 @@ export function ChatView({
           break;
         case "command_result":
           resetRollbackRef.current = null;
+          if (msg.command === "reset_to_turn") {
+            break;
+          }
           setMessages((prev) => [
             ...prev,
             { kind: "command", command: msg.command, data: msg.data },

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -1152,6 +1152,7 @@ export function ChatView({
   );
 
   const onWsDisconnect = useCallback(() => {
+    resetRollbackRef.current = null;
     queueRef.current = null;
     lastThinkingStartedAtRef.current = null;
     setQueuedMessage(null);

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -356,12 +356,19 @@ function completedTurnMessageIndices(messages: ChatMessage[]): number[] {
   return messages.flatMap((message, index) => (isTurnTerminalMessage(message) ? [index] : []));
 }
 
-function latestTurnStartMessageIndex(messages: ChatMessage[]): number {
-  for (let index = messages.length - 1; index >= 0; index--) {
-    if (messages[index].kind === "user") {
+function latestCompletedTurnStartMessageIndex(messages: ChatMessage[]): number {
+  const latestTerminalIndex = completedTurnMessageIndices(messages).at(-1);
+  if (latestTerminalIndex == null) {
+    return messages.length;
+  }
+
+  for (let index = latestTerminalIndex; index >= 0; index--) {
+    const message = messages[index];
+    if (message.kind === "user" && !message.content.startsWith("/")) {
       return index;
     }
   }
+
   return messages.length;
 }
 
@@ -1184,7 +1191,7 @@ export function ChatView({
     setQueuedMessage(null);
     lastThinkingStartedAtRef.current = null;
     setLlmActivity(null);
-    setMessages((prev) => prev.slice(0, latestTurnStartMessageIndex(prev)));
+    setMessages((prev) => prev.slice(0, latestCompletedTurnStartMessageIndex(prev)));
     setWaiting(true);
     send({ type: "retry_latest_turn" });
   }

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -1204,10 +1204,11 @@ export function ChatView({
 
   function handleRetry() {
     if (waiting || status !== "connected") return;
+    const currentMessages = messages;
     const startIndex = latestCompletedTurnStartMessageIndex(messages);
     if (startIndex >= messages.length) return;
 
-    resetRollbackRef.current = null;
+    resetRollbackRef.current = currentMessages;
     queueRef.current = null;
     setQueuedMessage(null);
     lastThinkingStartedAtRef.current = null;

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -21,6 +21,7 @@ import type {
   ChatMessage,
   ClientMessage,
   EscalationDecision,
+  HistoryMessage,
   LlmActivity,
   ServerMessage,
   SessionInfo,
@@ -347,6 +348,285 @@ function updateToolResultById(
   }));
 }
 
+function isTurnTerminalMessage(message: ChatMessage): boolean {
+  return message.kind === "assistant" || (message.kind === "error" && message.turnTerminal === true);
+}
+
+function completedTurnMessageIndices(messages: ChatMessage[]): number[] {
+  return messages.flatMap((message, index) => (isTurnTerminalMessage(message) ? [index] : []));
+}
+
+function latestTurnStartMessageIndex(messages: ChatMessage[]): number {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if (messages[index].kind === "user") {
+      return index;
+    }
+  }
+  return messages.length;
+}
+
+function eventIndexForMessage(message: ChatMessage): number | undefined {
+  if (message.kind === "assistant" || message.kind === "error") {
+    return typeof message.eventIndex === "number" ? message.eventIndex : undefined;
+  }
+  return undefined;
+}
+
+function projectHistoryToMessages(history: HistoryMessage[]): ChatMessage[] {
+  const msgs: ChatMessage[] = [];
+  const pendingToolCallIndices = new Map<string, number[]>();
+
+  function findLaterEscalationDecision(
+    fromIndex: number,
+    requestId: string,
+    roleMatches: (role: string) => boolean,
+  ): EscalationDecision | undefined {
+    for (let index = fromIndex + 1; index < history.length; index++) {
+      const entry = history[index];
+      if (entry.request_id !== requestId || !roleMatches(entry.role)) continue;
+      const decision = entry.decision;
+      if (decision === "allow" || decision === "deny") return decision;
+    }
+    return undefined;
+  }
+
+  for (let index = 0; index < history.length; index++) {
+    const entry = history[index];
+    if (entry.role === "user") {
+      msgs.push({ kind: "user", content: entry.content });
+    } else if (entry.role === "tool_call") {
+      const rawContexts = entry.contexts ?? entry.args?.contexts;
+      const isLoading = isToolCallLoading(
+        entry.tool ?? "",
+        entry.approval_source,
+        entry.approval_verdict,
+      );
+      if (
+        isUserApprovedReplay(
+          entry.tool ?? "",
+          entry.detail,
+          entry.approval_source,
+          entry.approval_verdict,
+        )
+      ) {
+        const patched = applyApprovedApprovalToMessages(
+          msgs,
+          {
+            tool: entry.tool ?? "",
+            args: (entry.args ?? {}) as Record<string, unknown>,
+          },
+          isLoading,
+        );
+        msgs.length = 0;
+        msgs.push(...patched);
+        continue;
+      }
+      msgs.push({
+        kind: "tool_call",
+        tool: entry.tool ?? "",
+        args: entry.args ?? {},
+        detail: entry.detail ?? "",
+        contexts: Array.isArray(rawContexts)
+          ? (rawContexts as string[])
+          : undefined,
+        approvalSource: entry.approval_source,
+        approvalVerdict: entry.approval_verdict,
+        approvalExplanation: entry.approval_explanation,
+        loading: isLoading,
+        toolId: entry.tool_id as string | undefined,
+        parentToolId: entry.parent_tool_id as string | undefined,
+      });
+      const toolName = entry.tool ?? "";
+      const queue = pendingToolCallIndices.get(toolName) ?? [];
+      queue.push(msgs.length - 1);
+      pendingToolCallIndices.set(toolName, queue);
+    } else if (entry.role === "tool_result") {
+      const toolResultId = entry.tool_id as string | undefined;
+      if (toolResultId) {
+        const updated = updateToolResultById(msgs, toolResultId, {
+          result: entry.result ?? "",
+          exitCode: entry.exit_code,
+        });
+        if (updated.found) {
+          msgs.length = 0;
+          msgs.push(...updated.messages);
+          continue;
+        }
+      }
+
+      const toolName = entry.tool ?? "";
+      const queue = pendingToolCallIndices.get(toolName);
+      const pendingIndex = queue?.shift();
+      if (pendingIndex != null && msgs[pendingIndex]?.kind === "tool_call") {
+        const toolCall = msgs[pendingIndex];
+        msgs[pendingIndex] = {
+          ...toolCall,
+          result: entry.result,
+          exitCode: entry.exit_code,
+          loading: false,
+        };
+      }
+      if (queue && queue.length === 0) {
+        pendingToolCallIndices.delete(toolName);
+      }
+    } else if (entry.role === "approval_response") {
+      continue;
+    } else if (entry.role === "approval_request" && entry.tool_call_id) {
+      const request = {
+        type: "approval_request" as const,
+        tool_call_id: entry.tool_call_id,
+        tool: entry.tool ?? "",
+        args: (entry.args ?? {}) as Record<string, unknown>,
+        explanation: entry.explanation ?? "",
+        risk_level: entry.risk_level ?? "",
+      };
+      const response = history.find(
+        (candidate) =>
+          candidate.role === "approval_response" &&
+          candidate.tool_call_id === entry.tool_call_id,
+      );
+      if (!response) {
+        msgs.push({ kind: "approval", request });
+      } else if (response.decision === "approved") {
+        const patched = applyApprovedApprovalToMessages(msgs, request);
+        msgs.length = 0;
+        msgs.push(...patched);
+      } else if (response.decision === "denied") {
+        const patched = applyDeniedApprovalToMessages(
+          msgs,
+          request,
+          response.message,
+        );
+        msgs.length = 0;
+        msgs.push(...patched);
+      }
+    } else if (
+      (entry.role === "domain_access_approval" || entry.role === "proxy_approval") &&
+      entry.request_id
+    ) {
+      if (!entry.decision) {
+        const decision = findLaterEscalationDecision(
+          index,
+          entry.request_id,
+          (role) => role === "domain_access_approval" || role === "proxy_approval",
+        );
+        if (!decision) {
+          msgs.push({
+            kind: "domain_access_approval",
+            request: {
+              type: "domain_access_approval_request",
+              request_id: entry.request_id,
+              domain: entry.domain ?? "",
+              command: entry.command ?? "",
+            },
+            decision,
+          });
+        }
+      }
+    } else if (entry.role === "git_push_approval" && entry.request_id) {
+      if (!entry.decision) {
+        const decision = findLaterEscalationDecision(
+          index,
+          entry.request_id,
+          (role) => role === "git_push_approval",
+        );
+        if (!decision) {
+          msgs.push({
+            kind: "git_push_approval",
+            request: {
+              type: "git_push_approval_request",
+              request_id: entry.request_id,
+              ref: entry.ref ?? "",
+              explanation: entry.explanation ?? "",
+              changed_files: (entry.changed_files as string[] | undefined) ?? [],
+            },
+            decision,
+          });
+        }
+      }
+    } else if (entry.role === "credential_approval" && entry.request_id) {
+      if (!entry.decision) {
+        const decision = findLaterEscalationDecision(
+          index,
+          entry.request_id,
+          (role) => role === "credential_approval",
+        );
+        if (!decision) {
+          msgs.push({
+            kind: "credential_approval",
+            request: {
+              type: "credential_approval_request",
+              request_id: entry.request_id,
+              vault_paths: entry.vault_paths ?? [],
+              names: entry.names ?? [],
+              descriptions: entry.descriptions ?? [],
+              skill_name: entry.skill_name,
+              explanation: entry.explanation ?? "",
+            },
+            decision,
+          });
+        }
+      }
+    } else if (entry.role === "git_push") {
+      msgs.push({
+        kind: "tool_call",
+        tool: "git_push",
+        args: { ref: entry.ref ?? "", decision: entry.decision ?? "" },
+        detail: entry.detail ?? "",
+        approvalSource: entry.approval_source,
+        approvalVerdict: entry.approval_verdict,
+        approvalExplanation: entry.approval_explanation,
+        toolId: entry.tool_id as string | undefined,
+        parentToolId: entry.parent_tool_id as string | undefined,
+      });
+    } else if (entry.role === "command") {
+      msgs.push({
+        kind: "command",
+        command: entry.command ?? "",
+        data: entry.data,
+      });
+    } else if (entry.role === "thinking" && entry.content) {
+      msgs.push({
+        kind: "thinking",
+        content: entry.content,
+        reasoningDurationMs: entry.reasoning_duration_ms,
+        reasoningTokens: entry.reasoning_tokens,
+      });
+    } else {
+      msgs.push({
+        kind: "assistant",
+        content: entry.content,
+        eventIndex: typeof entry.event_index === "number" ? entry.event_index : undefined,
+      });
+    }
+  }
+
+  const parentIndex = new Map<string, number>();
+  for (let index = 0; index < msgs.length; index++) {
+    const message = msgs[index];
+    if (message.kind === "tool_call" && message.toolId) {
+      parentIndex.set(message.toolId, index);
+    }
+  }
+
+  const childIndices = new Set<number>();
+  for (let index = 0; index < msgs.length; index++) {
+    const message = msgs[index];
+    if (message.kind !== "tool_call" || !message.parentToolId) continue;
+    const parentMessageIndex = parentIndex.get(message.parentToolId);
+    if (parentMessageIndex == null) continue;
+    const parent = msgs[parentMessageIndex];
+    if (parent.kind !== "tool_call") continue;
+    if (!parent.children) parent.children = [];
+    parent.children.push(message);
+    childIndices.add(index);
+  }
+
+  return childIndices.size > 0
+    ? msgs.filter((_, index) => !childIndices.has(index))
+    : msgs;
+}
+
 export function ChatView({
   server,
   token,
@@ -377,6 +657,7 @@ export function ChatView({
   const [deletingSession, setDeletingSession] = useState(false);
   const [savingKnowledge, setSavingKnowledge] = useState(false);
   const [togglingPrivacy, setTogglingPrivacy] = useState(false);
+  const [turnActionBusyIndex, setTurnActionBusyIndex] = useState<number | null>(null);
   const [knowledgeNotice, setKnowledgeNotice] = useState<{
     tone: "neutral" | "success" | "error";
     message: string;
@@ -475,262 +756,7 @@ export function ChatView({
     fetchHistory(server, token, sessionId)
       .then((history) => {
         if (cancelled) return;
-        const msgs: ChatMessage[] = [];
-        const pendingToolCallIndices = new Map<string, number[]>();
-
-        function findLaterEscalationDecision(
-          fromIndex: number,
-          requestId: string,
-          roleMatches: (role: string) => boolean,
-        ): EscalationDecision | undefined {
-          for (let j = fromIndex + 1; j < history.length; j++) {
-            const e = history[j];
-            if (e.request_id !== requestId || !roleMatches(e.role)) continue;
-            const d = e.decision;
-            if (d === "allow" || d === "deny") return d;
-          }
-          return undefined;
-        }
-
-        for (let i = 0; i < history.length; i++) {
-          const h = history[i];
-          if (h.role === "user") {
-            msgs.push({ kind: "user", content: h.content });
-          } else if (h.role === "tool_call") {
-            const rawContexts = h.contexts ?? h.args?.contexts;
-            const isLoading = isToolCallLoading(
-              h.tool ?? "",
-              h.approval_source,
-              h.approval_verdict,
-            );
-            if (
-              isUserApprovedReplay(
-                h.tool ?? "",
-                h.detail,
-                h.approval_source,
-                h.approval_verdict,
-              )
-            ) {
-              const patched = applyApprovedApprovalToMessages(
-                msgs,
-                {
-                  tool: h.tool ?? "",
-                  args: (h.args ?? {}) as Record<string, unknown>,
-                },
-                isLoading,
-              );
-              msgs.length = 0;
-              msgs.push(...patched);
-              continue;
-            }
-            msgs.push({
-              kind: "tool_call",
-              tool: h.tool ?? "",
-              args: h.args ?? {},
-              detail: h.detail ?? "",
-              contexts: Array.isArray(rawContexts)
-                ? (rawContexts as string[])
-                : undefined,
-              approvalSource: h.approval_source,
-              approvalVerdict: h.approval_verdict,
-              approvalExplanation: h.approval_explanation,
-              loading: isLoading,
-              toolId: h.tool_id as string | undefined,
-              parentToolId: h.parent_tool_id as string | undefined,
-            });
-            const toolName = h.tool ?? "";
-            const idx = msgs.length - 1;
-            const queue = pendingToolCallIndices.get(toolName) ?? [];
-            queue.push(idx);
-            pendingToolCallIndices.set(toolName, queue);
-          } else if (h.role === "tool_result") {
-            const toolResultId = h.tool_id as string | undefined;
-            if (toolResultId) {
-              const updated = updateToolResultById(msgs, toolResultId, {
-                result: h.result ?? "",
-                exitCode: h.exit_code,
-              });
-              if (updated.found) {
-                msgs.length = 0;
-                msgs.push(...updated.messages);
-                continue;
-              }
-            }
-
-            const toolName = h.tool ?? "";
-            const queue = pendingToolCallIndices.get(toolName);
-            const idx = queue?.shift();
-            if (idx != null && msgs[idx]?.kind === "tool_call") {
-              const toolCall = msgs[idx];
-              msgs[idx] = {
-                ...toolCall,
-                result: h.result,
-                exitCode: h.exit_code,
-                loading: false,
-              };
-            }
-            if (queue && queue.length === 0) {
-              pendingToolCallIndices.delete(toolName);
-            }
-          } else if (h.role === "approval_response") {
-            // Skip — consumed by the approval_request above
-          } else if (h.role === "approval_request" && h.tool_call_id) {
-            const request = {
-              type: "approval_request" as const,
-              tool_call_id: h.tool_call_id,
-              tool: h.tool ?? "",
-              args: (h.args ?? {}) as Record<string, unknown>,
-              explanation: h.explanation ?? "",
-              risk_level: h.risk_level ?? "",
-            };
-            const response = history.find(
-              (r) =>
-                r.role === "approval_response" &&
-                r.tool_call_id === h.tool_call_id,
-            );
-            if (!response) {
-              msgs.push({ kind: "approval", request });
-            } else if (response.decision === "approved") {
-              const patched = applyApprovedApprovalToMessages(msgs, request);
-              msgs.length = 0;
-              msgs.push(...patched);
-            } else if (response.decision === "denied") {
-              const patched = applyDeniedApprovalToMessages(
-                msgs,
-                request,
-                response.message,
-              );
-              msgs.length = 0;
-              msgs.push(...patched);
-            }
-          } else if (
-            (h.role === "domain_access_approval" ||
-              h.role === "proxy_approval") &&
-            h.request_id
-          ) {
-            // Domain access approval: request entry, then decision (may be non-adjacent)
-            if (!h.decision) {
-              const decision = findLaterEscalationDecision(
-                i,
-                h.request_id,
-                (role) =>
-                  role === "domain_access_approval" ||
-                  role === "proxy_approval",
-              );
-              if (!decision) {
-                msgs.push({
-                  kind: "domain_access_approval",
-                  request: {
-                    type: "domain_access_approval_request",
-                    request_id: h.request_id,
-                    domain: h.domain ?? "",
-                    command: h.command ?? "",
-                  },
-                  decision,
-                });
-              }
-            }
-            // Skip decision-only events (consumed above)
-          } else if (h.role === "git_push_approval" && h.request_id) {
-            // Git push approval: request entry, then decision (may be non-adjacent)
-            if (!h.decision) {
-              const decision = findLaterEscalationDecision(
-                i,
-                h.request_id,
-                (role) => role === "git_push_approval",
-              );
-              if (!decision) {
-                msgs.push({
-                  kind: "git_push_approval",
-                  request: {
-                    type: "git_push_approval_request",
-                    request_id: h.request_id,
-                    ref: h.ref ?? "",
-                    explanation: h.explanation ?? "",
-                    changed_files:
-                      (h.changed_files as string[] | undefined) ?? [],
-                  },
-                  decision,
-                });
-              }
-            }
-          } else if (h.role === "credential_approval" && h.request_id) {
-            if (!h.decision) {
-              const decision = findLaterEscalationDecision(
-                i,
-                h.request_id,
-                (role) => role === "credential_approval",
-              );
-              if (!decision) {
-                msgs.push({
-                  kind: "credential_approval",
-                  request: {
-                    type: "credential_approval_request",
-                    request_id: h.request_id,
-                    vault_paths: h.vault_paths ?? [],
-                    names: h.names ?? [],
-                    descriptions: h.descriptions ?? [],
-                    skill_name: h.skill_name,
-                    explanation: h.explanation ?? "",
-                  },
-                  decision,
-                });
-              }
-            }
-          } else if (h.role === "git_push") {
-            msgs.push({
-              kind: "tool_call",
-              tool: "git_push",
-              args: { ref: h.ref ?? "", decision: h.decision ?? "" },
-              detail: h.detail ?? "",
-              approvalSource: h.approval_source,
-              approvalVerdict: h.approval_verdict,
-              approvalExplanation: h.approval_explanation,
-              toolId: h.tool_id as string | undefined,
-              parentToolId: h.parent_tool_id as string | undefined,
-            });
-          } else if (h.role === "command") {
-            msgs.push({
-              kind: "command",
-              command: h.command ?? "",
-              data: h.data,
-            });
-          } else if (h.role === "thinking" && h.content) {
-            msgs.push({
-              kind: "thinking",
-              content: h.content,
-              reasoningDurationMs: h.reasoning_duration_ms,
-              reasoningTokens: h.reasoning_tokens,
-            });
-          } else {
-            msgs.push({ kind: "assistant", content: h.content });
-          }
-        }
-        // Group auxiliary tool calls (credential_access, proxy_domain, git_push)
-        // under their parent tool call by matching parentToolId → toolId.
-        const parentIndex = new Map<string, number>();
-        for (let i = 0; i < msgs.length; i++) {
-          const m = msgs[i];
-          if (m.kind === "tool_call" && m.toolId) {
-            parentIndex.set(m.toolId, i);
-          }
-        }
-        const childIndices = new Set<number>();
-        for (let i = 0; i < msgs.length; i++) {
-          const m = msgs[i];
-          if (m.kind !== "tool_call" || !m.parentToolId) continue;
-          const pi = parentIndex.get(m.parentToolId);
-          if (pi == null) continue;
-          const parent = msgs[pi];
-          if (parent.kind !== "tool_call") continue;
-          if (!parent.children) parent.children = [];
-          parent.children.push(m);
-          childIndices.add(i);
-        }
-        const grouped = childIndices.size > 0
-          ? msgs.filter((_, i) => !childIndices.has(i))
-          : msgs;
-        setMessages(grouped);
+        setMessages(projectHistoryToMessages(history));
       })
       .catch(() => {
         // history fetch can fail for new sessions - that's fine
@@ -1008,7 +1034,7 @@ export function ChatView({
         case "error":
           setMessages((prev) => [
             ...prev,
-            { kind: "error", detail: msg.detail },
+            { kind: "error", detail: msg.detail, turnTerminal: true },
           ]);
           setLlmActivity(null);
           lastThinkingStartedAtRef.current = null;
@@ -1017,7 +1043,7 @@ export function ChatView({
         case "cancelled":
           setMessages((prev) => [
             ...prev,
-            { kind: "error", detail: msg.detail },
+            { kind: "error", detail: msg.detail, turnTerminal: true },
           ]);
           setLlmActivity(null);
           lastThinkingStartedAtRef.current = null;
@@ -1113,6 +1139,10 @@ export function ChatView({
     sendRef.current = send;
   }, [send]);
 
+  const terminalIndices = completedTurnMessageIndices(messages);
+  const latestTerminalIndex = terminalIndices.length > 0 ? terminalIndices[terminalIndices.length - 1] : -1;
+  const turnActionsDisabled = waiting || loadingHistory || status !== "connected" || turnActionBusyIndex !== null;
+
   // Auto-scroll only when already at bottom
   useEffect(() => {
     if (isAtBottomRef.current) {
@@ -1146,6 +1176,54 @@ export function ChatView({
     queueRef.current = content;
     setQueuedMessage(content);
     send({ type: "cancel" });
+  }
+
+  function handleRetry() {
+    if (waiting || status !== "connected") return;
+    queueRef.current = null;
+    setQueuedMessage(null);
+    lastThinkingStartedAtRef.current = null;
+    setLlmActivity(null);
+    setMessages((prev) => prev.slice(0, latestTurnStartMessageIndex(prev)));
+    setWaiting(true);
+    send({ type: "retry_latest_turn" });
+  }
+
+  async function handleReset(messageIndex: number) {
+    if (waiting || status !== "connected") return;
+
+    const currentMessages = messages;
+    const localTerminalIndices = completedTurnMessageIndices(currentMessages);
+    const localTurnOrdinal = localTerminalIndices.indexOf(messageIndex);
+    if (localTurnOrdinal === -1) return;
+
+    setTurnActionBusyIndex(messageIndex);
+    try {
+      let targetEventIndex = eventIndexForMessage(currentMessages[messageIndex]);
+
+      if (targetEventIndex == null) {
+        const history = await fetchHistory(server, token, sessionId);
+        const canonicalMessages = projectHistoryToMessages(history);
+        const canonicalTerminalIndices = completedTurnMessageIndices(canonicalMessages);
+        const canonicalMessageIndex = canonicalTerminalIndices[localTurnOrdinal];
+        if (canonicalMessageIndex != null) {
+          targetEventIndex = eventIndexForMessage(canonicalMessages[canonicalMessageIndex]);
+        }
+      }
+
+      if (targetEventIndex == null) {
+        setMessages((prev) => [
+          ...prev,
+          { kind: "error", detail: "Could not resolve reset target." },
+        ]);
+        return;
+      }
+
+      send({ type: "reset_to_turn", event_index: targetEventIndex });
+      setMessages((prev) => prev.slice(0, messageIndex + 1));
+    } finally {
+      setTurnActionBusyIndex(null);
+    }
   }
 
   async function handleWipeSandbox() {
@@ -1572,9 +1650,14 @@ export function ChatView({
               key={i}
               message={msg}
               activeLlmActivity={llmActivity}
+              canRetry={i === latestTerminalIndex && isTurnTerminalMessage(msg)}
+              canReset={i !== latestTerminalIndex && isTurnTerminalMessage(msg)}
+              actionDisabled={turnActionsDisabled}
               onApproval={handleApproval}
               onEscalation={handleEscalation}
               onCredentialApproval={handleCredentialEscalation}
+              onRetry={i === latestTerminalIndex && isTurnTerminalMessage(msg) ? handleRetry : undefined}
+              onReset={i !== latestTerminalIndex && isTurnTerminalMessage(msg) ? () => void handleReset(i) : undefined}
             />
           ))}
           {waitingLabel && (

--- a/frontend/src/components/message.tsx
+++ b/frontend/src/components/message.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Brain, Check, ChevronRight, Copy, Loader2, RotateCcw } from "lucide-react";
+import { Brain, Check, ChevronRight, Copy, Loader2, RotateCcw, Undo2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 
 import type { ChatMessage, EscalationDecision, LlmActivity } from "@/lib/types";
@@ -43,12 +43,11 @@ function MessageCopyButton({
     <button
       type="button"
       className={cn(
-        "rounded-md p-1 text-muted-foreground transition-[opacity,colors] hover:bg-muted hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-        "opacity-100 md:opacity-0 md:group-hover:opacity-100",
+        "rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
         className,
       )}
-      aria-label={copied ? "Copied" : "Copy original Markdown"}
-      title="Copy original Markdown"
+      aria-label={copied ? "Copied" : "Copy message"}
+      title={copied ? "Copied" : "Copy message"}
       onClick={() => void copy()}
     >
       {copied ? (
@@ -164,12 +163,14 @@ function ThinkingBadge({
   );
 }
 
-function TurnActionButton({
+function MessageActionButton({
   label,
+  icon,
   disabled,
   onClick,
 }: {
   label: string;
+  icon: React.ReactNode;
   disabled?: boolean;
   onClick?: () => void;
 }) {
@@ -180,36 +181,51 @@ function TurnActionButton({
       type="button"
       disabled={disabled}
       onClick={onClick}
+      aria-label={label}
+      title={label}
       className={cn(
-        "inline-flex items-center gap-1 rounded-md border border-border/70 px-2 py-1 text-xs text-muted-foreground transition-colors",
+        "inline-flex items-center rounded-md border border-border/70 p-1.5 text-muted-foreground transition-colors",
         "hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50",
       )}
     >
-      <RotateCcw className="size-3" />
-      <span>{label}</span>
+      {icon}
     </button>
   );
 }
 
-function TurnActions({
+function MessageActions({
+  copyText,
   canRetry,
   canReset,
   disabled,
   onRetry,
   onReset,
 }: {
+  copyText?: string;
   canRetry?: boolean;
   canReset?: boolean;
   disabled?: boolean;
   onRetry?: () => void;
   onReset?: () => void;
 }) {
-  if (!canRetry && !canReset) return null;
+  const hasCopy = typeof copyText === "string" && copyText.length > 0;
+  if (!hasCopy && !canRetry && !canReset) return null;
 
   return (
     <div className="mt-2 flex items-center gap-2">
-      <TurnActionButton label="Retry" disabled={disabled} onClick={canRetry ? onRetry : undefined} />
-      <TurnActionButton label="Reset" disabled={disabled} onClick={canReset ? onReset : undefined} />
+      <MessageCopyButton text={copyText ?? ""} className="border border-border/70 p-1.5" />
+      <MessageActionButton
+        label="Retry turn"
+        icon={<RotateCcw className="size-3.5" />}
+        disabled={disabled}
+        onClick={canRetry ? onRetry : undefined}
+      />
+      <MessageActionButton
+        label="Reset conversation to after this turn"
+        icon={<Undo2 className="size-3.5" />}
+        disabled={disabled}
+        onClick={canReset ? onReset : undefined}
+      />
     </div>
   );
 }
@@ -265,13 +281,11 @@ export function Message({
     case "assistant":
       return (
         <div className="group max-w-[85%] text-sm">
-          <div className="flex items-start gap-1.5">
-            <div className="min-w-0 flex-1">
-              <MarkdownContent content={message.content} />
-            </div>
-            <MessageCopyButton text={message.content} className="shrink-0" />
+          <div className="min-w-0 flex-1">
+            <MarkdownContent content={message.content} />
           </div>
-          <TurnActions
+          <MessageActions
+            copyText={message.content}
             canRetry={canRetry}
             canReset={canReset}
             disabled={actionDisabled}
@@ -287,7 +301,6 @@ export function Message({
           <div className="min-w-0 flex-1">
             <MarkdownContent content={message.content} />
           </div>
-          <MessageCopyButton text={message.content} className="shrink-0" />
         </div>
       );
 
@@ -398,7 +411,8 @@ export function Message({
       return (
         <div className="my-1 max-w-[85%] rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
           <pre className="whitespace-pre-wrap font-mono text-xs">{message.detail}</pre>
-          <TurnActions
+          <MessageActions
+            copyText={message.detail}
             canRetry={canRetry}
             canReset={canReset}
             disabled={actionDisabled}

--- a/frontend/src/components/message.tsx
+++ b/frontend/src/components/message.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Brain, Check, ChevronRight, Copy, Loader2 } from "lucide-react";
+import { Brain, Check, ChevronRight, Copy, Loader2, RotateCcw } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 
 import type { ChatMessage, EscalationDecision, LlmActivity } from "@/lib/types";
@@ -164,9 +164,62 @@ function ThinkingBadge({
   );
 }
 
+function TurnActionButton({
+  label,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  disabled?: boolean;
+  onClick?: () => void;
+}) {
+  if (!onClick) return null;
+
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center gap-1 rounded-md border border-border/70 px-2 py-1 text-xs text-muted-foreground transition-colors",
+        "hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50",
+      )}
+    >
+      <RotateCcw className="size-3" />
+      <span>{label}</span>
+    </button>
+  );
+}
+
+function TurnActions({
+  canRetry,
+  canReset,
+  disabled,
+  onRetry,
+  onReset,
+}: {
+  canRetry?: boolean;
+  canReset?: boolean;
+  disabled?: boolean;
+  onRetry?: () => void;
+  onReset?: () => void;
+}) {
+  if (!canRetry && !canReset) return null;
+
+  return (
+    <div className="mt-2 flex items-center gap-2">
+      <TurnActionButton label="Retry" disabled={disabled} onClick={canRetry ? onRetry : undefined} />
+      <TurnActionButton label="Reset" disabled={disabled} onClick={canReset ? onReset : undefined} />
+    </div>
+  );
+}
+
 interface MessageProps {
   message: ChatMessage;
   activeLlmActivity?: LlmActivity | null;
+  canRetry?: boolean;
+  canReset?: boolean;
+  actionDisabled?: boolean;
   onApproval?: (toolCallId: string, approved: boolean, message?: string) => void;
   onEscalation?: (
     requestId: string,
@@ -178,14 +231,21 @@ interface MessageProps {
     decision: EscalationDecision,
     message?: string,
   ) => void;
+  onRetry?: () => void;
+  onReset?: () => void;
 }
 
 export function Message({
   message,
   activeLlmActivity,
+  canRetry,
+  canReset,
+  actionDisabled,
   onApproval,
   onEscalation,
   onCredentialApproval,
+  onRetry,
+  onReset,
 }: MessageProps) {
   switch (message.kind) {
     case "user":
@@ -204,11 +264,20 @@ export function Message({
 
     case "assistant":
       return (
-        <div className="group flex max-w-[85%] items-start gap-1.5 text-sm">
-          <div className="min-w-0 flex-1">
-            <MarkdownContent content={message.content} />
+        <div className="group max-w-[85%] text-sm">
+          <div className="flex items-start gap-1.5">
+            <div className="min-w-0 flex-1">
+              <MarkdownContent content={message.content} />
+            </div>
+            <MessageCopyButton text={message.content} className="shrink-0" />
           </div>
-          <MessageCopyButton text={message.content} className="shrink-0" />
+          <TurnActions
+            canRetry={canRetry}
+            canReset={canReset}
+            disabled={actionDisabled}
+            onRetry={onRetry}
+            onReset={onReset}
+          />
         </div>
       );
 
@@ -327,10 +396,15 @@ export function Message({
 
     case "error":
       return (
-        <div className="my-1 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
-          <pre className="whitespace-pre-wrap font-mono text-xs">
-            {message.detail}
-          </pre>
+        <div className="my-1 max-w-[85%] rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+          <pre className="whitespace-pre-wrap font-mono text-xs">{message.detail}</pre>
+          <TurnActions
+            canRetry={canRetry}
+            canReset={canReset}
+            disabled={actionDisabled}
+            onRetry={onRetry}
+            onReset={onReset}
+          />
         </div>
       );
   }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -52,6 +52,7 @@ export interface SessionArchiveCommitResponse {
 export interface HistoryMessage {
   role: string;
   content: string;
+  event_index?: number;
   reasoning_duration_ms?: number;
   reasoning_tokens?: number;
   tool?: string;
@@ -315,17 +316,28 @@ export interface CancelRequest {
   type: "cancel";
 }
 
+export interface RetryLatestTurnRequest {
+  type: "retry_latest_turn";
+}
+
+export interface ResetToTurnRequest {
+  type: "reset_to_turn";
+  event_index: number;
+}
+
 export type ClientMessage =
   | UserMessage
   | ApprovalResponse
   | EscalationResponse
-  | CancelRequest;
+  | CancelRequest
+  | RetryLatestTurnRequest
+  | ResetToTurnRequest;
 
 // Chat UI messages
 
 export type ChatMessage =
   | { kind: "user"; content: string }
-  | { kind: "assistant"; content: string }
+  | { kind: "assistant"; content: string; eventIndex?: number }
   | { kind: "streaming"; content: string }
   | {
       kind: "thinking";
@@ -400,4 +412,9 @@ export type ChatMessage =
       decision?: EscalationDecision;
     }
   | { kind: "command"; command: string; data: unknown }
-  | { kind: "error"; detail: string };
+  | {
+      kind: "error";
+      detail: string;
+      eventIndex?: number;
+      turnTerminal?: boolean;
+    };

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -246,6 +246,7 @@ export interface CommandResult {
 export interface ErrorMessage {
   type: "error";
   detail: string;
+  turn_terminal?: boolean;
 }
 
 export interface Cancelled {

--- a/src/carapace/channels/matrix/subscriber.py
+++ b/src/carapace/channels/matrix/subscriber.py
@@ -129,7 +129,7 @@ class MatrixSubscriber:
         self._stream_last_len = 0
         self._stop_typing()
 
-    async def on_error(self, detail: str) -> None:
+    async def on_error(self, detail: str, *, turn_terminal: bool = False) -> None:
         self._stream_buffer = ""
         self._stream_last_len = 0
         self._stream_event_id = None

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -883,8 +883,8 @@ class WebSocketSubscriber:
     async def on_done(self, content: str, usage: TurnUsage, *, thinking: str | None = None) -> None:
         await self._safe_send(Done(content=content, thinking=thinking, usage=usage))
 
-    async def on_error(self, detail: str) -> None:
-        await self._safe_send(ErrorMessage(detail=detail))
+    async def on_error(self, detail: str, *, turn_terminal: bool = False) -> None:
+        await self._safe_send(ErrorMessage(detail=detail, turn_terminal=turn_terminal))
 
     async def on_cancelled(self) -> None:
         await self._safe_send(Cancelled())

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -1096,6 +1096,13 @@ async def chat_ws(
 
             if isinstance(client_msg, ResetToTurnRequest):
                 await _engine.reset_to_turn(session_id, client_msg.event_index)
+                await _send(
+                    websocket,
+                    CommandResult(
+                        command="reset_to_turn",
+                        data={"event_index": client_msg.event_index},
+                    ),
+                )
                 continue
 
             # --- Approval responses — forward to engine ---

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -1095,14 +1095,15 @@ async def chat_ws(
                 continue
 
             if isinstance(client_msg, ResetToTurnRequest):
-                await _engine.reset_to_turn(session_id, client_msg.event_index)
-                await _send(
-                    websocket,
-                    CommandResult(
-                        command="reset_to_turn",
-                        data={"event_index": client_msg.event_index},
-                    ),
-                )
+                reset_applied = await _engine.reset_to_turn(session_id, client_msg.event_index)
+                if reset_applied:
+                    await _send(
+                        websocket,
+                        CommandResult(
+                            command="reset_to_turn",
+                            data={"event_index": client_msg.event_index},
+                        ),
+                    )
                 continue
 
             # --- Approval responses — forward to engine ---

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -66,6 +66,8 @@ from carapace.ws_models import (
     GitPushApprovalRequest,
     LlmActivity,
     LlmActivityUpdate,
+    ResetToTurnRequest,
+    RetryLatestTurnRequest,
     ServerEnvelope,
     SessionTitleUpdate,
     StatusUpdate,
@@ -686,6 +688,7 @@ _HistoryRole = Literal[
 class HistoryMessage(BaseModel):
     role: _HistoryRole
     content: str = ""
+    event_index: int | None = None
     reasoning_duration_ms: int | None = None
     reasoning_tokens: int | None = None
     tool: str | None = None
@@ -737,7 +740,14 @@ async def get_session_history(
         raise HTTPException(status_code=404, detail="Session not found")
 
     events = _engine.session_mgr.load_events(session_id)
-    result = [HistoryMessage.model_validate(e) for e in events] if events else _history_from_messages(session_id)
+    result = (
+        [HistoryMessage.model_validate({**event, "event_index": index}) for index, event in enumerate(events)]
+        if events
+        else [
+            HistoryMessage.model_validate({**message.model_dump(mode="python"), "event_index": index})
+            for index, message in enumerate(_history_from_messages(session_id))
+        ]
+    )
 
     if limit > 0:
         result = result[-limit:]
@@ -1078,6 +1088,14 @@ async def chat_ws(
             # --- Cancel in-flight agent turn ---
             if isinstance(client_msg, CancelRequest):
                 await _engine.submit_cancel(session_id)
+                continue
+
+            if isinstance(client_msg, RetryLatestTurnRequest):
+                await _engine.retry_latest_turn(session_id, origin=sub)
+                continue
+
+            if isinstance(client_msg, ResetToTurnRequest):
+                await _engine.reset_to_turn(session_id, client_msg.event_index)
                 continue
 
             # --- Approval responses — forward to engine ---

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -1626,11 +1626,19 @@ class SessionEngine:
             )
             if not has_user_prompt:
                 continue
-            if current_turn_start is not None:
+            if (
+                current_turn_start is not None
+                and index - 1 > current_turn_start
+                and isinstance(messages[index - 1], ModelResponse)
+            ):
                 turn_end_indexes.append(index - 1)
             current_turn_start = index
 
-        if current_turn_start is not None:
+        if (
+            current_turn_start is not None
+            and len(messages) - 1 > current_turn_start
+            and isinstance(messages[-1], ModelResponse)
+        ):
             turn_end_indexes.append(len(messages) - 1)
 
         return turn_end_indexes

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -161,7 +161,7 @@ class SessionSubscriber(Protocol):
     async def on_thinking_token(self, content: str) -> None: ...
     async def on_llm_activity(self, activity: LlmRequestState | None) -> None: ...
     async def on_done(self, content: str, usage: TurnUsage, *, thinking: str | None = None) -> None: ...
-    async def on_error(self, detail: str) -> None: ...
+    async def on_error(self, detail: str, *, turn_terminal: bool = False) -> None: ...
     async def on_cancelled(self) -> None: ...
     async def on_approval_request(self, req: ApprovalRequest) -> None: ...
     async def on_domain_access_approval_request(self, request_id: str, domain: str, command: str) -> None: ...
@@ -1476,7 +1476,7 @@ class SessionEngine:
                 self._session_mgr.append_events(session_id, events_to_append)
 
                 if output.startswith("Unexpected agent output type:"):
-                    await self._broadcast(active, "on_error", output)
+                    await self._broadcast(active, "on_error", output, turn_terminal=True)
                 else:
                     usage_payload = self._turn_usage_payload(active) or TurnUsage()
                     logger.info(
@@ -1528,7 +1528,7 @@ class SessionEngine:
                 latest_messages=latest_messages,
                 terminal_message=str(exc),
             )
-            await self._broadcast(active, "on_error", str(exc))
+            await self._broadcast(active, "on_error", str(exc), turn_terminal=True)
         except UsageLimitExceeded as exc:
             sentinel_evals = active.security.sentinel_eval_count if active.security else 0
             logger.error(
@@ -1544,7 +1544,7 @@ class SessionEngine:
                 latest_messages=latest_messages,
                 terminal_message="The previous turn failed before completion.",
             )
-            await self._broadcast(active, "on_error", str(exc))
+            await self._broadcast(active, "on_error", str(exc), turn_terminal=True)
         except Exception:
             logger.exception(f"Agent error session={session_id} prompt={_truncate_for_log(user_input)}")
             active.llm_request_thinking.clear()
@@ -1555,7 +1555,7 @@ class SessionEngine:
                 latest_messages=latest_messages,
                 terminal_message="The previous turn failed before completion.",
             )
-            await self._broadcast(active, "on_error", traceback.format_exc())
+            await self._broadcast(active, "on_error", traceback.format_exc(), turn_terminal=True)
         finally:
             active.agent_task = None
 

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -241,6 +241,13 @@ class ActiveSession:
     _pending_sends: set[asyncio.Task[Any]] = field(default_factory=set)
 
 
+@dataclass(frozen=True, slots=True)
+class CompletedEventTurn:
+    start_event_index: int
+    end_event_index: int
+    user_content: str
+
+
 # ---------------------------------------------------------------------------
 # SessionEngine — central owner of session lifecycle and agent execution
 # ---------------------------------------------------------------------------
@@ -814,6 +821,42 @@ class SessionEngine:
             self._run_turn(active, content, origin=origin),
             name=f"agent-turn-{session_id}",
         )
+
+    async def retry_latest_turn(
+        self,
+        session_id: str,
+        *,
+        origin: SessionSubscriber | None = None,
+    ) -> None:
+        active = self._ensure_active(session_id)
+        if active.agent_task and not active.agent_task.done():
+            await self._broadcast(active, "on_error", "Agent is busy — cancel first")
+            return
+
+        events = self._truncate_incomplete_events(self._session_mgr.load_events(session_id))
+        turns = self._completed_event_turns(events)
+        if not turns:
+            await self._broadcast(active, "on_error", "No completed turn available to retry")
+            return
+
+        target = turns[-1]
+        self._rewrite_session_transcript(session_id, events[: target.start_event_index])
+        await self.submit_message(session_id, target.user_content, origin=origin)
+
+    async def reset_to_turn(self, session_id: str, event_index: int) -> None:
+        active = self._ensure_active(session_id)
+        if active.agent_task and not active.agent_task.done():
+            await self._broadcast(active, "on_error", "Agent is busy — cancel first")
+            return
+
+        events = self._truncate_incomplete_events(self._session_mgr.load_events(session_id))
+        turns = self._completed_event_turns(events)
+        target = next((turn for turn in turns if turn.end_event_index == event_index), None)
+        if target is None:
+            await self._broadcast(active, "on_error", "Unknown reset target")
+            return
+
+        self._rewrite_session_transcript(session_id, events[: target.end_event_index + 1])
 
     async def submit_cancel(self, session_id: str) -> None:
         """Cancel the running agent turn for *session_id*."""
@@ -1549,6 +1592,74 @@ class SessionEngine:
                 }
             )
         self._session_mgr.save_events(session_id, events)
+
+    def _completed_event_turns(self, events: list[dict[str, Any]]) -> list[CompletedEventTurn]:
+        turns: list[CompletedEventTurn] = []
+        start_event_index: int | None = None
+        user_content: str | None = None
+
+        for index, event in enumerate(events):
+            role = event.get("role")
+            if role == "user" and isinstance(content := event.get("content"), str) and not content.startswith("/"):
+                start_event_index = index
+                user_content = content
+            elif role == "assistant" and start_event_index is not None and user_content is not None:
+                turns.append(
+                    CompletedEventTurn(
+                        start_event_index=start_event_index,
+                        end_event_index=index,
+                        user_content=user_content,
+                    )
+                )
+                start_event_index = None
+                user_content = None
+
+        return turns
+
+    def _completed_model_turn_end_indexes(self, messages: list[ModelMessage]) -> list[int]:
+        turn_end_indexes: list[int] = []
+        current_turn_start: int | None = None
+
+        for index, message in enumerate(messages):
+            has_user_prompt = isinstance(message, ModelRequest) and any(
+                isinstance(part, UserPromptPart) and isinstance(part.content, str) for part in message.parts
+            )
+            if not has_user_prompt:
+                continue
+            if current_turn_start is not None:
+                turn_end_indexes.append(index - 1)
+            current_turn_start = index
+
+        if current_turn_start is not None:
+            turn_end_indexes.append(len(messages) - 1)
+
+        return turn_end_indexes
+
+    def _history_for_completed_turn_count(self, messages: list[ModelMessage], turn_count: int) -> list[ModelMessage]:
+        if turn_count <= 0:
+            return []
+
+        turn_end_indexes = self._completed_model_turn_end_indexes(messages)
+        if not turn_end_indexes:
+            return []
+
+        capped_turn_count = min(turn_count, len(turn_end_indexes))
+        return messages[: turn_end_indexes[capped_turn_count - 1] + 1]
+
+    def _rewrite_session_transcript(self, session_id: str, events: list[dict[str, Any]]) -> None:
+        truncated_events = self._truncate_incomplete_events(events)
+        turn_count = len(self._completed_event_turns(truncated_events))
+        history = self._truncate_incomplete_model_history(self._session_mgr.load_history(session_id))
+        truncated_history = self._history_for_completed_turn_count(history, turn_count)
+
+        self._session_mgr.save_events(session_id, truncated_events)
+        self._session_mgr.save_history(session_id, truncated_history)
+        self._session_mgr.clear_llm_request_state(session_id)
+
+        active = self._active.get(session_id)
+        if active is not None:
+            active.llm_request_state = None
+            active.llm_request_thinking.clear()
 
     def _truncate_incomplete_model_history(self, messages: list[ModelMessage]) -> list[ModelMessage]:
         pending_tool_calls: set[str] = set()

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -843,20 +843,21 @@ class SessionEngine:
         self._rewrite_session_transcript(session_id, events[: target.start_event_index])
         await self.submit_message(session_id, target.user_content, origin=origin)
 
-    async def reset_to_turn(self, session_id: str, event_index: int) -> None:
+    async def reset_to_turn(self, session_id: str, event_index: int) -> bool:
         active = self._ensure_active(session_id)
         if active.agent_task and not active.agent_task.done():
             await self._broadcast(active, "on_error", "Agent is busy — cancel first")
-            return
+            return False
 
         events = self._truncate_incomplete_events(self._session_mgr.load_events(session_id))
         turns = self._completed_event_turns(events)
         target = next((turn for turn in turns if turn.end_event_index == event_index), None)
         if target is None:
             await self._broadcast(active, "on_error", "Unknown reset target")
-            return
+            return False
 
         self._rewrite_session_transcript(session_id, events[: target.end_event_index + 1])
+        return True
 
     async def submit_cancel(self, session_id: str) -> None:
         """Cancel the running agent turn for *session_id*."""

--- a/src/carapace/ws_models.py
+++ b/src/carapace/ws_models.py
@@ -244,6 +244,7 @@ class CommandResult(BaseModel):
 class ErrorMessage(BaseModel):
     type: Literal["error"] = "error"
     detail: str
+    turn_terminal: bool = False
 
 
 class Cancelled(BaseModel):

--- a/src/carapace/ws_models.py
+++ b/src/carapace/ws_models.py
@@ -75,7 +75,22 @@ class CancelRequest(BaseModel):
     type: Literal["cancel"] = "cancel"
 
 
-ClientEnvelope = UserMessage | ApprovalResponse | EscalationResponse | CancelRequest
+class RetryLatestTurnRequest(BaseModel):
+    """Client → Server: rewind the latest completed turn and run it again."""
+
+    type: Literal["retry_latest_turn"] = "retry_latest_turn"
+
+
+class ResetToTurnRequest(BaseModel):
+    """Client → Server: rewind session chat state to a completed turn boundary."""
+
+    type: Literal["reset_to_turn"] = "reset_to_turn"
+    event_index: int
+
+
+ClientEnvelope = (
+    UserMessage | ApprovalResponse | EscalationResponse | CancelRequest | RetryLatestTurnRequest | ResetToTurnRequest
+)
 
 
 def parse_client_message(raw: dict[str, Any]) -> ClientEnvelope:
@@ -88,6 +103,10 @@ def parse_client_message(raw: dict[str, Any]) -> ClientEnvelope:
             return EscalationResponse.model_validate(raw)
         case "cancel":
             return CancelRequest.model_validate(raw)
+        case "retry_latest_turn":
+            return RetryLatestTurnRequest.model_validate(raw)
+        case "reset_to_turn":
+            return ResetToTurnRequest.model_validate(raw)
         case other:
             msg = f"Unknown client message type: {other}"
             raise ValueError(msg)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -700,6 +700,42 @@ def test_ws_session_command(client, auth_headers, bearer):
         assert msg["data"]["session_id"] == sid
 
 
+def test_ws_reset_to_turn_emits_ack(client, auth_headers, bearer):
+    create_resp = client.post("/api/sessions", headers=auth_headers)
+    sid = create_resp.json()["session_id"]
+    srv._engine.session_mgr.save_events(
+        sid,
+        [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "first answer"},
+            {"role": "user", "content": "second"},
+            {"role": "assistant", "content": "second answer"},
+        ],
+    )
+    srv._engine.session_mgr.save_history(
+        sid,
+        [
+            ModelRequest(parts=[UserPromptPart(content="first")]),
+            ModelResponse(parts=[TextPart(content="first answer")]),
+            ModelRequest(parts=[UserPromptPart(content="second")]),
+            ModelResponse(parts=[TextPart(content="second answer")]),
+        ],
+    )
+
+    with client.websocket_connect(f"/api/chat/{sid}?token={bearer}") as ws:
+        _consume_status(ws)
+        ws.send_json({"type": "reset_to_turn", "event_index": 1})
+        msg = ws.receive_json()
+        assert msg["type"] == "command_result"
+        assert msg["command"] == "reset_to_turn"
+        assert msg["data"] == {"event_index": 1}
+
+    assert srv._engine.session_mgr.load_events(sid) == [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "first answer"},
+    ]
+
+
 def test_ws_status_includes_budget_gauges_for_configured_defaults(client, auth_headers, bearer):
     srv._engine.config.agent.default_session_budget = SessionBudget(input_tokens=1_000)
     create_resp = client.post("/api/sessions", headers=auth_headers)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -966,6 +966,20 @@ def test_reset_to_turn_rejects_unknown_target(tmp_path: Path):
         asyncio.run(_run())
 
 
+def test_history_for_completed_turn_count_excludes_trailing_incomplete_request(tmp_path: Path):
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path)
+
+    history = [
+        ModelRequest(parts=[UserPromptPart(content="first")]),
+        ModelResponse(parts=[TextPart(content="first answer")]),
+        ModelRequest(parts=[UserPromptPart(content="second")]),
+    ]
+
+    assert engine._completed_model_turn_end_indexes(history) == [1]
+    assert engine._history_for_completed_turn_count(history, 2) == history[:2]
+
+
 def test_handle_slash_command_session(tmp_path: Path):
     """handle_slash_command /session returns session metadata."""
     with _patch_sentinel():

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -925,7 +925,9 @@ def test_reset_to_turn_rewinds_later_turns(tmp_path: Path):
             ],
         )
 
-        await engine.reset_to_turn(sid, 1)
+        reset_applied = await engine.reset_to_turn(sid, 1)
+
+        assert reset_applied is True
 
         events = engine.session_mgr.load_events(sid)
         assert _without_timestamps(events) == [
@@ -957,8 +959,9 @@ def test_reset_to_turn_rejects_unknown_target(tmp_path: Path):
             ],
         )
 
-        await engine.reset_to_turn(sid, 99)
+        reset_applied = await engine.reset_to_turn(sid, 99)
 
+        assert reset_applied is False
         assert sub.errors == ["Unknown reset target"]
         assert sub.error_events == [("Unknown reset target", False)]
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -775,6 +775,194 @@ def test_submit_cancel_noop_when_inactive(tmp_path: Path):
     asyncio.run(_run())
 
 
+def test_retry_latest_turn_rewinds_and_restarts(tmp_path: Path):
+    async def _run() -> None:
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session()
+        sid = state.session_id
+
+        sub = _FakeSubscriber()
+        engine.subscribe(sid, sub)
+
+        engine.session_mgr.save_events(
+            sid,
+            [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "first answer"},
+                {"role": "user", "content": "second"},
+                {"role": "assistant", "content": "second answer"},
+            ],
+        )
+        engine.session_mgr.save_history(
+            sid,
+            [
+                ModelRequest(parts=[UserPromptPart(content="first")]),
+                ModelResponse(parts=[TextPart(content="first answer")]),
+                ModelRequest(parts=[UserPromptPart(content="second")]),
+                ModelResponse(parts=[TextPart(content="second answer")]),
+            ],
+        )
+
+        async def _fake_run_turn(
+            user_input: str,
+            _deps: Any,
+            message_history: list[Any],
+            **_kwargs: Any,
+        ) -> tuple[list[Any], str, str]:
+            assert user_input == "second"
+            assert len(message_history) == 2
+            assert isinstance(message_history[0], ModelRequest)
+            assert isinstance(message_history[1], ModelResponse)
+            return (
+                [
+                    *message_history,
+                    ModelRequest(parts=[UserPromptPart(content=user_input)]),
+                    ModelResponse(parts=[TextPart(content="retried answer")]),
+                ],
+                "retried answer",
+                "",
+            )
+
+        with patch("carapace.session.engine.run_agent_turn", new=_fake_run_turn):
+            await engine.retry_latest_turn(sid, origin=sub)
+            active = engine.get_active(sid)
+            assert active is not None and active.agent_task is not None
+            await active.agent_task
+
+        events = engine.session_mgr.load_events(sid)
+        assert _without_timestamps(events) == [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "first answer"},
+            {"role": "user", "content": "second"},
+            {"role": "assistant", "content": "retried answer"},
+        ]
+
+        history = engine.session_mgr.load_history(sid)
+        assert len(history) == 4
+        assert isinstance(history[-1], ModelResponse)
+        assert any(isinstance(part, TextPart) and part.content == "retried answer" for part in history[-1].parts)
+
+    with _patch_sentinel():
+        asyncio.run(_run())
+
+
+def test_retry_latest_turn_after_failure_uses_terminal_marker_history(tmp_path: Path):
+    async def _run() -> None:
+        engine = _make_engine(tmp_path)
+        sid = engine.session_mgr.create_session().session_id
+
+        engine.session_mgr.save_events(
+            sid,
+            [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "The previous turn failed before completion."},
+            ],
+        )
+        engine.session_mgr.save_history(
+            sid,
+            [
+                ModelRequest(parts=[UserPromptPart(content="hello")]),
+                ModelResponse(parts=[TextPart(content="The previous turn failed before completion.")]),
+            ],
+        )
+
+        async def _fake_run_turn(
+            user_input: str,
+            _deps: Any,
+            message_history: list[Any],
+            **_kwargs: Any,
+        ) -> tuple[list[Any], str, str]:
+            assert user_input == "hello"
+            assert message_history == []
+            return (
+                [
+                    ModelRequest(parts=[UserPromptPart(content=user_input)]),
+                    ModelResponse(parts=[TextPart(content="recovered")]),
+                ],
+                "recovered",
+                "",
+            )
+
+        with patch("carapace.session.engine.run_agent_turn", new=_fake_run_turn):
+            await engine.retry_latest_turn(sid)
+            active = engine.get_active(sid)
+            assert active is not None and active.agent_task is not None
+            await active.agent_task
+
+        events = engine.session_mgr.load_events(sid)
+        assert _without_timestamps(events) == [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "recovered"},
+        ]
+
+    with _patch_sentinel():
+        asyncio.run(_run())
+
+
+def test_reset_to_turn_rewinds_later_turns(tmp_path: Path):
+    async def _run() -> None:
+        engine = _make_engine(tmp_path)
+        sid = engine.session_mgr.create_session().session_id
+
+        engine.session_mgr.save_events(
+            sid,
+            [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "first answer"},
+                {"role": "user", "content": "second"},
+                {"role": "assistant", "content": "second answer"},
+            ],
+        )
+        engine.session_mgr.save_history(
+            sid,
+            [
+                ModelRequest(parts=[UserPromptPart(content="first")]),
+                ModelResponse(parts=[TextPart(content="first answer")]),
+                ModelRequest(parts=[UserPromptPart(content="second")]),
+                ModelResponse(parts=[TextPart(content="second answer")]),
+            ],
+        )
+
+        await engine.reset_to_turn(sid, 1)
+
+        events = engine.session_mgr.load_events(sid)
+        assert _without_timestamps(events) == [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "first answer"},
+        ]
+
+        history = engine.session_mgr.load_history(sid)
+        assert len(history) == 2
+        assert isinstance(history[0], ModelRequest)
+        assert isinstance(history[1], ModelResponse)
+
+    with _patch_sentinel():
+        asyncio.run(_run())
+
+
+def test_reset_to_turn_rejects_unknown_target(tmp_path: Path):
+    async def _run() -> None:
+        engine = _make_engine(tmp_path)
+        sid = engine.session_mgr.create_session().session_id
+        sub = _FakeSubscriber()
+        engine.subscribe(sid, sub)
+
+        engine.session_mgr.save_events(
+            sid,
+            [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "world"},
+            ],
+        )
+
+        await engine.reset_to_turn(sid, 99)
+
+        assert sub.errors == ["Unknown reset target"]
+
+    with _patch_sentinel():
+        asyncio.run(_run())
+
+
 def test_handle_slash_command_session(tmp_path: Path):
     """handle_slash_command /session returns session metadata."""
     with _patch_sentinel():

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -298,6 +298,7 @@ class _FakeSubscriber:
     def __init__(self) -> None:
         self.user_messages: list[tuple[str, bool]] = []
         self.errors: list[str] = []
+        self.error_events: list[tuple[str, bool]] = []
         self.cancelled: int = 0
         self.done_messages: list[tuple[str, TurnUsage]] = []
         self.title_updates: list[tuple[str, TurnUsage | None]] = []
@@ -315,8 +316,9 @@ class _FakeSubscriber:
     async def on_done(self, content: str, usage: TurnUsage) -> None:
         self.done_messages.append((content, usage))
 
-    async def on_error(self, detail: str) -> None:
+    async def on_error(self, detail: str, *, turn_terminal: bool = False) -> None:
         self.errors.append(detail)
+        self.error_events.append((detail, turn_terminal))
 
     async def on_cancelled(self) -> None:
         self.cancelled += 1
@@ -958,6 +960,7 @@ def test_reset_to_turn_rejects_unknown_target(tmp_path: Path):
         await engine.reset_to_turn(sid, 99)
 
         assert sub.errors == ["Unknown reset target"]
+        assert sub.error_events == [("Unknown reset target", False)]
 
     with _patch_sentinel():
         asyncio.run(_run())
@@ -1371,6 +1374,9 @@ def test_submit_message_budget_exceeded_persists_history(tmp_path: Path):
             "content": "Session budget reached: input 1.0k tokens / 1.0k tokens",
         }
         assert any("Session budget reached" in err for err in sub.errors)
+        assert any(
+            detail.startswith("Session budget reached") and turn_terminal for detail, turn_terminal in sub.error_events
+        )
 
     with _patch_sentinel():
         asyncio.run(_run())


### PR DESCRIPTION
Co-authored-by: Copilot <copilot@github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Rewrites persisted session `events` and model `history` when retrying/resetting turns; incorrect turn boundary detection or indexing could drop or misalign conversation state.
> 
> **Overview**
> Adds **turn-level recovery controls** to chat: users can *retry the latest completed turn* or *reset the conversation to after an earlier turn* from the message UI.
> 
> This introduces new WebSocket client messages `retry_latest_turn` and `reset_to_turn`, plus a `command_result` ack for resets. The backend now annotates history entries with `event_index`, rewrites stored `events` and model `history` when rewinding, and marks certain `error` messages as `turn_terminal` so the UI can treat failures as completed turns (enabling retry/reset).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 418785916e18daf08550a0cbd18d17e55c957c39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->