### PR TITLE
✨ feat: auto-allow some read-only exec ops

### DIFF
--- a/src/carapace/security/__init__.py
+++ b/src/carapace/security/__init__.py
@@ -82,7 +82,8 @@ async def evaluate_with(
     if tool_name == "exec":
         matched_exec = match_auto_allowed_exec(args)
         if matched_exec is not None:
-            entry = ToolCallEntry(tool=tool_name, args=args, decision="auto_allowed")
+            explanation = f"Auto-allowed by read-only exec heuristic ({matched_exec})."
+            entry = ToolCallEntry(tool=tool_name, args=args, decision="auto_allowed", explanation=explanation)
             session.append(entry)
             session.write_audit(
                 AuditEntry.now(
@@ -90,7 +91,7 @@ async def evaluate_with(
                     tool=tool_name,
                     args_summary=args,
                     final_decision="auto_allowed",
-                    explanation=f"Auto-allowed by read-only exec heuristic ({matched_exec}).",
+                    explanation=explanation,
                 )
             )
             if verbose:
@@ -101,7 +102,7 @@ async def evaluate_with(
                     tool_call_callback,
                     approval_source="safe-list",
                     approval_verdict="allow",
-                    approval_explanation=f"auto-allowed by read-only exec heuristic ({matched_exec})",
+                    approval_explanation=explanation,
                 )
             return
 

--- a/src/carapace/security/__init__.py
+++ b/src/carapace/security/__init__.py
@@ -26,6 +26,7 @@ from carapace.security.context import (
     normalize_optional_message,
 )
 from carapace.security.context import CredentialAccessEntry as CredentialAccessEntry
+from carapace.security.exec_allowlist import match_auto_allowed_exec
 from carapace.security.sentinel import Sentinel
 from carapace.usage import UsageTracker
 
@@ -77,6 +78,32 @@ async def evaluate_with(
                 approval_explanation="auto-allowed",
             )
         return
+
+    if tool_name == "exec":
+        matched_exec = match_auto_allowed_exec(args)
+        if matched_exec is not None:
+            entry = ToolCallEntry(tool=tool_name, args=args, decision="auto_allowed")
+            session.append(entry)
+            session.write_audit(
+                AuditEntry.now(
+                    kind="tool_call",
+                    tool=tool_name,
+                    args_summary=args,
+                    final_decision="auto_allowed",
+                    explanation=f"Auto-allowed by read-only exec heuristic ({matched_exec}).",
+                )
+            )
+            if verbose:
+                _log_tool_call(
+                    tool_name,
+                    args,
+                    f"[safe-list] auto-allowed read-only exec heuristic ({matched_exec})",
+                    tool_call_callback,
+                    approval_source="safe-list",
+                    approval_verdict="allow",
+                    approval_explanation=f"auto-allowed by read-only exec heuristic ({matched_exec})",
+                )
+            return
 
     if verbose:
         _log_tool_call(

--- a/src/carapace/security/exec_allowlist.py
+++ b/src/carapace/security/exec_allowlist.py
@@ -11,7 +11,7 @@ _EXEC_RELATIVE_PATH = (
 _EXEC_PATH = rf"(?:{_EXEC_WORKSPACE_PATH}|{_EXEC_RELATIVE_PATH})"
 _EXEC_NEEDLE = r"[^\s'\";&|<>`$(){}\[\]\\\n\r*?~]+"
 _EXEC_FIXED_STRING_FLAGS = r"(?:\s+-[A-Za-z]+)*\s+-[A-Za-z]*F[A-Za-z]*(?:\s+-[A-Za-z]+)*"
-_UNSAFE_EXEC_SHELL_RE = re.compile(r"""[;&|<>`$(){}\[\]\\\n\r'\"*?~]""")
+_UNSAFE_EXEC_SHELL_RE = re.compile(r"""[;&|<>`$(){}\[\]\\\n\r'\"*?~#]""")
 _AUTO_ALLOWED_EXEC_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("ls", re.compile(rf"^\s*(?:/bin/ls|/usr/bin/ls|ls)(?:\s+-[A-Za-z]+)*(?:\s+{_EXEC_PATH})*\s*$")),
     ("cat", re.compile(rf"^\s*(?:/bin/cat|/usr/bin/cat|cat)(?:\s+{_EXEC_PATH})+\s*$")),

--- a/src/carapace/security/exec_allowlist.py
+++ b/src/carapace/security/exec_allowlist.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import re
 from typing import Any
 
-_EXEC_PATH_SEGMENT = r"[A-Za-z0-9_:@%+=,-][A-Za-z0-9_:@%+=.,-]*"
+_EXEC_PATH_SEGMENT = r"[A-Za-z0-9_:@%+=,][A-Za-z0-9_:@%+=.,-]*"
 _EXEC_WORKSPACE_PATH = rf"/workspace(?:/{_EXEC_PATH_SEGMENT})+/?"
 _EXEC_RELATIVE_PATH = (
     rf"(?:\.|{_EXEC_PATH_SEGMENT}(?:/{_EXEC_PATH_SEGMENT})*|" + rf"\./{_EXEC_PATH_SEGMENT}(?:/{_EXEC_PATH_SEGMENT})*)/?"
 )
 _EXEC_PATH = rf"(?:{_EXEC_WORKSPACE_PATH}|{_EXEC_RELATIVE_PATH})"
 _EXEC_NEEDLE = r"[^\s'\";&|<>`$(){}\[\]\\\n\r*?~]+"
+_EXEC_FIXED_STRING_FLAGS = r"(?:\s+-[A-Za-z]+)*\s+-[A-Za-z]*F[A-Za-z]*(?:\s+-[A-Za-z]+)*"
 _UNSAFE_EXEC_SHELL_RE = re.compile(r"""[;&|<>`$(){}\[\]\\\n\r'\"*?~]""")
 _AUTO_ALLOWED_EXEC_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("ls", re.compile(rf"^\s*(?:/bin/ls|/usr/bin/ls|ls)(?:\s+-[A-Za-z]+)*(?:\s+{_EXEC_PATH})*\s*$")),
@@ -27,15 +28,14 @@ _AUTO_ALLOWED_EXEC_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "grep",
         re.compile(
-            r"^\s*(?:/bin/grep|/usr/bin/grep|grep)(?=.*(?:^|\s)-[A-Za-z]*F[A-Za-z]*(?:\s|$))(?:\s+-[A-Za-z]+)*"
-            + rf"(?:\s+--)?\s+{_EXEC_NEEDLE}(?:\s+{_EXEC_PATH})+\s*$"
+            rf"^\s*(?:/bin/grep|/usr/bin/grep|grep){_EXEC_FIXED_STRING_FLAGS}"
+            + rf"\s+--\s+{_EXEC_NEEDLE}(?:\s+{_EXEC_PATH})+\s*$"
         ),
     ),
     (
         "rg",
         re.compile(
-            r"^\s*(?:/usr/bin/rg|rg)(?=.*(?:^|\s)-[A-Za-z]*F[A-Za-z]*(?:\s|$))(?:\s+-[A-Za-z]+)*"
-            + rf"(?:\s+--)?\s+{_EXEC_NEEDLE}(?:\s+{_EXEC_PATH})+\s*$"
+            rf"^\s*(?:/usr/bin/rg|rg){_EXEC_FIXED_STRING_FLAGS}" + rf"\s+--\s+{_EXEC_NEEDLE}(?:\s+{_EXEC_PATH})+\s*$"
         ),
     ),
 )

--- a/src/carapace/security/exec_allowlist.py
+++ b/src/carapace/security/exec_allowlist.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_EXEC_PATH_SEGMENT = r"[A-Za-z0-9_:@%+=,-][A-Za-z0-9_:@%+=.,-]*"
+_EXEC_WORKSPACE_PATH = rf"/workspace(?:/{_EXEC_PATH_SEGMENT})+/?"
+_EXEC_RELATIVE_PATH = (
+    rf"(?:\.|{_EXEC_PATH_SEGMENT}(?:/{_EXEC_PATH_SEGMENT})*|" + rf"\./{_EXEC_PATH_SEGMENT}(?:/{_EXEC_PATH_SEGMENT})*)/?"
+)
+_EXEC_PATH = rf"(?:{_EXEC_WORKSPACE_PATH}|{_EXEC_RELATIVE_PATH})"
+_EXEC_NEEDLE = r"[^\s'\";&|<>`$(){}\[\]\\\n\r*?~]+"
+_UNSAFE_EXEC_SHELL_RE = re.compile(r"""[;&|<>`$(){}\[\]\\\n\r'\"*?~]""")
+_AUTO_ALLOWED_EXEC_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("ls", re.compile(rf"^\s*(?:/bin/ls|/usr/bin/ls|ls)(?:\s+-[A-Za-z]+)*(?:\s+{_EXEC_PATH})*\s*$")),
+    ("cat", re.compile(rf"^\s*(?:/bin/cat|/usr/bin/cat|cat)(?:\s+{_EXEC_PATH})+\s*$")),
+    (
+        "head",
+        re.compile(rf"^\s*(?:/usr/bin/head|head)(?:\s+-n\s+[0-9]+)?(?:\s+{_EXEC_PATH})+\s*$"),
+    ),
+    (
+        "tail",
+        re.compile(rf"^\s*(?:/usr/bin/tail|tail)(?:\s+-n\s+[0-9]+)?(?:\s+{_EXEC_PATH})+\s*$"),
+    ),
+    ("wc", re.compile(rf"^\s*(?:/usr/bin/wc|wc)\s+-l(?:\s+{_EXEC_PATH})+\s*$")),
+    ("file", re.compile(rf"^\s*(?:/usr/bin/file|file)(?:\s+-b)?(?:\s+{_EXEC_PATH})+\s*$")),
+    (
+        "grep",
+        re.compile(
+            r"^\s*(?:/bin/grep|/usr/bin/grep|grep)(?=.*(?:^|\s)-[A-Za-z]*F[A-Za-z]*(?:\s|$))(?:\s+-[A-Za-z]+)*"
+            + rf"(?:\s+--)?\s+{_EXEC_NEEDLE}(?:\s+{_EXEC_PATH})+\s*$"
+        ),
+    ),
+    (
+        "rg",
+        re.compile(
+            r"^\s*(?:/usr/bin/rg|rg)(?=.*(?:^|\s)-[A-Za-z]*F[A-Za-z]*(?:\s|$))(?:\s+-[A-Za-z]+)*"
+            + rf"(?:\s+--)?\s+{_EXEC_NEEDLE}(?:\s+{_EXEC_PATH})+\s*$"
+        ),
+    ),
+)
+
+
+def match_auto_allowed_exec(args: dict[str, Any]) -> str | None:
+    if args.get("contexts"):
+        return None
+
+    command = args.get("command")
+    if not isinstance(command, str):
+        return None
+
+    if _UNSAFE_EXEC_SHELL_RE.search(command):
+        return None
+
+    stripped = command.strip()
+    for label, pattern in _AUTO_ALLOWED_EXEC_PATTERNS:
+        if pattern.fullmatch(stripped):
+            return label
+    return None

--- a/tests/test_exec_auto_allow.py
+++ b/tests/test_exec_auto_allow.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from carapace.security import evaluate_with
+from carapace.security.context import SentinelVerdict, SessionSecurity, ToolCallEntry
+from carapace.security.sentinel import Sentinel
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command", "expected_label"),
+    [
+        ("ls -la .", "ls"),
+        ("cat README.md docs/quickstart.md", "cat"),
+        ("grep -nF -- sentinel README.md", "grep"),
+        ("rg -nF -- session src tests", "rg"),
+        ("head -n 20 /workspace/README.md", "head"),
+    ],
+)
+async def test_exec_auto_allow_skips_sentinel_for_read_only_commands(
+    tmp_path,
+    command: str,
+    expected_label: str,
+) -> None:
+    session = SessionSecurity("test-session", audit_dir=tmp_path)
+    sentinel = MagicMock(spec=Sentinel)
+    sentinel.evaluate_tool_call = AsyncMock(
+        return_value=SentinelVerdict(decision="deny", explanation="should not be used")
+    )
+    callback_calls: list[tuple[str, dict[str, object], str, str | None, str | None, str | None]] = []
+
+    await evaluate_with(
+        session,
+        sentinel,
+        "exec",
+        {"command": command},
+        tool_call_callback=lambda tool, args, detail, source, verdict, explanation: callback_calls.append(
+            (tool, args, detail, source, verdict, explanation)
+        ),
+    )
+
+    sentinel.evaluate_tool_call.assert_not_awaited()
+    entry = session.action_log[-1]
+    assert isinstance(entry, ToolCallEntry)
+    assert entry.tool == "exec"
+    assert entry.decision == "auto_allowed"
+
+    assert callback_calls == [
+        (
+            "exec",
+            {"command": command},
+            f"[safe-list] auto-allowed read-only exec heuristic ({expected_label})",
+            "safe-list",
+            "allow",
+            f"auto-allowed by read-only exec heuristic ({expected_label})",
+        )
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command,args",
+    [
+        ("cat README.md && rm -f data.txt", {"command": "cat README.md && rm -f data.txt"}),
+        ("grep sentinel README.md", {"command": "grep sentinel README.md"}),
+        ("cat ../secrets.env", {"command": "cat ../secrets.env"}),
+        ("rg -nF -- token src", {"command": "rg -nF -- token src", "contexts": ["moneydb"]}),
+    ],
+)
+async def test_exec_auto_allow_falls_back_to_sentinel_for_non_matching_commands(
+    tmp_path,
+    command: str,
+    args: dict[str, object],
+) -> None:
+    session = SessionSecurity("test-session", audit_dir=tmp_path)
+    sentinel = MagicMock(spec=Sentinel)
+    sentinel.evaluate_tool_call = AsyncMock(
+        return_value=SentinelVerdict(decision="allow", explanation="allowed by sentinel")
+    )
+
+    await evaluate_with(session, sentinel, "exec", args)
+
+    sentinel.evaluate_tool_call.assert_awaited_once_with(
+        session,
+        "exec",
+        args,
+        usage_tracker=None,
+        assert_llm_budget_available=None,
+        usage_limits=None,
+    )
+    entry = session.action_log[-1]
+    assert isinstance(entry, ToolCallEntry)
+    assert entry.tool == "exec"
+    assert entry.decision == "allowed"
+    assert entry.explanation == "allowed by sentinel"

