### PR TITLE
✨ feat: Persist interrupted LLM requests on cancel

### DIFF
--- a/src/carapace/session/turns.py
+++ b/src/carapace/session/turns.py
@@ -38,7 +38,7 @@ from carapace.sandbox.manager import SandboxManager
 from carapace.security.context import ApprovalSource, ApprovalVerdict, format_denial_message, normalize_optional_message
 from carapace.session.manager import SessionManager
 from carapace.session.types import ActiveSession, SessionSubscriber, TurnExecutionResult
-from carapace.usage import LlmRequestState, SessionBudgetExceededError
+from carapace.usage import LlmRequestState, SessionBudgetExceededError, interrupted_request_record
 from carapace.ws_models import ApprovalRequest, ApprovalResponse, TurnUsage
 
 
@@ -542,6 +542,8 @@ class SessionTurnMixin(SessionTurnHost):
     ) -> None:
         active.llm_request_thinking.clear()
         if save_progress:
+            if active.llm_request_state is not None:
+                active.llm_request_log.records.append(interrupted_request_record(active.llm_request_state))
             self._save_turn_progress(session_id, active)
         await self._clear_llm_request_state(active)
         self._save_user_message_on_failure(

--- a/src/carapace/usage.py
+++ b/src/carapace/usage.py
@@ -268,6 +268,7 @@ def usage_limits_for_remaining_budget(
 
 LlmSource = Literal["agent", "sentinel", "titler"]
 LlmRequestPhase = Literal["processing_prompt", "thinking", "generating"]
+LlmRequestOutcome = Literal["completed", "interrupted"]
 
 _llm_request_sink: ContextVar[LlmRequestObserver | None] = ContextVar(
     "llm_request_sink",
@@ -344,6 +345,7 @@ class LlmRequestRecord(BaseModel):
     request_id: str | None = None
     source: LlmSource
     model_name: str | None = None
+    outcome: LlmRequestOutcome = "completed"
     input_tokens: int = 0
     output_tokens: int = 0
     started_at: datetime | None = None
@@ -360,9 +362,33 @@ class LlmRequestLog(BaseModel):
     records: list[LlmRequestRecord] = Field(default_factory=list)
 
 
-def last_record_for_source(log: LlmRequestLog, source: LlmSource) -> LlmRequestRecord | None:
+def interrupted_request_record(state: LlmRequestState, *, ts: datetime | None = None) -> LlmRequestRecord:
+    when = ts or datetime.now(tz=UTC)
+    return LlmRequestRecord(
+        ts=when,
+        request_id=state.request_id,
+        source=state.source,
+        model_name=state.model_name,
+        outcome="interrupted",
+        started_at=state.started_at,
+        first_thinking_at=state.first_thinking_at,
+        last_thinking_at=state.last_thinking_at,
+        first_text_at=state.first_text_at,
+    )
+
+
+def last_record_for_source(
+    log: LlmRequestLog,
+    source: LlmSource,
+    *,
+    include_interrupted: bool = False,
+) -> LlmRequestRecord | None:
     for rec in reversed(log.records):
-        if rec.source == source:
+        if rec.source != source:
+            continue
+        if include_interrupted:
+            return rec
+        if rec.outcome == "completed":
             return rec
     return None
 

--- a/tests/test_llm_request_log.py
+++ b/tests/test_llm_request_log.py
@@ -7,9 +7,11 @@ from pydantic_ai.messages import ModelRequest, ModelResponse, SystemPromptPart, 
 
 from carapace.usage import (
     InputShapeRatios,
+    LlmRequestLog,
     LlmRequestRecord,
     gauge_breakdown_pct_dict,
     input_shape_ratios_from_messages,
+    last_record_for_source,
     usage_last_request_row,
 )
 
@@ -155,6 +157,31 @@ def test_usage_last_request_row_calculates_durations() -> None:
     assert row["ttft_ms"] == 3000
     assert row["reasoning_duration_ms"] == 2000
     assert row["total_duration_ms"] == 5000
+
+
+def test_last_record_for_source_skips_interrupted_records_by_default() -> None:
+    started_at = datetime.now(tz=UTC)
+    completed = LlmRequestRecord(
+        ts=started_at + timedelta(seconds=1),
+        request_id="req-complete",
+        source="agent",
+        outcome="completed",
+        input_tokens=100,
+        output_tokens=50,
+        started_at=started_at,
+        completed_at=started_at + timedelta(seconds=1),
+    )
+    interrupted = LlmRequestRecord(
+        ts=started_at + timedelta(seconds=2),
+        request_id="req-interrupted",
+        source="agent",
+        outcome="interrupted",
+        started_at=started_at + timedelta(seconds=2),
+    )
+    log = LlmRequestLog(records=[completed, interrupted])
+
+    assert last_record_for_source(log, "agent") == completed
+    assert last_record_for_source(log, "agent", include_interrupted=True) == interrupted
 
 
 def test_usage_last_request_row_falls_back_to_completion_for_tool_only_request() -> None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -973,6 +973,59 @@ def test_submit_cancel_persists_interruption_marker(tmp_path: Path):
         asyncio.run(_run())
 
 
+def test_submit_cancel_persists_interrupted_llm_request_log(tmp_path: Path):
+    """Cancelled in-flight LLM requests are saved in the request log as interrupted."""
+
+    async def _run() -> None:
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session()
+        sid = state.session_id
+
+        engine.subscribe(sid, _FakeSubscriber())
+
+        started_at = datetime(2026, 5, 2, 12, 0, tzinfo=UTC)
+
+        async def _hanging_turn(*_args: Any, **_kwargs: Any) -> str:
+            sink = usage_mod._llm_request_sink.get()
+            assert sink is not None
+            await sink.on_request_started(
+                LlmRequestState(
+                    request_id="req-1",
+                    source="agent",
+                    model_name="anthropic:claude-haiku-4-5",
+                    started_at=started_at,
+                    phase="thinking",
+                    first_thinking_at=started_at,
+                    last_thinking_at=started_at + timedelta(seconds=1),
+                )
+            )
+            await asyncio.sleep(999)
+            return "unreachable"
+
+        with patch("carapace.session.engine.run_agent_turn", new=_hanging_turn):
+            await engine.submit_message(sid, "hello")
+            await asyncio.sleep(0.05)
+            await engine.submit_cancel(sid)
+
+        log = engine.session_mgr.load_llm_request_log(sid)
+        assert len(log.records) == 1
+        record = log.records[0]
+        assert record.request_id == "req-1"
+        assert record.source == "agent"
+        assert record.model_name == "anthropic:claude-haiku-4-5"
+        assert record.outcome == "interrupted"
+        assert record.input_tokens == 0
+        assert record.output_tokens == 0
+        assert record.started_at == started_at
+        assert record.first_thinking_at == started_at
+        assert record.last_thinking_at == started_at + timedelta(seconds=1)
+        assert record.completed_at is None
+        assert engine.session_mgr.load_llm_request_state(sid) is None
+
+    with _patch_sentinel():
+        asyncio.run(_run())
+
+
 def test_submit_cancel_noop_when_inactive(tmp_path: Path):
     """submit_cancel is a no-op when session is not active."""
 


### PR DESCRIPTION
## Summary
Persist an explicit interrupted LLM request record when a running turn is cancelled so aborted in-flight requests are visible in the session log.

## What changed
- add an `outcome` field to persisted LLM request records
- persist an `interrupted` request record during cancelled turn finalization
- keep last-request lookups biased toward completed requests so the usage UI does not regress
- add focused regression tests for interrupted request logging and cancellation persistence

## Validation
- `uv run pytest tests/test_llm_request_log.py -k interrupted`
- `uv run pytest tests/test_session.py -k submit_cancel_persists_interrupted_llm_request_log`
- `uv run pytest tests/test_session.py -k "submit_cancel_persists_interruption_marker or submit_cancel_persists_interrupted_llm_request_log"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new persisted `outcome` field to LLM request records and changes cancel/failure finalization to write an explicit interrupted record, which can affect usage/last-request displays and any log consumers. Risk is moderate due to data schema evolution and behavioral changes during cancellation paths.
> 
> **Overview**
> Cancelled turns now **persist an explicit interrupted LLM request entry** so in-flight requests are visible in the session request log.
> 
> This introduces `LlmRequestRecord.outcome` (`completed` vs `interrupted`), adds `interrupted_request_record()` to snapshot the current `LlmRequestState` on cancellation, and updates `last_record_for_source()` to *skip interrupted records by default* (opt-in via `include_interrupted=True`) to avoid regressing existing “last request”/usage UI behavior.
> 
> Tests add coverage for the new last-record behavior and for persisting an interrupted record (with timing fields but no token counts) when `submit_cancel` aborts a hanging turn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91ac7796362687848fcd890d413142a65d5a99ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->