### PR TITLE
✨ feat: Add session fork action

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -247,6 +247,12 @@ function HomeContent() {
     handleSessionUpdate(session);
   }, []);
 
+  const handleForkSession = useCallback((session: SessionInfo) => {
+    handleSessionUpdate(session);
+    setActiveSessionId(session.session_id);
+    setSidebarOpen(false);
+  }, []);
+
   const handleActiveSessionDelete = useCallback(async () => {
     if (!activeSessionId) return;
     await handleDeleteSession(activeSessionId);
@@ -315,6 +321,7 @@ function HomeContent() {
             onTitleUpdate={handleActiveSessionTitleUpdate}
             onSessionUpdate={handleActiveSessionUpdate}
             onSandboxUpdate={handleActiveSessionSandboxUpdate}
+            onForkSession={handleForkSession}
             onDeleteSession={handleActiveSessionDelete}
           />
         ) : (

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -10,6 +10,7 @@ import {
   fetchHistory,
   fetchSandbox,
   fetchModels,
+  forkSession,
   type SlashCommand,
   startSandbox,
   stopSandbox,
@@ -48,6 +49,7 @@ interface ChatViewProps {
   onTitleUpdate?: (title: string) => void;
   onSessionUpdate?: (session: SessionInfo) => void;
   onSandboxUpdate?: (sandbox: SessionSandboxSnapshot) => void;
+  onForkSession?: (session: SessionInfo) => void;
   onDeleteSession?: () => Promise<void>;
 }
 
@@ -705,6 +707,7 @@ export function ChatView({
   onTitleUpdate,
   onSessionUpdate,
   onSandboxUpdate,
+  onForkSession,
   onDeleteSession,
 }: ChatViewProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -1284,27 +1287,34 @@ export function ChatView({
     send({ type: "retry_latest_turn" });
   }
 
+  async function resolveTurnTargetEventIndex(messageIndex: number): Promise<number | undefined> {
+    const currentMessages = messages;
+    const localTerminalIndices = completedTurnMessageIndices(currentMessages);
+    const localTurnOrdinal = localTerminalIndices.indexOf(messageIndex);
+    if (localTurnOrdinal === -1) return undefined;
+
+    let targetEventIndex = eventIndexForMessage(currentMessages[messageIndex]);
+
+    if (targetEventIndex == null) {
+      const history = await fetchHistory(server, token, sessionId);
+      const canonicalMessages = projectHistoryToMessages(history);
+      const canonicalTerminalIndices = completedTurnMessageIndices(canonicalMessages);
+      const canonicalMessageIndex = canonicalTerminalIndices[localTurnOrdinal];
+      if (canonicalMessageIndex != null) {
+        targetEventIndex = eventIndexForMessage(canonicalMessages[canonicalMessageIndex]);
+      }
+    }
+
+    return targetEventIndex;
+  }
+
   async function handleReset(messageIndex: number) {
     if (waiting || status !== "connected") return;
 
     const currentMessages = messages;
-    const localTerminalIndices = completedTurnMessageIndices(currentMessages);
-    const localTurnOrdinal = localTerminalIndices.indexOf(messageIndex);
-    if (localTurnOrdinal === -1) return;
-
     setTurnActionBusyIndex(messageIndex);
     try {
-      let targetEventIndex = eventIndexForMessage(currentMessages[messageIndex]);
-
-      if (targetEventIndex == null) {
-        const history = await fetchHistory(server, token, sessionId);
-        const canonicalMessages = projectHistoryToMessages(history);
-        const canonicalTerminalIndices = completedTurnMessageIndices(canonicalMessages);
-        const canonicalMessageIndex = canonicalTerminalIndices[localTurnOrdinal];
-        if (canonicalMessageIndex != null) {
-          targetEventIndex = eventIndexForMessage(canonicalMessages[canonicalMessageIndex]);
-        }
-      }
+      const targetEventIndex = await resolveTurnTargetEventIndex(messageIndex);
 
       if (targetEventIndex == null) {
         setMessages((prev) => [
@@ -1317,6 +1327,32 @@ export function ChatView({
       resetRollbackRef.current = currentMessages;
       send({ type: "reset_to_turn", event_index: targetEventIndex });
       setMessages((prev) => prev.slice(0, messageIndex + 1));
+    } finally {
+      setTurnActionBusyIndex(null);
+    }
+  }
+
+  async function handleFork(messageIndex: number) {
+    if (waiting || status !== "connected" || !onForkSession) return;
+
+    setTurnActionBusyIndex(messageIndex);
+    try {
+      const targetEventIndex = await resolveTurnTargetEventIndex(messageIndex);
+      if (targetEventIndex == null) {
+        setMessages((prev) => [
+          ...prev,
+          { kind: "error", detail: "Could not resolve fork target." },
+        ]);
+        return;
+      }
+
+      const forked = await forkSession(server, token, sessionId, {
+        eventIndex: targetEventIndex,
+        channelType: "web",
+      });
+      onForkSession(forked);
+    } catch (error) {
+      setMessages((prev) => [...prev, { kind: "error", detail: errorDetail(error) }]);
     } finally {
       setTurnActionBusyIndex(null);
     }
@@ -1746,12 +1782,14 @@ export function ChatView({
               key={i}
               message={msg}
               activeLlmActivity={llmActivity}
+              canFork={msg.kind === "assistant"}
               canRetry={i === latestTerminalIndex && isTurnTerminalMessage(msg)}
               canReset={i !== latestTerminalIndex && isTurnTerminalMessage(msg)}
               actionDisabled={turnActionsDisabled}
               onApproval={handleApproval}
               onEscalation={handleEscalation}
               onCredentialApproval={handleCredentialEscalation}
+              onFork={msg.kind === "assistant" ? () => void handleFork(i) : undefined}
               onRetry={i === latestTerminalIndex && isTurnTerminalMessage(msg) ? handleRetry : undefined}
               onReset={i !== latestTerminalIndex && isTurnTerminalMessage(msg) ? () => void handleReset(i) : undefined}
             />

--- a/frontend/src/components/message.tsx
+++ b/frontend/src/components/message.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Brain, Check, ChevronRight, Copy, Loader2, RotateCcw, Undo2 } from "lucide-react";
+import { Brain, Check, ChevronRight, Copy, GitBranch, Loader2, RotateCcw, Undo2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 
 import type { ChatMessage, EscalationDecision, LlmActivity } from "@/lib/types";
@@ -195,25 +195,35 @@ function MessageActionButton({
 
 function MessageActions({
   copyText,
+  canFork,
   canRetry,
   canReset,
   disabled,
+  onFork,
   onRetry,
   onReset,
 }: {
   copyText?: string;
+  canFork?: boolean;
   canRetry?: boolean;
   canReset?: boolean;
   disabled?: boolean;
+  onFork?: () => void;
   onRetry?: () => void;
   onReset?: () => void;
 }) {
   const hasCopy = typeof copyText === "string" && copyText.length > 0;
-  if (!hasCopy && !canRetry && !canReset) return null;
+  if (!hasCopy && !canFork && !canRetry && !canReset) return null;
 
   return (
     <div className="mt-2 flex items-center gap-2">
       <MessageCopyButton text={copyText ?? ""} className="border border-border/70 p-1.5" />
+      <MessageActionButton
+        label="Fork session from here"
+        icon={<GitBranch className="size-3.5" />}
+        disabled={disabled}
+        onClick={canFork ? onFork : undefined}
+      />
       <MessageActionButton
         label="Retry turn"
         icon={<RotateCcw className="size-3.5" />}
@@ -233,6 +243,7 @@ function MessageActions({
 interface MessageProps {
   message: ChatMessage;
   activeLlmActivity?: LlmActivity | null;
+  canFork?: boolean;
   canRetry?: boolean;
   canReset?: boolean;
   actionDisabled?: boolean;
@@ -247,6 +258,7 @@ interface MessageProps {
     decision: EscalationDecision,
     message?: string,
   ) => void;
+  onFork?: () => void;
   onRetry?: () => void;
   onReset?: () => void;
 }
@@ -254,12 +266,14 @@ interface MessageProps {
 export function Message({
   message,
   activeLlmActivity,
+  canFork,
   canRetry,
   canReset,
   actionDisabled,
   onApproval,
   onEscalation,
   onCredentialApproval,
+  onFork,
   onRetry,
   onReset,
 }: MessageProps) {
@@ -286,9 +300,11 @@ export function Message({
           </div>
           <MessageActions
             copyText={message.content}
+            canFork={canFork}
             canRetry={canRetry}
             canReset={canReset}
             disabled={actionDisabled}
+            onFork={onFork}
             onRetry={onRetry}
             onReset={onReset}
           />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -53,6 +53,25 @@ export async function updateSession(
   return res.json();
 }
 
+export async function forkSession(
+  server: string,
+  token: string,
+  sessionId: string,
+  body: { eventIndex: number; channelType: string; channelRef?: string },
+): Promise<SessionInfo> {
+  const res = await fetch(`${server}/api/sessions/${sessionId}/fork`, {
+    method: "POST",
+    headers: headers(token),
+    body: JSON.stringify({
+      event_index: body.eventIndex,
+      channel_type: body.channelType,
+      channel_ref: body.channelRef ?? "",
+    }),
+  });
+  if (!res.ok) throw new Error(`Failed to fork session: ${res.status}`);
+  return res.json();
+}
+
 export async function commitSessionKnowledge(
   server: string,
   token: string,

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -455,6 +455,12 @@ class SessionUpdateRequest(BaseModel):
     private: bool | None = None
 
 
+class SessionForkRequest(BaseModel):
+    event_index: int
+    channel_type: str = "cli"
+    channel_ref: str = ""
+
+
 class SessionInfo(BaseModel):
     session_id: str
     channel_type: str
@@ -571,6 +577,31 @@ async def update_session(
 
     sandbox = _engine.session_mgr.load_sandbox_snapshot(session_id)
     return SessionInfo.from_state(state, message_count=_session_message_count(session_id), sandbox=sandbox)
+
+
+@router.post("/sessions/{session_id}/fork", response_model=SessionInfo)
+async def fork_session(
+    session_id: str,
+    body: SessionForkRequest,
+    _token: str = Depends(_verify_token),
+) -> SessionInfo:
+    state = _engine.session_mgr.load_state(session_id)
+    if state is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    try:
+        forked = _engine.fork_session(
+            session_id,
+            event_index=body.event_index,
+            channel_type=body.channel_type,
+            channel_ref=body.channel_ref,
+        )
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return SessionInfo.from_state(forked, message_count=_session_message_count(forked.session_id))
 
 
 @router.post("/sessions/{session_id}/knowledge/commit", response_model=SessionArchiveCommitResponse)

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -16,6 +16,7 @@ import secrets
 import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, Literal
@@ -727,6 +728,57 @@ class SessionEngine(SessionTurnMixin):
 
         self._rewrite_session_transcript(session_id, events[: target.end_event_index + 1])
         return True
+
+    def fork_session(
+        self,
+        session_id: str,
+        *,
+        event_index: int,
+        channel_type: str,
+        channel_ref: str = "",
+    ) -> SessionState:
+        active = self._ensure_active(session_id)
+        if active.agent_task and not active.agent_task.done():
+            msg = "Agent is busy — cancel first"
+            raise RuntimeError(msg)
+
+        source_state = active.state.model_copy(deep=True)
+        events = self._truncate_incomplete_events(self._session_mgr.load_events(session_id))
+        turns = self._completed_event_turns(events)
+        target = next((turn for turn in turns if turn.end_event_index == event_index), None)
+        if target is None:
+            msg = "Unknown fork target"
+            raise ValueError(msg)
+
+        forked_events = events[: target.end_event_index + 1]
+        turn_count = len(self._completed_event_turns(forked_events))
+        history = self._truncate_incomplete_model_history(self._session_mgr.load_history(session_id))
+        forked_history = self._history_for_completed_turn_count(history, turn_count)
+
+        now = datetime.now(tz=UTC)
+        forked_session_id = f"{now:%Y-%m-%d-%H-%M}-{secrets.token_hex(4)}"
+        forked_state = source_state.model_copy(
+            deep=True,
+            update={
+                "session_id": forked_session_id,
+                "channel_type": channel_type,
+                "channel_ref": channel_ref or None,
+                "title": f"{source_state.title} (Kopie)" if source_state.title else None,
+                "created_at": now,
+                "last_active": now,
+                "knowledge_last_committed_at": None,
+                "knowledge_last_archive_path": None,
+                "knowledge_last_export_hash": None,
+                "knowledge_last_commit_trigger": None,
+            },
+        )
+
+        self._session_mgr.save_state(forked_state)
+        self._session_mgr.save_events(forked_session_id, forked_events)
+        self._session_mgr.save_history(forked_session_id, forked_history)
+        self._session_mgr.clear_llm_request_state(forked_session_id)
+        self._session_mgr.clear_sandbox_snapshot(forked_session_id)
+        return forked_state
 
     async def submit_cancel(self, session_id: str) -> None:
         """Cancel the running agent turn for *session_id*."""

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -763,7 +763,7 @@ class SessionEngine(SessionTurnMixin):
                 "session_id": forked_session_id,
                 "channel_type": channel_type,
                 "channel_ref": channel_ref or None,
-                "title": f"{source_state.title} (Kopie)" if source_state.title else None,
+                "title": f"{source_state.title} (Copy)" if source_state.title else None,
                 "created_at": now,
                 "last_active": now,
                 "knowledge_last_committed_at": None,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -255,7 +255,7 @@ def test_fork_session_creates_new_session_from_turn(client, auth_headers):
     assert data["session_id"] != sid
     assert data["channel_type"] == "web"
     assert data["channel_ref"] is None
-    assert data["title"] == "Fork me (Kopie)"
+    assert data["title"] == "Fork me (Copy)"
     assert data["message_count"] == 2
     forked_sid = data["session_id"]
     forked_state = srv._engine.session_mgr.load_state(forked_sid)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -225,6 +225,46 @@ def test_update_session_privacy_updates_active_session_state(client, auth_header
     assert active.state.activated_skills == ["demo-skill"]
 
 
+def test_fork_session_creates_new_session_from_turn(client, auth_headers):
+    create_resp = client.post("/api/sessions", headers=auth_headers)
+    sid = create_resp.json()["session_id"]
+    state = srv._engine.session_mgr.load_state(sid)
+    state.title = "Fork me"
+    state.activated_skills = ["web"]
+    state.channel_type = "matrix"
+    state.channel_ref = "!room:example.com"
+    srv._engine.session_mgr.save_state(state)
+    srv._engine.session_mgr.append_events(
+        sid,
+        [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "world"},
+            {"role": "user", "content": "follow-up"},
+            {"role": "assistant", "content": "next"},
+        ],
+    )
+
+    resp = client.post(
+        f"/api/sessions/{sid}/fork",
+        headers=auth_headers,
+        json={"event_index": 1, "channel_type": "web", "channel_ref": ""},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["session_id"] != sid
+    assert data["channel_type"] == "web"
+    assert data["channel_ref"] is None
+    assert data["title"] == "Fork me (Kopie)"
+    assert data["message_count"] == 2
+    forked_sid = data["session_id"]
+    forked_state = srv._engine.session_mgr.load_state(forked_sid)
+    assert forked_state is not None
+    assert forked_state.activated_skills == ["web"]
+    assert srv._engine.session_mgr.load_events(forked_sid)[-1]["content"] == "world"
+    assert srv._engine.session_mgr.load_events(sid)[-1]["content"] == "next"
+
+
 def test_commit_session_knowledge_writes_archive(client, auth_headers, tmp_path):
     create_resp = client.post("/api/sessions", headers=auth_headers)
     sid = create_resp.json()["session_id"]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -456,7 +456,7 @@ def test_fork_session_copies_transcript_and_security_context(tmp_path: Path) -> 
     assert forked.session_id != sid
     assert forked.channel_type == "web"
     assert forked.channel_ref is None
-    assert forked.title == "Original title (Kopie)"
+    assert forked.title == "Original title (Copy)"
     assert forked.private is True
     assert forked.approved_operations == ["exec"]
     assert forked.activated_skills == ["web"]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -408,6 +408,78 @@ def test_record_tool_call_event_reuses_sentinel_row_for_user_decision(tmp_path: 
     ]
 
 
+def test_fork_session_copies_transcript_and_security_context(tmp_path: Path) -> None:
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path)
+
+    source = engine.session_mgr.create_session(channel_type="matrix", channel_ref="!room:example.com", private=True)
+    sid = source.session_id
+    active = engine.get_or_activate(sid)
+    active.state.title = "Original title"
+    active.state.approved_operations = ["exec"]
+    active.state.activated_skills = ["web"]
+    active.state.context_grants["web"] = ContextGrant(skill_name="web", domains={"example.com"})
+    active.state.knowledge_last_archive_path = "sessions/archive.json"
+    active.state.knowledge_last_commit_trigger = "manual"
+    active.state.knowledge_last_committed_at = datetime.now(tz=UTC)
+    engine.session_mgr.save_state(active.state)
+    engine.session_mgr.save_usage(
+        sid,
+        usage_mod.UsageTracker(models={"anthropic:test": ModelUsage(input_tokens=11, output_tokens=7)}),
+    )
+    engine.session_mgr.save_sandbox_snapshot(
+        sid,
+        SessionSandboxSnapshot(runtime="kubernetes", status="scaled_down", storage_present=True),
+    )
+    engine.session_mgr.append_events(
+        sid,
+        [
+            {"role": "user", "content": "first"},
+            {"role": "tool_call", "tool": "read", "args": {"path": "README.md"}, "detail": "reading"},
+            {"role": "assistant", "content": "reply one"},
+            {"role": "user", "content": "second"},
+            {"role": "assistant", "content": "reply two"},
+        ],
+    )
+    engine.session_mgr.save_history(
+        sid,
+        [
+            ModelRequest(parts=[UserPromptPart(content="first")]),
+            ModelResponse(parts=[TextPart(content="reply one")]),
+            ModelRequest(parts=[UserPromptPart(content="second")]),
+            ModelResponse(parts=[TextPart(content="reply two")]),
+        ],
+    )
+
+    forked = engine.fork_session(sid, event_index=2, channel_type="web")
+
+    assert forked.session_id != sid
+    assert forked.channel_type == "web"
+    assert forked.channel_ref is None
+    assert forked.title == "Original title (Kopie)"
+    assert forked.private is True
+    assert forked.approved_operations == ["exec"]
+    assert forked.activated_skills == ["web"]
+    assert forked.context_grants["web"].domains == {"example.com"}
+    assert forked.knowledge_last_committed_at is None
+    assert forked.knowledge_last_archive_path is None
+    assert forked.knowledge_last_commit_trigger is None
+    assert _without_timestamps(engine.session_mgr.load_events(forked.session_id)) == [
+        {"role": "user", "content": "first"},
+        {"role": "tool_call", "tool": "read", "args": {"path": "README.md"}, "detail": "reading"},
+        {"role": "assistant", "content": "reply one"},
+    ]
+    forked_history = engine.session_mgr.load_history(forked.session_id)
+    assert len(forked_history) == 2
+    assert isinstance(forked_history[0], ModelRequest)
+    assert isinstance(forked_history[1], ModelResponse)
+    assert forked_history[0].parts[0].content == "first"
+    assert forked_history[1].parts[0].content == "reply one"
+    assert engine.session_mgr.load_usage(forked.session_id).models == {}
+    assert engine.session_mgr.load_sandbox_snapshot(forked.session_id) is None
+    assert len(engine.session_mgr.load_events(sid)) == 5
+
+
 def test_handle_token_chunk_promotes_activity_and_broadcasts(tmp_path: Path) -> None:
     async def _run() -> None:
         with _patch_sentinel():


### PR DESCRIPTION
## Summary
Add a session fork action that creates a new session from any completed assistant turn.

## What changed
- add a backend `POST /api/sessions/{session_id}/fork` endpoint
- copy transcript and security context into a new session with fresh session/channel metadata
- keep usage, in-flight LLM activity, and sandbox state out of the forked session
- add a fork button to the turn toolbar in the web UI and switch to the new session after forking
- cover the fork flow with focused backend tests

## Validation
- `uv run pytest tests/test_session.py::test_fork_session_copies_transcript_and_security_context tests/test_server.py::test_fork_session_creates_new_session_from_turn`
- `pnpm --dir frontend exec tsc --noEmit`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new server endpoint and session-engine logic that clones session state/history, which can affect persistence and session integrity if event/turn indexing is wrong. UI changes are straightforward but depend on correct backend fork semantics and error handling.
> 
> **Overview**
> Adds **session forking**: the server now exposes `POST /api/sessions/{session_id}/fork` to create a new session copied from a specified completed turn, duplicating transcript/history and security context while resetting knowledge-commit metadata, usage/LLM request state, and sandbox snapshot.
> 
> The web UI adds a *Fork* action on assistant turns, resolves the correct `event_index` (falling back to canonical history when needed), calls the new API, and switches the user to the newly created session. Backend coverage is added to assert the forked session’s metadata, truncated events/history, and cleared runtime state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71c632b1bc2c7c2f53da5d0120bc7fdfd6dc81c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->