--- a/tests/test_exec_auto_allow.py
+++ b/tests/test_exec_auto_allow.py
@@ -18,6 +18,9 @@ from carapace.security.sentinel import Sentinel
         ("grep -nF -- sentinel README.md", "grep"),
         ("rg -nF -- session src tests", "rg"),
         ("head -n 20 /workspace/README.md", "head"),
+        ("tail -n 20 /workspace/README.md", "tail"),
+        ("wc -l README.md", "wc"),
+        ("file -b README.md", "file"),
     ],
 )
 async def test_exec_auto_allow_skips_sentinel_for_read_only_commands(
@@ -47,6 +50,7 @@ async def test_exec_auto_allow_skips_sentinel_for_read_only_commands(
     assert isinstance(entry, ToolCallEntry)
     assert entry.tool == "exec"
     assert entry.decision == "auto_allowed"
+    assert entry.explanation == f"Auto-allowed by read-only exec heuristic ({expected_label})."
 
     assert callback_calls == [
         (
@@ -55,7 +59,7 @@ async def test_exec_auto_allow_skips_sentinel_for_read_only_commands(
             f"[safe-list] auto-allowed read-only exec heuristic ({expected_label})",
             "safe-list",
             "allow",
-            f"auto-allowed by read-only exec heuristic ({expected_label})",
+            f"Auto-allowed by read-only exec heuristic ({expected_label}).",
         )
     ]
 
@@ -67,6 +71,10 @@ async def test_exec_auto_allow_skips_sentinel_for_read_only_commands(
         ("cat README.md && rm -f data.txt", {"command": "cat README.md && rm -f data.txt"}),
         ("grep sentinel README.md", {"command": "grep sentinel README.md"}),
         ("cat ../secrets.env", {"command": "cat ../secrets.env"}),
+        ("rg -nF --pre=python README.md", {"command": "rg -nF --pre=python README.md"}),
+        ("grep -nF --color=always README.md", {"command": "grep -nF --color=always README.md"}),
+        ("tail -f /workspace/app/server.log", {"command": "tail -f /workspace/app/server.log"}),
+        ("grep -n -- -F README.md", {"command": "grep -n -- -F README.md"}),
         ("rg -nF -- token src", {"command": "rg -nF -- token src", "contexts": ["moneydb"]}),
     ],
 )

--- a/tests/test_exec_auto_allow.py
+++ b/tests/test_exec_auto_allow.py
@@ -70,6 +70,7 @@ async def test_exec_auto_allow_skips_sentinel_for_read_only_commands(
     [
         ("cat README.md && rm -f data.txt", {"command": "cat README.md && rm -f data.txt"}),
         ("grep sentinel README.md", {"command": "grep sentinel README.md"}),
+        ("grep -nF -- #include src/main.c", {"command": "grep -nF -- #include src/main.c"}),
         ("cat ../secrets.env", {"command": "cat ../secrets.env"}),
         ("rg -nF --pre=python README.md", {"command": "rg -nF --pre=python README.md"}),
         ("grep -nF --color=always README.md", {"command": "grep -nF --color=always README.md"}),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes security gating to bypass sentinel review for some `exec` calls, so incorrect pattern matching could unintentionally allow more shell access than intended. Impact is limited by strict regex patterns and disallowing shell metacharacters/contexts.
> 
> **Overview**
> **Security gating now auto-allows some read-only `exec` calls.** `evaluate_with` short-circuits sentinel evaluation when `match_auto_allowed_exec` recognizes safe commands and records an `auto_allowed` tool/audit entry with an explicit explanation.
> 
> Adds `security/exec_allowlist.py` with regex-based matching for a small set of read-only commands (`ls`, `cat`, `head`, `tail`, `wc -l`, `file`, `grep -F`, `rg -F`), rejecting anything with shell metacharacters, non-path-like args, or `contexts`. Includes tests verifying sentinel is skipped for matching commands and still used for non-matches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2eaa4bdd321c13cf22bc116e5b4bfde7bc34be8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->