### PR TITLE
✨ feat: Batch proxy sentinel domain reviews

### DIFF
--- a/src/carapace/models.py
+++ b/src/carapace/models.py
@@ -271,11 +271,17 @@ class AgentConfig(BaseModel):
 
     max_parallel_llm: int = 2
 
+    # Maximum number of extra sentinel-backed proxy domain reviews one tool call can trigger.
+    # 0 disables the cap.
+    max_sentinel_calls_per_tool_call: int = 5
+
     # Cap string length returned to the model (and mirrored to tool_result_callback). 0 = no limit.
     tool_output_max_chars: int = 16_000
 
     @model_validator(mode="after")
     def _defaults_listed_in_available_models(self) -> AgentConfig:
+        if self.max_sentinel_calls_per_tool_call < 0:
+            raise ValueError("agent.max_sentinel_calls_per_tool_call must be >= 0")
         catalog_ids = {e.model_id for e in self.available_models}
         for field_name in ("model", "sentinel_model", "title_model"):
             mid = getattr(self, field_name)

--- a/src/carapace/models.py
+++ b/src/carapace/models.py
@@ -271,9 +271,12 @@ class AgentConfig(BaseModel):
 
     max_parallel_llm: int = 2
 
-    # Maximum number of extra sentinel-backed proxy domain reviews one tool call can trigger.
+    # Maximum number of sentinel-backed proxy domain review batches one tool call can trigger.
     # 0 disables the cap.
     max_sentinel_calls_per_tool_call: int = 5
+
+    # Debounce window for coalescing proxy domain requests within a tool call.
+    sentinel_domain_batch_window_ms: int = 100
 
     # Cap string length returned to the model (and mirrored to tool_result_callback). 0 = no limit.
     tool_output_max_chars: int = 16_000
@@ -282,6 +285,8 @@ class AgentConfig(BaseModel):
     def _defaults_listed_in_available_models(self) -> AgentConfig:
         if self.max_sentinel_calls_per_tool_call < 0:
             raise ValueError("agent.max_sentinel_calls_per_tool_call must be >= 0")
+        if self.sentinel_domain_batch_window_ms < 0:
+            raise ValueError("agent.sentinel_domain_batch_window_ms must be >= 0")
         catalog_ids = {e.model_id for e in self.available_models}
         for field_name in ("model", "sentinel_model", "title_model"):
             mid = getattr(self, field_name)

