### PR TITLE
✨ feat: add a timeout for the sentinel

### DIFF
--- a/src/carapace/models.py
+++ b/src/carapace/models.py
@@ -291,6 +291,9 @@ class AgentConfig(BaseModel):
     # Debounce window for coalescing proxy domain requests within a tool call.
     sentinel_domain_batch_window_ms: int = 100
 
+    # Max wall-clock time for one sentinel LLM review.
+    sentinel_timeout_seconds: int = Field(default=60, ge=1)
+
     # Cap string length returned to the model (and mirrored to tool_result_callback). 0 = no limit.
     tool_output_max_chars: int = 16_000
 

--- a/src/carapace/security/sentinel.py
+++ b/src/carapace/security/sentinel.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
+from datetime import timedelta
 from os import stat_result
 from pathlib import Path
 from typing import Any
@@ -136,6 +137,7 @@ class Sentinel:
         model: str,
         knowledge_dir: Path,
         skills_dir: Path,
+        timeout: timedelta = timedelta(seconds=60),
         reset_threshold: int = _RESET_THRESHOLD_DEFAULT,
         model_factory: Callable[[str], Model] | None = None,
         model_settings_resolver: Callable[[str], ModelSettings | None] | None = None,
@@ -143,6 +145,7 @@ class Sentinel:
         self._model = model
         self._knowledge_dir = knowledge_dir
         self._skills_dir = skills_dir
+        self._timeout = timeout
         self._reset_threshold = reset_threshold
         self._model_factory = model_factory
         self._model_settings_resolver = model_settings_resolver
@@ -291,6 +294,12 @@ class Sentinel:
             + f"cache_misses={stats['cache_misses']}{path_text}"
         )
 
+    def _timeout_explanation(self) -> str:
+        return (
+            f"Automatic sentinel review timed out after {self._timeout.total_seconds():g}s. "
+            + "The tool call was blocked so the agent can decide whether to retry."
+        )
+
     async def _run_evaluation(
         self,
         session: SessionSecurity,
@@ -313,12 +322,22 @@ class Sentinel:
         try:
             if assert_llm_budget_available is not None:
                 assert_llm_budget_available()
-            result = await self._agent.run(
-                prompt,
-                deps=self._skills_dir,
-                message_history=self._message_history or None,
-                usage_limits=usage_limits,
+            async with asyncio.timeout(self._timeout.total_seconds()):
+                result = await self._agent.run(
+                    prompt,
+                    deps=self._skills_dir,
+                    message_history=self._message_history or None,
+                    usage_limits=usage_limits,
+                )
+        except TimeoutError:
+            stats = self._end_eval_logging()
+            session.sentinel_eval_count += 1
+            explanation = self._timeout_explanation()
+            logger.warning(
+                f"Sentinel eval timed out session={session.session_id} seq={eval_no} kind={kind} subject={subject} "
+                + f"timeout_seconds={self._timeout.total_seconds():g} {self._format_eval_stats(stats)}"
             )
+            return SentinelVerdict(decision="deny", explanation=explanation, risk_level="high")
         except Exception as exc:
             stats = self._end_eval_logging()
             logger.error(

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -16,7 +16,7 @@ import secrets
 import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, Literal
@@ -476,6 +476,7 @@ class SessionEngine(SessionTurnMixin):
             model=self._config.agent.sentinel_model,
             knowledge_dir=self._knowledge_dir,
             skills_dir=self._knowledge_dir / "skills",
+            timeout=timedelta(seconds=self._config.agent.sentinel_timeout_seconds),
             model_factory=self._model_factory,
             model_settings_resolver=self._resolve_model_settings,
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,11 +19,13 @@ def test_load_config_defaults(tmp_path: Path):
 def test_load_config_from_yaml(tmp_path: Path):
     (tmp_path / "config.yaml").write_text(
         "agent:\n  model: anthropic:claude-sonnet-4-6\n  sentinel_model: anthropic:claude-haiku-4-5\n"
+        "  sentinel_timeout_seconds: 15\n"
         "  tool_output_max_chars: 5000\n"
     )
     cfg = load_config(tmp_path)
     assert cfg.agent.model == "anthropic:claude-sonnet-4-6"
     assert cfg.agent.sentinel_model == "anthropic:claude-haiku-4-5"
+    assert cfg.agent.sentinel_timeout_seconds == 15
     assert cfg.agent.tool_output_max_chars == 5000
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,6 +29,7 @@ def test_config_defaults():
     assert cfg.carapace.log_level == "info"
     assert cfg.agent.model == "anthropic:claude-sonnet-4-6"
     assert cfg.agent.default_session_budget.has_any_limit is False
+    assert cfg.agent.sentinel_timeout_seconds == 60
     assert cfg.agent.tool_output_max_chars == 16_000
     assert cfg.sandbox.network_name == "carapace-sandbox"
     ids = {e.model_id for e in cfg.agent.available_models}

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
+import asyncio
+from datetime import timedelta
 from pathlib import Path
 
+import pytest
 from pydantic_ai.models.test import TestModel
 
 from carapace.security.context import SessionSecurity
 from carapace.security.sentinel import Sentinel
 
 
-def _make_sentinel(tmp_path: Path) -> tuple[Sentinel, Path]:
+def _make_sentinel(tmp_path: Path, *, timeout: timedelta = timedelta(seconds=60)) -> tuple[Sentinel, Path]:
     knowledge_dir = tmp_path / "knowledge"
     skills_dir = tmp_path / "skills"
     knowledge_dir.mkdir()
@@ -17,6 +20,7 @@ def _make_sentinel(tmp_path: Path) -> tuple[Sentinel, Path]:
         model="test:model",
         knowledge_dir=knowledge_dir,
         skills_dir=skills_dir,
+        timeout=timeout,
         model_factory=lambda _name: TestModel(),
     )
     return sentinel, skills_dir
@@ -83,3 +87,24 @@ def test_eval_tool_logging_includes_context(tmp_path: Path, monkeypatch) -> None
         "Sentinel tool result session=session-1 eval=7 step=1 tool=read_skill_file "
         + "summary=cache_hit=true reuse_previous_result=true",
     ]
+
+
+@pytest.mark.asyncio
+async def test_evaluate_tool_call_timeout_returns_deny_verdict(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sentinel, _skills_dir = _make_sentinel(tmp_path, timeout=timedelta(seconds=0.01))
+    session = SessionSecurity("session-1")
+
+    async def _hang(*_args, **_kwargs):
+        await asyncio.sleep(1)
+
+    monkeypatch.setattr(sentinel._agent, "run", _hang)
+
+    verdict = await sentinel.evaluate_tool_call(session, "exec", {"command": "echo hi"})
+
+    assert verdict.decision == "deny"
+    assert verdict.risk_level == "high"
+    assert verdict.explanation == (
+        "Automatic sentinel review timed out after 0.01s. "
+        "The tool call was blocked so the agent can decide whether to retry."
+    )
+    assert session.sentinel_eval_count == 1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the sentinel security gate to time out LLM reviews and default to a high-risk deny verdict, which can block tool/domain/credential approvals if the model stalls. Adds a new configuration knob that affects runtime behavior across sessions.
> 
> **Overview**
> Adds a new `agent.sentinel_timeout_seconds` config (default `60`) and wires it into session startup so each `Sentinel` evaluation has a wall-clock deadline.
> 
> Wraps sentinel `_agent.run` calls in `asyncio.timeout`; on timeout it logs the event, increments `sentinel_eval_count`, and returns a **high-risk `deny` verdict** with a standard explanation (covered by new tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98dd3ccc182ca9ebca0cc75bdffde6bdd46e27d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->