### PR TITLE
✨ feat: sentinel can approve domain during tool call

### DIFF
--- a/src/carapace/security/__init__.py
+++ b/src/carapace/security/__init__.py
@@ -5,6 +5,7 @@ import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Literal
+from urllib.parse import urlsplit
 
 from pydantic_ai import ApprovalRequired
 from pydantic_ai.exceptions import UsageLimitExceeded
@@ -143,6 +144,9 @@ async def evaluate_with(
         explanation=verdict.explanation,
     )
     session.append(entry)
+    auto_approved_domain: str | None = None
+    if verdict.decision == "allow":
+        auto_approved_domain = _normalize_auto_approve_domain(verdict.auto_approve_domain)
 
     detail = f"[sentinel: {verdict.decision}] {verdict.explanation}"
     if verbose:
@@ -154,6 +158,25 @@ async def evaluate_with(
             approval_source="sentinel",
             approval_verdict=verdict.decision,
             approval_explanation=verdict.explanation,
+        )
+
+    if verdict.decision == "allow" and auto_approved_domain is not None:
+        await session.cache_domain_approval_for_current_tool(
+            auto_approved_domain,
+            CachedDomainApproval(
+                allowed=True,
+                approval_source="sentinel",
+                approval_verdict="allow",
+                explanation=verdict.explanation,
+                detail=f"[sentinel: allow] {verdict.explanation}",
+                final_decision="allowed",
+                audit_explanation=(
+                    f"{verdict.explanation} (auto-approved domain: {auto_approved_domain})"
+                    if verdict.explanation
+                    else f"auto-approved domain: {auto_approved_domain}"
+                ),
+                sentinel_verdict=verdict,
+            ),
         )
 
     if verdict.decision == "deny":