--- a/src/carapace/security/__init__.py
+++ b/src/carapace/security/__init__.py
@@ -16,6 +16,7 @@ from carapace.security.context import (
     ApprovalSource,
     ApprovalVerdict,
     AuditEntry,
+    CachedDomainApproval,
     GitPushEntry,
     SecurityDeniedError,
     SentinelVerdict,
@@ -182,30 +183,47 @@ async def evaluate_domain_with(
     If the sentinel escalates, delegates to the session's user escalation callback.
     """
 
-    session.notify_domain_decision(domain, "[sentinel] reviewing", approval_source="sentinel")
+    cached_approval = session.get_cached_domain_approval(domain)
+    if cached_approval is not None:
+        detail = (
+            f"[cached {cached_approval.approval_source}: {cached_approval.approval_verdict}] "
+            + "reused earlier decision"
+        )
+        session.notify_domain_decision(
+            domain,
+            detail,
+            approval_source=cached_approval.approval_source,
+            approval_verdict=cached_approval.approval_verdict,
+            approval_explanation=cached_approval.explanation,
+        )
+        session.write_audit(
+            AuditEntry.now(
+                kind="proxy_domain",
+                domain=domain,
+                final_decision="allowed" if cached_approval.allowed else "denied",
+                explanation="Reused earlier domain decision within the same tool call.",
+            )
+        )
+        return cached_approval.allowed
 
-    verdict = await sentinel.evaluate_domain_access(
-        session,
-        domain,
-        command,
-        usage_tracker=usage_tracker,
-        assert_llm_budget_available=assert_llm_budget_available,
-        usage_limits=usage_limits,
-    )
+    can_review, _review_no, review_limit = session.begin_domain_sentinel_review()
 
+    verdict: SentinelVerdict
     allowed: bool
     final_decision: str
     user_message: str | None = None
 
-    if verdict.decision == "allow":
-        allowed = True
-        final_decision = "allowed"
-        detail = f"[sentinel: allow] {verdict.explanation}"
-    elif verdict.decision == "deny":
-        allowed = False
-        final_decision = "denied"
-        detail = f"[sentinel: deny] {verdict.explanation}"
-    else:
+    if not can_review:
+        limit_text = (
+            "Automatic sentinel review hit the per-tool-call domain review limit"
+            + (f" ({review_limit})" if review_limit is not None else "")
+            + ". Please approve or deny this domain manually."
+        )
+        verdict = SentinelVerdict(
+            decision="escalate",
+            explanation=limit_text,
+            risk_level="high",
+        )
         user_decision = await session.escalate_to_user(
             domain,
             {"command": command, "explanation": verdict.explanation, "kind": "domain_access"},
@@ -213,16 +231,61 @@ async def evaluate_domain_with(
         allowed = user_decision.allowed
         user_message = user_decision.message
         final_decision = "allowed" if allowed else "denied"
-        detail = format_denial_message("user", user_message) if not allowed else "[user: allow]"
+        detail = (
+            "[user: allow] sentinel domain review limit reached"
+            if allowed
+            else format_denial_message("user", user_message)
+        )
+    else:
+        session.notify_domain_decision(domain, "[sentinel] reviewing", approval_source="sentinel")
+
+        verdict = await sentinel.evaluate_domain_access(
+            session,
+            domain,
+            command,
+            usage_tracker=usage_tracker,
+            assert_llm_budget_available=assert_llm_budget_available,
+            usage_limits=usage_limits,
+        )
+
+        if verdict.decision == "allow":
+            allowed = True
+            final_decision = "allowed"
+            detail = f"[sentinel: allow] {verdict.explanation}"
+        elif verdict.decision == "deny":
+            allowed = False
+            final_decision = "denied"
+            detail = f"[sentinel: deny] {verdict.explanation}"
+        else:
+            user_decision = await session.escalate_to_user(
+                domain,
+                {"command": command, "explanation": verdict.explanation, "kind": "domain_access"},
+            )
+            allowed = user_decision.allowed
+            user_message = user_decision.message
+            final_decision = "allowed" if allowed else "denied"
+            detail = format_denial_message("user", user_message) if not allowed else "[user: allow]"
 
     source: ApprovalSource = "sentinel" if verdict.decision != "escalate" else "user"
     approval_verdict: ApprovalVerdict = "allow" if allowed else "deny"
+    approval_explanation = (
+        verdict.explanation if source == "sentinel" else normalize_optional_message(user_message) or verdict.explanation
+    )
+    session.cache_domain_approval(
+        domain,
+        CachedDomainApproval(
+            allowed=allowed,
+            approval_source=source,
+            approval_verdict=approval_verdict,
+            explanation=approval_explanation,
+        ),
+    )
     session.notify_domain_decision(
         domain,
         detail,
         approval_source=source,
         approval_verdict=approval_verdict,
-        approval_explanation=verdict.explanation if source == "sentinel" else normalize_optional_message(user_message),
+        approval_explanation=approval_explanation,
     )
 
     session.write_audit(

--- a/src/carapace/security/__init__.py
+++ b/src/carapace/security/__init__.py
@@ -243,7 +243,32 @@ async def evaluate_domain_with(
         return cached_approval.allowed
 
     if pending_result is None:
-        raise RuntimeError("Expected a pending domain review future for batched proxy gating.")
+        result = await _evaluate_single_domain_access(
+            session,
+            sentinel,
+            domain,
+            command,
+            usage_tracker=usage_tracker,
+            assert_llm_budget_available=assert_llm_budget_available,
+            usage_limits=usage_limits,
+        )
+        session.notify_domain_decision(
+            domain,
+            result.detail,
+            approval_source=result.approval_source,
+            approval_verdict=result.approval_verdict,
+            approval_explanation=result.explanation,
+        )
+        session.write_audit(
+            AuditEntry.now(
+                kind="proxy_domain",
+                domain=domain,
+                sentinel_verdict=result.sentinel_verdict,
+                final_decision=result.final_decision,
+                explanation=result.audit_explanation,
+            )
+        )
+        return result.allowed
 
     if should_notify_queued:
         session.notify_domain_decision(domain, "[sentinel] queued for batched review", approval_source="sentinel")

--- a/src/carapace/security/__init__.py
+++ b/src/carapace/security/__init__.py
@@ -416,7 +416,7 @@ async def _evaluate_domain_batch(
         session.notify_domain_decision(domain, "[sentinel] reviewing", approval_source="sentinel")
 
     try:
-        verdicts = await sentinel.evaluate_domain_access_batch(
+        verdict = await sentinel.evaluate_domain_access_batch(
             session,
             domain_commands,
             usage_tracker=usage_tracker,
@@ -429,21 +429,10 @@ async def _evaluate_domain_batch(
             for domain, command in domain_commands.items()
         }
 
-    results: dict[str, CachedDomainApproval] = {}
-    for domain, command in domain_commands.items():
-        verdict = verdicts.get(
-            domain,
-            SentinelVerdict(
-                decision="escalate",
-                explanation=(
-                    "Automatic sentinel review did not return a decision for this domain. "
-                    + "Please approve or deny it manually."
-                ),
-                risk_level="high",
-            ),
-        )
-        results[domain] = await _decision_from_verdict(session, domain, command, verdict)
-    return results
+    return {
+        domain: await _decision_from_verdict(session, domain, command, verdict)
+        for domain, command in domain_commands.items()
+    }
 
 
 async def _run_domain_batch_worker(

--- a/src/carapace/security/__init__.py
+++ b/src/carapace/security/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -9,14 +10,13 @@ from pydantic_ai import ApprovalRequired
 from pydantic_ai.exceptions import UsageLimitExceeded
 from pydantic_ai.usage import UsageLimits
 
-from carapace.security.context import (
-    ActionLogEntry as ActionLogEntry,
-)
+from carapace.security.context import ActionLogEntry as ActionLogEntry
 from carapace.security.context import (
     ApprovalSource,
     ApprovalVerdict,
     AuditEntry,
     CachedDomainApproval,
+    DomainBatchSnapshot,
     GitPushEntry,
     SecurityDeniedError,
     SentinelVerdict,
@@ -25,9 +25,7 @@ from carapace.security.context import (
     format_denial_message,
     normalize_optional_message,
 )
-from carapace.security.context import (
-    CredentialAccessEntry as CredentialAccessEntry,
-)
+from carapace.security.context import CredentialAccessEntry as CredentialAccessEntry
 from carapace.security.sentinel import Sentinel
 from carapace.usage import UsageTracker
 
@@ -183,7 +181,47 @@ async def evaluate_domain_with(
     If the sentinel escalates, delegates to the session's user escalation callback.
     """
 
-    cached_approval = session.get_cached_domain_approval(domain)
+    if session.current_parent_tool_id is None:
+        result = await _evaluate_single_domain_access(
+            session,
+            sentinel,
+            domain,
+            command,
+            usage_tracker=usage_tracker,
+            assert_llm_budget_available=assert_llm_budget_available,
+            usage_limits=usage_limits,
+        )
+        session.notify_domain_decision(
+            domain,
+            result.detail,
+            approval_source=result.approval_source,
+            approval_verdict=result.approval_verdict,
+            approval_explanation=result.explanation,
+        )
+        session.write_audit(
+            AuditEntry.now(
+                kind="proxy_domain",
+                domain=domain,
+                sentinel_verdict=result.sentinel_verdict,
+                final_decision=result.final_decision,
+                explanation=result.audit_explanation,
+            )
+        )
+        return result.allowed
+
+    cached_approval, pending_result, should_notify_queued = await session.get_or_enqueue_domain_approval(
+        domain,
+        command,
+        lambda: asyncio.create_task(
+            _run_domain_batch_worker(
+                session,
+                sentinel,
+                usage_tracker=usage_tracker,
+                assert_llm_budget_available=assert_llm_budget_available,
+                usage_limits=usage_limits,
+            )
+        ),
+    )
     if cached_approval is not None:
         detail = (
             f"[cached {cached_approval.approval_source}: {cached_approval.approval_verdict}] "
@@ -206,24 +244,74 @@ async def evaluate_domain_with(
         )
         return cached_approval.allowed
 
-    can_review, _review_no, review_limit = session.begin_domain_sentinel_review()
+    if pending_result is None:
+        raise RuntimeError("Expected a pending domain review future for batched proxy gating.")
 
-    verdict: SentinelVerdict
+    if should_notify_queued:
+        session.notify_domain_decision(domain, "[sentinel] queued for batched review", approval_source="sentinel")
+
+    result = await pending_result
+    session.notify_domain_decision(
+        domain,
+        result.detail,
+        approval_source=result.approval_source,
+        approval_verdict=result.approval_verdict,
+        approval_explanation=result.explanation,
+    )
+    session.write_audit(
+        AuditEntry.now(
+            kind="proxy_domain",
+            domain=domain,
+            sentinel_verdict=result.sentinel_verdict,
+            final_decision=result.final_decision,
+            explanation=result.audit_explanation,
+        )
+    )
+    return result.allowed
+
+
+async def _evaluate_single_domain_access(
+    session: SessionSecurity,
+    sentinel: Sentinel,
+    domain: str,
+    command: str,
+    *,
+    usage_tracker: UsageTracker | None = None,
+    assert_llm_budget_available: Callable[[], None] | None = None,
+    usage_limits: UsageLimits | None = None,
+) -> CachedDomainApproval:
+    session.notify_domain_decision(domain, "[sentinel] reviewing", approval_source="sentinel")
+
+    verdict = await sentinel.evaluate_domain_access(
+        session,
+        domain,
+        command,
+        usage_tracker=usage_tracker,
+        assert_llm_budget_available=assert_llm_budget_available,
+        usage_limits=usage_limits,
+    )
+    return await _decision_from_verdict(session, domain, command, verdict)
+
+
+async def _decision_from_verdict(
+    session: SessionSecurity,
+    domain: str,
+    command: str,
+    verdict: SentinelVerdict,
+) -> CachedDomainApproval:
     allowed: bool
-    final_decision: str
+    final_decision: Literal["allowed", "denied"]
     user_message: str | None = None
 
-    if not can_review:
-        limit_text = (
-            "Automatic sentinel review hit the per-tool-call domain review limit"
-            + (f" ({review_limit})" if review_limit is not None else "")
-            + ". Please approve or deny this domain manually."
-        )
-        verdict = SentinelVerdict(
-            decision="escalate",
-            explanation=limit_text,
-            risk_level="high",
-        )
+    if verdict.decision == "allow":
+        allowed = True
+        final_decision = "allowed"
+        detail = f"[sentinel: allow] {verdict.explanation}"
+    elif verdict.decision == "deny":
+        allowed = False
+        final_decision = "denied"
+        detail = f"[sentinel: deny] {verdict.explanation}"
+    else:
         user_decision = await session.escalate_to_user(
             domain,
             {"command": command, "explanation": verdict.explanation, "kind": "domain_access"},
@@ -231,74 +319,169 @@ async def evaluate_domain_with(
         allowed = user_decision.allowed
         user_message = user_decision.message
         final_decision = "allowed" if allowed else "denied"
-        detail = (
-            "[user: allow] sentinel domain review limit reached"
-            if allowed
-            else format_denial_message("user", user_message)
-        )
-    else:
-        session.notify_domain_decision(domain, "[sentinel] reviewing", approval_source="sentinel")
-
-        verdict = await sentinel.evaluate_domain_access(
-            session,
-            domain,
-            command,
-            usage_tracker=usage_tracker,
-            assert_llm_budget_available=assert_llm_budget_available,
-            usage_limits=usage_limits,
-        )
-
-        if verdict.decision == "allow":
-            allowed = True
-            final_decision = "allowed"
-            detail = f"[sentinel: allow] {verdict.explanation}"
-        elif verdict.decision == "deny":
-            allowed = False
-            final_decision = "denied"
-            detail = f"[sentinel: deny] {verdict.explanation}"
-        else:
-            user_decision = await session.escalate_to_user(
-                domain,
-                {"command": command, "explanation": verdict.explanation, "kind": "domain_access"},
-            )
-            allowed = user_decision.allowed
-            user_message = user_decision.message
-            final_decision = "allowed" if allowed else "denied"
-            detail = format_denial_message("user", user_message) if not allowed else "[user: allow]"
+        detail = format_denial_message("user", user_message) if not allowed else "[user: allow]"
 
     source: ApprovalSource = "sentinel" if verdict.decision != "escalate" else "user"
     approval_verdict: ApprovalVerdict = "allow" if allowed else "deny"
     approval_explanation = (
         verdict.explanation if source == "sentinel" else normalize_optional_message(user_message) or verdict.explanation
     )
-    session.cache_domain_approval(
-        domain,
-        CachedDomainApproval(
-            allowed=allowed,
-            approval_source=source,
-            approval_verdict=approval_verdict,
-            explanation=approval_explanation,
-        ),
-    )
-    session.notify_domain_decision(
-        domain,
-        detail,
+    return CachedDomainApproval(
+        allowed=allowed,
         approval_source=source,
         approval_verdict=approval_verdict,
-        approval_explanation=approval_explanation,
+        explanation=approval_explanation,
+        detail=detail,
+        final_decision=final_decision,
+        audit_explanation=verdict.explanation,
+        sentinel_verdict=verdict,
     )
 
-    session.write_audit(
-        AuditEntry.now(
-            kind="proxy_domain",
-            domain=domain,
-            sentinel_verdict=verdict,
-            final_decision=final_decision,
-            explanation=verdict.explanation,
+
+async def _decision_for_batch_limit(
+    session: SessionSecurity,
+    domain: str,
+    command: str,
+    review_limit: int | None,
+) -> CachedDomainApproval:
+    limit_text = (
+        "Automatic sentinel review hit the per-tool-call domain batch limit"
+        + (f" ({review_limit})" if review_limit is not None else "")
+        + ". Please approve or deny this domain manually."
+    )
+    verdict = SentinelVerdict(
+        decision="escalate",
+        explanation=limit_text,
+        risk_level="high",
+    )
+    user_decision = await session.escalate_to_user(
+        domain,
+        {"command": command, "explanation": verdict.explanation, "kind": "domain_access"},
+    )
+    allowed = user_decision.allowed
+    user_message = user_decision.message
+    return CachedDomainApproval(
+        allowed=allowed,
+        approval_source="user",
+        approval_verdict="allow" if allowed else "deny",
+        explanation=normalize_optional_message(user_message) or verdict.explanation,
+        detail=(
+            "[user: allow] sentinel domain batch limit reached"
+            if allowed
+            else format_denial_message("user", user_message)
+        ),
+        final_decision="allowed" if allowed else "denied",
+        audit_explanation=verdict.explanation,
+        sentinel_verdict=verdict,
+    )
+
+
+async def _decision_for_usage_limit(
+    session: SessionSecurity,
+    domain: str,
+    command: str,
+) -> CachedDomainApproval:
+    verdict = SentinelVerdict(
+        decision="escalate",
+        explanation=(
+            "Automatic sentinel review hit its internal request limit and could not finish. "
+            + "Please approve or deny this domain manually."
+        ),
+        risk_level="high",
+    )
+    return await _decision_from_verdict(session, domain, command, verdict)
+
+
+async def _evaluate_domain_batch(
+    session: SessionSecurity,
+    sentinel: Sentinel,
+    snapshot: DomainBatchSnapshot,
+    *,
+    usage_tracker: UsageTracker | None = None,
+    assert_llm_budget_available: Callable[[], None] | None = None,
+    usage_limits: UsageLimits | None = None,
+) -> dict[str, CachedDomainApproval]:
+    domain_commands = {domain: request.command for domain, request in snapshot.requests.items()}
+    if not snapshot.can_review:
+        return {
+            domain: await _decision_for_batch_limit(session, domain, command, snapshot.review_limit)
+            for domain, command in domain_commands.items()
+        }
+
+    for domain in domain_commands:
+        session.notify_domain_decision(domain, "[sentinel] reviewing", approval_source="sentinel")
+
+    try:
+        verdicts = await sentinel.evaluate_domain_access_batch(
+            session,
+            domain_commands,
+            usage_tracker=usage_tracker,
+            assert_llm_budget_available=assert_llm_budget_available,
+            usage_limits=usage_limits,
         )
-    )
+    except UsageLimitExceeded:
+        return {
+            domain: await _decision_for_usage_limit(session, domain, command)
+            for domain, command in domain_commands.items()
+        }
 
-    return allowed
+    results: dict[str, CachedDomainApproval] = {}
+    for domain, command in domain_commands.items():
+        verdict = verdicts.get(
+            domain,
+            SentinelVerdict(
+                decision="escalate",
+                explanation=(
+                    "Automatic sentinel review did not return a decision for this domain. "
+                    + "Please approve or deny it manually."
+                ),
+                risk_level="high",
+            ),
+        )
+        results[domain] = await _decision_from_verdict(session, domain, command, verdict)
+    return results
+
+
+async def _run_domain_batch_worker(
+    session: SessionSecurity,
+    sentinel: Sentinel,
+    *,
+    usage_tracker: UsageTracker | None = None,
+    assert_llm_budget_available: Callable[[], None] | None = None,
+    usage_limits: UsageLimits | None = None,
+) -> None:
+    while True:
+        snapshot = await session.next_domain_batch()
+        if snapshot is None:
+            return
+
+        try:
+            results = await _evaluate_domain_batch(
+                session,
+                sentinel,
+                snapshot,
+                usage_tracker=usage_tracker,
+                assert_llm_budget_available=assert_llm_budget_available,
+                usage_limits=usage_limits,
+            )
+        except asyncio.CancelledError:
+            await session.fail_domain_batch(snapshot)
+            for request in snapshot.requests.values():
+                if not request.future.done():
+                    request.future.set_exception(RuntimeError("Proxy domain batch was cancelled."))
+            raise
+        except Exception as exc:
+            await session.fail_domain_batch(snapshot)
+            for request in snapshot.requests.values():
+                if not request.future.done():
+                    request.future.set_exception(exc)
+            raise
+
+        await session.complete_domain_batch(snapshot, results)
+        for domain, request in snapshot.requests.items():
+            result = results[domain]
+            if not request.future.done():
+                request.future.set_result(result)
 
 
 async def evaluate_push_with(

--- a/src/carapace/security/__init__.py
+++ b/src/carapace/security/__init__.py
@@ -282,14 +282,18 @@ async def _evaluate_single_domain_access(
 ) -> CachedDomainApproval:
     session.notify_domain_decision(domain, "[sentinel] reviewing", approval_source="sentinel")
 
-    verdict = await sentinel.evaluate_domain_access(
-        session,
-        domain,
-        command,
-        usage_tracker=usage_tracker,
-        assert_llm_budget_available=assert_llm_budget_available,
-        usage_limits=usage_limits,
-    )
+    try:
+        verdict = await sentinel.evaluate_domain_access(
+            session,
+            domain,
+            command,
+            usage_tracker=usage_tracker,
+            assert_llm_budget_available=assert_llm_budget_available,
+            usage_limits=usage_limits,
+        )
+    except UsageLimitExceeded:
+        return await _decision_for_usage_limit(session, domain, command)
+
     return await _decision_from_verdict(session, domain, command, verdict)
 
 
@@ -472,10 +476,11 @@ async def _run_domain_batch_worker(
             raise
         except Exception as exc:
             await session.fail_domain_batch(snapshot)
+            await session.fail_pending_domain_requests(snapshot, exc)
             for request in snapshot.requests.values():
                 if not request.future.done():
                     request.future.set_exception(exc)
-            raise
+            continue
 
         await session.complete_domain_batch(snapshot, results)
         for domain, request in snapshot.requests.items():

--- a/src/carapace/security/__init__.py
+++ b/src/carapace/security/__init__.py
@@ -223,14 +223,12 @@ async def evaluate_domain_with(
         ),
     )
     if cached_approval is not None:
-        detail = (
-            f"[cached {cached_approval.approval_source}: {cached_approval.approval_verdict}] "
-            + "reused earlier decision"
-        )
+        display_source: ApprovalSource = "safe-list" if cached_approval.allowed else cached_approval.approval_source
+        detail = f"[cached {display_source}: {cached_approval.approval_verdict}] " + "reused earlier decision"
         session.notify_domain_decision(
             domain,
             detail,
-            approval_source=cached_approval.approval_source,
+            approval_source=display_source,
             approval_verdict=cached_approval.approval_verdict,
             approval_explanation=cached_approval.explanation,
         )

--- a/src/carapace/security/context.py
+++ b/src/carapace/security/context.py
@@ -383,6 +383,12 @@ class SessionSecurity:
             self._sync_domain_scope()
             for domain in snapshot.requests:
                 self._domain_scope_inflight_futures.pop(domain, None)
+            if (
+                snapshot.can_review
+                and self.current_parent_tool_id == snapshot.scope_id
+                and self._domain_scope_sentinel_calls > 0
+            ):
+                self._domain_scope_sentinel_calls -= 1
 
     async def fail_pending_domain_requests(self, snapshot: DomainBatchSnapshot, exc: Exception) -> None:
         async with self._domain_scope_lock:

--- a/src/carapace/security/context.py
+++ b/src/carapace/security/context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -129,6 +130,17 @@ class SentinelVerdict(BaseModel):
     risk_level: Literal["low", "medium", "high"] = "medium"
 
 
+class BatchedSentinelVerdictEntry(BaseModel):
+    domain: str
+    decision: Literal["allow", "escalate", "deny"]
+    explanation: str = ""
+    risk_level: Literal["low", "medium", "high"] = "medium"
+
+
+class BatchedSentinelVerdict(BaseModel):
+    decisions: list[BatchedSentinelVerdictEntry] = []
+
+
 ApprovalSource = Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"]
 ApprovalVerdict = Literal["allow", "deny", "escalate"]
 
@@ -139,6 +151,24 @@ class CachedDomainApproval:
     approval_source: ApprovalSource
     approval_verdict: ApprovalVerdict
     explanation: str | None = None
+    detail: str = ""
+    final_decision: Literal["allowed", "denied"] = "allowed"
+    audit_explanation: str | None = None
+    sentinel_verdict: SentinelVerdict | None = None
+
+
+@dataclass(slots=True)
+class PendingDomainRequest:
+    command: str
+    future: asyncio.Future[CachedDomainApproval]
+
+
+@dataclass(frozen=True, slots=True)
+class DomainBatchSnapshot:
+    scope_id: str
+    requests: dict[str, PendingDomainRequest]
+    can_review: bool
+    review_limit: int | None
 
 
 # --- Audit Log ---
@@ -190,6 +220,7 @@ class SessionSecurity:
         *,
         audit_dir: Path | None = None,
         max_sentinel_calls_per_tool_call: int = 5,
+        sentinel_domain_batch_window_ms: int = 100,
     ) -> None:
         self.session_id = session_id
         self.action_log: list[
@@ -206,6 +237,7 @@ class SessionSecurity:
         ] = []
         self.sentinel_eval_count: int = 0
         self.max_sentinel_calls_per_tool_call = max_sentinel_calls_per_tool_call
+        self.sentinel_domain_batch_window_ms = sentinel_domain_batch_window_ms
         self._last_synced_idx: int = 0
         self._audit_dir = audit_dir
         self._user_escalation_callback: (
@@ -222,13 +254,41 @@ class SessionSecurity:
         ) = None
         self._credential_notify_suppress: Callable[[str], bool] | None = None
         self.current_parent_tool_id: str | None = None
+        self._domain_scope_lock = asyncio.Lock()
         self._domain_scope_parent_tool_id: str | None = None
         self._domain_scope_approvals: dict[str, CachedDomainApproval] = {}
         self._domain_scope_sentinel_calls: int = 0
+        self._domain_scope_pending_generation: int = 0
+        self._domain_scope_pending_requests: dict[str, PendingDomainRequest] = {}
+        self._domain_scope_inflight_futures: dict[str, asyncio.Future[CachedDomainApproval]] = {}
+        self._domain_scope_worker_task: asyncio.Task[None] | None = None
+
+    def _cancel_domain_future(self, future: asyncio.Future[CachedDomainApproval], message: str) -> None:
+        if not future.done():
+            future.set_exception(RuntimeError(message))
 
     def _reset_domain_scope(self) -> None:
+        current_task: asyncio.Task[None] | None
+        try:
+            current_task = asyncio.current_task()
+        except RuntimeError:
+            current_task = None
+        if (
+            self._domain_scope_worker_task is not None
+            and not self._domain_scope_worker_task.done()
+            and self._domain_scope_worker_task is not current_task
+        ):
+            self._domain_scope_worker_task.cancel()
+        for request in self._domain_scope_pending_requests.values():
+            self._cancel_domain_future(request.future, "Proxy domain batch was cancelled.")
+        for future in self._domain_scope_inflight_futures.values():
+            self._cancel_domain_future(future, "Proxy domain batch was cancelled.")
         self._domain_scope_approvals = {}
         self._domain_scope_sentinel_calls = 0
+        self._domain_scope_pending_generation = 0
+        self._domain_scope_pending_requests = {}
+        self._domain_scope_inflight_futures = {}
+        self._domain_scope_worker_task = None
 
     def _sync_domain_scope(self) -> None:
         if self.current_parent_tool_id != self._domain_scope_parent_tool_id:
@@ -251,17 +311,101 @@ class SessionSecurity:
             return
         self._domain_scope_approvals[domain] = approval
 
-    def begin_domain_sentinel_review(self) -> tuple[bool, int | None, int | None]:
-        self._sync_domain_scope()
-        if self.current_parent_tool_id is None:
-            return True, None, None
+    async def get_or_enqueue_domain_approval(
+        self,
+        domain: str,
+        command: str,
+        worker_factory: Callable[[], asyncio.Task[None]],
+    ) -> tuple[CachedDomainApproval | None, asyncio.Future[CachedDomainApproval] | None, bool]:
+        async with self._domain_scope_lock:
+            self._sync_domain_scope()
+            if self.current_parent_tool_id is None:
+                return None, None, False
 
-        limit = self.max_sentinel_calls_per_tool_call
-        if limit > 0 and self._domain_scope_sentinel_calls >= limit:
-            return False, self._domain_scope_sentinel_calls, limit
+            cached = self._domain_scope_approvals.get(domain)
+            if cached is not None:
+                return cached, None, False
 
-        self._domain_scope_sentinel_calls += 1
-        return True, self._domain_scope_sentinel_calls, limit if limit > 0 else None
+            inflight = self._domain_scope_inflight_futures.get(domain)
+            if inflight is not None:
+                return None, inflight, False
+
+            pending = self._domain_scope_pending_requests.get(domain)
+            if pending is None:
+                future = asyncio.get_running_loop().create_future()
+                self._domain_scope_pending_requests[domain] = PendingDomainRequest(command=command, future=future)
+                should_notify_queued = True
+            else:
+                pending.command = command
+                future = pending.future
+                should_notify_queued = False
+
+            self._domain_scope_pending_generation += 1
+            if self._domain_scope_worker_task is None or self._domain_scope_worker_task.done():
+                self._domain_scope_worker_task = worker_factory()
+            return None, future, should_notify_queued
+
+    async def next_domain_batch(self) -> DomainBatchSnapshot | None:
+        while True:
+            async with self._domain_scope_lock:
+                self._sync_domain_scope()
+                if self.current_parent_tool_id is None or not self._domain_scope_pending_requests:
+                    self._domain_scope_worker_task = None
+                    return None
+                generation = self._domain_scope_pending_generation
+                wait_seconds = max(self.sentinel_domain_batch_window_ms, 0) / 1000
+
+            if wait_seconds > 0:
+                await asyncio.sleep(wait_seconds)
+
+            async with self._domain_scope_lock:
+                self._sync_domain_scope()
+                if self.current_parent_tool_id is None or not self._domain_scope_pending_requests:
+                    self._domain_scope_worker_task = None
+                    return None
+                if generation != self._domain_scope_pending_generation:
+                    continue
+
+                scope_id = self.current_parent_tool_id
+                if scope_id is None:
+                    self._domain_scope_worker_task = None
+                    return None
+
+                requests = self._domain_scope_pending_requests
+                self._domain_scope_pending_requests = {}
+                for domain, request in requests.items():
+                    self._domain_scope_inflight_futures[domain] = request.future
+
+                limit = self.max_sentinel_calls_per_tool_call
+                can_review = limit <= 0 or self._domain_scope_sentinel_calls < limit
+                if can_review:
+                    self._domain_scope_sentinel_calls += 1
+
+                return DomainBatchSnapshot(
+                    scope_id=scope_id,
+                    requests=requests,
+                    can_review=can_review,
+                    review_limit=limit if limit > 0 else None,
+                )
+
+    async def complete_domain_batch(
+        self,
+        snapshot: DomainBatchSnapshot,
+        results: dict[str, CachedDomainApproval],
+    ) -> None:
+        async with self._domain_scope_lock:
+            self._sync_domain_scope()
+            for domain in snapshot.requests:
+                self._domain_scope_inflight_futures.pop(domain, None)
+            if self.current_parent_tool_id == snapshot.scope_id:
+                for domain, result in results.items():
+                    self._domain_scope_approvals[domain] = result
+
+    async def fail_domain_batch(self, snapshot: DomainBatchSnapshot) -> None:
+        async with self._domain_scope_lock:
+            self._sync_domain_scope()
+            for domain in snapshot.requests:
+                self._domain_scope_inflight_futures.pop(domain, None)
 
     def append(self, entry: ActionLogEntry) -> None:
         self.action_log.append(entry)

--- a/src/carapace/security/context.py
+++ b/src/carapace/security/context.py
@@ -312,12 +312,12 @@ class SessionSecurity:
                 future = asyncio.get_running_loop().create_future()
                 self._domain_scope_pending_requests[domain] = PendingDomainRequest(command=command, future=future)
                 should_notify_queued = True
+                self._domain_scope_pending_generation += 1
             else:
                 pending.command = command
                 future = pending.future
                 should_notify_queued = False
 
-            self._domain_scope_pending_generation += 1
             if self._domain_scope_worker_task is None or self._domain_scope_worker_task.done():
                 self._domain_scope_worker_task = worker_factory()
             return None, future, should_notify_queued

--- a/src/carapace/security/context.py
+++ b/src/carapace/security/context.py
@@ -130,17 +130,6 @@ class SentinelVerdict(BaseModel):
     risk_level: Literal["low", "medium", "high"] = "medium"
 
 
-class BatchedSentinelVerdictEntry(BaseModel):
-    domain: str
-    decision: Literal["allow", "escalate", "deny"]
-    explanation: str = ""
-    risk_level: Literal["low", "medium", "high"] = "medium"
-
-
-class BatchedSentinelVerdict(BaseModel):
-    decisions: list[BatchedSentinelVerdictEntry] = []
-
-
 ApprovalSource = Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"]
 ApprovalVerdict = Literal["allow", "deny", "escalate"]
 

--- a/src/carapace/security/context.py
+++ b/src/carapace/security/context.py
@@ -299,18 +299,6 @@ class SessionSecurity:
         self.current_parent_tool_id = None
         self._sync_domain_scope()
 
-    def get_cached_domain_approval(self, domain: str) -> CachedDomainApproval | None:
-        self._sync_domain_scope()
-        if self.current_parent_tool_id is None:
-            return None
-        return self._domain_scope_approvals.get(domain)
-
-    def cache_domain_approval(self, domain: str, approval: CachedDomainApproval) -> None:
-        self._sync_domain_scope()
-        if self.current_parent_tool_id is None:
-            return
-        self._domain_scope_approvals[domain] = approval
-
     async def get_or_enqueue_domain_approval(
         self,
         domain: str,
@@ -406,6 +394,19 @@ class SessionSecurity:
             self._sync_domain_scope()
             for domain in snapshot.requests:
                 self._domain_scope_inflight_futures.pop(domain, None)
+
+    async def fail_pending_domain_requests(self, snapshot: DomainBatchSnapshot, exc: Exception) -> None:
+        async with self._domain_scope_lock:
+            self._sync_domain_scope()
+            if self.current_parent_tool_id != snapshot.scope_id:
+                return
+
+            pending_requests = self._domain_scope_pending_requests
+            self._domain_scope_pending_requests = {}
+            self._domain_scope_pending_generation += 1
+
+        for request in pending_requests.values():
+            self._cancel_domain_future(request.future, str(exc))
 
     def append(self, entry: ActionLogEntry) -> None:
         self.action_log.append(entry)

--- a/src/carapace/security/context.py
+++ b/src/carapace/security/context.py
@@ -133,6 +133,14 @@ ApprovalSource = Literal["safe-list", "sentinel", "user", "skill", "bypass", "un
 ApprovalVerdict = Literal["allow", "deny", "escalate"]
 
 
+@dataclass(frozen=True, slots=True)
+class CachedDomainApproval:
+    allowed: bool
+    approval_source: ApprovalSource
+    approval_verdict: ApprovalVerdict
+    explanation: str | None = None
+
+
 # --- Audit Log ---
 
 
@@ -176,7 +184,13 @@ class AuditEntry(BaseModel):
 class SessionSecurity:
     """Mutable per-session security state managed by the security module."""
 
-    def __init__(self, session_id: str, *, audit_dir: Path | None = None) -> None:
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        audit_dir: Path | None = None,
+        max_sentinel_calls_per_tool_call: int = 5,
+    ) -> None:
         self.session_id = session_id
         self.action_log: list[
             UserMessageEntry
@@ -191,6 +205,7 @@ class SessionSecurity:
             | ContextGrantEntry
         ] = []
         self.sentinel_eval_count: int = 0
+        self.max_sentinel_calls_per_tool_call = max_sentinel_calls_per_tool_call
         self._last_synced_idx: int = 0
         self._audit_dir = audit_dir
         self._user_escalation_callback: (
@@ -207,6 +222,46 @@ class SessionSecurity:
         ) = None
         self._credential_notify_suppress: Callable[[str], bool] | None = None
         self.current_parent_tool_id: str | None = None
+        self._domain_scope_parent_tool_id: str | None = None
+        self._domain_scope_approvals: dict[str, CachedDomainApproval] = {}
+        self._domain_scope_sentinel_calls: int = 0
+
+    def _reset_domain_scope(self) -> None:
+        self._domain_scope_approvals = {}
+        self._domain_scope_sentinel_calls = 0
+
+    def _sync_domain_scope(self) -> None:
+        if self.current_parent_tool_id != self._domain_scope_parent_tool_id:
+            self._domain_scope_parent_tool_id = self.current_parent_tool_id
+            self._reset_domain_scope()
+
+    def clear_current_parent_tool(self) -> None:
+        self.current_parent_tool_id = None
+        self._sync_domain_scope()
+
+    def get_cached_domain_approval(self, domain: str) -> CachedDomainApproval | None:
+        self._sync_domain_scope()
+        if self.current_parent_tool_id is None:
+            return None
+        return self._domain_scope_approvals.get(domain)
+
+    def cache_domain_approval(self, domain: str, approval: CachedDomainApproval) -> None:
+        self._sync_domain_scope()
+        if self.current_parent_tool_id is None:
+            return
+        self._domain_scope_approvals[domain] = approval
+
+    def begin_domain_sentinel_review(self) -> tuple[bool, int | None, int | None]:
+        self._sync_domain_scope()
+        if self.current_parent_tool_id is None:
+            return True, None, None
+
+        limit = self.max_sentinel_calls_per_tool_call
+        if limit > 0 and self._domain_scope_sentinel_calls >= limit:
+            return False, self._domain_scope_sentinel_calls, limit
+
+        self._domain_scope_sentinel_calls += 1
+        return True, self._domain_scope_sentinel_calls, limit if limit > 0 else None
 
     def append(self, entry: ActionLogEntry) -> None:
         self.action_log.append(entry)

--- a/src/carapace/security/sentinel.py
+++ b/src/carapace/security/sentinel.py
@@ -16,7 +16,6 @@ from carapace.security.context import (
     ActionLogEntry,
     AgentResponseEntry,
     ApprovalEntry,
-    BatchedSentinelVerdict,
     ContextGrantEntry,
     CredentialAccessEntry,
     GitPushEntry,
@@ -148,7 +147,6 @@ class Sentinel:
         self._model_factory = model_factory
         self._model_settings_resolver = model_settings_resolver
         self._agent = self._create_agent()
-        self._batch_agent = self._create_batch_agent()
         self._message_history: list[Any] = []
         self._skill_file_cache: dict[tuple[str, str], tuple[int, int, str]] = {}
         self._eval_skill_reads: int = 0
@@ -164,7 +162,6 @@ class Sentinel:
         """Switch the sentinel model, recreating the internal agent."""
         self._model = model
         self._agent = self._create_agent()
-        self._batch_agent = self._create_batch_agent()
 
     def _load_system_prompt(self, _ctx: RunContext[Path]) -> str:
         return _build_system_prompt(self._load_security_md())
@@ -409,77 +406,6 @@ class Sentinel:
         self._register_agent_tools(agent)
         return agent
 
-    def _create_batch_agent(self) -> Agent[Path, BatchedSentinelVerdict]:
-        resolved = self._model_factory(self._model) if self._model_factory is not None else infer_model(self._model)
-        model_settings = (
-            self._model_settings_resolver(self._model) if self._model_settings_resolver is not None else None
-        )
-        agent: Agent[Path, BatchedSentinelVerdict] = Agent(
-            resolved,
-            deps_type=Path,
-            output_type=ToolOutput(BatchedSentinelVerdict, name="judge_batch"),
-            instructions=self._load_system_prompt,
-            capabilities=[LlmRequestLogCapability(source="sentinel")],
-            model_settings=model_settings,
-            output_retries=2,
-            retries=1,
-        )
-        self._register_agent_tools(agent)
-        return agent
-
-    async def _run_batch_evaluation(
-        self,
-        session: SessionSecurity,
-        prompt: str,
-        *,
-        subject: str,
-        new_entries_count: int,
-        usage_tracker: UsageTracker | None = None,
-        assert_llm_budget_available: Callable[[], None] | None = None,
-        usage_limits: UsageLimits | None = None,
-    ) -> BatchedSentinelVerdict:
-        eval_no = session.sentinel_eval_count + 1
-        logger.info(
-            f"Sentinel eval start session={session.session_id} seq={eval_no} "
-            + f"kind=domain_access_batch subject={subject} "
-            + f"history_messages={len(self._message_history)} new_entries={new_entries_count}"
-        )
-        self._begin_eval_logging(session.session_id, eval_no)
-
-        try:
-            if assert_llm_budget_available is not None:
-                assert_llm_budget_available()
-            result = await self._batch_agent.run(
-                prompt,
-                deps=self._skills_dir,
-                message_history=self._message_history or None,
-                usage_limits=usage_limits,
-            )
-        except Exception as exc:
-            stats = self._end_eval_logging()
-            logger.error(
-                f"Sentinel eval failed session={session.session_id} seq={eval_no} "
-                + f"kind=domain_access_batch subject={subject} "
-                + f"error={type(exc).__name__}: {exc} {self._format_eval_stats(stats)}"
-            )
-            raise
-
-        stats = self._end_eval_logging()
-        self._message_history = result.all_messages()
-        session.sentinel_eval_count += 1
-
-        if usage_tracker:
-            usage_tracker.record(self._model, "sentinel", result.usage())
-
-        usage = result.usage()
-        decisions = ", ".join(f"{item.domain}:{item.decision}" for item in result.output.decisions[:5]) or "none"
-        logger.info(
-            f"Sentinel eval done session={session.session_id} seq={eval_no} kind=domain_access_batch subject={subject} "
-            + f"decisions={decisions} input_tokens={usage.input_tokens or 0} output_tokens={usage.output_tokens or 0} "
-            + self._format_eval_stats(stats)
-        )
-        return result.output
-
     async def evaluate_tool_call(
         self,
         session: SessionSecurity,
@@ -567,7 +493,7 @@ class Sentinel:
         usage_tracker: UsageTracker | None = None,
         assert_llm_budget_available: Callable[[], None] | None = None,
         usage_limits: UsageLimits | None = None,
-    ) -> dict[str, SentinelVerdict]:
+    ) -> SentinelVerdict:
         async with self._lock:
             if self._should_reset(session):
                 self._reset(session)
@@ -586,41 +512,19 @@ class Sentinel:
             for domain, command in sorted(domain_commands.items()):
                 prompt_parts.append(f"Domain: {domain}")
                 prompt_parts.append(f"Triggered by: {command}")
+            prompt_parts.append("Apply one verdict to the entire batch of domains.")
 
             prompt = "\n".join(prompt_parts)
-            output = await self._run_batch_evaluation(
+            return await self._run_evaluation(
                 session,
                 prompt,
+                kind="domain_access_batch",
                 subject=f"{len(domain_commands)} domains",
                 new_entries_count=len(new_entries),
                 usage_tracker=usage_tracker,
                 assert_llm_budget_available=assert_llm_budget_available,
                 usage_limits=usage_limits,
             )
-
-            verdicts: dict[str, SentinelVerdict] = {}
-            for item in output.decisions:
-                if item.domain in domain_commands and item.domain not in verdicts:
-                    verdicts[item.domain] = SentinelVerdict(
-                        decision=item.decision,
-                        explanation=item.explanation,
-                        risk_level=item.risk_level,
-                    )
-
-            for domain in domain_commands:
-                verdicts.setdefault(
-                    domain,
-                    SentinelVerdict(
-                        decision="escalate",
-                        explanation=(
-                            "Automatic sentinel review did not return a decision for this domain. "
-                            + "Please approve or deny it manually."
-                        ),
-                        risk_level="high",
-                    ),
-                )
-
-            return verdicts
 
     async def evaluate_credential_access(
         self,
@@ -674,7 +578,6 @@ class Sentinel:
             + f"after {session.sentinel_eval_count} evaluations"
         )
         self._agent = self._create_agent()
-        self._batch_agent = self._create_batch_agent()
         self._message_history.clear()
         self._skill_file_cache.clear()
         self._end_eval_logging()

--- a/src/carapace/security/sentinel.py
+++ b/src/carapace/security/sentinel.py
@@ -16,6 +16,7 @@ from carapace.security.context import (
     ActionLogEntry,
     AgentResponseEntry,
     ApprovalEntry,
+    BatchedSentinelVerdict,
     ContextGrantEntry,
     CredentialAccessEntry,
     GitPushEntry,
@@ -54,7 +55,7 @@ for the duration of that skill's usage. Your job is to judge whether
 activating the skill makes sense for the user's request, not whether
 each individual credential or domain is justified separately.
 
-Always respond with a SentinelVerdict (structured output).
+Always respond using the requested structured output schema.
 
 """
 
@@ -147,6 +148,7 @@ class Sentinel:
         self._model_factory = model_factory
         self._model_settings_resolver = model_settings_resolver
         self._agent = self._create_agent()
+        self._batch_agent = self._create_batch_agent()
         self._message_history: list[Any] = []
         self._skill_file_cache: dict[tuple[str, str], tuple[int, int, str]] = {}
         self._eval_skill_reads: int = 0
@@ -162,6 +164,7 @@ class Sentinel:
         """Switch the sentinel model, recreating the internal agent."""
         self._model = model
         self._agent = self._create_agent()
+        self._batch_agent = self._create_batch_agent()
 
     def _load_system_prompt(self, _ctx: RunContext[Path]) -> str:
         return _build_system_prompt(self._load_security_md())
@@ -343,22 +346,7 @@ class Sentinel:
         )
         return result.output
 
-    def _create_agent(self) -> Agent[Path, SentinelVerdict]:
-        resolved = self._model_factory(self._model) if self._model_factory is not None else infer_model(self._model)
-        model_settings = (
-            self._model_settings_resolver(self._model) if self._model_settings_resolver is not None else None
-        )
-        agent: Agent[Path, SentinelVerdict] = Agent(
-            resolved,
-            deps_type=Path,
-            output_type=ToolOutput(SentinelVerdict, name="judge"),
-            instructions=self._load_system_prompt,
-            capabilities=[LlmRequestLogCapability(source="sentinel")],
-            model_settings=model_settings,
-            output_retries=2,
-            retries=1,
-        )
-
+    def _register_agent_tools(self, agent: Agent[Path, Any]) -> None:
         @agent.tool
         async def list_skill_files(ctx: RunContext[Path], skill_name: str) -> str:
             """List files in a skill's master directory. Skills are trusted user-authored content."""
@@ -402,7 +390,95 @@ class Sentinel:
             )
             return result
 
+    def _create_agent(self) -> Agent[Path, SentinelVerdict]:
+        resolved = self._model_factory(self._model) if self._model_factory is not None else infer_model(self._model)
+        model_settings = (
+            self._model_settings_resolver(self._model) if self._model_settings_resolver is not None else None
+        )
+        agent: Agent[Path, SentinelVerdict] = Agent(
+            resolved,
+            deps_type=Path,
+            output_type=ToolOutput(SentinelVerdict, name="judge"),
+            instructions=self._load_system_prompt,
+            capabilities=[LlmRequestLogCapability(source="sentinel")],
+            model_settings=model_settings,
+            output_retries=2,
+            retries=1,
+        )
+
+        self._register_agent_tools(agent)
         return agent
+
+    def _create_batch_agent(self) -> Agent[Path, BatchedSentinelVerdict]:
+        resolved = self._model_factory(self._model) if self._model_factory is not None else infer_model(self._model)
+        model_settings = (
+            self._model_settings_resolver(self._model) if self._model_settings_resolver is not None else None
+        )
+        agent: Agent[Path, BatchedSentinelVerdict] = Agent(
+            resolved,
+            deps_type=Path,
+            output_type=ToolOutput(BatchedSentinelVerdict, name="judge_batch"),
+            instructions=self._load_system_prompt,
+            capabilities=[LlmRequestLogCapability(source="sentinel")],
+            model_settings=model_settings,
+            output_retries=2,
+            retries=1,
+        )
+        self._register_agent_tools(agent)
+        return agent
+
+    async def _run_batch_evaluation(
+        self,
+        session: SessionSecurity,
+        prompt: str,
+        *,
+        subject: str,
+        new_entries_count: int,
+        usage_tracker: UsageTracker | None = None,
+        assert_llm_budget_available: Callable[[], None] | None = None,
+        usage_limits: UsageLimits | None = None,
+    ) -> BatchedSentinelVerdict:
+        eval_no = session.sentinel_eval_count + 1
+        logger.info(
+            f"Sentinel eval start session={session.session_id} seq={eval_no} "
+            + f"kind=domain_access_batch subject={subject} "
+            + f"history_messages={len(self._message_history)} new_entries={new_entries_count}"
+        )
+        self._begin_eval_logging(session.session_id, eval_no)
+
+        try:
+            if assert_llm_budget_available is not None:
+                assert_llm_budget_available()
+            result = await self._batch_agent.run(
+                prompt,
+                deps=self._skills_dir,
+                message_history=self._message_history or None,
+                usage_limits=usage_limits,
+            )
+        except Exception as exc:
+            stats = self._end_eval_logging()
+            logger.error(
+                f"Sentinel eval failed session={session.session_id} seq={eval_no} "
+                + f"kind=domain_access_batch subject={subject} "
+                + f"error={type(exc).__name__}: {exc} {self._format_eval_stats(stats)}"
+            )
+            raise
+
+        stats = self._end_eval_logging()
+        self._message_history = result.all_messages()
+        session.sentinel_eval_count += 1
+
+        if usage_tracker:
+            usage_tracker.record(self._model, "sentinel", result.usage())
+
+        usage = result.usage()
+        decisions = ", ".join(f"{item.domain}:{item.decision}" for item in result.output.decisions[:5]) or "none"
+        logger.info(
+            f"Sentinel eval done session={session.session_id} seq={eval_no} kind=domain_access_batch subject={subject} "
+            + f"decisions={decisions} input_tokens={usage.input_tokens or 0} output_tokens={usage.output_tokens or 0} "
+            + self._format_eval_stats(stats)
+        )
+        return result.output
 
     async def evaluate_tool_call(
         self,
@@ -483,6 +559,69 @@ class Sentinel:
                 usage_limits=usage_limits,
             )
 
+    async def evaluate_domain_access_batch(
+        self,
+        session: SessionSecurity,
+        domain_commands: dict[str, str],
+        *,
+        usage_tracker: UsageTracker | None = None,
+        assert_llm_budget_available: Callable[[], None] | None = None,
+        usage_limits: UsageLimits | None = None,
+    ) -> dict[str, SentinelVerdict]:
+        async with self._lock:
+            if self._should_reset(session):
+                self._reset(session)
+
+            new_entries = session.new_entries_since_sync()
+
+            prompt_parts: list[str] = []
+            if not self._message_history:
+                prompt_parts.append("Session started. Action log so far:")
+                prompt_parts.append(_format_action_log(session.action_log))
+            elif new_entries:
+                prompt_parts.append("New entries since last evaluation:")
+                prompt_parts.append(_format_action_log(new_entries))
+
+            prompt_parts.append("\nEVALUATE domain_access_batch_request:")
+            for domain, command in sorted(domain_commands.items()):
+                prompt_parts.append(f"Domain: {domain}")
+                prompt_parts.append(f"Triggered by: {command}")
+
+            prompt = "\n".join(prompt_parts)
+            output = await self._run_batch_evaluation(
+                session,
+                prompt,
+                subject=f"{len(domain_commands)} domains",
+                new_entries_count=len(new_entries),
+                usage_tracker=usage_tracker,
+                assert_llm_budget_available=assert_llm_budget_available,
+                usage_limits=usage_limits,
+            )
+
+            verdicts: dict[str, SentinelVerdict] = {}
+            for item in output.decisions:
+                if item.domain in domain_commands and item.domain not in verdicts:
+                    verdicts[item.domain] = SentinelVerdict(
+                        decision=item.decision,
+                        explanation=item.explanation,
+                        risk_level=item.risk_level,
+                    )
+
+            for domain in domain_commands:
+                verdicts.setdefault(
+                    domain,
+                    SentinelVerdict(
+                        decision="escalate",
+                        explanation=(
+                            "Automatic sentinel review did not return a decision for this domain. "
+                            + "Please approve or deny it manually."
+                        ),
+                        risk_level="high",
+                    ),
+                )
+
+            return verdicts
+
     async def evaluate_credential_access(
         self,
         session: SessionSecurity,
@@ -535,6 +674,7 @@ class Sentinel:
             + f"after {session.sentinel_eval_count} evaluations"
         )
         self._agent = self._create_agent()
+        self._batch_agent = self._create_batch_agent()
         self._message_history.clear()
         self._skill_file_cache.clear()
         self._end_eval_logging()

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -1231,7 +1231,10 @@ class SessionEngine(SessionTurnMixin):
         if isinstance(contexts_raw, list):
             event["contexts"] = list(contexts_raw)
 
-        should_update_existing = approval_verdict is not None and approval_source in {"sentinel", "user"}
+        is_pending_sentinel_update = approval_source == "sentinel" and approval_verdict is None
+        should_update_existing = approval_source in {"sentinel", "user"} and (
+            approval_verdict is not None or (tool == "proxy_domain" and is_pending_sentinel_update)
+        )
 
         def _mutate(events: list[dict[str, Any]]) -> str:
             if should_update_existing:

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -426,6 +426,7 @@ class SessionEngine(SessionTurnMixin):
             session_id,
             audit_dir=audit_dir,
             max_sentinel_calls_per_tool_call=self._config.agent.max_sentinel_calls_per_tool_call,
+            sentinel_domain_batch_window_ms=self._config.agent.sentinel_domain_batch_window_ms,
         )
         sentinel = Sentinel(
             model=self._config.agent.sentinel_model,

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -422,7 +422,11 @@ class SessionEngine(SessionTurnMixin):
             raise KeyError(f"Session {session_id} not found on disk")
 
         audit_dir = self._data_dir / "sessions" / session_id
-        security = SessionSecurity(session_id, audit_dir=audit_dir)
+        security = SessionSecurity(
+            session_id,
+            audit_dir=audit_dir,
+            max_sentinel_calls_per_tool_call=self._config.agent.max_sentinel_calls_per_tool_call,
+        )
         sentinel = Sentinel(
             model=self._config.agent.sentinel_model,
             knowledge_dir=self._knowledge_dir,

--- a/src/carapace/session/turns.py
+++ b/src/carapace/session/turns.py
@@ -227,6 +227,8 @@ class SessionTurnMixin(SessionTurnHost):
                     }
                 ],
             )
+            if active.security and active.security.current_parent_tool_id == tr.tool_id:
+                active.security.clear_current_parent_tool()
             logger.info(
                 f"Tool result session={session_id} tool={tr.tool} exit_code={tr.exit_code} "
                 + f"summary={_summarize_tool_result_for_log(tr)}"
@@ -237,6 +239,8 @@ class SessionTurnMixin(SessionTurnHost):
 
         try:
             async with active.lock:
+                if active.security:
+                    active.security.clear_current_parent_tool()
                 deps, message_history = await self._prepare_turn_execution(
                     active,
                     session_id,
@@ -320,6 +324,8 @@ class SessionTurnMixin(SessionTurnHost):
             )
             await self._broadcast(active, "on_error", traceback.format_exc(), turn_terminal=True)
         finally:
+            if active.security:
+                active.security.clear_current_parent_tool()
             active.agent_task = None
 
     def _save_turn_progress(self, session_id: str, active: ActiveSession) -> None:

--- a/tests/test_proxy_gating.py
+++ b/tests/test_proxy_gating.py
@@ -104,6 +104,31 @@ async def test_reuses_sentinel_domain_approval_within_tool_call() -> None:
 
 
 @pytest.mark.anyio
+async def test_reused_allowed_domain_reports_auto_source() -> None:
+    session = SessionSecurity("session-1", sentinel_domain_batch_window_ms=0)
+    session.current_parent_tool_id = "tool-1"
+    domain_updates: list[tuple[str, str, str | None, str | None, str | None]] = []
+    sentinel = StubSentinel(batch_verdicts=[SentinelVerdict(decision="allow", explanation="looks fine")])
+
+    session.set_domain_info_callback(
+        lambda domain, detail, source, verdict, explanation: domain_updates.append(
+            (domain, detail, source, verdict, explanation)
+        )
+    )
+
+    assert await evaluate_domain_with(session, sentinel, "api.example.com", "curl https://api.example.com") is True
+    assert await evaluate_domain_with(session, sentinel, "api.example.com", "curl https://api.example.com") is True
+
+    assert domain_updates[-1] == (
+        "api.example.com",
+        "[cached safe-list: allow] reused earlier decision",
+        "safe-list",
+        "allow",
+        "looks fine",
+    )
+
+
+@pytest.mark.anyio
 async def test_reuses_user_domain_approval_within_tool_call() -> None:
     session = SessionSecurity("session-1", sentinel_domain_batch_window_ms=0)
     session.current_parent_tool_id = "tool-1"

--- a/tests/test_proxy_gating.py
+++ b/tests/test_proxy_gating.py
@@ -129,6 +129,30 @@ async def test_reused_allowed_domain_reports_auto_source() -> None:
 
 
 @pytest.mark.anyio
+async def test_scope_change_before_enqueue_falls_back_to_single_domain_review() -> None:
+    session = SessionSecurity("session-1", sentinel_domain_batch_window_ms=0)
+    session.current_parent_tool_id = "tool-1"
+    sentinel = StubSentinel(single_side_effects=[SentinelVerdict(decision="allow", explanation="fallback")])
+
+    async def simulate_scope_change(
+        domain: str,
+        command: str,
+        worker_factory: object,
+    ) -> tuple[None, None, bool]:
+        del domain, command, worker_factory
+        session.current_parent_tool_id = None
+        return None, None, False
+
+    session.get_or_enqueue_domain_approval = simulate_scope_change  # type: ignore[method-assign]
+
+    allowed = await evaluate_domain_with(session, sentinel, "api.example.com", "curl https://api.example.com")
+
+    assert allowed is True
+    assert sentinel.calls == [("api.example.com", "curl https://api.example.com")]
+    assert sentinel.batch_calls == []
+
+
+@pytest.mark.anyio
 async def test_reuses_user_domain_approval_within_tool_call() -> None:
     session = SessionSecurity("session-1", sentinel_domain_batch_window_ms=0)
     session.current_parent_tool_id = "tool-1"
@@ -331,3 +355,34 @@ async def test_pending_requests_fail_when_worker_errors() -> None:
     assert str(first[0]) == "sentinel batch blew up"
     assert isinstance(second[0], RuntimeError)
     assert str(second[0]) == "sentinel batch blew up"
+
+
+@pytest.mark.anyio
+async def test_failed_batch_does_not_consume_review_budget() -> None:
+    session = SessionSecurity("session-1", max_sentinel_calls_per_tool_call=1, sentinel_domain_batch_window_ms=0)
+    session.current_parent_tool_id = "tool-1"
+    user_calls: list[tuple[str, dict[str, object]]] = []
+    sentinel = StubSentinel(
+        batch_side_effects=[RuntimeError("sentinel batch blew up"), SentinelVerdict(decision="allow", explanation="ok")]
+    )
+
+    async def approve(subject: str, context: dict[str, object]) -> UserEscalationDecision:
+        user_calls.append((subject, context))
+        return UserEscalationDecision(allowed=True)
+
+    session.set_user_escalation_callback(lambda _sid, subject, context: approve(subject, context))
+
+    first = await asyncio.gather(
+        evaluate_domain_with(session, sentinel, "a.example.com", "curl https://a.example.com"),
+        return_exceptions=True,
+    )
+    second = await evaluate_domain_with(session, sentinel, "b.example.com", "curl https://b.example.com")
+
+    assert isinstance(first[0], RuntimeError)
+    assert str(first[0]) == "sentinel batch blew up"
+    assert second is True
+    assert sentinel.batch_calls == [
+        {"a.example.com": "curl https://a.example.com"},
+        {"b.example.com": "curl https://b.example.com"},
+    ]
+    assert user_calls == []

--- a/tests/test_proxy_gating.py
+++ b/tests/test_proxy_gating.py
@@ -14,9 +14,9 @@ class StubSentinel:
         self,
         *,
         verdicts: list[SentinelVerdict] | None = None,
-        batch_verdicts: list[dict[str, SentinelVerdict]] | None = None,
+        batch_verdicts: list[SentinelVerdict] | None = None,
         single_side_effects: list[SentinelVerdict | Exception] | None = None,
-        batch_side_effects: list[dict[str, SentinelVerdict] | Exception] | None = None,
+        batch_side_effects: list[SentinelVerdict | Exception] | None = None,
         batch_blocker: asyncio.Event | None = None,
     ) -> None:
         self._single_side_effects = single_side_effects or list(verdicts or [])
@@ -69,9 +69,7 @@ class StubSentinel:
 async def test_reuses_sentinel_domain_approval_within_tool_call() -> None:
     session = SessionSecurity("session-1", sentinel_domain_batch_window_ms=0)
     session.current_parent_tool_id = "tool-1"
-    sentinel = StubSentinel(
-        batch_verdicts=[{"api.example.com": SentinelVerdict(decision="allow", explanation="looks fine")}]
-    )
+    sentinel = StubSentinel(batch_verdicts=[SentinelVerdict(decision="allow", explanation="looks fine")])
 
     first = await evaluate_domain_with(session, sentinel, "api.example.com", "curl https://api.example.com")
     second = await evaluate_domain_with(session, sentinel, "api.example.com", "curl https://api.example.com")
@@ -92,9 +90,7 @@ async def test_reuses_user_domain_approval_within_tool_call() -> None:
         return UserEscalationDecision(allowed=True, message="approved")
 
     session.set_user_escalation_callback(lambda _sid, subject, context: approve(subject, context))
-    sentinel = StubSentinel(
-        batch_verdicts=[{"api.example.com": SentinelVerdict(decision="escalate", explanation="needs confirmation")}]
-    )
+    sentinel = StubSentinel(batch_verdicts=[SentinelVerdict(decision="escalate", explanation="needs confirmation")])
 
     first = await evaluate_domain_with(session, sentinel, "api.example.com", "curl https://api.example.com")
     second = await evaluate_domain_with(session, sentinel, "api.example.com", "curl https://api.example.com")
@@ -118,8 +114,8 @@ async def test_domain_review_limit_falls_back_to_user_approval() -> None:
     session.set_user_escalation_callback(lambda _sid, subject, context: approve(subject, context))
     sentinel = StubSentinel(
         batch_verdicts=[
-            {"a.example.com": SentinelVerdict(decision="allow", explanation="first")},
-            {"b.example.com": SentinelVerdict(decision="allow", explanation="second")},
+            SentinelVerdict(decision="allow", explanation="first batch"),
+            SentinelVerdict(decision="allow", explanation="second batch"),
         ]
     )
 
@@ -141,8 +137,8 @@ async def test_domain_approval_cache_resets_for_new_tool_call() -> None:
     session = SessionSecurity("session-1", sentinel_domain_batch_window_ms=0)
     sentinel = StubSentinel(
         batch_verdicts=[
-            {"api.example.com": SentinelVerdict(decision="allow", explanation="tool one")},
-            {"api.example.com": SentinelVerdict(decision="allow", explanation="tool two")},
+            SentinelVerdict(decision="allow", explanation="tool one"),
+            SentinelVerdict(decision="allow", explanation="tool two"),
         ]
     )
 
@@ -159,9 +155,7 @@ async def test_domain_approval_cache_resets_for_new_tool_call() -> None:
 async def test_parallel_same_domain_requests_share_one_batch() -> None:
     session = SessionSecurity("session-1", sentinel_domain_batch_window_ms=10)
     session.current_parent_tool_id = "tool-1"
-    sentinel = StubSentinel(
-        batch_verdicts=[{"api.example.com": SentinelVerdict(decision="allow", explanation="shared")}]
-    )
+    sentinel = StubSentinel(batch_verdicts=[SentinelVerdict(decision="allow", explanation="shared")])
 
     first, second = await asyncio.gather(
         evaluate_domain_with(session, sentinel, "api.example.com", "curl https://api.example.com"),
@@ -177,15 +171,7 @@ async def test_parallel_same_domain_requests_share_one_batch() -> None:
 async def test_parallel_distinct_domains_share_one_batch() -> None:
     session = SessionSecurity("session-1", sentinel_domain_batch_window_ms=10)
     session.current_parent_tool_id = "tool-1"
-    sentinel = StubSentinel(
-        batch_verdicts=[
-            {
-                "a.example.com": SentinelVerdict(decision="allow", explanation="a"),
-                "b.example.com": SentinelVerdict(decision="allow", explanation="b"),
-                "c.example.com": SentinelVerdict(decision="allow", explanation="c"),
-            }
-        ]
-    )
+    sentinel = StubSentinel(batch_verdicts=[SentinelVerdict(decision="allow", explanation="batch allow")])
 
     results = await asyncio.gather(
         evaluate_domain_with(session, sentinel, "a.example.com", "curl https://a.example.com"),
@@ -204,8 +190,8 @@ async def test_new_domain_wave_after_submission_forms_second_batch() -> None:
     blocker = asyncio.Event()
     sentinel = StubSentinel(
         batch_verdicts=[
-            {"a.example.com": SentinelVerdict(decision="allow", explanation="first wave")},
-            {"b.example.com": SentinelVerdict(decision="allow", explanation="second wave")},
+            SentinelVerdict(decision="allow", explanation="first wave"),
+            SentinelVerdict(decision="allow", explanation="second wave"),
         ],
         batch_blocker=blocker,
     )

--- a/tests/test_proxy_gating.py
+++ b/tests/test_proxy_gating.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 
 import pytest
+from pydantic_ai.exceptions import UsageLimitExceeded
 
 from carapace.security import evaluate_domain_with
 from carapace.security.context import SentinelVerdict, SessionSecurity, UserEscalationDecision
@@ -14,10 +15,12 @@ class StubSentinel:
         *,
         verdicts: list[SentinelVerdict] | None = None,
         batch_verdicts: list[dict[str, SentinelVerdict]] | None = None,
+        single_side_effects: list[SentinelVerdict | Exception] | None = None,
+        batch_side_effects: list[dict[str, SentinelVerdict] | Exception] | None = None,
         batch_blocker: asyncio.Event | None = None,
     ) -> None:
-        self._verdicts = verdicts or []
-        self._batch_verdicts = batch_verdicts or []
+        self._single_side_effects = single_side_effects or list(verdicts or [])
+        self._batch_side_effects = batch_side_effects or list(batch_verdicts or [])
         self._batch_blocker = batch_blocker
         self.calls: list[tuple[str, str]] = []
         self.batch_calls: list[dict[str, str]] = []
@@ -34,9 +37,12 @@ class StubSentinel:
     ) -> SentinelVerdict:
         del session, usage_tracker, assert_llm_budget_available, usage_limits
         self.calls.append((domain, command))
-        if len(self.calls) > len(self._verdicts):
+        if len(self.calls) > len(self._single_side_effects):
             raise AssertionError("Unexpected extra sentinel domain review")
-        return self._verdicts[len(self.calls) - 1]
+        effect = self._single_side_effects[len(self.calls) - 1]
+        if isinstance(effect, Exception):
+            raise effect
+        return effect
 
     async def evaluate_domain_access_batch(
         self,
@@ -51,9 +57,12 @@ class StubSentinel:
         self.batch_calls.append(dict(domain_commands))
         if self._batch_blocker is not None and len(self.batch_calls) == 1:
             await self._batch_blocker.wait()
-        if len(self.batch_calls) > len(self._batch_verdicts):
+        if len(self.batch_calls) > len(self._batch_side_effects):
             raise AssertionError("Unexpected extra batched sentinel domain review")
-        return self._batch_verdicts[len(self.batch_calls) - 1]
+        effect = self._batch_side_effects[len(self.batch_calls) - 1]
+        if isinstance(effect, Exception):
+            raise effect
+        return effect
 
 
 @pytest.mark.anyio
@@ -222,3 +231,68 @@ async def test_new_domain_wave_after_submission_forms_second_batch() -> None:
         {"a.example.com": "curl https://a.example.com"},
         {"b.example.com": "curl https://b.example.com"},
     ]
+
+
+@pytest.mark.anyio
+async def test_single_domain_usage_limit_falls_back_to_user_approval() -> None:
+    session = SessionSecurity("session-1")
+    user_calls: list[tuple[str, dict[str, object]]] = []
+
+    async def approve(subject: str, context: dict[str, object]) -> UserEscalationDecision:
+        user_calls.append((subject, context))
+        return UserEscalationDecision(allowed=True)
+
+    session.set_user_escalation_callback(lambda _sid, subject, context: approve(subject, context))
+    sentinel = StubSentinel(
+        single_side_effects=[UsageLimitExceeded("The next request would exceed the request_limit of 5")]
+    )
+
+    allowed = await evaluate_domain_with(session, sentinel, "solo.example.com", "curl https://solo.example.com")
+
+    assert allowed is True
+    assert user_calls == [
+        (
+            "solo.example.com",
+            {
+                "command": "curl https://solo.example.com",
+                "explanation": (
+                    "Automatic sentinel review hit its internal request limit and could not finish. "
+                    + "Please approve or deny this domain manually."
+                ),
+                "kind": "domain_access",
+            },
+        )
+    ]
+
+
+@pytest.mark.anyio
+async def test_pending_requests_fail_when_worker_errors() -> None:
+    session = SessionSecurity("session-1", sentinel_domain_batch_window_ms=0)
+    session.current_parent_tool_id = "tool-1"
+    blocker = asyncio.Event()
+    sentinel = StubSentinel(
+        batch_side_effects=[RuntimeError("sentinel batch blew up")],
+        batch_blocker=blocker,
+    )
+
+    first_task = asyncio.create_task(
+        evaluate_domain_with(session, sentinel, "a.example.com", "curl https://a.example.com")
+    )
+    for _ in range(50):
+        if sentinel.batch_calls:
+            break
+        await asyncio.sleep(0)
+
+    second_task = asyncio.create_task(
+        evaluate_domain_with(session, sentinel, "b.example.com", "curl https://b.example.com")
+    )
+    await asyncio.sleep(0)
+    blocker.set()
+
+    first = await asyncio.gather(first_task, return_exceptions=True)
+    second = await asyncio.gather(second_task, return_exceptions=True)
+
+    assert isinstance(first[0], RuntimeError)
+    assert str(first[0]) == "sentinel batch blew up"
+    assert isinstance(second[0], RuntimeError)
+    assert str(second[0]) == "sentinel batch blew up"

--- a/tests/test_proxy_gating.py
+++ b/tests/test_proxy_gating.py
@@ -52,7 +52,7 @@ class StubSentinel:
         usage_tracker: object | None = None,
         assert_llm_budget_available: object | None = None,
         usage_limits: object | None = None,
-    ) -> dict[str, SentinelVerdict]:
+    ) -> SentinelVerdict:
         del session, usage_tracker, assert_llm_budget_available, usage_limits
         self.batch_calls.append(dict(domain_commands))
         if self._batch_blocker is not None and len(self.batch_calls) == 1:
@@ -63,6 +63,30 @@ class StubSentinel:
         if isinstance(effect, Exception):
             raise effect
         return effect
+
+
+@pytest.mark.anyio
+async def test_duplicate_pending_domain_request_does_not_restart_debounce_generation() -> None:
+    session = SessionSecurity("session-1", sentinel_domain_batch_window_ms=100)
+    session.current_parent_tool_id = "tool-1"
+
+    async def worker() -> None:
+        return None
+
+    await session.get_or_enqueue_domain_approval(
+        "api.example.com",
+        "curl https://api.example.com",
+        lambda: asyncio.create_task(worker()),
+    )
+    first_generation = session._domain_scope_pending_generation
+
+    await session.get_or_enqueue_domain_approval(
+        "api.example.com",
+        "curl https://api.example.com --retry 2",
+        lambda: asyncio.create_task(worker()),
+    )
+
+    assert session._domain_scope_pending_generation == first_generation
 
 
 @pytest.mark.anyio

--- a/tests/test_proxy_gating.py
+++ b/tests/test_proxy_gating.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import pytest
+
+from carapace.security import evaluate_domain_with
+from carapace.security.context import SentinelVerdict, SessionSecurity, UserEscalationDecision
+
+
+class StubSentinel:
+    def __init__(self, verdicts: list[SentinelVerdict]) -> None:
+        self._verdicts = verdicts
+        self.calls: list[tuple[str, str]] = []
+
+    async def evaluate_domain_access(
+        self,
+        session: SessionSecurity,
+        domain: str,
+        command: str,
+        *,
+        usage_tracker: object | None = None,
+        assert_llm_budget_available: object | None = None,
+        usage_limits: object | None = None,
+    ) -> SentinelVerdict:
+        del session, usage_tracker, assert_llm_budget_available, usage_limits
+        self.calls.append((domain, command))
+        if len(self.calls) > len(self._verdicts):
+            raise AssertionError("Unexpected extra sentinel domain review")
+        return self._verdicts[len(self.calls) - 1]
+
+
+@pytest.mark.anyio
+async def test_reuses_sentinel_domain_approval_within_tool_call() -> None:
+    session = SessionSecurity("session-1")
+    session.current_parent_tool_id = "tool-1"
+    sentinel = StubSentinel([SentinelVerdict(decision="allow", explanation="looks fine")])
+
+    first = await evaluate_domain_with(session, sentinel, "api.example.com", "curl https://api.example.com")
+    second = await evaluate_domain_with(session, sentinel, "api.example.com", "curl https://api.example.com")
+
+    assert first is True
+    assert second is True
+    assert sentinel.calls == [("api.example.com", "curl https://api.example.com")]
+
+
+@pytest.mark.anyio
+async def test_reuses_user_domain_approval_within_tool_call() -> None:
+    session = SessionSecurity("session-1")
+    session.current_parent_tool_id = "tool-1"
+    user_calls: list[tuple[str, dict[str, object]]] = []
+
+    async def approve(subject: str, context: dict[str, object]) -> UserEscalationDecision:
+        user_calls.append((subject, context))
+        return UserEscalationDecision(allowed=True, message="approved")
+
+    session.set_user_escalation_callback(lambda _sid, subject, context: approve(subject, context))
+    sentinel = StubSentinel([SentinelVerdict(decision="escalate", explanation="needs confirmation")])
+
+    first = await evaluate_domain_with(session, sentinel, "api.example.com", "curl https://api.example.com")
+    second = await evaluate_domain_with(session, sentinel, "api.example.com", "curl https://api.example.com")
+
+    assert first is True
+    assert second is True
+    assert len(sentinel.calls) == 1
+    assert len(user_calls) == 1
+
+
+@pytest.mark.anyio
+async def test_domain_review_limit_falls_back_to_user_approval() -> None:
+    session = SessionSecurity("session-1", max_sentinel_calls_per_tool_call=2)
+    session.current_parent_tool_id = "tool-1"
+    user_calls: list[tuple[str, dict[str, object]]] = []
+
+    async def approve(subject: str, context: dict[str, object]) -> UserEscalationDecision:
+        user_calls.append((subject, context))
+        return UserEscalationDecision(allowed=True)
+
+    session.set_user_escalation_callback(lambda _sid, subject, context: approve(subject, context))
+    sentinel = StubSentinel(
+        [
+            SentinelVerdict(decision="allow", explanation="first"),
+            SentinelVerdict(decision="allow", explanation="second"),
+        ]
+    )
+
+    assert await evaluate_domain_with(session, sentinel, "a.example.com", "curl https://a.example.com") is True
+    assert await evaluate_domain_with(session, sentinel, "b.example.com", "curl https://b.example.com") is True
+    assert await evaluate_domain_with(session, sentinel, "c.example.com", "curl https://c.example.com") is True
+
+    assert [domain for domain, _command in sentinel.calls] == ["a.example.com", "b.example.com"]
+    assert len(user_calls) == 1
+    assert user_calls[0][0] == "c.example.com"
+    assert "limit" in str(user_calls[0][1]["explanation"])
+
+
+@pytest.mark.anyio
+async def test_domain_approval_cache_resets_for_new_tool_call() -> None:
+    session = SessionSecurity("session-1")
+    sentinel = StubSentinel(
+        [
+            SentinelVerdict(decision="allow", explanation="tool one"),
+            SentinelVerdict(decision="allow", explanation="tool two"),
+        ]
+    )
+
+    session.current_parent_tool_id = "tool-1"
+    assert await evaluate_domain_with(session, sentinel, "api.example.com", "curl https://api.example.com") is True
+
+    session.current_parent_tool_id = "tool-2"
+    assert await evaluate_domain_with(session, sentinel, "api.example.com", "curl https://api.example.com") is True
+
+    assert len(sentinel.calls) == 2

--- a/tests/test_proxy_gating.py
+++ b/tests/test_proxy_gating.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from carapace.security import evaluate_domain_with
@@ -7,9 +9,18 @@ from carapace.security.context import SentinelVerdict, SessionSecurity, UserEsca
 
 
 class StubSentinel:
-    def __init__(self, verdicts: list[SentinelVerdict]) -> None:
-        self._verdicts = verdicts
+    def __init__(
+        self,
+        *,
+        verdicts: list[SentinelVerdict] | None = None,
+        batch_verdicts: list[dict[str, SentinelVerdict]] | None = None,
+        batch_blocker: asyncio.Event | None = None,
+    ) -> None:
+        self._verdicts = verdicts or []
+        self._batch_verdicts = batch_verdicts or []
+        self._batch_blocker = batch_blocker
         self.calls: list[tuple[str, str]] = []
+        self.batch_calls: list[dict[str, str]] = []
 
     async def evaluate_domain_access(
         self,
@@ -27,24 +38,43 @@ class StubSentinel:
             raise AssertionError("Unexpected extra sentinel domain review")
         return self._verdicts[len(self.calls) - 1]
 
+    async def evaluate_domain_access_batch(
+        self,
+        session: SessionSecurity,
+        domain_commands: dict[str, str],
+        *,
+        usage_tracker: object | None = None,
+        assert_llm_budget_available: object | None = None,
+        usage_limits: object | None = None,
+    ) -> dict[str, SentinelVerdict]:
+        del session, usage_tracker, assert_llm_budget_available, usage_limits
+        self.batch_calls.append(dict(domain_commands))
+        if self._batch_blocker is not None and len(self.batch_calls) == 1:
+            await self._batch_blocker.wait()
+        if len(self.batch_calls) > len(self._batch_verdicts):
+            raise AssertionError("Unexpected extra batched sentinel domain review")
+        return self._batch_verdicts[len(self.batch_calls) - 1]
+
 
 @pytest.mark.anyio
 async def test_reuses_sentinel_domain_approval_within_tool_call() -> None:
-    session = SessionSecurity("session-1")
+    session = SessionSecurity("session-1", sentinel_domain_batch_window_ms=0)
     session.current_parent_tool_id = "tool-1"
-    sentinel = StubSentinel([SentinelVerdict(decision="allow", explanation="looks fine")])
+    sentinel = StubSentinel(
+        batch_verdicts=[{"api.example.com": SentinelVerdict(decision="allow", explanation="looks fine")}]
+    )
 
     first = await evaluate_domain_with(session, sentinel, "api.example.com", "curl https://api.example.com")
     second = await evaluate_domain_with(session, sentinel, "api.example.com", "curl https://api.example.com")
 
     assert first is True
     assert second is True
-    assert sentinel.calls == [("api.example.com", "curl https://api.example.com")]
+    assert sentinel.batch_calls == [{"api.example.com": "curl https://api.example.com"}]
 
 
 @pytest.mark.anyio
 async def test_reuses_user_domain_approval_within_tool_call() -> None:
-    session = SessionSecurity("session-1")
+    session = SessionSecurity("session-1", sentinel_domain_batch_window_ms=0)
     session.current_parent_tool_id = "tool-1"
     user_calls: list[tuple[str, dict[str, object]]] = []
 
@@ -53,20 +83,22 @@ async def test_reuses_user_domain_approval_within_tool_call() -> None:
         return UserEscalationDecision(allowed=True, message="approved")
 
     session.set_user_escalation_callback(lambda _sid, subject, context: approve(subject, context))
-    sentinel = StubSentinel([SentinelVerdict(decision="escalate", explanation="needs confirmation")])
+    sentinel = StubSentinel(
+        batch_verdicts=[{"api.example.com": SentinelVerdict(decision="escalate", explanation="needs confirmation")}]
+    )
 
     first = await evaluate_domain_with(session, sentinel, "api.example.com", "curl https://api.example.com")
     second = await evaluate_domain_with(session, sentinel, "api.example.com", "curl https://api.example.com")
 
     assert first is True
     assert second is True
-    assert len(sentinel.calls) == 1
+    assert len(sentinel.batch_calls) == 1
     assert len(user_calls) == 1
 
 
 @pytest.mark.anyio
 async def test_domain_review_limit_falls_back_to_user_approval() -> None:
-    session = SessionSecurity("session-1", max_sentinel_calls_per_tool_call=2)
+    session = SessionSecurity("session-1", max_sentinel_calls_per_tool_call=2, sentinel_domain_batch_window_ms=0)
     session.current_parent_tool_id = "tool-1"
     user_calls: list[tuple[str, dict[str, object]]] = []
 
@@ -76,9 +108,9 @@ async def test_domain_review_limit_falls_back_to_user_approval() -> None:
 
     session.set_user_escalation_callback(lambda _sid, subject, context: approve(subject, context))
     sentinel = StubSentinel(
-        [
-            SentinelVerdict(decision="allow", explanation="first"),
-            SentinelVerdict(decision="allow", explanation="second"),
+        batch_verdicts=[
+            {"a.example.com": SentinelVerdict(decision="allow", explanation="first")},
+            {"b.example.com": SentinelVerdict(decision="allow", explanation="second")},
         ]
     )
 
@@ -86,7 +118,10 @@ async def test_domain_review_limit_falls_back_to_user_approval() -> None:
     assert await evaluate_domain_with(session, sentinel, "b.example.com", "curl https://b.example.com") is True
     assert await evaluate_domain_with(session, sentinel, "c.example.com", "curl https://c.example.com") is True
 
-    assert [domain for domain, _command in sentinel.calls] == ["a.example.com", "b.example.com"]
+    assert sentinel.batch_calls == [
+        {"a.example.com": "curl https://a.example.com"},
+        {"b.example.com": "curl https://b.example.com"},
+    ]
     assert len(user_calls) == 1
     assert user_calls[0][0] == "c.example.com"
     assert "limit" in str(user_calls[0][1]["explanation"])
@@ -94,11 +129,11 @@ async def test_domain_review_limit_falls_back_to_user_approval() -> None:
 
 @pytest.mark.anyio
 async def test_domain_approval_cache_resets_for_new_tool_call() -> None:
-    session = SessionSecurity("session-1")
+    session = SessionSecurity("session-1", sentinel_domain_batch_window_ms=0)
     sentinel = StubSentinel(
-        [
-            SentinelVerdict(decision="allow", explanation="tool one"),
-            SentinelVerdict(decision="allow", explanation="tool two"),
+        batch_verdicts=[
+            {"api.example.com": SentinelVerdict(decision="allow", explanation="tool one")},
+            {"api.example.com": SentinelVerdict(decision="allow", explanation="tool two")},
         ]
     )
 
@@ -108,4 +143,82 @@ async def test_domain_approval_cache_resets_for_new_tool_call() -> None:
     session.current_parent_tool_id = "tool-2"
     assert await evaluate_domain_with(session, sentinel, "api.example.com", "curl https://api.example.com") is True
 
-    assert len(sentinel.calls) == 2
+    assert len(sentinel.batch_calls) == 2
+
+
+@pytest.mark.anyio
+async def test_parallel_same_domain_requests_share_one_batch() -> None:
+    session = SessionSecurity("session-1", sentinel_domain_batch_window_ms=10)
+    session.current_parent_tool_id = "tool-1"
+    sentinel = StubSentinel(
+        batch_verdicts=[{"api.example.com": SentinelVerdict(decision="allow", explanation="shared")}]
+    )
+
+    first, second = await asyncio.gather(
+        evaluate_domain_with(session, sentinel, "api.example.com", "curl https://api.example.com"),
+        evaluate_domain_with(session, sentinel, "api.example.com", "curl https://api.example.com"),
+    )
+
+    assert first is True
+    assert second is True
+    assert sentinel.batch_calls == [{"api.example.com": "curl https://api.example.com"}]
+
+
+@pytest.mark.anyio
+async def test_parallel_distinct_domains_share_one_batch() -> None:
+    session = SessionSecurity("session-1", sentinel_domain_batch_window_ms=10)
+    session.current_parent_tool_id = "tool-1"
+    sentinel = StubSentinel(
+        batch_verdicts=[
+            {
+                "a.example.com": SentinelVerdict(decision="allow", explanation="a"),
+                "b.example.com": SentinelVerdict(decision="allow", explanation="b"),
+                "c.example.com": SentinelVerdict(decision="allow", explanation="c"),
+            }
+        ]
+    )
+
+    results = await asyncio.gather(
+        evaluate_domain_with(session, sentinel, "a.example.com", "curl https://a.example.com"),
+        evaluate_domain_with(session, sentinel, "b.example.com", "curl https://b.example.com"),
+        evaluate_domain_with(session, sentinel, "c.example.com", "curl https://c.example.com"),
+    )
+
+    assert results == [True, True, True]
+    assert list(sorted(sentinel.batch_calls[0])) == ["a.example.com", "b.example.com", "c.example.com"]
+
+
+@pytest.mark.anyio
+async def test_new_domain_wave_after_submission_forms_second_batch() -> None:
+    session = SessionSecurity("session-1", sentinel_domain_batch_window_ms=0)
+    session.current_parent_tool_id = "tool-1"
+    blocker = asyncio.Event()
+    sentinel = StubSentinel(
+        batch_verdicts=[
+            {"a.example.com": SentinelVerdict(decision="allow", explanation="first wave")},
+            {"b.example.com": SentinelVerdict(decision="allow", explanation="second wave")},
+        ],
+        batch_blocker=blocker,
+    )
+
+    first_task = asyncio.create_task(
+        evaluate_domain_with(session, sentinel, "a.example.com", "curl https://a.example.com")
+    )
+    for _ in range(50):
+        if sentinel.batch_calls:
+            break
+        await asyncio.sleep(0)
+
+    second_task = asyncio.create_task(
+        evaluate_domain_with(session, sentinel, "b.example.com", "curl https://b.example.com")
+    )
+    blocker.set()
+
+    first, second = await asyncio.gather(first_task, second_task)
+
+    assert first is True
+    assert second is True
+    assert sentinel.batch_calls == [
+        {"a.example.com": "curl https://a.example.com"},
+        {"b.example.com": "curl https://b.example.com"},
+    ]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -408,6 +408,57 @@ def test_record_tool_call_event_reuses_sentinel_row_for_user_decision(tmp_path: 
     ]
 
 
+def test_record_tool_call_event_reuses_proxy_domain_row_for_queued_reviewing_and_final(tmp_path: Path) -> None:
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path)
+
+    sid = engine.session_mgr.create_session().session_id
+
+    queued_tool_id = engine._record_tool_call_event(
+        sid,
+        tool="proxy_domain",
+        args={"domain": "example.com"},
+        detail="[sentinel] queued for batched review",
+        approval_source="sentinel",
+        parent_tool_id="tool-1",
+    )
+    reviewing_tool_id = engine._record_tool_call_event(
+        sid,
+        tool="proxy_domain",
+        args={"domain": "example.com"},
+        detail="[sentinel] reviewing",
+        approval_source="sentinel",
+        parent_tool_id="tool-1",
+    )
+    approved_tool_id = engine._record_tool_call_event(
+        sid,
+        tool="proxy_domain",
+        args={"domain": "example.com"},
+        detail="[sentinel: allow] looks fine",
+        approval_source="sentinel",
+        approval_verdict="allow",
+        approval_explanation="looks fine",
+        parent_tool_id="tool-1",
+    )
+
+    assert queued_tool_id == reviewing_tool_id == approved_tool_id
+    events = engine.session_mgr.load_events(sid)
+    assert all("timestamp" in event for event in events)
+    assert _without_timestamps(events) == [
+        {
+            "role": "tool_call",
+            "tool": "proxy_domain",
+            "args": {"domain": "example.com"},
+            "detail": "[sentinel: allow] looks fine",
+            "approval_source": "sentinel",
+            "approval_verdict": "allow",
+            "approval_explanation": "looks fine",
+            "parent_tool_id": "tool-1",
+            "tool_id": queued_tool_id,
+        }
+    ]
+
+
 def test_fork_session_copies_transcript_and_security_context(tmp_path: Path) -> None:
     with _patch_sentinel():
         engine = _make_engine(tmp_path)


### PR DESCRIPTION
## Summary
This changes proxy gating from one sentinel review per unknown domain to debounced, batched domain review scoped to a single tool call. Domains that already have a cached decision for the active tool still return immediately.

## Changes
- batch unknown proxy domains per active tool call and submit them to the sentinel together
- debounce batch submission with `agent.sentinel_domain_batch_window_ms` (default `100` ms), restarting the timer when new domains arrive
- have the sentinel return a single verdict for the whole batch, then apply that verdict to every domain in that batch round
- keep immediate fast-path reuse for domains already approved or denied earlier in the same tool call
- count `agent.max_sentinel_calls_per_tool_call` as a cap on batched sentinel review rounds, with manual approval fallback once exceeded
- keep tool-call-scoped cleanup so cached and in-flight domain state does not leak across tools or failed turns
- add regression coverage for sequential reuse, parallel same-domain coalescing, parallel multi-domain batching, second-wave batching, single-path usage-limit fallback, and worker-failure propagation

## Validation
- `uv run pytest tests/test_proxy_gating.py`
- `uvx ruff check src/carapace/security/context.py src/carapace/security/sentinel.py src/carapace/security/__init__.py tests/test_proxy_gating.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes proxy-domain approval flow and introduces new async batching/caching logic scoped to a tool call; mistakes could cause incorrect allow/deny decisions or stuck futures under concurrency.
> 
> **Overview**
> Proxy domain gating is refactored to **debounce and batch unknown domains per active tool call**, calling a new `Sentinel.evaluate_domain_access_batch()` and applying one verdict across the batch, while **reusing cached decisions** for repeat domains within the same tool call.
> 
> Adds tool-call-scoped async state to `SessionSecurity` (queueing, inflight futures, worker lifecycle, cancellation/reset on tool boundary), plus config knobs `agent.max_sentinel_calls_per_tool_call` and `agent.sentinel_domain_batch_window_ms` with validation and engine wiring; when the per-tool-call batch cap or sentinel usage limits are hit, the flow **falls back to user escalation**.
> 
> Updates event recording to reuse the same `proxy_domain` tool-call row for queued/reviewing/final updates, ensures tool-scope cleanup on tool results/turn boundaries, and adds a comprehensive `tests/test_proxy_gating.py` suite covering caching, parallel batching, wave separation, limit handling, and failure propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7437bfe73e0bfd823b28e5a3aa16e0fd6ea4778c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->