### PR TITLE
✨ feat: make tool calls budgetable

### DIFF
--- a/frontend/src/components/command-result.tsx
+++ b/frontend/src/components/command-result.tsx
@@ -373,7 +373,7 @@ interface UsageBucket {
 }
 
 interface BudgetGaugeData {
-  key: "input" | "output" | "cost";
+  key: "input" | "output" | "cost" | "tool_calls";
   label: string;
   current_value: string;
   limit_value: string;
@@ -410,6 +410,7 @@ interface UsagePayload {
   categories: Record<string, UsageBucket>;
   total_input: number;
   total_output: number;
+  total_tool_calls?: number;
   costs?: Record<string, string>;
   category_costs?: Record<string, string>;
   budget_gauges?: BudgetGaugeData[];
@@ -458,6 +459,7 @@ function lastRequestRowsShowOtherPct(rows: LastLlmRequestRow[]): boolean {
 
 function UsageView({ data }: { data: UsagePayload }) {
   const budgetGauges = Array.isArray(data.budget_gauges) ? data.budget_gauges : [];
+  const totalToolCalls = data.total_tool_calls ?? 0;
   const allBuckets = [
     ...Object.values(data.models),
     ...Object.values(data.categories),
@@ -473,7 +475,8 @@ function UsageView({ data }: { data: UsagePayload }) {
   const isEmpty =
     Object.keys(data.models).length === 0 &&
     Object.keys(data.categories).length === 0 &&
-    budgetGauges.length === 0;
+    budgetGauges.length === 0 &&
+    totalToolCalls === 0;
   if (isEmpty) {
     return (
       <p className="my-1 text-sm text-muted-foreground">
@@ -573,6 +576,9 @@ function UsageView({ data }: { data: UsagePayload }) {
       <p className="mb-2 text-xs text-muted-foreground">
         Total: {fmt(total)} tokens ({fmt(data.total_input)} in +{" "}
         {fmt(data.total_output)} out){costStr}
+      </p>
+      <p className="mb-2 text-xs text-muted-foreground">
+        Tool Calls: {fmt(totalToolCalls)}
       </p>
       {budgetGauges.length > 0 ? <BudgetTable gauges={budgetGauges} /> : null}
       {Object.keys(data.models).length > 0 &&

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -212,7 +212,7 @@ export interface TurnUsageBreakdownPct {
 }
 
 export interface BudgetGauge {
-  key: "input" | "output" | "cost";
+  key: "input" | "output" | "cost" | "tool_calls";
   label: string;
   current_value: string;
   current_amount?: number | null;

--- a/src/carapace/channels/matrix/channel.py
+++ b/src/carapace/channels/matrix/channel.py
@@ -485,7 +485,7 @@ class MatrixChannel:
                     "- `/memory` — List memory files\n"
                     "- `/retitle` — Regenerate title, or `/retitle My title` to set it\n"
                     "- `/budget` — Show current budgets; set with `/budget input N`, "
-                    "`/budget output N`, or `/budget cost N`\n"
+                    "`/budget output N`, `/budget cost N`, or `/budget tools N`\n"
                     "- `/usage` — Show token usage\n"
                     "- `/model` — View or switch agent, sentinel, and title models together\n"
                     "- `/model-agent` — View or switch the agent model only\n"

--- a/src/carapace/channels/matrix/formatting.py
+++ b/src/carapace/channels/matrix/formatting.py
@@ -94,9 +94,10 @@ def format_command_result_text(result: CommandResult) -> str:
             budget_gauges: list[dict] = data.get("budget_gauges", [])
             total_input = data.get("total_input", 0)
             total_output = data.get("total_output", 0)
+            total_tool_calls = int(data.get("total_tool_calls", 0) or 0)
             total_cost = float(costs.get("total", 0))
 
-            if not models and not categories and not budget_gauges:
+            if not models and not categories and not budget_gauges and total_tool_calls == 0:
                 return "No token usage recorded yet."
 
             has_cache = any(
@@ -143,6 +144,7 @@ def format_command_result_text(result: CommandResult) -> str:
             parts.append(
                 f"**Total:** {total_tokens:,} tokens ({total_input:,} in + {total_output:,} out){cost_str}",
             )
+            parts.append(f"**Tool Calls:** {total_tool_calls:,}")
             if budget_gauges:
                 lines = [
                     "**Session Budgets**\n",

--- a/src/carapace/cli.py
+++ b/src/carapace/cli.py
@@ -230,8 +230,9 @@ def _render_usage(payload: dict[str, Any]) -> None:
     costs: dict[str, str] = payload.get("costs", {})
     category_costs: dict[str, str] = payload.get("category_costs", {})
     budget_gauges: list[dict[str, Any]] = payload.get("budget_gauges", [])
+    total_tool_calls = int(payload.get("total_tool_calls", 0) or 0)
 
-    if not models and not categories and not budget_gauges:
+    if not models and not categories and not budget_gauges and total_tool_calls == 0:
         console.print("[dim]No token usage recorded yet.[/dim]")
         return
 
@@ -286,6 +287,7 @@ def _render_usage(payload: dict[str, Any]) -> None:
     cost_str = f" | {_styled_cost(total_cost)}" if total_cost != "0" else ""
     tokens_str = f"{total_in + total_out:,} tokens ({total_in:,} in + {total_out:,} out)"
     console.print(f"[bold]Total:[/bold] {tokens_str}{cost_str}")
+    console.print(f"[bold]Tool calls:[/bold] {total_tool_calls:,}")
 
     if budget_gauges:
         console.print(_make_budget_table(budget_gauges))

--- a/src/carapace/models.py
+++ b/src/carapace/models.py
@@ -48,6 +48,7 @@ class SessionBudget(BaseModel):
     input_tokens: int | None = None
     output_tokens: int | None = None
     cost_usd: Decimal | None = None
+    tool_calls: int | None = None
 
     @model_validator(mode="after")
     def _normalize_limits(self) -> SessionBudget:
@@ -66,11 +67,18 @@ class SessionBudget(BaseModel):
                 raise ValueError("budget.cost_usd must be >= 0")
             if self.cost_usd == 0:
                 self.cost_usd = None
+        if self.tool_calls is not None:
+            if self.tool_calls < 0:
+                raise ValueError("budget.tool_calls must be >= 0")
+            if self.tool_calls == 0:
+                self.tool_calls = None
         return self
 
     @property
     def has_any_limit(self) -> bool:
-        return any(limit is not None for limit in (self.input_tokens, self.output_tokens, self.cost_usd))
+        return any(
+            limit is not None for limit in (self.input_tokens, self.output_tokens, self.cost_usd, self.tool_calls)
+        )
 
 
 class SessionAttributes(BaseModel):

--- a/src/carapace/security/__init__.py
+++ b/src/carapace/security/__init__.py
@@ -67,16 +67,15 @@ async def evaluate_with(
                 final_decision="auto_allowed",
             )
         )
-        if verbose:
-            _log_tool_call(
-                tool_name,
-                args,
-                "[safe-list] auto-allowed",
-                tool_call_callback,
-                approval_source="safe-list",
-                approval_verdict="allow",
-                approval_explanation="auto-allowed",
-            )
+        _log_tool_call(
+            tool_name,
+            args,
+            "[safe-list] auto-allowed",
+            tool_call_callback,
+            approval_source="safe-list",
+            approval_verdict="allow",
+            approval_explanation="auto-allowed",
+        )
         return
 
     if tool_name == "exec":
@@ -94,16 +93,15 @@ async def evaluate_with(
                     explanation=explanation,
                 )
             )
-            if verbose:
-                _log_tool_call(
-                    tool_name,
-                    args,
-                    f"[safe-list] auto-allowed read-only exec heuristic ({matched_exec})",
-                    tool_call_callback,
-                    approval_source="safe-list",
-                    approval_verdict="allow",
-                    approval_explanation=explanation,
-                )
+            _log_tool_call(
+                tool_name,
+                args,
+                f"[safe-list] auto-allowed read-only exec heuristic ({matched_exec})",
+                tool_call_callback,
+                approval_source="safe-list",
+                approval_verdict="allow",
+                approval_explanation=explanation,
+            )
             return
 
     if verbose:
@@ -145,16 +143,15 @@ async def evaluate_with(
     session.append(entry)
 
     detail = f"[sentinel: {verdict.decision}] {verdict.explanation}"
-    if verbose:
-        _log_tool_call(
-            tool_name,
-            args,
-            detail,
-            tool_call_callback,
-            approval_source="sentinel",
-            approval_verdict=verdict.decision,
-            approval_explanation=verdict.explanation,
-        )
+    _log_tool_call(
+        tool_name,
+        args,
+        detail,
+        tool_call_callback,
+        approval_source="sentinel",
+        approval_verdict=verdict.decision,
+        approval_explanation=verdict.explanation,
+    )
 
     if verdict.decision == "deny":
         session.write_audit(

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -246,6 +246,7 @@ class SessionEngine(SessionTurnMixin):
             input_tokens_limit=budget.input_tokens,
             output_tokens_limit=budget.output_tokens,
             total_cost_limit=budget.cost_usd,
+            tool_calls_limit=budget.tool_calls,
         )
 
     def _budget_exceeded_error(self, active: ActiveSession) -> SessionBudgetExceededError | None:
@@ -255,6 +256,7 @@ class SessionEngine(SessionTurnMixin):
             input_tokens_limit=budget.input_tokens,
             output_tokens_limit=budget.output_tokens,
             total_cost_limit=budget.cost_usd,
+            tool_calls_limit=budget.tool_calls,
         )
 
     def _assert_llm_budget_available(self, active: ActiveSession) -> None:
@@ -323,7 +325,10 @@ class SessionEngine(SessionTurnMixin):
 
     def _budget_command_payload(self, active: ActiveSession, *, message: str | None = None) -> dict[str, Any]:
         gauges = self._budget_gauges(active)
-        usage_hint = "Set budgets with /budget input N, /budget output N, or /budget cost N. Use 0 to clear a limit."
+        usage_hint = (
+            "Set budgets with /budget input N, /budget output N, /budget cost N, "
+            "or /budget tools N. Use 0 to clear a limit."
+        )
         payload: dict[str, Any] = {
             "gauges": [g.model_dump(mode="json") for g in gauges],
             "usage_hint": usage_hint,
@@ -334,9 +339,11 @@ class SessionEngine(SessionTurnMixin):
             payload["message"] = "No session budgets configured."
         return payload
 
-    def _parse_budget_limit_value(self, metric: Literal["input", "output", "cost"], raw: str) -> int | Decimal:
+    def _parse_budget_limit_value(
+        self, metric: Literal["input", "output", "cost", "tool_calls"], raw: str
+    ) -> int | Decimal:
         cleaned = raw.replace(",", "").replace("_", "")
-        if metric in ("input", "output"):
+        if metric in ("input", "output", "tool_calls"):
             lowered = cleaned.lower()
             multiplier = 1
             if lowered.endswith("k"):
@@ -372,7 +379,7 @@ class SessionEngine(SessionTurnMixin):
     def _set_budget_metric(
         self,
         active: ActiveSession,
-        metric: Literal["input", "output", "cost"],
+        metric: Literal["input", "output", "cost", "tool_calls"],
         value: int | Decimal,
     ) -> str:
         budget = active.state.budget.model_copy(deep=True)
@@ -394,6 +401,16 @@ class SessionEngine(SessionTurnMixin):
             if budget.output_tokens is None:
                 return "Cleared output token budget."
             return f"Set output token budget to {budget.output_tokens:,} tokens."
+        if metric == "tool_calls":
+            budget.tool_calls = int(value)
+            if budget.tool_calls == 0:
+                budget.tool_calls = None
+            active.state.budget = budget
+            self._session_mgr.save_state(active.state)
+            if budget.tool_calls is None:
+                return "Cleared tool call budget."
+            suffix = "call" if budget.tool_calls == 1 else "calls"
+            return f"Set tool call budget to {budget.tool_calls:,} tool {suffix}."
         budget.cost_usd = Decimal(value)
         if budget.cost_usd == 0:
             budget.cost_usd = None
@@ -982,6 +999,7 @@ class SessionEngine(SessionTurnMixin):
                     "categories": {k: v.model_dump() for k, v in tracker.categories.items()},
                     "total_input": tracker.total_input,
                     "total_output": tracker.total_output,
+                    "total_tool_calls": tracker.tool_calls,
                     "costs": {k: str(v) for k, v in costs.items()},
                     "category_costs": {k: str(v) for k, v in cat_costs.items()},
                     "budget_gauges": [g.model_dump(mode="json") for g in self._budget_gauges(active)],
@@ -995,16 +1013,27 @@ class SessionEngine(SessionTurnMixin):
                 return {"command": "budget", "data": self._budget_command_payload(active)}
 
             args = parts[1].strip().split(maxsplit=1)
-            if len(args) != 2 or args[0] not in ("input", "output", "cost"):
+            metric_aliases = {
+                "input": "input",
+                "output": "output",
+                "cost": "cost",
+                "tools": "tool_calls",
+                "tool": "tool_calls",
+                "tool_calls": "tool_calls",
+                "tool-calls": "tool_calls",
+            }
+            metric = metric_aliases.get(args[0].lower()) if len(args) == 2 else None
+            if len(args) != 2 or metric is None:
                 return {
                     "command": "budget",
                     "data": {
                         **self._budget_command_payload(active),
-                        "error": "Usage: /budget, /budget input N, /budget output N, or /budget cost N",
+                        "error": (
+                            "Usage: /budget, /budget input N, /budget output N, /budget cost N, or /budget tools N"
+                        ),
                     },
                 }
 
-            metric = args[0]
             try:
                 value = self._parse_budget_limit_value(metric, args[1].strip())
             except ValueError as exc:

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -353,16 +353,17 @@ class SessionEngine(SessionTurnMixin):
                 multiplier = 1_000_000
                 lowered = lowered[:-1]
 
+            budget_type = "tool call budget" if metric == "tool_calls" else "token budget"
             if not lowered:
-                raise ValueError(f"Invalid token budget: {raw}")
+                raise ValueError(f"Invalid {budget_type}: {raw}")
 
             try:
                 scaled = Decimal(lowered) * multiplier
             except InvalidOperation as exc:
-                raise ValueError(f"Invalid token budget: {raw}") from exc
+                raise ValueError(f"Invalid {budget_type}: {raw}") from exc
 
             if scaled != scaled.to_integral_value():
-                raise ValueError(f"Invalid token budget: {raw}")
+                raise ValueError(f"Invalid {budget_type}: {raw}")
 
             value = int(scaled)
             if value < 0:

--- a/src/carapace/session/turns.py
+++ b/src/carapace/session/turns.py
@@ -182,6 +182,17 @@ class SessionTurnMixin(SessionTurnHost):
             approval_verdict: ApprovalVerdict | None = None,
             approval_explanation: str | None = None,
         ) -> None:
+            if approval_verdict == "allow":
+                budget = active.state.budget
+                if budget.tool_calls is not None and active.usage_tracker.tool_calls >= budget.tool_calls:
+                    raise SessionBudgetExceededError(
+                        (
+                            "Session budget reached: tool calls "
+                            f"{active.usage_tracker.tool_calls:,} tool calls / {budget.tool_calls:,} tool calls"
+                        ),
+                        gauges=self._budget_gauges(active),
+                    )
+                active.usage_tracker.record_tool_call()
             tool_id = self._record_tool_call_event(
                 session_id,
                 tool=tool,

--- a/src/carapace/usage.py
+++ b/src/carapace/usage.py
@@ -86,6 +86,7 @@ class UsageTracker(BaseModel):
     models: dict[str, ModelUsage] = {}
     categories: dict[str, ModelUsage] = {}
     category_by_model: dict[str, dict[str, ModelUsage]] = {}
+    tool_calls: int = 0
 
     def record(self, model: str, category: str, usage: RunUsage) -> None:
         for bucket in (
@@ -96,6 +97,9 @@ class UsageTracker(BaseModel):
         cm = self.category_by_model.setdefault(category, {})
         m_bucket = cm.setdefault(model, ModelUsage())
         _merge_run_usage_into_bucket(m_bucket, usage)
+
+    def record_tool_call(self) -> None:
+        self.tool_calls += 1
 
     @property
     def total_input(self) -> int:
@@ -131,7 +135,7 @@ class UsageTracker(BaseModel):
 
 
 class BudgetGauge(BaseModel):
-    key: Literal["input", "output", "cost"]
+    key: Literal["input", "output", "cost", "tool_calls"]
     label: str
     current_value: str
     current_amount: float | None = None
@@ -160,12 +164,18 @@ def _format_usd(value: Decimal) -> str:
     return f"${value:.4f}"
 
 
+def _format_tool_calls(value: int) -> str:
+    suffix = "call" if value == 1 else "calls"
+    return f"{value:,} tool {suffix}"
+
+
 def usage_budget_gauges(
     tracker: UsageTracker,
     *,
     input_tokens_limit: int | None = None,
     output_tokens_limit: int | None = None,
     total_cost_limit: Decimal | None = None,
+    tool_calls_limit: int | None = None,
 ) -> list[BudgetGauge]:
     gauges: list[BudgetGauge] = []
 
@@ -220,6 +230,23 @@ def usage_budget_gauges(
             )
         )
 
+    if tool_calls_limit is not None:
+        current = tracker.tool_calls
+        remaining = max(0, tool_calls_limit - current)
+        fill_pct = min(100.0, (100.0 * current / tool_calls_limit)) if tool_calls_limit > 0 else 0.0
+        gauges.append(
+            BudgetGauge(
+                key="tool_calls",
+                label="Tool Calls",
+                current_value=_format_tool_calls(current),
+                current_amount=float(current),
+                limit_value=_format_tool_calls(tool_calls_limit),
+                remaining_value=_format_tool_calls(remaining),
+                fill_pct=round(fill_pct, 1),
+                reached=current >= tool_calls_limit,
+            )
+        )
+
     return gauges
 
 
@@ -229,12 +256,14 @@ def usage_budget_exceeded_error(
     input_tokens_limit: int | None = None,
     output_tokens_limit: int | None = None,
     total_cost_limit: Decimal | None = None,
+    tool_calls_limit: int | None = None,
 ) -> SessionBudgetExceededError | None:
     gauges = usage_budget_gauges(
         tracker,
         input_tokens_limit=input_tokens_limit,
         output_tokens_limit=output_tokens_limit,
         total_cost_limit=total_cost_limit,
+        tool_calls_limit=tool_calls_limit,
     )
     offenders = [gauge for gauge in gauges if gauge.reached]
     if not offenders:

--- a/src/carapace/ws_models.py
+++ b/src/carapace/ws_models.py
@@ -31,7 +31,8 @@ SLASH_COMMANDS: list[dict[str, str]] = [
     },
     {
         "command": "/budget",
-        "description": "Show current budgets. Set with /budget input N, /budget output N, or /budget cost N",
+        "description": "Show current budgets. Set with /budget input N, /budget output N, "
+        + "/budget cost N, or /budget tools N",
     },
     {"command": "/model-agent", "description": "View or switch the agent model only"},
     {"command": "/model-sentinel", "description": "View or switch the sentinel model"},

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -464,6 +464,7 @@ def test_format_command_result_usage_context_table_preceded_by_blank_line():
             "category_costs": {},
             "total_input": 1,
             "total_output": 0,
+            "total_tool_calls": 2,
             "last_llm_agent": {
                 "context_size": 100,
                 "breakdown_pct": {
@@ -477,6 +478,7 @@ def test_format_command_result_usage_context_table_preceded_by_blank_line():
         },
     )
     text = _format_command_result_text(result)
+    assert "**Tool Calls:** 2" in text
     assert "**Context**\n\n| Source |" in text
     assert "<table" in _md_to_html(text)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -38,17 +38,24 @@ def test_config_defaults():
 
 def test_session_budget_zero_values_normalize_to_unlimited() -> None:
     budget = SessionBudget.model_validate(
-        {"input_tokens": 0, "output_tokens": 0, "cost_usd": "0"},
+        {"input_tokens": 0, "output_tokens": 0, "cost_usd": "0", "tool_calls": 0},
     )
     assert budget.input_tokens is None
     assert budget.output_tokens is None
     assert budget.cost_usd is None
+    assert budget.tool_calls is None
     assert budget.has_any_limit is False
 
 
 def test_session_budget_accepts_decimal_cost() -> None:
     budget = SessionBudget(cost_usd=Decimal("1.25"))
     assert budget.cost_usd == Decimal("1.25")
+
+
+def test_session_budget_accepts_tool_call_limit() -> None:
+    budget = SessionBudget(tool_calls=7)
+    assert budget.tool_calls == 7
+    assert budget.has_any_limit is True
 
 
 def test_available_model_entry_shorthand_string():

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -73,13 +73,14 @@ def test_create_session(tmp_path: Path):
 
 def test_create_session_persists_budget(tmp_path: Path):
     mgr = SessionManager(tmp_path)
-    budget = SessionBudget(input_tokens=1_000, cost_usd=Decimal("5.00"))
+    budget = SessionBudget(input_tokens=1_000, cost_usd=Decimal("5.00"), tool_calls=4)
     state = mgr.create_session(budget=budget)
 
     resumed = mgr.resume_session(state.session_id)
     assert resumed is not None
     assert resumed.budget.input_tokens == 1_000
     assert resumed.budget.cost_usd == Decimal("5.00")
+    assert resumed.budget.tool_calls == 4
 
 
 def test_create_session_persists_private_attribute(tmp_path: Path):
@@ -1347,6 +1348,7 @@ def test_handle_slash_command_budget_sets_and_clears(tmp_path: Path):
             assert initial is not None
             assert "usage_hint" in initial["data"]
             assert "/budget input N" in initial["data"]["usage_hint"]
+            assert "/budget tools N" in initial["data"]["usage_hint"]
 
             set_result = await engine.handle_slash_command(sid, "/budget input 1000")
             assert set_result is not None
@@ -1362,6 +1364,28 @@ def test_handle_slash_command_budget_sets_and_clears(tmp_path: Path):
             reloaded = engine.session_mgr.load_state(sid)
             assert reloaded is not None
             assert reloaded.budget.input_tokens is None
+
+        asyncio.run(_run())
+
+
+def test_handle_slash_command_budget_sets_tool_call_limit(tmp_path: Path):
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session()
+        sid = state.session_id
+        engine.get_or_activate(sid)
+
+        async def _run() -> None:
+            result = await engine.handle_slash_command(sid, "/budget tools 3")
+
+            assert result is not None
+            assert result["command"] == "budget"
+            assert result["data"]["message"] == "Set tool call budget to 3 tool calls."
+            assert result["data"]["gauges"][0]["key"] == "tool_calls"
+
+            reloaded = engine.session_mgr.load_state(sid)
+            assert reloaded is not None
+            assert reloaded.budget.tool_calls == 3
 
         asyncio.run(_run())
 
@@ -1402,6 +1426,25 @@ def test_handle_slash_command_help_lists_budget(tmp_path: Path):
             assert result is not None
             commands = result["data"]["commands"]
             assert any(item["command"] == "/budget" for item in commands)
+
+        asyncio.run(_run())
+
+
+def test_handle_slash_command_usage_includes_tool_call_total(tmp_path: Path):
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session()
+        sid = state.session_id
+        active = engine.get_or_activate(sid)
+        active.usage_tracker.record_tool_call()
+        active.usage_tracker.record_tool_call()
+
+        async def _run() -> None:
+            result = await engine.handle_slash_command(sid, "/usage")
+
+            assert result is not None
+            assert result["command"] == "usage"
+            assert result["data"]["total_tool_calls"] == 2
 
         asyncio.run(_run())
 
@@ -1581,6 +1624,40 @@ def test_submit_message_budget_exhausted_broadcasts_error(tmp_path: Path):
 
         mocked_turn.assert_not_awaited()
         assert any("Session budget reached" in err for err in sub.errors)
+
+    with _patch_sentinel():
+        asyncio.run(_run())
+
+
+def test_submit_message_tool_call_budget_exhausted_broadcasts_error(tmp_path: Path):
+    async def _run() -> None:
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session(budget=SessionBudget(tool_calls=1))
+        sid = state.session_id
+        sub = _FakeSubscriber()
+        engine.subscribe(sid, sub)
+
+        async def _fail_on_second_tool_call(
+            _user_input: str,
+            deps,
+            _message_history: list[Any],
+            *_args: Any,
+            **_kwargs: Any,
+        ):
+            callback = deps.tool_call_callback
+            assert callback is not None
+            callback("read", {"path": "README.md"}, "[safe-list] auto-allowed", "safe-list", "allow", "ok")
+            callback("read", {"path": "README.md"}, "[safe-list] auto-allowed", "safe-list", "allow", "ok")
+            return [], "done", ""
+
+        with patch("carapace.session.engine.run_agent_turn", new=_fail_on_second_tool_call):
+            await engine.submit_message(sid, "hello")
+            await asyncio.sleep(0.1)
+
+        active = engine.get_active(sid)
+        assert active is not None
+        assert active.usage_tracker.tool_calls == 1
+        assert any("Session budget reached: tool calls 1 tool calls / 1 tool calls" in err for err in sub.errors)
 
     with _patch_sentinel():
         asyncio.run(_run())

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -26,6 +26,15 @@ def test_record_accumulates_tokens_across_events() -> None:
     assert t.categories["agent"].output_tokens == 55
 
 
+def test_record_tool_call_increments_counter() -> None:
+    tracker = UsageTracker()
+
+    tracker.record_tool_call()
+    tracker.record_tool_call()
+
+    assert tracker.tool_calls == 2
+
+
 def test_category_by_model_splits_per_category() -> None:
     t = UsageTracker()
     t.record(
@@ -85,6 +94,33 @@ def test_usage_budget_gauges_include_tokens_and_cost() -> None:
     assert gauges[1].current_amount == 250.0
     assert gauges[2].limit_value == "$1.0000"
     assert gauges[2].current_amount is not None
+
+
+def test_usage_budget_gauges_include_tool_calls() -> None:
+    tracker = UsageTracker(tool_calls=3)
+
+    gauges = usage_budget_gauges(
+        tracker,
+        tool_calls_limit=5,
+    )
+
+    assert [g.key for g in gauges] == ["tool_calls"]
+    assert gauges[0].current_value == "3 tool calls"
+    assert gauges[0].limit_value == "5 tool calls"
+    assert gauges[0].remaining_value == "2 tool calls"
+    assert gauges[0].current_amount == 3.0
+
+
+def test_usage_budget_exceeded_error_includes_tool_calls() -> None:
+    tracker = UsageTracker(tool_calls=2)
+
+    error = usage_budget_exceeded_error(
+        tracker,
+        tool_calls_limit=2,
+    )
+
+    assert error is not None
+    assert str(error) == "Session budget reached: tool calls 2 tool calls / 2 tool calls"
 
 
 def test_usage_budget_exceeded_error_treats_unknown_cost_pricing_as_zero() -> None:


### PR DESCRIPTION
Co-authored-by: Copilot <copilot@github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new budget dimension that can halt turns when tool calls hit a limit, and changes tool-call notification behavior across channels; mistakes could cause unexpected session stops or noisy logging.
> 
> **Overview**
> Adds **tool call usage tracking** end-to-end: `UsageTracker` now counts tool calls, `/usage` payloads include `total_tool_calls`, and Matrix/CLI/frontend usage views render the new total and treat it as non-empty usage.
> 
> Extends **session budgets** to support `tool_calls`, including a new budget gauge, `/budget tools N` (with aliases) parsing + persistence, and enforcement during turn execution (increment on allowed tool calls and raise `SessionBudgetExceededError` when the limit is reached).
> 
> Adjusts tool-call logging so `_log_tool_call` is invoked for auto-allowed and sentinel-reviewed tool calls regardless of `verbose`, and updates help/command descriptions plus tests to cover the new budget/usage behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa0a0313cb642c30bea1dd0fdd8c821cf5985d9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->