@@ -747,3 +770,44 @@ def _log_tool_call(
         callback(tool_name, args, detail, approval_source, approval_verdict, approval_explanation)
     else:
         print(f"  \033[2m{tool_name}({args_str}) {detail}\033[0m")
+
+
+def _normalize_auto_approve_domain(candidate: str | None) -> str | None:
+    if candidate is None:
+        return None
+
+    text = candidate.strip().lower().rstrip(".")
+    if not text:
+        return None
+    if any(char.isspace() for char in text) or "," in text:
+        return None
+
+    hostname = _extract_hostname(text)
+    if hostname is None:
+        return None
+    if "*" in hostname or "@" in hostname:
+        return None
+    if not re.fullmatch(r"[a-z0-9.-]+", hostname):
+        return None
+    if hostname.startswith(".") or hostname.endswith(".") or ".." in hostname:
+        return None
+    if "." not in hostname:
+        return None
+    return hostname
+
+
+def _extract_hostname(text: str) -> str | None:
+    if "://" in text:
+        parsed = urlsplit(text)
+        return parsed.hostname.lower() if parsed.hostname else None
+
+    if any(sep in text for sep in ("/", "?", "#")):
+        parsed = urlsplit(f"https://{text}")
+        return parsed.hostname.lower() if parsed.hostname else None
+
+    if text.count(":") == 1:
+        host, port = text.rsplit(":", 1)
+        if port.isdigit() and host:
+            return host
+
+    return text

--- a/src/carapace/security/__init__.py
+++ b/src/carapace/security/__init__.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Any, Literal
 from urllib.parse import urlsplit
 
+from loguru import logger
 from pydantic_ai import ApprovalRequired
 from pydantic_ai.exceptions import UsageLimitExceeded
 from pydantic_ai.usage import UsageLimits
@@ -136,19 +137,21 @@ async def evaluate_with(
         )
 
     decision_str = _verdict_to_decision(verdict)
+    auto_approved_domain: str | None = None
+    approval_explanation = verdict.explanation
+    if verdict.decision == "allow":
+        auto_approved_domain = _normalize_auto_approve_domain(verdict.auto_approve_domain)
+        approval_explanation = _format_tool_approval_explanation(verdict.explanation, auto_approved_domain)
 
     entry = ToolCallEntry(
         tool=tool_name,
         args=args,
         decision=decision_str,
-        explanation=verdict.explanation,
+        explanation=approval_explanation,
     )
     session.append(entry)
-    auto_approved_domain: str | None = None
-    if verdict.decision == "allow":
-        auto_approved_domain = _normalize_auto_approve_domain(verdict.auto_approve_domain)
 
-    detail = f"[sentinel: {verdict.decision}] {verdict.explanation}"
+    detail = f"[sentinel: {verdict.decision}] {approval_explanation}"
     if verbose:
         _log_tool_call(
             tool_name,
@@ -157,7 +160,7 @@ async def evaluate_with(
             tool_call_callback,
             approval_source="sentinel",
             approval_verdict=verdict.decision,
-            approval_explanation=verdict.explanation,
+            approval_explanation=approval_explanation,
         )
 
     if verdict.decision == "allow" and auto_approved_domain is not None:
@@ -167,17 +170,14 @@ async def evaluate_with(
                 allowed=True,
                 approval_source="sentinel",
                 approval_verdict="allow",
-                explanation=verdict.explanation,
-                detail=f"[sentinel: allow] {verdict.explanation}",
+                explanation=approval_explanation,
+                detail=f"[sentinel: allow] {approval_explanation}",
                 final_decision="allowed",
-                audit_explanation=(
-                    f"{verdict.explanation} (auto-approved domain: {auto_approved_domain})"
-                    if verdict.explanation
-                    else f"auto-approved domain: {auto_approved_domain}"
-                ),
+                audit_explanation=approval_explanation,
                 sentinel_verdict=verdict,
             ),
         )
+        logger.info(f"Sentinel auto-approved domain for tool call tool={tool_name} domain={auto_approved_domain}")
 
     if verdict.decision == "deny":
         session.write_audit(
@@ -187,7 +187,7 @@ async def evaluate_with(
                 args_summary=args,
                 sentinel_verdict=verdict,
                 final_decision="denied",
-                explanation=verdict.explanation,
+                explanation=approval_explanation,
             )
         )
         raise SecurityDeniedError(format_denial_message("sentinel", verdict.explanation))
@@ -197,7 +197,7 @@ async def evaluate_with(
             metadata={
                 "tool": tool_name,
                 "args": args,
-                "explanation": verdict.explanation,
+                "explanation": approval_explanation,
                 "risk_level": verdict.risk_level,
                 "sentinel_verdict": verdict,
                 "args_summary": args,
@@ -212,7 +212,7 @@ async def evaluate_with(
             args_summary=args,
             sentinel_verdict=verdict,
             final_decision="allowed",
-            explanation=verdict.explanation,
+            explanation=approval_explanation,
         )
     )
 
@@ -794,6 +794,15 @@ def _normalize_auto_approve_domain(candidate: str | None) -> str | None:
     if "." not in hostname:
         return None
     return hostname
+
+
+def _format_tool_approval_explanation(explanation: str, auto_approved_domain: str | None) -> str:
+    if auto_approved_domain is None:
+        return explanation
+    suffix = f"Auto-approved domain for this tool call: {auto_approved_domain}."
+    if explanation:
+        return f"{explanation} {suffix}"
+    return suffix
 
 
 def _extract_hostname(text: str) -> str | None:

--- a/src/carapace/security/context.py
+++ b/src/carapace/security/context.py
@@ -128,6 +128,7 @@ class SentinelVerdict(BaseModel):
     decision: Literal["allow", "escalate", "deny"]
     explanation: str = ""
     risk_level: Literal["low", "medium", "high"] = "medium"
+    auto_approve_domain: str | None = None
 
 
 ApprovalSource = Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"]
@@ -287,6 +288,18 @@ class SessionSecurity:
     def clear_current_parent_tool(self) -> None:
         self.current_parent_tool_id = None
         self._sync_domain_scope()
+
+    async def cache_domain_approval_for_current_tool(
+        self,
+        domain: str,
+        approval: CachedDomainApproval,
+    ) -> bool:
+        async with self._domain_scope_lock:
+            self._sync_domain_scope()
+            if self.current_parent_tool_id is None:
+                return False
+            self._domain_scope_approvals[domain] = approval
+            return True
 
     async def get_or_enqueue_domain_approval(
         self,

--- a/src/carapace/security/sentinel.py
+++ b/src/carapace/security/sentinel.py
@@ -56,6 +56,16 @@ each individual credential or domain is justified separately.
 
 Always respond using the requested structured output schema.
 
+When evaluating a tool call, you may optionally set `auto_approve_domain`
+to exactly one hostname if all of the following are true:
+- the verdict is `allow`
+- the tool call itself already makes the intended network target clear
+- that hostname is the single specific domain you intend to allow for the
+    current tool call only
+
+Do not include schemes, ports, paths, query strings, wildcards, or multiple
+domains. Use a bare hostname like `google.de`. Leave it null when unsure.
+
 """
 
 _RESET_THRESHOLD_DEFAULT = 20
@@ -434,6 +444,10 @@ class Sentinel:
             args_str = ", ".join(f"{k}={_truncate(v)}" for k, v in args.items())
             prompt_parts.append(f"\nEVALUATE tool_call:\n{tool_name}({args_str})")
             prompt_parts.append(f"Last user message was {tool_calls_since_user} tool calls ago.")
+            prompt_parts.append(
+                "If you allow this tool call and it clearly targets exactly one network hostname, "
+                + "you may set auto_approve_domain to that hostname for this tool call only."
+            )
 
             prompt = "\n".join(prompt_parts)
             return await self._run_evaluation(

--- a/tests/test_exec_auto_allow.py
+++ b/tests/test_exec_auto_allow.py
@@ -111,6 +111,7 @@ async def test_exec_auto_allow_falls_back_to_sentinel_for_non_matching_commands(
 async def test_allowed_tool_can_auto_approve_one_domain_for_same_tool_call(tmp_path) -> None:
     session = SessionSecurity("test-session", audit_dir=tmp_path, sentinel_domain_batch_window_ms=0)
     sentinel = MagicMock(spec=Sentinel)
+    callback_calls: list[tuple[str, dict[str, object], str, str | None, str | None, str | None]] = []
     sentinel.evaluate_tool_call = AsyncMock(
         return_value=SentinelVerdict(
             decision="allow",
@@ -133,7 +134,7 @@ async def test_allowed_tool_can_auto_approve_one_domain_for_same_tool_call(tmp_p
         verdict: str | None,
         explanation: str | None,
     ) -> None:
-        del tool, args, detail, source, verdict, explanation
+        callback_calls.append((tool, args, detail, source, verdict, explanation))
         session.current_parent_tool_id = "tool-1"
 
     await evaluate_with(
@@ -150,6 +151,44 @@ async def test_allowed_tool_can_auto_approve_one_domain_for_same_tool_call(tmp_p
     sentinel.evaluate_tool_call.assert_awaited_once()
     sentinel.evaluate_domain_access.assert_not_awaited()
     sentinel.evaluate_domain_access_batch.assert_not_awaited()
+    entry = session.action_log[-1]
+    assert isinstance(entry, ToolCallEntry)
+    assert entry.explanation == "curl target is clear Auto-approved domain for this tool call: google.de."
+    assert callback_calls == [
+        (
+            "exec",
+            {"command": "curl https://google.de/search?q=test"},
+            "[sentinel: allow] curl target is clear Auto-approved domain for this tool call: google.de.",
+            "sentinel",
+            "allow",
+            "curl target is clear Auto-approved domain for this tool call: google.de.",
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_auto_approved_domain_emits_log_line(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    session = SessionSecurity("test-session", audit_dir=tmp_path)
+    sentinel = MagicMock(spec=Sentinel)
+    sentinel.evaluate_tool_call = AsyncMock(
+        return_value=SentinelVerdict(
+            decision="allow",
+            explanation="curl target is clear",
+            auto_approve_domain="google.de",
+        )
+    )
+    messages: list[str] = []
+    monkeypatch.setattr("carapace.security.logger.info", messages.append)
+
+    await evaluate_with(
+        session,
+        sentinel,
+        "exec",
+        {"command": "curl google.de"},
+        verbose=False,
+    )
+
+    assert messages == ["Sentinel auto-approved domain for tool call tool=exec domain=google.de"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_exec_auto_allow.py
+++ b/tests/test_exec_auto_allow.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from carapace.security import evaluate_with
+from carapace.security import evaluate_domain_with, evaluate_with
 from carapace.security.context import SentinelVerdict, SessionSecurity, ToolCallEntry
 from carapace.security.sentinel import Sentinel
 
@@ -105,3 +105,104 @@ async def test_exec_auto_allow_falls_back_to_sentinel_for_non_matching_commands(
     assert entry.tool == "exec"
     assert entry.decision == "allowed"
     assert entry.explanation == "allowed by sentinel"
+
+
+@pytest.mark.asyncio
+async def test_allowed_tool_can_auto_approve_one_domain_for_same_tool_call(tmp_path) -> None:
+    session = SessionSecurity("test-session", audit_dir=tmp_path, sentinel_domain_batch_window_ms=0)
+    sentinel = MagicMock(spec=Sentinel)
+    sentinel.evaluate_tool_call = AsyncMock(
+        return_value=SentinelVerdict(
+            decision="allow",
+            explanation="curl target is clear",
+            auto_approve_domain="https://google.de/search?q=test",
+        )
+    )
+    sentinel.evaluate_domain_access = AsyncMock(
+        side_effect=AssertionError("tool-call auto approval should skip single-domain sentinel review")
+    )
+    sentinel.evaluate_domain_access_batch = AsyncMock(
+        side_effect=AssertionError("tool-call auto approval should skip batched sentinel review")
+    )
+
+    def record_tool_call(
+        tool: str,
+        args: dict[str, object],
+        detail: str,
+        source: str | None,
+        verdict: str | None,
+        explanation: str | None,
+    ) -> None:
+        del tool, args, detail, source, verdict, explanation
+        session.current_parent_tool_id = "tool-1"
+
+    await evaluate_with(
+        session,
+        sentinel,
+        "exec",
+        {"command": "curl https://google.de/search?q=test"},
+        tool_call_callback=record_tool_call,
+    )
+
+    allowed = await evaluate_domain_with(session, sentinel, "google.de", "curl https://google.de/search?q=test")
+
+    assert allowed is True
+    sentinel.evaluate_tool_call.assert_awaited_once()
+    sentinel.evaluate_domain_access.assert_not_awaited()
+    sentinel.evaluate_domain_access_batch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auto_approve_domain",
+    [
+        "https://google.de/path with spaces",
+        "*.google.de",
+        "google",
+        "google.de,example.com",
+        "user@google.de",
+    ],
+)
+async def test_invalid_auto_approved_domain_is_ignored(tmp_path, auto_approve_domain: str) -> None:
+    session = SessionSecurity("test-session", audit_dir=tmp_path, sentinel_domain_batch_window_ms=0)
+    sentinel = MagicMock(spec=Sentinel)
+    sentinel.evaluate_tool_call = AsyncMock(
+        return_value=SentinelVerdict(
+            decision="allow",
+            explanation="allowed by sentinel",
+            auto_approve_domain=auto_approve_domain,
+        )
+    )
+    sentinel.evaluate_domain_access_batch = AsyncMock(
+        return_value=SentinelVerdict(decision="allow", explanation="needs normal proxy path")
+    )
+
+    def record_tool_call(
+        tool: str,
+        args: dict[str, object],
+        detail: str,
+        source: str | None,
+        verdict: str | None,
+        explanation: str | None,
+    ) -> None:
+        del tool, args, detail, source, verdict, explanation
+        session.current_parent_tool_id = "tool-1"
+
+    await evaluate_with(
+        session,
+        sentinel,
+        "exec",
+        {"command": "curl https://google.de"},
+        tool_call_callback=record_tool_call,
+    )
+
+    allowed = await evaluate_domain_with(session, sentinel, "google.de", "curl https://google.de")
+
+    assert allowed is True
+    sentinel.evaluate_domain_access_batch.assert_awaited_once_with(
+        session,
+        {"google.de": "curl https://google.de"},
+        usage_tracker=None,
+        assert_llm_budget_available=None,
+        usage_limits=None,
+    )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes security-gating behavior by letting a tool-call `allow` verdict pre-approve a hostname and bypass subsequent domain sentinel review within that tool scope; mistakes or parsing bugs could incorrectly grant network access.
> 
> **Overview**
> Adds support for Sentinel to return an optional `auto_approve_domain` on `allow` tool-call verdicts, which is normalized to a single hostname and then cached for the current tool call so subsequent `evaluate_domain_with` checks can be auto-allowed without extra Sentinel review.
> 
> Updates tool-call logging/audit/ApprovalRequired metadata to include an augmented explanation noting the auto-approved domain, extends `SessionSecurity` with `cache_domain_approval_for_current_tool`, and updates the Sentinel system prompt plus new tests covering valid, invalid, and logging behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35f84793b917e6d11f85e34ae1716fdaf1d0e1dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->