### PR TITLE
✨ feat: Persist model overrides across backend restarts

### DIFF
--- a/src/carapace/models.py
+++ b/src/carapace/models.py
@@ -78,6 +78,9 @@ class SessionState(BaseModel):
     channel_type: str = "cli"
     channel_ref: str | None = None
     title: str | None = None
+    agent_model_name: str | None = None
+    sentinel_model_name: str | None = None
+    title_model_name: str | None = None
     private: bool = False
     approved_operations: list[str] = []
     activated_skills: list[str] = []

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -410,6 +410,49 @@ class SessionEngine(SessionTurnMixin):
         """Build per-model request settings from the configured catalog."""
         return model_settings_for_config(self._config, name, default_thinking=True)
 
+    def _restore_persisted_model_overrides(self, active: ActiveSession) -> None:
+        """Validate restored overrides, falling back to defaults when they are no longer usable."""
+        state_changed = False
+
+        if active.agent_model_name is not None:
+            try:
+                active.agent_model = self._resolve_model(active.agent_model_name)
+            except Exception as exc:
+                logger.warning(
+                    f"Persisted agent model override {active.agent_model_name!r} for session "
+                    + f"{active.state.session_id} is no longer valid: {exc}. Falling back to "
+                    + f"{self._config.agent.model!r}."
+                )
+                self._apply_model_override(active, "agent", None, None)
+                state_changed = True
+
+        if active.sentinel_model_name is not None and active.sentinel is not None:
+            try:
+                active.sentinel.set_model(active.sentinel_model_name)
+            except Exception as exc:
+                logger.warning(
+                    f"Persisted sentinel model override {active.sentinel_model_name!r} for session "
+                    + f"{active.state.session_id} is no longer valid: {exc}. Falling back to "
+                    + f"{self._config.agent.sentinel_model!r}."
+                )
+                self._apply_model_override(active, "sentinel", None, None)
+                state_changed = True
+
+        if active.title_model_name is not None:
+            try:
+                self._resolve_model(active.title_model_name)
+            except Exception as exc:
+                logger.warning(
+                    f"Persisted title model override {active.title_model_name!r} for session "
+                    + f"{active.state.session_id} is no longer valid: {exc}. Falling back to "
+                    + f"{self._config.agent.title_model!r}."
+                )
+                self._apply_model_override(active, "title", None, None)
+                state_changed = True
+
+        if state_changed:
+            self._session_mgr.save_state(active.state)
+
     # -- session lifecycle --
 
     def _ensure_active(self, session_id: str) -> ActiveSession:
@@ -447,8 +490,7 @@ class SessionEngine(SessionTurnMixin):
             sentinel_model_name=state.sentinel_model_name,
             title_model_name=state.title_model_name,
         )
-        if active.sentinel_model_name:
-            sentinel.set_model(active.sentinel_model_name)
+        self._restore_persisted_model_overrides(active)
         self._active[session_id] = active
 
         # Wire security callbacks so domain escalation / info works
@@ -652,6 +694,7 @@ class SessionEngine(SessionTurnMixin):
                 agent_model = self._agent_model or self._resolve_model(self._config.agent.model)
             else:
                 agent_model = self._resolve_model(active.agent_model_name)
+                active.agent_model = agent_model
 
         def _append_session_events(events: list[dict[str, Any]]) -> None:
             self._session_mgr.append_events(session_id, events)

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -443,7 +443,12 @@ class SessionEngine(SessionTurnMixin):
             sentinel=sentinel,
             usage_tracker=usage_tracker,
             llm_request_log=llm_log,
+            agent_model_name=state.agent_model_name,
+            sentinel_model_name=state.sentinel_model_name,
+            title_model_name=state.title_model_name,
         )
+        if active.sentinel_model_name:
+            sentinel.set_model(active.sentinel_model_name)
         self._active[session_id] = active
 
         # Wire security callbacks so domain escalation / info works
@@ -640,6 +645,13 @@ class SessionEngine(SessionTurnMixin):
     ) -> Deps:
         assert active.security is not None and active.sentinel is not None
         session_id = active.state.session_id
