### PR TITLE
📋 docs: enhance README with Bitwarden and Vaultwarden support for context-scoped credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ carapace is a self-hosted AI agent with a web UI, CLI, and Matrix channel for op
 - Git-native knowledge repo. `SOUL.md`, `USER.md`, `SECURITY.md`, skills, memory, and archived sessions live in files you can inspect, diff, sync, and push upstream.
 - No-direct-internet sandboxes. Sandbox workloads do not get ambient internet access; outbound traffic is forced through the proxy path.
 - Proxy system with tunnels. HTTP traffic is mediated by the proxy, and exec-scoped tunnels cover non-HTTP protocols without leaving long-lived daemons behind.
-- Context-scoped credentials. Secrets stay in your vault and are only injected or fetched on demand for exec calls that have the matching approved skill context.
+- Context-scoped credentials. Secrets stay in your vault, with native Bitwarden and Vaultwarden support, and are only injected or fetched on demand for exec calls that have the matching approved skill context.
 
 ## Knowledge Repo, Not Hidden State
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a README highlight line; no runtime behavior or security logic is modified.
> 
> **Overview**
> Updates the README Highlights to explicitly state that *context-scoped credentials* have native **Bitwarden** and **Vaultwarden** support, clarifying where secrets can be sourced from.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 510547c69fc56047f2579031bf5b939776fd9706. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->