+        agent_model_id = active.agent_model_name or self._config.agent.model
+        agent_model = active.agent_model
+        if agent_model is None:
+            if active.agent_model_name is None:
+                agent_model = self._agent_model or self._resolve_model(self._config.agent.model)
+            else:
+                agent_model = self._resolve_model(active.agent_model_name)
 
         def _append_session_events(events: list[dict[str, Any]]) -> None:
             self._session_mgr.append_events(session_id, events)
@@ -653,8 +665,8 @@ class SessionEngine(SessionTurnMixin):
             sentinel=active.sentinel,
             git_store=self._git_store,
             skill_catalog=self._skill_catalog,
-            agent_model=active.agent_model or self._agent_model or self._resolve_model(self._config.agent.model),
-            agent_model_id=active.agent_model_name or self._config.agent.model,
+            agent_model=agent_model,
+            agent_model_id=agent_model_id,
             verbose=active.verbose,
             tool_call_callback=tool_call_callback,
             tool_result_callback=tool_result_callback,
@@ -1040,6 +1052,7 @@ class SessionEngine(SessionTurnMixin):
         if arg == "reset":
             for mt in self._MODEL_TYPES:
                 self._apply_model_override(active, mt, None, None)
+            self._session_mgr.save_state(active.state)
             reset_view = {t: {"current": defaults[t], "default": defaults[t]} for t in self._MODEL_TYPES}
             return {
                 "command": "model",
@@ -1054,6 +1067,7 @@ class SessionEngine(SessionTurnMixin):
         self._apply_model_override(active, "agent", arg, new_model)
         self._apply_model_override(active, "sentinel", arg, None)
         self._apply_model_override(active, "title", arg, None)
+        self._session_mgr.save_state(active.state)
         switched = {t: {"current": arg, "default": defaults[t]} for t in self._MODEL_TYPES}
         return {
             "command": "model",
@@ -1088,6 +1102,7 @@ class SessionEngine(SessionTurnMixin):
         # Reset
         if arg == "reset":
             self._apply_model_override(active, model_type, None, None)
+            self._session_mgr.save_state(active.state)
             if model_type == "title":
                 await self._regenerate_title(active, pending_user_line=slash_line)
             return {
@@ -1102,6 +1117,7 @@ class SessionEngine(SessionTurnMixin):
             return {"command": cmd_name, "data": {"current": current, "default": default, "error": str(exc)}}
 
         self._apply_model_override(active, model_type, arg, new_model if model_type == "agent" else None)
+        self._session_mgr.save_state(active.state)
         if model_type == "title":
             await self._regenerate_title(active, pending_user_line=slash_line)
         return {
@@ -1115,12 +1131,15 @@ class SessionEngine(SessionTurnMixin):
         if model_type == "agent":
             active.agent_model = model_obj
             active.agent_model_name = name
+            active.state.agent_model_name = name
         elif model_type == "sentinel":
             active.sentinel_model_name = name
+            active.state.sentinel_model_name = name
             if active.sentinel:
                 active.sentinel.set_model(name or self._config.agent.sentinel_model)
         elif model_type == "title":
             active.title_model_name = name
+            active.state.title_model_name = name
 
     async def _regenerate_title(self, active: ActiveSession, *, pending_user_line: str | None = None) -> None:
         """Regenerate the session title using the current title model.

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1789,6 +1789,40 @@ def test_handle_slash_command_model_agent_only(tmp_path: Path):
         asyncio.run(_run())
 
 
+def test_model_overrides_persist_across_restart(tmp_path: Path) -> None:
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session()
+        sid = state.session_id
+        engine.get_or_activate(sid)
+
+        async def _run() -> None:
+            result = await engine.handle_slash_command(sid, "/model openai:gpt-4o")
+            assert result is not None
+            assert result["command"] == "model"
+
+        asyncio.run(_run())
+
+    persisted = engine.session_mgr.load_state(sid)
+    assert persisted is not None
+    assert persisted.agent_model_name == "openai:gpt-4o"
+    assert persisted.sentinel_model_name == "openai:gpt-4o"
+    assert persisted.title_model_name == "openai:gpt-4o"
+
+    with _patch_sentinel():
+        restarted = _make_engine(tmp_path)
+        active = restarted.get_or_activate(sid)
+        deps = restarted._build_deps(active)
+
+    assert active.agent_model_name == "openai:gpt-4o"
+    assert active.sentinel_model_name == "openai:gpt-4o"
+    assert active.title_model_name == "openai:gpt-4o"
+    assert isinstance(deps.agent_model, TestModel)
+    assert deps.agent_model_id == "openai:gpt-4o"
+    assert active.sentinel is not None
+    active.sentinel.set_model.assert_called_once_with("openai:gpt-4o")
+
+
 def test_non_slash_user_message_count_ignores_slash_lines() -> None:
     events: list[dict[str, Any]] = [
         {"role": "user", "content": "/model-agent openai:gpt-4o"},

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1819,8 +1819,57 @@ def test_model_overrides_persist_across_restart(tmp_path: Path) -> None:
     assert active.title_model_name == "openai:gpt-4o"
     assert isinstance(deps.agent_model, TestModel)
     assert deps.agent_model_id == "openai:gpt-4o"
+    assert active.agent_model is deps.agent_model
     assert active.sentinel is not None
     active.sentinel.set_model.assert_called_once_with("openai:gpt-4o")
+
+
+def test_invalid_model_overrides_fall_back_on_restart(tmp_path: Path) -> None:
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session()
+
+    state.agent_model_name = "openai:missing-agent"
+    state.sentinel_model_name = "openai:missing-sentinel"
+    state.title_model_name = "openai:missing-title"
+    engine.session_mgr.save_state(state)
+
+    with _patch_sentinel() as sentinel_cls, patch("carapace.session.engine.logger.warning") as warning_mock:
+        sentinel_instance = sentinel_cls.return_value
+
+        def _set_model(name: str) -> None:
+            if name == "openai:missing-sentinel":
+                raise ValueError("missing sentinel model")
+
+        sentinel_instance.set_model.side_effect = _set_model
+
+        restarted = _make_engine(tmp_path)
+        restarted._resolve_model = MagicMock(
+            side_effect=lambda name: (
+                TestModel()
+                if name == restarted._config.agent.model
+                else (_ for _ in ()).throw(ValueError("missing agent model"))
+            )
+        )
+
+        active = restarted.get_or_activate(state.session_id)
+        deps = restarted._build_deps(active)
+
+    assert active.agent_model_name is None
+    assert active.sentinel_model_name is None
+    assert active.title_model_name is None
+    assert isinstance(deps.agent_model, TestModel)
+    assert deps.agent_model_id == restarted._config.agent.model
+
+    persisted = restarted.session_mgr.load_state(state.session_id)
+    assert persisted is not None
+    assert persisted.agent_model_name is None
+    assert persisted.sentinel_model_name is None
+    assert persisted.title_model_name is None
+
+    sentinel_instance.set_model.assert_any_call("openai:missing-sentinel")
+    sentinel_instance.set_model.assert_any_call(restarted._config.agent.sentinel_model)
+    assert warning_mock.call_count == 3
 
 
 def test_non_slash_user_message_count_ignores_slash_lines() -> None:


### PR DESCRIPTION
## Summary
Persist per-session model overrides so backend restarts do not silently reset the agent, sentinel, or title model selection.

- store `agent_model_name`, `sentinel_model_name`, and `title_model_name` in persisted `SessionState`
- restore those overrides when reactivating a session, including resolving the overridden agent model and reapplying the sentinel model
- save updated session state from `/model`, `/model-agent`, `/model-sentinel`, and `/model-title`
- add a regression test covering override persistence across a simulated restart

## Testing
`uv run pytest tests/test_session.py -k 'handle_slash_command_model or model_overrides_persist_across_restart'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session persistence and resume logic for model selection, which could affect which LLMs are used after a restart and potentially break session loading if state handling is wrong.
> 
> **Overview**
> Per-session model overrides (`agent`, `sentinel`, `title`) are now persisted in `SessionState` and restored when a session is reactivated, so backend restarts no longer silently reset model choices.
> 
> Slash commands that change or reset models now also save updated session state, and session resume validates any persisted overrides, logging a warning and falling back to configured defaults when an override can’t be resolved. New tests cover persistence across restart and fallback behavior for invalid persisted model ids.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90c34821732ae2b6d59846130d1cd5302907415e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->