### PR TITLE
✨ feat: Add unattended session mode

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,6 +4,7 @@ import { Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Menu, X } from "lucide-react";
 import { ConnectForm } from "@/components/connect-form";
+import { NewSessionButton } from "@/components/new-session-button";
 import { Sidebar } from "@/components/sidebar";
 import { ChatView } from "@/components/chat-view";
 import { createSession, deleteSession, getSession, listSessions, updateSession } from "@/lib/api";
@@ -307,10 +308,10 @@ function HomeContent() {
     setActiveSessionId(null);
   }
 
-  async function handleNewSession() {
+  async function handleNewSession(unattended = false) {
     setCreatingSession(true);
     try {
-      const session = await createSession(server, token);
+      const session = await createSession(server, token, { unattended });
       setSessions((prev) => sortSessions([session, ...prev]));
       setActiveSessionId(session.session_id);
       setSidebarOpen(false);
@@ -477,17 +478,11 @@ function HomeContent() {
               <p className="mt-1 text-sm text-muted-foreground">
                 Select a session or start a new one
               </p>
-              <button
-                onClick={handleNewSession}
+              <NewSessionButton
+                onCreate={handleNewSession}
                 disabled={loading}
-                className={cn(
-                  "mt-4 rounded-lg px-4 py-2 text-sm font-medium transition-colors",
-                  "bg-foreground text-background hover:bg-foreground/90",
-                  "disabled:opacity-50",
-                )}
-              >
-                New session
-              </button>
+                className="mt-4"
+              />
             </div>
           </div>
         )}

--- a/frontend/src/components/chat-input.tsx
+++ b/frontend/src/components/chat-input.tsx
@@ -357,7 +357,7 @@ export function ChatInput({
           />
           <button
             onClick={waiting ? onCancel : submit}
-            disabled={disabled || (waiting ? false : !connected || !hasText)}
+            disabled={waiting ? !onCancel : disabled || !connected || !hasText}
             title={tooltip}
             className={cn(
               "shrink-0 rounded-lg p-2 transition-colors",

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -1351,6 +1351,7 @@ export function ChatView({
       const forked = await forkSession(server, token, sessionId, {
         eventIndex: targetEventIndex,
         channelType: "web",
+        unattended: session?.attributes.unattended ? false : undefined,
       });
       onForkSession(forked);
     } catch (error) {
@@ -1608,9 +1609,14 @@ export function ChatView({
   const hasKnowledgeContent = messages.length > 0;
   const hasKnowledgeChanges = sessionHasKnowledgeChanges(session);
   const sessionArchived = session?.attributes.archived ?? false;
+  const sessionUnattended = session?.attributes.unattended ?? false;
   const sessionPrivate = session?.attributes.private ?? false;
   const sessionPinned = session?.attributes.pinned ?? false;
   const sessionFavorite = session?.attributes.favorite ?? false;
+  const inputDisabled = sessionArchived || sessionUnattended;
+  const inputDisabledPlaceholder = sessionArchived
+    ? "Unarchive first"
+    : "This session is unattended. Fork it first to continue here.";
   const canCommitKnowledge = !!session && !sessionPrivate && !sessionArchived && hasKnowledgeContent && hasKnowledgeChanges;
   const waitingLabel = !waiting
     ? null
@@ -1912,8 +1918,8 @@ export function ChatView({
         onCancel={handleCancel}
         onInterrupt={handleInterrupt}
         connected={connected}
-        disabled={sessionArchived}
-        disabledPlaceholder="Unarchive first"
+        disabled={inputDisabled}
+        disabledPlaceholder={inputDisabledPlaceholder}
         waiting={waiting}
         queuedMessage={queuedMessage}
         commands={commands}

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Archive, ArchiveRestore, Loader2, Lock, Pin, Play, RotateCcw, Save, Square, Star, Trash2, Unlock } from "lucide-react";
+import { Archive, ArchiveRestore, Bot, Loader2, Lock, Pin, Play, RotateCcw, Save, Square, Star, Trash2, Unlock } from "lucide-react";
 import { useWebSocket } from "@/hooks/use-websocket";
 import {
   type AvailableModelInfo,
@@ -1610,10 +1610,14 @@ export function ChatView({
   const hasKnowledgeChanges = sessionHasKnowledgeChanges(session);
   const sessionArchived = session?.attributes.archived ?? false;
   const sessionUnattended = session?.attributes.unattended ?? false;
+  const hasSubmittedUserMessage = messages.some(
+    (message) => message.kind === "user" && !message.content.startsWith("/"),
+  );
+  const unattendedInputLocked = sessionUnattended && hasSubmittedUserMessage;
   const sessionPrivate = session?.attributes.private ?? false;
   const sessionPinned = session?.attributes.pinned ?? false;
   const sessionFavorite = session?.attributes.favorite ?? false;
-  const inputDisabled = sessionArchived || sessionUnattended;
+  const inputDisabled = sessionArchived || unattendedInputLocked;
   const inputDisabledPlaceholder = sessionArchived
     ? "Unarchive first"
     : "This session is unattended. Fork it first to continue here.";
@@ -1671,6 +1675,14 @@ export function ChatView({
       <div className="border-b border-border px-3 py-2.5 sm:px-4 sm:py-3">
         <div className="w-full">
           <div className="min-w-0 w-full space-y-2">
+            {sessionUnattended ? (
+              <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                <span className="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 font-medium text-emerald-800">
+                  <Bot className="h-3 w-3 shrink-0" />
+                  <span>Unattended</span>
+                </span>
+              </div>
+            ) : null}
             <div className="grid grid-cols-2 gap-2">
               <div className="min-w-0 rounded-lg border border-border/70 bg-muted/20 px-2.5 py-2 sm:px-3">
                 <div className="flex items-start justify-between gap-2">

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -31,6 +31,7 @@ import type {
 } from "@/lib/types";
 import { isRecord } from "@/lib/decoding";
 import {
+  canArchiveSession,
   cn,
   formatBytes,
   sandboxStatusIndicatorClass,
@@ -692,6 +693,7 @@ function projectHistoryToMessages(history: HistoryMessage[]): ChatMessage[] {
     messages.push({
       kind: "assistant",
       content: entry.content,
+      finalStatus: entry.final_status,
       eventIndex: typeof entry.event_index === "number" ? entry.event_index : undefined,
     });
   }
@@ -754,11 +756,12 @@ export function ChatView({
     onSandboxUpdateRef.current = onSandboxUpdate;
   }, [onSandboxUpdate]);
 
-  const markSessionKnowledgeChanged = useCallback(() => {
+  const markSessionKnowledgeChanged = useCallback((hasNewMessage = false) => {
     if (!session) return;
     onSessionUpdate?.({
       ...session,
       last_active: new Date().toISOString(),
+      message_count: hasNewMessage ? Math.max(session.message_count, 1) : session.message_count,
     });
   }, [onSessionUpdate, session]);
 
@@ -935,9 +938,13 @@ export function ChatView({
             // Replace streaming message with the final content
             const streamIdx = updated.findLastIndex((m) => m.kind === "streaming");
             if (streamIdx !== -1) {
-              updated[streamIdx] = { kind: "assistant", content: msg.content };
+              updated[streamIdx] = {
+                kind: "assistant",
+                content: msg.content,
+                finalStatus: msg.final_status,
+              };
             } else {
-              updated.push({ kind: "assistant", content: msg.content });
+              updated.push({ kind: "assistant", content: msg.content, finalStatus: msg.final_status });
             }
             return updated;
           });
@@ -1261,7 +1268,7 @@ export function ChatView({
     } else {
       lastThinkingStartedAtRef.current = null;
       send({ type: "message", content });
-      markSessionKnowledgeChanged();
+      markSessionKnowledgeChanged(true);
       setWaiting(true);
     }
   }
@@ -1408,7 +1415,10 @@ export function ChatView({
 
   async function handleDeleteSession() {
     if (waiting || sandboxPowerAction || wipingSandbox || deletingSession || !onDeleteSession) return;
-    if (!window.confirm("Delete this session? Chat history and sandbox state will be removed.")) {
+    if (
+      (session?.message_count ?? 0) > 0
+      && !window.confirm("Delete this session? Chat history and sandbox state will be removed.")
+    ) {
       return;
     }
     setDeletingSession(true);
@@ -1423,6 +1433,9 @@ export function ChatView({
     if (!session || updatingSessionAttribute || deletingSession || !onUpdateSessionAttributes) return;
 
     const nextArchived = !session.attributes.archived;
+    if (nextArchived && !canArchiveSession(session)) {
+      return;
+    }
     const confirmation = nextArchived
       ? "Archive this session? It will leave the default list, reset its sandbox, and stay in the knowledge repo."
       : "Unarchive this session? It will return to the active session list.";
@@ -1617,6 +1630,7 @@ export function ChatView({
   const sessionPrivate = session?.attributes.private ?? false;
   const sessionPinned = session?.attributes.pinned ?? false;
   const sessionFavorite = session?.attributes.favorite ?? false;
+  const sessionCanArchive = canArchiveSession(session);
   const inputDisabled = sessionArchived || unattendedInputLocked;
   const inputDisabledPlaceholder = sessionArchived
     ? "Unarchive first"
@@ -1780,20 +1794,22 @@ export function ChatView({
                         <Star className="h-3.5 w-3.5" />
                       )}
                     </button>
-                    <button
-                      onClick={() => void handleToggleArchived()}
-                      disabled={!session || !!updatingSessionAttribute || deletingSession || !onUpdateSessionAttributes}
-                      title={sessionArchived ? "Unarchive session" : "Archive session"}
-                      className="rounded-md p-1.5 text-violet-900 transition-colors hover:bg-violet-100 disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      {updatingSessionAttribute === "archived" ? (
-                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                      ) : sessionArchived ? (
-                        <ArchiveRestore className="h-3.5 w-3.5" />
-                      ) : (
-                        <Archive className="h-3.5 w-3.5" />
-                      )}
-                    </button>
+                    {sessionArchived || sessionCanArchive ? (
+                      <button
+                        onClick={() => void handleToggleArchived()}
+                        disabled={!session || !!updatingSessionAttribute || deletingSession || !onUpdateSessionAttributes}
+                        title={sessionArchived ? "Unarchive session" : "Archive session"}
+                        className="rounded-md p-1.5 text-violet-900 transition-colors hover:bg-violet-100 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {updatingSessionAttribute === "archived" ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : sessionArchived ? (
+                          <ArchiveRestore className="h-3.5 w-3.5" />
+                        ) : (
+                          <Archive className="h-3.5 w-3.5" />
+                        )}
+                      </button>
+                    ) : null}
                     <button
                       onClick={() => void handleTogglePrivacy()}
                       disabled={!session || !!updatingSessionAttribute || deletingSession}

--- a/frontend/src/components/message.tsx
+++ b/frontend/src/components/message.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Brain, Check, ChevronRight, Copy, GitBranch, Loader2, RotateCcw, Undo2 } from "lucide-react";
+import { AlertTriangle, Brain, Check, ChevronRight, Copy, GitBranch, Info, Loader2, RotateCcw, Undo2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 
 import type { ChatMessage, EscalationDecision, LlmActivity } from "@/lib/types";
@@ -240,6 +240,33 @@ function MessageActions({
   );
 }
 
+function FinalStatusNotice({ status }: { status: "success" | "warning" }) {
+  const isWarning = status === "warning";
+
+  return (
+    <div
+      className={cn(
+        "mt-3 rounded-xl border px-3 py-2.5 text-sm",
+        isWarning
+          ? "border-amber-200 bg-amber-50 text-amber-900"
+          : "border-sky-200 bg-sky-50 text-sky-900",
+      )}
+    >
+      <div className="flex items-start gap-2">
+        {isWarning ? (
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+        ) : (
+          <Info className="mt-0.5 h-4 w-4 shrink-0" />
+        )}
+        <p>
+          The agent has ended its task with a {status} message. The session is now read-only, but you can fork it to
+          continue chatting.
+        </p>
+      </div>
+    </div>
+  );
+}
+
 interface MessageProps {
   message: ChatMessage;
   activeLlmActivity?: LlmActivity | null;
@@ -297,6 +324,7 @@ export function Message({
         <div className="group max-w-[85%] text-sm">
           <div className="min-w-0 flex-1">
             <MarkdownContent content={message.content} />
+            {message.finalStatus ? <FinalStatusNotice status={message.finalStatus} /> : null}
           </div>
           <MessageActions
             copyText={message.content}

--- a/frontend/src/components/new-session-button.tsx
+++ b/frontend/src/components/new-session-button.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { ChevronDown, Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface NewSessionButtonProps {
+  onCreate: (unattended?: boolean) => void;
+  disabled?: boolean;
+  fullWidth?: boolean;
+  className?: string;
+}
+
+export function NewSessionButton({
+  onCreate,
+  disabled = false,
+  fullWidth = false,
+  className,
+}: NewSessionButtonProps) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("keydown", handleEscape);
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("keydown", handleEscape);
+    };
+  }, [open]);
+
+  function handleCreate(unattended = false) {
+    setOpen(false);
+    onCreate(unattended);
+  }
+
+  return (
+    <div
+      ref={rootRef}
+      className={cn("relative", fullWidth && "w-full", className)}
+    >
+      <div className="flex w-full items-stretch">
+        <button
+          onClick={() => handleCreate(false)}
+          disabled={disabled}
+          className={cn(
+            "flex items-center gap-2 rounded-l-lg border border-border px-3 py-2 text-sm transition-colors",
+            "bg-background hover:bg-muted",
+            "disabled:opacity-50",
+            fullWidth && "flex-1 justify-start",
+          )}
+        >
+          <Plus className="h-4 w-4" />
+          New session
+        </button>
+        <button
+          onClick={() => setOpen((current) => !current)}
+          disabled={disabled}
+          aria-label="Choose session mode"
+          aria-expanded={open}
+          aria-haspopup="menu"
+          className={cn(
+            "rounded-r-lg border border-l-0 border-border px-2.5 transition-colors",
+            "bg-background hover:bg-muted",
+            "disabled:opacity-50",
+          )}
+        >
+          <ChevronDown className={cn("h-4 w-4 transition-transform", open && "rotate-180")} />
+        </button>
+      </div>
+
+      {open ? (
+        <div
+          role="menu"
+          className="absolute right-0 z-20 mt-1 min-w-72 rounded-xl border border-border bg-background p-1.5 shadow-lg"
+        >
+          <button
+            onClick={() => handleCreate(false)}
+            className="flex w-full flex-col rounded-lg px-3 py-2 text-left transition-colors hover:bg-muted"
+          >
+            <span className="text-sm font-medium text-foreground">Attended</span>
+            <span className="text-xs text-muted-foreground">
+              Chat normally and approve escalations in place.
+            </span>
+          </button>
+          <button
+            onClick={() => handleCreate(true)}
+            className="flex w-full flex-col rounded-lg px-3 py-2 text-left transition-colors hover:bg-muted"
+          >
+            <span className="text-sm font-medium text-foreground">Unattended</span>
+            <span className="text-xs text-muted-foreground">
+              Runs on its own with no user approval path.
+            </span>
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { Archive, ArchiveRestore, Loader2, Lock, LogOut, Mail, MessageSquare, Pin, Plus, Save, Star, Trash2 } from "lucide-react";
+import { Archive, ArchiveRestore, Bot, Loader2, Lock, LogOut, Mail, MessageSquare, Pin, Save, Star, Trash2 } from "lucide-react";
 import { EmojiText } from "@/components/emoji-text";
+import { NewSessionButton } from "@/components/new-session-button";
 import type { SessionAttributesPatch, SessionInfo, SessionSandboxSnapshot } from "@/lib/types";
 import {
   cn,
@@ -16,7 +17,7 @@ interface SidebarProps {
   sessions: SessionInfo[];
   activeSessionId: string | null;
   onSelect: (sessionId: string) => void;
-  onNew: () => void;
+  onNew: (unattended?: boolean) => void;
   onUpdateAttributes: (sessionId: string, attributes: SessionAttributesPatch) => Promise<SessionInfo>;
   onDelete: (sessionId: string) => void;
   onDisconnect: () => void;
@@ -127,6 +128,7 @@ export function Sidebar({
       && !!session.knowledge_last_committed_at
       && !sessionHasKnowledgeChanges(session);
     const showKnowledgeIndicator = showPrivateIcon || showSavedIcon;
+    const showUnattendedIcon = session.attributes.unattended;
     const channelLabel = session.channel_type !== "web" && session.channel_type !== "cli"
       ? session.channel_type
       : null;
@@ -167,6 +169,15 @@ export function Sidebar({
                 <span className="font-mono break-all">{session.session_id}</span>
               )}
           </div>
+          {showUnattendedIcon ? (
+            <span
+              className="mt-0.5 inline-flex shrink-0 items-center text-emerald-700"
+              title="Unattended session"
+            >
+              <Bot className="h-3.5 w-3.5" />
+              <span className="sr-only">Unattended session</span>
+            </span>
+          ) : null}
         </div>
         <div className="flex items-start gap-2 px-3 pb-2">
           <div className="min-w-0 flex-1 text-left">
@@ -336,18 +347,7 @@ export function Sidebar({
 
       {/* New session button */}
       <div className="px-3 pt-3 pb-1">
-        <button
-          onClick={onNew}
-          disabled={loading}
-          className={cn(
-            "flex w-full items-center gap-2 rounded-lg border border-border px-3 py-2 text-sm",
-            "hover:bg-muted transition-colors",
-            "disabled:opacity-50",
-          )}
-        >
-          <Plus className="h-4 w-4" />
-          New session
-        </button>
+        <NewSessionButton onCreate={onNew} disabled={loading} fullWidth />
       </div>
 
       {/* Session list */}

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -6,6 +6,7 @@ import { EmojiText } from "@/components/emoji-text";
 import { NewSessionButton } from "@/components/new-session-button";
 import type { SessionAttributesPatch, SessionInfo, SessionSandboxSnapshot } from "@/lib/types";
 import {
+  canArchiveSession,
   cn,
   formatBytes,
   sandboxStatusIndicatorClass,
@@ -63,6 +64,17 @@ function runSidebarAttributeUpdate(promise: Promise<SessionInfo>): void {
   void promise.catch(() => {
     // Sidebar actions currently fail silently like delete; avoid unhandled rejections.
   });
+}
+
+function shouldConfirmSessionDeletion(
+  session: Pick<SessionInfo, "message_count">,
+  event: { shiftKey: boolean },
+): boolean {
+  return session.message_count === 0
+    || shouldConfirmDestructiveAction(
+      event,
+      "Delete this session? Chat history and sandbox state will be removed.",
+    );
 }
 
 export function Sidebar({
@@ -123,6 +135,7 @@ export function Sidebar({
   function renderSessionRow(session: SessionInfo) {
     const sandbox = sandboxSummary(session);
     const sandboxLabel = sandbox ? sandboxSummaryLabel(sandbox) : null;
+    const sessionCanArchive = canArchiveSession(session);
     const showPrivateIcon = session.attributes.private;
     const showSavedIcon = !session.attributes.private
       && !!session.knowledge_last_committed_at
@@ -278,45 +291,49 @@ export function Sidebar({
           >
             <Star className="h-3.5 w-3.5" />
           </button>
+          {session.attributes.archived || sessionCanArchive ? (
+            <button
+              onClick={(event) => {
+                event.stopPropagation();
+                const nextArchived = !session.attributes.archived;
+                if (
+                  nextArchived
+                  && !shouldConfirmDestructiveAction(
+                    event,
+                    "Archive this session? It will leave the default list, reset its sandbox, and stay in the knowledge repo.",
+                  )
+                ) {
+                  return;
+                }
+                runSidebarAttributeUpdate(onUpdateAttributes(session.session_id, { archived: nextArchived }));
+              }}
+              title={session.attributes.archived ? "Unarchive session" : ["Archive session", "Shift+click to skip confirmation"].join("\n")}
+              className={cn(
+                "rounded-md p-1.5 transition-colors",
+                session.attributes.archived
+                  ? "text-violet-700 group-hover:text-emerald-900 hover:bg-emerald-100"
+                  : "text-muted-foreground/0 group-hover:text-muted-foreground hover:bg-muted hover:text-foreground",
+              )}
+            >
+              {session.attributes.archived ? (
+                <>
+                  <Archive className="h-3.5 w-3.5 group-hover:hidden" />
+                  <ArchiveRestore className="hidden h-3.5 w-3.5 group-hover:block" />
+                </>
+              ) : <Archive className="h-3.5 w-3.5" />}
+            </button>
+          ) : null}
           <button
             onClick={(event) => {
               event.stopPropagation();
-              const nextArchived = !session.attributes.archived;
-              if (
-                nextArchived
-                && !shouldConfirmDestructiveAction(
-                  event,
-                  "Archive this session? It will leave the default list, reset its sandbox, and stay in the knowledge repo.",
-                )
-              ) {
-                return;
-              }
-              runSidebarAttributeUpdate(onUpdateAttributes(session.session_id, { archived: nextArchived }));
-            }}
-            title={session.attributes.archived ? "Unarchive session" : ["Archive session", "Shift+click to skip confirmation"].join("\n")}
-            className={cn(
-              "rounded-md p-1.5 transition-colors",
-              session.attributes.archived
-                ? "text-violet-700 group-hover:text-emerald-900 hover:bg-emerald-100"
-                : "text-muted-foreground/0 group-hover:text-muted-foreground hover:bg-muted hover:text-foreground",
-            )}
-          >
-            {session.attributes.archived ? (
-              <>
-                <Archive className="h-3.5 w-3.5 group-hover:hidden" />
-                <ArchiveRestore className="hidden h-3.5 w-3.5 group-hover:block" />
-              </>
-            ) : <Archive className="h-3.5 w-3.5" />}
-          </button>
-          <button
-            onClick={(event) => {
-              event.stopPropagation();
-              if (!shouldConfirmDestructiveAction(event, "Delete this session? Chat history and sandbox state will be removed.")) {
+              if (!shouldConfirmSessionDeletion(session, event)) {
                 return;
               }
               onDelete(session.session_id);
             }}
-            title={["Delete session", "Shift+click to skip confirmation"].join("\n")}
+            title={session.message_count === 0
+              ? "Delete empty session"
+              : ["Delete session", "Shift+click to skip confirmation"].join("\n")}
             className={cn(
               "rounded-md p-1.5 transition-colors",
               "text-muted-foreground/0 group-hover:text-muted-foreground",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -33,7 +33,7 @@ export async function listSessions(
 export async function createSession(
   server: string,
   token: string,
-  options?: { private?: boolean },
+  options?: { private?: boolean; unattended?: boolean },
 ): Promise<SessionInfo> {
   const res = await fetch(`${server}/api/sessions`, {
     method: "POST",
@@ -63,7 +63,12 @@ export async function forkSession(
   server: string,
   token: string,
   sessionId: string,
-  body: { eventIndex: number; channelType: string; channelRef?: string },
+  body: {
+    eventIndex: number;
+    channelType: string;
+    channelRef?: string;
+    unattended?: boolean;
+  },
 ): Promise<SessionInfo> {
   const res = await fetch(`${server}/api/sessions/${sessionId}/fork`, {
     method: "POST",
@@ -72,6 +77,7 @@ export async function forkSession(
       event_index: body.eventIndex,
       channel_type: body.channelType,
       channel_ref: body.channelRef ?? "",
+      unattended: body.unattended,
     }),
   });
   if (!res.ok) throw new Error(`Failed to fork session: ${res.status}`);

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -74,6 +74,7 @@ export interface SessionArchiveCommitResponse {
 export interface HistoryMessage {
   role: string;
   content: string;
+  final_status?: "success" | "warning";
   event_index?: number;
   reasoning_duration_ms?: number;
   reasoning_tokens?: number;
@@ -257,6 +258,7 @@ export interface Done {
   content: string;
   thinking?: string;
   usage?: TurnUsage;
+  final_status?: "success" | "warning";
 }
 
 export interface CommandResult {
@@ -360,7 +362,12 @@ export type ClientMessage =
 
 export type ChatMessage =
   | { kind: "user"; content: string }
-  | { kind: "assistant"; content: string; eventIndex?: number }
+  | {
+      kind: "assistant";
+      content: string;
+      eventIndex?: number;
+      finalStatus?: "success" | "warning";
+    }
   | { kind: "streaming"; content: string }
   | {
       kind: "thinking";

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -28,6 +28,7 @@ export interface SessionAttributes {
   archived: boolean;
   pinned: boolean;
   favorite: boolean;
+  unattended: boolean;
 }
 
 export interface SessionAttributesPatch {
@@ -35,6 +36,7 @@ export interface SessionAttributesPatch {
   archived?: boolean;
   pinned?: boolean;
   favorite?: boolean;
+  unattended?: boolean;
 }
 
 export interface SessionInfo {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -27,6 +27,12 @@ export function sessionHasKnowledgeChanges(
   return lastActive > committedAt;
 }
 
+export function canArchiveSession(
+  session: Pick<SessionInfo, "message_count"> | null | undefined,
+): boolean {
+  return (session?.message_count ?? 0) > 0;
+}
+
 export function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   const units = ["KB", "MB", "GB", "TB"];

--- a/src/carapace/agent/loop.py
+++ b/src/carapace/agent/loop.py
@@ -28,7 +28,7 @@ from pydantic_ai.messages import (
 from pydantic_ai.usage import UsageLimits
 
 from carapace.agent.tools import create_agent
-from carapace.models import Deps
+from carapace.models import Deps, TaskDone, TaskFailed
 from carapace.security.context import (
     AgentResponseEntry,
     ApprovalEntry,
@@ -166,11 +166,19 @@ async def run_agent_turn(
         if on_messages_snapshot is not None:
             on_messages_snapshot(list(messages))
 
+    output_text: str | None = None
     if isinstance(result.output, str):
+        output_text = result.output
+    elif isinstance(result.output, TaskDone):
+        output_text = result.output.result
+    elif isinstance(result.output, TaskFailed):
+        output_text = result.output.problem
+
+    if output_text is not None:
         last_usage = result.usage()
         token_count = (last_usage.output_tokens or 0) + (last_usage.input_tokens or 0)
         deps.security.append(AgentResponseEntry(token_count=token_count))
-        return messages, result.output, last_thinking
+        return messages, output_text, last_thinking
 
     output = f"Unexpected agent output type: {type(result.output).__name__}"
     return messages, output, last_thinking

--- a/src/carapace/agent/loop.py
+++ b/src/carapace/agent/loop.py
@@ -36,7 +36,7 @@ from carapace.security.context import (
     SentinelVerdict,
     UserMessageEntry,
 )
-from carapace.ws_models import ApprovalRequest
+from carapace.ws_models import ApprovalRequest, FinalStatus
 
 
 async def run_agent_turn(
@@ -50,10 +50,10 @@ async def run_agent_turn(
     on_messages_snapshot: Callable[[list[Any]], None] | None = None,
     before_llm_call: Callable[[], None] | None = None,
     get_usage_limits: Callable[[], UsageLimits | None] | None = None,
-) -> tuple[list[Any], str, str]:
+) -> tuple[list[Any], str, str, FinalStatus | None]:
     """Run one full agent turn, handling approval loops.
 
-    Returns ``(updated_message_history, output_text, thinking_text)``.
+    Returns ``(updated_message_history, output_text, thinking_text, final_status)``.
     The caller is responsible for persisting history and delivering the output
     to the user.
     """
@@ -167,18 +167,21 @@ async def run_agent_turn(
             on_messages_snapshot(list(messages))
 
     output_text: str | None = None
+    final_status: FinalStatus | None = None
     if isinstance(result.output, str):
         output_text = result.output
     elif isinstance(result.output, TaskDone):
         output_text = result.output.result
+        final_status = "success"
     elif isinstance(result.output, TaskFailed):
         output_text = result.output.problem
+        final_status = "warning"
 
     if output_text is not None:
         last_usage = result.usage()
         token_count = (last_usage.output_tokens or 0) + (last_usage.input_tokens or 0)
         deps.security.append(AgentResponseEntry(token_count=token_count))
-        return messages, output_text, last_thinking
+        return messages, output_text, last_thinking, final_status
 
     output = f"Unexpected agent output type: {type(result.output).__name__}"
-    return messages, output, last_thinking
+    return messages, output, last_thinking, None

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -10,7 +10,7 @@ from typing import Annotated, Any
 import httpx
 from loguru import logger
 from pydantic import Field
-from pydantic_ai import Agent, DeferredToolRequests, RunContext, ToolDenied
+from pydantic_ai import Agent, DeferredToolRequests, RunContext, ToolDenied, ToolOutput
 
 import carapace.security as security
 from carapace.config import load_workspace_file
@@ -21,6 +21,8 @@ from carapace.models import (
     Deps,
     SkillCarapaceConfig,
     SkillCredentialDecl,
+    TaskDone,
+    TaskFailed,
     ToolResult,
 )
 from carapace.sandbox.manager import READ_TOOL_MAX_LINE_WINDOW
@@ -433,6 +435,16 @@ def build_system_prompt(deps: Deps) -> str:
         "For LaTeX math, use $...$ inline and $$...$$ on their own lines for display equations."
     )
 
+    if deps.session_state.attributes.unattended:
+        parts.append(
+            "# Unattended Session\n"
+            "This session is unattended. No user will reply in-place.\n"
+            "Keep working until you can finish by returning `task_done` with the final result, "
+            + "or `task_failed` with the concrete blocking problem.\n"
+            "Do not end with plain conversational text, "
+            + "and do not ask the user to confirm or continue within this session."
+        )
+
     today = date.today()
     parts.append(
         f"# Session Info\nToday's date: {today:%A}, {today:%Y-%m-%d}\nSession ID: {deps.session_state.session_id}"
@@ -441,13 +453,23 @@ def build_system_prompt(deps: Deps) -> str:
     return "\n\n---\n\n".join(parts)
 
 
-def create_agent(deps: Deps) -> Agent[Deps, str | DeferredToolRequests]:
+def create_agent(deps: Deps) -> Agent[Deps, str | TaskDone | TaskFailed | DeferredToolRequests]:
     system_prompt = build_system_prompt(deps)
 
-    agent: Agent[Deps, str | DeferredToolRequests] = Agent(
+    output_type: list[Any]
+    if deps.session_state.attributes.unattended:
+        output_type = [
+            ToolOutput(TaskDone, name="task_done"),
+            ToolOutput(TaskFailed, name="task_failed"),
+            DeferredToolRequests,
+        ]
+    else:
+        output_type = [str, DeferredToolRequests]
+
+    agent: Agent[Deps, str | TaskDone | TaskFailed | DeferredToolRequests] = Agent(
         deps.agent_model,
         deps_type=Deps,
-        output_type=[str, DeferredToolRequests],  # type: ignore[arg-type]
+        output_type=output_type,  # type: ignore[arg-type]
         instructions=system_prompt,
         capabilities=[LlmRequestLogCapability(source="agent")],
         model_settings=model_settings_for_config(deps.config, deps.agent_model_id, default_thinking=True),

--- a/src/carapace/channels/matrix/subscriber.py
+++ b/src/carapace/channels/matrix/subscriber.py
@@ -114,7 +114,14 @@ class MatrixSubscriber:
     async def on_llm_activity(self, activity: LlmRequestState | None) -> None:
         pass
 
-    async def on_done(self, content: str, usage: TurnUsage, *, thinking: str | None = None) -> None:
+    async def on_done(
+        self,
+        content: str,
+        usage: TurnUsage,
+        *,
+        thinking: str | None = None,
+        final_status: str | None = None,
+    ) -> None:
         if self._stream_event_id is not None:
             await self._channel._edit_message(
                 self._room_id,

--- a/src/carapace/models.py
+++ b/src/carapace/models.py
@@ -86,6 +86,7 @@ class SessionAttributes(BaseModel):
     archived: bool = False
     pinned: bool = False
     favorite: bool = False
+    unattended: bool = False
 
 
 class SessionState(BaseModel):
@@ -117,6 +118,7 @@ class SessionState(BaseModel):
         channel_ref: str | None = None,
         title: str | None = None,
         private: bool = False,
+        unattended: bool = False,
         approved_operations: list[str] | None = None,
     ) -> SessionState:
         ts = datetime.now(tz=UTC)
@@ -125,7 +127,7 @@ class SessionState(BaseModel):
             channel_type=channel_type,
             channel_ref=channel_ref,
             title=title,
-            attributes=SessionAttributes(private=private),
+            attributes=SessionAttributes(private=private, unattended=unattended),
             approved_operations=approved_operations or [],
             activated_skills=[],
             context_grants={},
@@ -485,6 +487,18 @@ class ToolResult:
     output: str
     exit_code: int = 0
     tool_id: str | None = None
+
+
+class TaskDone(BaseModel):
+    """Explicit unattended completion output for successful runs."""
+
+    result: str
+
+
+class TaskFailed(BaseModel):
+    """Explicit unattended completion output for blocked or failed runs."""
+
+    problem: str
 
 
 class SkillCredentialDecl(BaseModel):

--- a/src/carapace/security/__init__.py
+++ b/src/carapace/security/__init__.py
@@ -40,6 +40,14 @@ SAFE_TOOLS: frozenset[str] = frozenset(
 )
 
 
+def _fallback_verdict(session: SessionSecurity, *, explanation: str) -> SentinelVerdict:
+    return SentinelVerdict(
+        decision="deny" if session.unattended else "escalate",
+        explanation=explanation,
+        risk_level="high",
+    )
+
+
 async def evaluate_with(
     session: SessionSecurity,
     sentinel: Sentinel,
@@ -123,13 +131,16 @@ async def evaluate_with(
             usage_limits=usage_limits,
         )
     except UsageLimitExceeded:
-        verdict = SentinelVerdict(
-            decision="escalate",
+        verdict = _fallback_verdict(
+            session,
             explanation=(
                 "Automatic sentinel review hit its internal request limit and could not finish. "
-                "Please approve or deny this tool call manually."
+                + (
+                    "The tool call was denied because no user approval path is available."
+                    if session.unattended
+                    else "Please approve or deny this tool call manually."
+                )
             ),
-            risk_level="high",
         )
 
     decision_str = _verdict_to_decision(verdict)
@@ -425,13 +436,24 @@ async def _decision_for_batch_limit(
     limit_text = (
         "Automatic sentinel review hit the per-tool-call domain batch limit"
         + (f" ({review_limit})" if review_limit is not None else "")
-        + ". Please approve or deny this domain manually."
+        + (
+            ". The domain request was denied because no user approval path is available."
+            if session.unattended
+            else ". Please approve or deny this domain manually."
+        )
     )
-    verdict = SentinelVerdict(
-        decision="escalate",
-        explanation=limit_text,
-        risk_level="high",
-    )
+    verdict = _fallback_verdict(session, explanation=limit_text)
+    if session.unattended:
+        return CachedDomainApproval(
+            allowed=False,
+            approval_source="sentinel",
+            approval_verdict="deny",
+            explanation=verdict.explanation,
+            detail=f"[sentinel: deny] {verdict.explanation}",
+            final_decision="denied",
+            audit_explanation=verdict.explanation,
+            sentinel_verdict=verdict,
+        )
     user_decision = await session.escalate_to_user(
         domain,
         {"command": command, "explanation": verdict.explanation, "kind": "domain_access"},
@@ -459,13 +481,16 @@ async def _decision_for_usage_limit(
     domain: str,
     command: str,
 ) -> CachedDomainApproval:
-    verdict = SentinelVerdict(
-        decision="escalate",
+    verdict = _fallback_verdict(
+        session,
         explanation=(
             "Automatic sentinel review hit its internal request limit and could not finish. "
-            + "Please approve or deny this domain manually."
+            + (
+                "The domain request was denied because no user approval path is available."
+                if session.unattended
+                else "Please approve or deny this domain manually."
+            )
         ),
-        risk_level="high",
     )
     return await _decision_from_verdict(session, domain, command, verdict)
 
@@ -581,6 +606,16 @@ async def evaluate_push_with(
         usage_limits=usage_limits,
     )
 
+    if verdict.decision == "escalate" and session.unattended:
+        verdict = SentinelVerdict(
+            decision="deny",
+            explanation=(
+                verdict.explanation
+                or "The push was denied because no user approval path is available for unattended sessions."
+            ),
+            risk_level=verdict.risk_level,
+        )
+
     decision = _verdict_to_decision(verdict)
     user_message: str | None = None
 
@@ -680,6 +715,16 @@ async def evaluate_credential_with(
         assert_llm_budget_available=assert_llm_budget_available,
         usage_limits=usage_limits,
     )
+
+    if verdict.decision == "escalate" and session.unattended:
+        verdict = SentinelVerdict(
+            decision="deny",
+            explanation=(
+                verdict.explanation
+                or "Credential access was denied because no user approval path is available for unattended sessions."
+            ),
+            risk_level=verdict.risk_level,
+        )
 
     decision = _verdict_to_decision(verdict)
     user_was_prompted = verdict.decision == "escalate"

--- a/src/carapace/security/context.py
+++ b/src/carapace/security/context.py
@@ -130,6 +130,12 @@ class SentinelVerdict(BaseModel):
     risk_level: Literal["low", "medium", "high"] = "medium"
 
 
+class UnattendedSentinelVerdict(BaseModel):
+    decision: Literal["allow", "deny"]
+    explanation: str = ""
+    risk_level: Literal["low", "medium", "high"] = "medium"
+
+
 ApprovalSource = Literal["safe-list", "sentinel", "user", "skill", "bypass", "unknown"]
 ApprovalVerdict = Literal["allow", "deny", "escalate"]
 
@@ -210,8 +216,10 @@ class SessionSecurity:
         audit_dir: Path | None = None,
         max_sentinel_calls_per_tool_call: int = 5,
         sentinel_domain_batch_window_ms: int = 100,
+        unattended: bool = False,
     ) -> None:
         self.session_id = session_id
+        self.unattended = unattended
         self.action_log: list[
             UserMessageEntry
             | ToolCallEntry

--- a/src/carapace/security/sentinel.py
+++ b/src/carapace/security/sentinel.py
@@ -25,6 +25,7 @@ from carapace.security.context import (
     SkillActivatedEntry,
     ToolCallEntry,
     ToolResultEntry,
+    UnattendedSentinelVerdict,
     UserMessageEntry,
     UserVouchedEntry,
 )
@@ -62,8 +63,17 @@ Always respond using the requested structured output schema.
 _RESET_THRESHOLD_DEFAULT = 20
 
 
-def _build_system_prompt(security_md: str) -> str:
-    return _SENTINEL_SYSTEM_PREFIX + security_md
+def _build_system_prompt(security_md: str, *, unattended: bool) -> str:
+    mode_text = (
+        "This session is unattended. No user approval path is available. "
+        + "You must make a final allow-or-deny decision yourself. Never choose escalation.\n\n"
+        if unattended
+        else ""
+    )
+    return _SENTINEL_SYSTEM_PREFIX + mode_text + security_md
+
+
+type _SentinelOutput = SentinelVerdict | UnattendedSentinelVerdict
 
 
 def _format_entry(entry: ActionLogEntry) -> str:
@@ -137,6 +147,7 @@ class Sentinel:
         model: str,
         knowledge_dir: Path,
         skills_dir: Path,
+        unattended: bool = False,
         timeout: timedelta = timedelta(seconds=60),
         reset_threshold: int = _RESET_THRESHOLD_DEFAULT,
         model_factory: Callable[[str], Model] | None = None,
@@ -145,6 +156,7 @@ class Sentinel:
         self._model = model
         self._knowledge_dir = knowledge_dir
         self._skills_dir = skills_dir
+        self._unattended = unattended
         self._timeout = timeout
         self._reset_threshold = reset_threshold
         self._model_factory = model_factory
@@ -167,7 +179,7 @@ class Sentinel:
         self._agent = self._create_agent()
 
     def _load_system_prompt(self, _ctx: RunContext[Path]) -> str:
-        return _build_system_prompt(self._load_security_md())
+        return _build_system_prompt(self._load_security_md(), unattended=self._unattended)
 
     def _load_security_md(self) -> str:
         path = self._knowledge_dir / "SECURITY.md"
@@ -354,13 +366,15 @@ class Sentinel:
             usage_tracker.record(self._model, "sentinel", result.usage())
 
         usage = result.usage()
+        output = self._normalize_verdict(result.output)
+
         logger.info(
             f"Sentinel eval done session={session.session_id} seq={eval_no} kind={kind} subject={subject} "
-            + f"decision={result.output.decision} risk={result.output.risk_level} "
+            + f"decision={output.decision} risk={output.risk_level} "
             + f"input_tokens={usage.input_tokens or 0} output_tokens={usage.output_tokens or 0} "
             + self._format_eval_stats(stats)
         )
-        return result.output
+        return output
 
     def _register_agent_tools(self, agent: Agent[Path, Any]) -> None:
         @agent.tool
@@ -406,15 +420,25 @@ class Sentinel:
             )
             return result
 
-    def _create_agent(self) -> Agent[Path, SentinelVerdict]:
+    def _normalize_verdict(self, output: _SentinelOutput) -> SentinelVerdict:
+        if isinstance(output, SentinelVerdict):
+            return output
+        return SentinelVerdict(
+            decision=output.decision,
+            explanation=output.explanation,
+            risk_level=output.risk_level,
+        )
+
+    def _create_agent(self) -> Agent[Path, _SentinelOutput]:
         resolved = self._model_factory(self._model) if self._model_factory is not None else infer_model(self._model)
         model_settings = (
             self._model_settings_resolver(self._model) if self._model_settings_resolver is not None else None
         )
-        agent: Agent[Path, SentinelVerdict] = Agent(
+        output_model = UnattendedSentinelVerdict if self._unattended else SentinelVerdict
+        agent: Agent[Path, _SentinelOutput] = Agent(
             resolved,
             deps_type=Path,
-            output_type=ToolOutput(SentinelVerdict, name="judge"),
+            output_type=ToolOutput(output_model, name="judge"),
             instructions=self._load_system_prompt,
             capabilities=[LlmRequestLogCapability(source="sentinel")],
             model_settings=model_settings,

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -449,6 +449,7 @@ class SessionCreateRequest(BaseModel):
     channel_type: str = "cli"
     channel_ref: str = ""
     private: bool | None = None
+    unattended: bool | None = None
 
 
 class SessionAttributesPatch(BaseModel):
@@ -456,6 +457,7 @@ class SessionAttributesPatch(BaseModel):
     archived: bool | None = None
     pinned: bool | None = None
     favorite: bool | None = None
+    unattended: bool | None = None
 
 
 class SessionUpdateRequest(BaseModel):
@@ -466,6 +468,7 @@ class SessionForkRequest(BaseModel):
     event_index: int
     channel_type: str = "cli"
     channel_ref: str = ""
+    unattended: bool | None = None
 
 
 class SessionInfo(BaseModel):
@@ -537,6 +540,7 @@ async def create_session(
         body.channel_ref,
         budget=_engine.config.agent.default_session_budget,
         private=_engine.config.sessions.default_private if body.private is None else body.private,
+        unattended=False if body.unattended is None else body.unattended,
     )
     return SessionInfo.from_state(state)
 
@@ -592,6 +596,13 @@ async def update_session(
         for field_name, value in body.attributes.model_dump(exclude_none=True).items():
             setattr(next_attributes, field_name, value)
 
+        unattended_changed = next_attributes.unattended != state.attributes.unattended
+        if unattended_changed:
+            raise HTTPException(
+                status_code=409,
+                detail="Cannot change unattended mode in place; fork the session instead",
+            )
+
         archive_changed = next_attributes.archived != state.attributes.archived
         archive_now = next_attributes.archived
 
@@ -643,6 +654,7 @@ async def fork_session(
             event_index=body.event_index,
             channel_type=body.channel_type,
             channel_ref=body.channel_ref,
+            unattended=body.unattended,
         )
     except RuntimeError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -64,6 +64,7 @@ from carapace.ws_models import (
     Done,
     ErrorMessage,
     EscalationResponse,
+    FinalStatus,
     GitPushApprovalRequest,
     LlmActivity,
     LlmActivityUpdate,
@@ -858,6 +859,7 @@ _HistoryRole = Literal[
 class HistoryMessage(BaseModel):
     role: _HistoryRole
     content: str = ""
+    final_status: FinalStatus | None = None
     event_index: int | None = None
     reasoning_duration_ms: int | None = None
     reasoning_tokens: int | None = None
@@ -1050,8 +1052,15 @@ class WebSocketSubscriber:
     async def on_llm_activity(self, activity: LlmRequestState | None) -> None:
         await self._safe_send(LlmActivityUpdate(activity=_llm_activity_payload(activity)))
 
-    async def on_done(self, content: str, usage: TurnUsage, *, thinking: str | None = None) -> None:
-        await self._safe_send(Done(content=content, thinking=thinking, usage=usage))
+    async def on_done(
+        self,
+        content: str,
+        usage: TurnUsage,
+        *,
+        thinking: str | None = None,
+        final_status: FinalStatus | None = None,
+    ) -> None:
+        await self._safe_send(Done(content=content, thinking=thinking, usage=usage, final_status=final_status))
 
     async def on_error(self, detail: str, *, turn_terminal: bool = False) -> None:
         await self._safe_send(ErrorMessage(detail=detail, turn_terminal=turn_terminal))

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -15,7 +15,7 @@ import contextlib
 import secrets
 import uuid
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
@@ -23,7 +23,15 @@ from typing import Any, Literal
 
 from loguru import logger
 from pydantic_ai.exceptions import UsageLimitExceeded
-from pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, UserPromptPart
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
 from pydantic_ai.models import Model, infer_model
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.usage import UsageLimits
@@ -489,11 +497,13 @@ class SessionEngine(SessionTurnMixin):
             audit_dir=audit_dir,
             max_sentinel_calls_per_tool_call=self._config.agent.max_sentinel_calls_per_tool_call,
             sentinel_domain_batch_window_ms=self._config.agent.sentinel_domain_batch_window_ms,
+            unattended=state.attributes.unattended,
         )
         sentinel = Sentinel(
             model=self._config.agent.sentinel_model,
             knowledge_dir=self._knowledge_dir,
             skills_dir=self._knowledge_dir / "skills",
+            unattended=state.attributes.unattended,
             timeout=timedelta(seconds=self._config.agent.sentinel_timeout_seconds),
             model_factory=self._model_factory,
             model_settings_resolver=self._resolve_model_settings,
@@ -818,6 +828,7 @@ class SessionEngine(SessionTurnMixin):
         event_index: int,
         channel_type: str,
         channel_ref: str = "",
+        unattended: bool | None = None,
     ) -> SessionState:
         active = self._ensure_active(session_id)
         if active.agent_task and not active.agent_task.done():
@@ -836,6 +847,9 @@ class SessionEngine(SessionTurnMixin):
         turn_count = len(self._completed_event_turns(forked_events))
         history = self._truncate_incomplete_model_history(self._session_mgr.load_history(session_id))
         forked_history = self._history_for_completed_turn_count(history, turn_count)
+        target_unattended = source_state.attributes.unattended if unattended is None else unattended
+        if source_state.attributes.unattended and not target_unattended:
+            forked_history = self._normalize_unattended_output_history(forked_history)
 
         now = datetime.now(tz=UTC)
         forked_session_id = f"{now:%Y-%m-%d-%H-%M}-{secrets.token_hex(4)}"
@@ -848,7 +862,10 @@ class SessionEngine(SessionTurnMixin):
                 "title": f"{source_state.title} (Copy)" if source_state.title else None,
                 "created_at": now,
                 "last_active": now,
-                "attributes": SessionAttributes(private=source_state.attributes.private),
+                "attributes": SessionAttributes(
+                    private=source_state.attributes.private,
+                    unattended=target_unattended,
+                ),
                 "knowledge_last_committed_at": None,
                 "knowledge_last_archive_path": None,
                 "knowledge_last_export_hash": None,
@@ -1337,7 +1354,7 @@ class SessionEngine(SessionTurnMixin):
             if (
                 current_turn_start is not None
                 and index - 1 > current_turn_start
-                and isinstance(messages[index - 1], ModelResponse)
+                and self._is_terminal_history_message(messages[index - 1])
             ):
                 turn_end_indexes.append(index - 1)
             current_turn_start = index
@@ -1345,11 +1362,21 @@ class SessionEngine(SessionTurnMixin):
         if (
             current_turn_start is not None
             and len(messages) - 1 > current_turn_start
-            and isinstance(messages[-1], ModelResponse)
+            and self._is_terminal_history_message(messages[-1])
         ):
             turn_end_indexes.append(len(messages) - 1)
 
         return turn_end_indexes
+
+    def _is_terminal_history_message(self, message: ModelMessage) -> bool:
+        if isinstance(message, ModelResponse):
+            return True
+        if not isinstance(message, ModelRequest):
+            return False
+        return any(
+            isinstance(part, ToolReturnPart) and part.tool_name in {"task_done", "task_failed"}
+            for part in message.parts
+        )
 
     def _history_for_completed_turn_count(self, messages: list[ModelMessage], turn_count: int) -> list[ModelMessage]:
         if turn_count <= 0:
@@ -1361,6 +1388,51 @@ class SessionEngine(SessionTurnMixin):
 
         capped_turn_count = min(turn_count, len(turn_end_indexes))
         return messages[: turn_end_indexes[capped_turn_count - 1] + 1]
+
+    def _normalize_unattended_output_history(self, messages: list[ModelMessage]) -> list[ModelMessage]:
+        """Rewrite unattended task output tools into plain assistant text for attended forks."""
+        normalized: list[ModelMessage] = []
+        index = 0
+
+        while index < len(messages):
+            current = messages[index]
+            next_message = messages[index + 1] if index + 1 < len(messages) else None
+
+            if (
+                isinstance(current, ModelResponse)
+                and len(current.parts) == 1
+                and isinstance(current.parts[0], ToolCallPart)
+                and current.parts[0].tool_name in {"task_done", "task_failed"}
+                and isinstance(next_message, ModelRequest)
+                and any(
+                    isinstance(part, ToolReturnPart)
+                    and part.tool_name == current.parts[0].tool_name
+                    and part.tool_call_id == current.parts[0].tool_call_id
+                    for part in next_message.parts
+                )
+            ):
+                content = self._task_output_text(current.parts[0])
+                if content is not None:
+                    normalized.append(replace(current, parts=[TextPart(content=content)]))
+                    index += 2
+                    continue
+
+            normalized.append(current)
+            index += 1
+
+        return normalized
+
+    def _task_output_text(self, part: ToolCallPart) -> str | None:
+        args = part.args if isinstance(part.args, dict) else None
+        if args is None:
+            return None
+        if part.tool_name == "task_done":
+            value = args.get("result")
+        elif part.tool_name == "task_failed":
+            value = args.get("problem")
+        else:
+            return None
+        return value if isinstance(value, str) and value else None
 
     def _rewrite_session_transcript(self, session_id: str, events: list[dict[str, Any]]) -> None:
         truncated_events = self._truncate_incomplete_events(events)

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -28,6 +28,7 @@ from pydantic_ai.messages import (
     ModelRequest,
     ModelResponse,
     TextPart,
+    ThinkingPart,
     ToolCallPart,
     ToolReturnPart,
     UserPromptPart,
@@ -1400,24 +1401,26 @@ class SessionEngine(SessionTurnMixin):
             current = messages[index]
             next_message = messages[index + 1] if index + 1 < len(messages) else None
 
-            if (
-                isinstance(current, ModelResponse)
-                and len(current.parts) == 1
-                and isinstance(current.parts[0], ToolCallPart)
-                and current.parts[0].tool_name in {"task_done", "task_failed"}
-                and isinstance(next_message, ModelRequest)
-                and any(
-                    isinstance(part, ToolReturnPart)
-                    and part.tool_name == current.parts[0].tool_name
-                    and part.tool_call_id == current.parts[0].tool_call_id
-                    for part in next_message.parts
-                )
-            ):
-                content = self._task_output_text(current.parts[0])
-                if content is not None:
-                    normalized.append(replace(current, parts=[TextPart(content=content)]))
-                    index += 2
-                    continue
+            if isinstance(current, ModelResponse):
+                tool_call_parts = [part for part in current.parts if isinstance(part, ToolCallPart)]
+                other_parts = [part for part in current.parts if not isinstance(part, ToolCallPart | ThinkingPart)]
+                if (
+                    len(tool_call_parts) == 1
+                    and not other_parts
+                    and tool_call_parts[0].tool_name in {"task_done", "task_failed"}
+                    and isinstance(next_message, ModelRequest)
+                    and any(
+                        isinstance(part, ToolReturnPart)
+                        and part.tool_name == tool_call_parts[0].tool_name
+                        and part.tool_call_id == tool_call_parts[0].tool_call_id
+                        for part in next_message.parts
+                    )
+                ):
+                    content = self._task_output_text(tool_call_parts[0])
+                    if content is not None:
+                        normalized.append(replace(current, parts=[TextPart(content=content)]))
+                        index += 2
+                        continue
 
             normalized.append(current)
             index += 1

--- a/src/carapace/session/manager.py
+++ b/src/carapace/session/manager.py
@@ -68,6 +68,7 @@ class SessionManager:
         budget: SessionBudget | None = None,
         *,
         private: bool = False,
+        unattended: bool = False,
     ) -> SessionState:
         now = datetime.now(tz=UTC)
         session_id = f"{now:%Y-%m-%d-%H-%M}-{secrets.token_hex(4)}"
@@ -75,7 +76,7 @@ class SessionManager:
             session_id=session_id,
             channel_type=channel_type,
             channel_ref=channel_ref or None,
-            attributes=SessionAttributes(private=private),
+            attributes=SessionAttributes(private=private, unattended=unattended),
             budget=budget.model_copy(deep=True) if budget is not None else SessionBudget(),
             created_at=now,
             last_active=now,

--- a/src/carapace/session/turns.py
+++ b/src/carapace/session/turns.py
@@ -575,7 +575,7 @@ class SessionTurnMixin(SessionTurnHost):
             user_input,
             latest_messages=latest_messages,
             terminal_message=terminal_message,
-            final_status="warning" if terminal_message else None,
+            final_status="warning" if (terminal_message and active.state.attributes.unattended) else None,
         )
 
     def _save_user_message_on_failure(

--- a/src/carapace/session/turns.py
+++ b/src/carapace/session/turns.py
@@ -39,7 +39,7 @@ from carapace.security.context import ApprovalSource, ApprovalVerdict, format_de
 from carapace.session.manager import SessionManager
 from carapace.session.types import ActiveSession, SessionSubscriber, TurnExecutionResult
 from carapace.usage import BudgetGauge, LlmRequestState, SessionBudgetExceededError, interrupted_request_record
-from carapace.ws_models import ApprovalRequest, ApprovalResponse, TurnUsage
+from carapace.ws_models import ApprovalRequest, ApprovalResponse, FinalStatus, TurnUsage
 
 
 def _non_slash_user_message_count(events: list[dict[str, Any]]) -> int:
@@ -287,6 +287,7 @@ class SessionTurnMixin(SessionTurnHost):
                     turn_result.messages,
                     turn_result.output,
                     turn_result.thinking,
+                    final_status=turn_result.final_status,
                 )
 
         except asyncio.CancelledError:
@@ -467,7 +468,7 @@ class SessionTurnMixin(SessionTurnHost):
         async with self._llm_semaphore:
             with self.llm_request_recording(active):
                 self._assert_llm_budget_available(active)
-                messages, output, thinking = await _engine_module().run_agent_turn(
+                messages, output, thinking, final_status = await _engine_module().run_agent_turn(
                     user_input,
                     deps,
                     message_history,
@@ -479,7 +480,12 @@ class SessionTurnMixin(SessionTurnHost):
                     before_llm_call=lambda: self._assert_llm_budget_available(active),
                     get_usage_limits=lambda: self._remaining_usage_limits(active),
                 )
-        return TurnExecutionResult(messages=messages, output=output, thinking=thinking)
+        return TurnExecutionResult(
+            messages=messages,
+            output=output,
+            thinking=thinking,
+            final_status=final_status,
+        )
 
     async def _handle_token_chunk(self, active: ActiveSession, chunk: str) -> None:
         await self._maybe_promote_llm_request_state(active, _engine_module().note_llm_request_text())
@@ -516,12 +522,16 @@ class SessionTurnMixin(SessionTurnHost):
         messages: list[ModelMessage],
         output: str,
         thinking: str,
+        final_status: FinalStatus | None = None,
     ) -> None:
         self._session_mgr.save_history(session_id, messages)
         self._session_mgr.save_state(active.state)
         self._save_turn_progress(session_id, active)
         await self._refresh_sandbox_snapshot_after_turn(session_id)
-        self._session_mgr.append_events(session_id, [{"role": "assistant", "content": output}])
+        assistant_event: dict[str, Any] = {"role": "assistant", "content": output}
+        if final_status is not None:
+            assistant_event["final_status"] = final_status
+        self._session_mgr.append_events(session_id, [assistant_event])
 
         if output.startswith("Unexpected agent output type:"):
             await self._broadcast(active, "on_error", output, turn_terminal=True)
@@ -539,6 +549,7 @@ class SessionTurnMixin(SessionTurnHost):
                 output,
                 usage_payload,
                 thinking=thinking or None,
+                final_status=final_status,
             )
 
         self._schedule_title_generation_if_needed(active, session_id, self._session_mgr.load_events(session_id))
@@ -564,6 +575,7 @@ class SessionTurnMixin(SessionTurnHost):
             user_input,
             latest_messages=latest_messages,
             terminal_message=terminal_message,
+            final_status="warning" if terminal_message else None,
         )
 
     def _save_user_message_on_failure(
@@ -573,6 +585,7 @@ class SessionTurnMixin(SessionTurnHost):
         *,
         latest_messages: list[ModelMessage] | None = None,
         terminal_message: str | None = None,
+        final_status: FinalStatus | None = None,
     ) -> None:
         """Persist the user message to history even when the agent turn fails.
 
@@ -591,13 +604,14 @@ class SessionTurnMixin(SessionTurnHost):
 
         events = self._truncate_incomplete_events(self._session_mgr.load_events(session_id))
         if terminal_message:
-            events.append(
-                {
-                    "role": "assistant",
-                    "content": terminal_message,
-                    "timestamp": datetime.now(tz=UTC).isoformat(),
-                }
-            )
+            event: dict[str, Any] = {
+                "role": "assistant",
+                "content": terminal_message,
+                "timestamp": datetime.now(tz=UTC).isoformat(),
+            }
+            if final_status is not None:
+                event["final_status"] = final_status
+            events.append(event)
         self._session_mgr.save_events(session_id, events)
 
     def _truncate_incomplete_model_history(self, messages: list[ModelMessage]) -> list[ModelMessage]:

--- a/src/carapace/session/types.py
+++ b/src/carapace/session/types.py
@@ -19,7 +19,7 @@ from carapace.models import SessionState, ToolResult
 from carapace.security.context import ApprovalSource, ApprovalVerdict, SessionSecurity
 from carapace.security.sentinel import Sentinel
 from carapace.usage import LlmRequestLog, LlmRequestState, UsageTracker
-from carapace.ws_models import ApprovalRequest, ApprovalResponse, EscalationResponse, TurnUsage
+from carapace.ws_models import ApprovalRequest, ApprovalResponse, EscalationResponse, FinalStatus, TurnUsage
 
 
 @runtime_checkable
@@ -42,7 +42,14 @@ class SessionSubscriber(Protocol):
     async def on_token(self, content: str) -> None: ...
     async def on_thinking_token(self, content: str) -> None: ...
     async def on_llm_activity(self, activity: LlmRequestState | None) -> None: ...
-    async def on_done(self, content: str, usage: TurnUsage, *, thinking: str | None = None) -> None: ...
+    async def on_done(
+        self,
+        content: str,
+        usage: TurnUsage,
+        *,
+        thinking: str | None = None,
+        final_status: FinalStatus | None = None,
+    ) -> None: ...
     async def on_error(self, detail: str, *, turn_terminal: bool = False) -> None: ...
     async def on_cancelled(self) -> None: ...
     async def on_approval_request(self, req: ApprovalRequest) -> None: ...
@@ -127,3 +134,4 @@ class TurnExecutionResult:
     messages: list[ModelMessage]
     output: str
     thinking: str
+    final_status: FinalStatus | None = None

--- a/src/carapace/ws_models.py
+++ b/src/carapace/ws_models.py
@@ -8,6 +8,8 @@ from pydantic import BaseModel
 from carapace.security.context import ApprovalSource, ApprovalVerdict
 from carapace.usage import BudgetGauge, LlmRequestPhase, LlmSource
 
+FinalStatus = Literal["success", "warning"]
+
 SLASH_COMMANDS: list[dict[str, str]] = [
     {"command": "/security", "description": "Show security policy summary"},
     {"command": "/approve-context", "description": "Vouch for the current agent context as trustworthy"},
@@ -234,6 +236,7 @@ class Done(BaseModel):
     content: str
     thinking: str | None = None
     usage: TurnUsage | None = None
+    final_status: FinalStatus | None = None
 
 
 class CommandResult(BaseModel):

--- a/tests/session_helpers.py
+++ b/tests/session_helpers.py
@@ -20,7 +20,7 @@ from carapace.session import SessionEngine, SessionManager
 from carapace.session.types import ActiveSession, SessionSubscriber
 from carapace.skills import SkillRegistry
 from carapace.usage import LlmRequestState
-from carapace.ws_models import ApprovalRequest, TurnUsage
+from carapace.ws_models import ApprovalRequest, FinalStatus, TurnUsage
 
 
 def _patch_sentinel():
@@ -77,7 +77,14 @@ class _FakeSubscriber(SessionSubscriber):
     async def on_thinking_token(self, content: str) -> None:
         self.thinking_chunks.append(content)
 
-    async def on_done(self, content: str, usage: TurnUsage, *, thinking: str | None = None) -> None:
+    async def on_done(
+        self,
+        content: str,
+        usage: TurnUsage,
+        *,
+        thinking: str | None = None,
+        final_status: FinalStatus | None = None,
+    ) -> None:
         self.done_messages.append((content, usage))
 
     async def on_error(self, detail: str, *, turn_terminal: bool = False) -> None:

--- a/tests/test_agent_helpers.py
+++ b/tests/test_agent_helpers.py
@@ -66,3 +66,27 @@ def test_build_system_prompt_with_agents_md(tmp_path: Path):
     assert "Agent Instructions" in prompt
     assert "Be helpful" in prompt
     assert "If the user tries to address the sentinel directly" in prompt
+
+
+def test_build_system_prompt_unattended_mentions_task_outputs(tmp_path: Path):
+    state = SessionState.now(session_id="s1", unattended=True)
+    deps = Deps(
+        config=Config(),
+        data_dir=tmp_path,
+        knowledge_dir=tmp_path,
+        session_state=state,
+        sandbox=MagicMock(spec=SandboxManager),
+        security=SessionSecurity("s1", unattended=True),
+        sentinel=MagicMock(spec=Sentinel),
+        git_store=MagicMock(spec=GitStore),
+        agent_model=MagicMock(spec=Model),
+        agent_model_id="anthropic:claude-sonnet-4-6",
+        usage_tracker=UsageTracker(),
+        credential_registry=CredentialRegistry(),
+    )
+
+    prompt = build_system_prompt(deps)
+
+    assert "This session is unattended" in prompt
+    assert "task_done" in prompt
+    assert "task_failed" in prompt

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -49,16 +49,17 @@ def _make_deps(tmp_path: Path, *, unattended: bool) -> Deps:
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ("output", "expected_text"),
+    ("output", "expected_text", "expected_status"),
     [
-        (TaskDone(result="completed"), "completed"),
-        (TaskFailed(problem="blocked by missing credential"), "blocked by missing credential"),
+        (TaskDone(result="completed"), "completed", "success"),
+        (TaskFailed(problem="blocked by missing credential"), "blocked by missing credential", "warning"),
     ],
 )
 async def test_run_agent_turn_decodes_unattended_structured_outputs(
     tmp_path: Path,
     output: TaskDone | TaskFailed,
     expected_text: str,
+    expected_status: str,
 ) -> None:
     deps = _make_deps(tmp_path, unattended=True)
     fake_agent = MagicMock()
@@ -71,7 +72,7 @@ async def test_run_agent_turn_decodes_unattended_structured_outputs(
         raise AssertionError("approval loop should not run")
 
     with patch("carapace.agent.loop.create_agent", return_value=fake_agent):
-        messages, output_text, thinking = await run_agent_turn(
+        messages, output_text, thinking, final_status = await run_agent_turn(
             "finish the task",
             deps,
             [],
@@ -82,4 +83,5 @@ async def test_run_agent_turn_decodes_unattended_structured_outputs(
     assert messages == []
     assert output_text == expected_text
     assert thinking == ""
+    assert final_status == expected_status
     assert isinstance(deps.security.action_log[-1], AgentResponseEntry)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic_ai.models import Model
+from pydantic_ai.usage import RunUsage
+
+from carapace.agent.loop import run_agent_turn
+from carapace.credentials import CredentialRegistry
+from carapace.git.store import GitStore
+from carapace.models import Config, Deps, SessionState, TaskDone, TaskFailed
+from carapace.sandbox.manager import SandboxManager
+from carapace.security.context import AgentResponseEntry, SessionSecurity
+from carapace.security.sentinel import Sentinel
+from carapace.usage import UsageTracker
+
+
+class _FakeResult:
+    def __init__(self, output: Any) -> None:
+        self.output = output
+
+    def usage(self) -> RunUsage:
+        return RunUsage(input_tokens=3, output_tokens=5)
+
+    def all_messages(self) -> list[Any]:
+        return []
+
+
+def _make_deps(tmp_path: Path, *, unattended: bool) -> Deps:
+    session_id = "session-1"
+    return Deps(
+        config=Config(),
+        data_dir=tmp_path,
+        knowledge_dir=tmp_path,
+        session_state=SessionState.now(session_id=session_id, unattended=unattended),
+        sandbox=MagicMock(spec=SandboxManager),
+        security=SessionSecurity(session_id, unattended=unattended),
+        sentinel=MagicMock(spec=Sentinel),
+        git_store=MagicMock(spec=GitStore),
+        agent_model=MagicMock(spec=Model),
+        agent_model_id="anthropic:claude-sonnet-4-6",
+        usage_tracker=UsageTracker(),
+        credential_registry=CredentialRegistry(),
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("output", "expected_text"),
+    [
+        (TaskDone(result="completed"), "completed"),
+        (TaskFailed(problem="blocked by missing credential"), "blocked by missing credential"),
+    ],
+)
+async def test_run_agent_turn_decodes_unattended_structured_outputs(
+    tmp_path: Path,
+    output: TaskDone | TaskFailed,
+    expected_text: str,
+) -> None:
+    deps = _make_deps(tmp_path, unattended=True)
+    fake_agent = MagicMock()
+    fake_agent.run = AsyncMock(return_value=_FakeResult(output))
+
+    async def _send_approval_request(_req: Any) -> None:
+        raise AssertionError("approval loop should not run")
+
+    async def _collect_approvals(_pending: set[str]) -> dict[str, bool]:
+        raise AssertionError("approval loop should not run")
+
+    with patch("carapace.agent.loop.create_agent", return_value=fake_agent):
+        messages, output_text, thinking = await run_agent_turn(
+            "finish the task",
+            deps,
+            [],
+            _send_approval_request,
+            _collect_approvals,
+        )
+
+    assert messages == []
+    assert output_text == expected_text
+    assert thinking == ""
+    assert isinstance(deps.security.action_log[-1], AgentResponseEntry)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -234,6 +234,20 @@ def test_update_session_privacy_updates_active_session_state(client, auth_header
     assert active.state.activated_skills == ["demo-skill"]
 
 
+def test_update_session_rejects_unattended_mode_change(client, auth_headers):
+    create_resp = client.post("/api/sessions", headers=auth_headers)
+    sid = create_resp.json()["session_id"]
+
+    resp = client.patch(
+        f"/api/sessions/{sid}",
+        headers=auth_headers,
+        json={"attributes": {"unattended": True}},
+    )
+
+    assert resp.status_code == 409
+    assert "fork the session instead" in resp.json()["detail"]
+
+
 def test_list_sessions_excludes_archived_by_default(client, auth_headers):
     sid = client.post("/api/sessions", headers=auth_headers).json()["session_id"]
     archive_resp = client.patch(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1172,6 +1172,25 @@ def test_history_includes_thinking_reasoning_metadata(client, auth_headers):
     assert history[0]["reasoning_tokens"] == 42
 
 
+def test_history_includes_assistant_final_status(client, auth_headers):
+    create_resp = client.post("/api/sessions", headers=auth_headers)
+    sid = create_resp.json()["session_id"]
+    srv._engine.session_mgr.append_events(
+        sid,
+        [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "done", "final_status": "success"},
+        ],
+    )
+
+    resp = client.get(f"/api/sessions/{sid}/history", headers=auth_headers)
+
+    assert resp.status_code == 200
+    history = resp.json()
+    assert history[1]["role"] == "assistant"
+    assert history[1]["final_status"] == "success"
+
+
 def test_ws_budget_command_emits_status_refresh(client, auth_headers, bearer):
     create_resp = client.post("/api/sessions", headers=auth_headers)
     sid = create_resp.json()["session_id"]

--- a/tests/test_session_engine_core.py
+++ b/tests/test_session_engine_core.py
@@ -9,7 +9,7 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
+from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, ToolCallPart, ToolReturnPart, UserPromptPart
 
 import carapace.usage as usage_mod
 from carapace.models import ContextGrant, CredentialRegistryProtocol, SkillCredentialDecl
@@ -256,6 +256,56 @@ def test_fork_session_copies_transcript_and_security_context(tmp_path: Path) -> 
     assert engine.session_mgr.load_usage(forked.session_id).models == {}
     assert engine.session_mgr.load_sandbox_snapshot(forked.session_id) is None
     assert len(engine.session_mgr.load_events(sid)) == 5
+
+
+def test_fork_session_normalizes_unattended_history_when_becoming_attended(tmp_path: Path) -> None:
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path)
+
+    source = engine.session_mgr.create_session(unattended=True)
+    sid = source.session_id
+    engine.get_or_activate(sid)
+    engine.session_mgr.append_events(
+        sid,
+        [
+            {"role": "user", "content": "run on your own"},
+            {"role": "assistant", "content": "completed"},
+        ],
+    )
+    engine.session_mgr.save_history(
+        sid,
+        [
+            ModelRequest(parts=[UserPromptPart(content="run on your own")]),
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name="task_done",
+                        args={"result": "completed"},
+                        tool_call_id="done-1",
+                    )
+                ]
+            ),
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name="task_done",
+                        content="Final result processed.",
+                        tool_call_id="done-1",
+                    )
+                ]
+            ),
+        ],
+    )
+
+    forked = engine.fork_session(sid, event_index=1, channel_type="web", unattended=False)
+
+    assert forked.attributes.unattended is False
+    forked_history = engine.session_mgr.load_history(forked.session_id)
+    assert len(forked_history) == 2
+    assert isinstance(forked_history[1], ModelResponse)
+    response_part = forked_history[1].parts[0]
+    assert isinstance(response_part, TextPart)
+    assert response_part.content == "completed"
 
 
 def test_handle_token_chunk_promotes_activity_and_broadcasts(tmp_path: Path) -> None:

--- a/tests/test_session_engine_core.py
+++ b/tests/test_session_engine_core.py
@@ -500,8 +500,8 @@ def test_user_message_from_self(tmp_path: Path):
         engine.subscribe(sid, origin)
         engine.subscribe(sid, other)
 
-        async def _noop_turn(*_a: Any, **_kw: Any) -> tuple[list[Any], str, str]:
-            return [], "ok", ""
+        async def _noop_turn(*_a: Any, **_kw: Any) -> tuple[list[Any], str, str, None]:
+            return [], "ok", "", None
 
         with patch("carapace.agent.loop.run_agent_turn", new=_noop_turn):
             await engine.submit_message(sid, "hello", origin=origin)
@@ -527,8 +527,8 @@ def test_user_message_no_origin(tmp_path: Path):
         engine.subscribe(sid, sub_a)
         engine.subscribe(sid, sub_b)
 
-        async def _noop_turn(*_a: Any, **_kw: Any) -> tuple[list[Any], str, str]:
-            return [], "ok", ""
+        async def _noop_turn(*_a: Any, **_kw: Any) -> tuple[list[Any], str, str, None]:
+            return [], "ok", "", None
 
         with patch("carapace.agent.loop.run_agent_turn", new=_noop_turn):
             await engine.submit_message(sid, "hi")

--- a/tests/test_session_engine_core.py
+++ b/tests/test_session_engine_core.py
@@ -9,7 +9,15 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, ToolCallPart, ToolReturnPart, UserPromptPart
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ThinkingPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
 
 import carapace.usage as usage_mod
 from carapace.models import ContextGrant, CredentialRegistryProtocol, SkillCredentialDecl
@@ -300,6 +308,56 @@ def test_fork_session_normalizes_unattended_history_when_becoming_attended(tmp_p
     forked = engine.fork_session(sid, event_index=1, channel_type="web", unattended=False)
 
     assert forked.attributes.unattended is False
+    forked_history = engine.session_mgr.load_history(forked.session_id)
+    assert len(forked_history) == 2
+    assert isinstance(forked_history[1], ModelResponse)
+    response_part = forked_history[1].parts[0]
+    assert isinstance(response_part, TextPart)
+    assert response_part.content == "completed"
+
+
+def test_fork_session_normalizes_unattended_history_with_thinking_parts(tmp_path: Path) -> None:
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path)
+
+    source = engine.session_mgr.create_session(unattended=True)
+    sid = source.session_id
+    engine.get_or_activate(sid)
+    engine.session_mgr.append_events(
+        sid,
+        [
+            {"role": "user", "content": "run on your own"},
+            {"role": "assistant", "content": "completed"},
+        ],
+    )
+    engine.session_mgr.save_history(
+        sid,
+        [
+            ModelRequest(parts=[UserPromptPart(content="run on your own")]),
+            ModelResponse(
+                parts=[
+                    ThinkingPart(content="working through result"),
+                    ToolCallPart(
+                        tool_name="task_done",
+                        args={"result": "completed"},
+                        tool_call_id="done-1",
+                    ),
+                ]
+            ),
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name="task_done",
+                        content="Final result processed.",
+                        tool_call_id="done-1",
+                    )
+                ]
+            ),
+        ],
+    )
+
+    forked = engine.fork_session(sid, event_index=1, channel_type="web", unattended=False)
+
     forked_history = engine.session_mgr.load_history(forked.session_id)
     assert len(forked_history) == 2
     assert isinstance(forked_history[1], ModelResponse)

--- a/tests/test_session_engine_lifecycle.py
+++ b/tests/test_session_engine_lifecycle.py
@@ -315,7 +315,7 @@ def test_retry_latest_turn_rewinds_and_restarts(tmp_path: Path):
             _deps: Any,
             message_history: list[Any],
             **_kwargs: Any,
-        ) -> tuple[list[Any], str, str]:
+        ) -> tuple[list[Any], str, str, None]:
             assert user_input == "second"
             assert len(message_history) == 2
             assert isinstance(message_history[0], ModelRequest)
@@ -328,6 +328,7 @@ def test_retry_latest_turn_rewinds_and_restarts(tmp_path: Path):
                 ],
                 "retried answer",
                 "",
+                None,
             )
 
         with patch("carapace.session.engine.run_agent_turn", new=_fake_run_turn):
@@ -378,7 +379,7 @@ def test_retry_latest_turn_after_failure_uses_terminal_marker_history(tmp_path: 
             _deps: Any,
             message_history: list[Any],
             **_kwargs: Any,
-        ) -> tuple[list[Any], str, str]:
+        ) -> tuple[list[Any], str, str, None]:
             assert user_input == "hello"
             assert message_history == []
             return (
@@ -388,6 +389,7 @@ def test_retry_latest_turn_after_failure_uses_terminal_marker_history(tmp_path: 
                 ],
                 "recovered",
                 "",
+                None,
             )
 
         with patch("carapace.session.engine.run_agent_turn", new=_fake_run_turn):

--- a/tests/test_session_engine_models.py
+++ b/tests/test_session_engine_models.py
@@ -90,6 +90,7 @@ def test_submit_message_unexpected_output_marks_terminal_error(tmp_path: Path):
                 ],
                 unexpected,
                 "",
+                None,
             )
 
         with patch("carapace.session.engine.run_agent_turn", new=_unexpected_run_agent_turn):

--- a/tests/test_session_engine_usage.py
+++ b/tests/test_session_engine_usage.py
@@ -402,12 +402,12 @@ def test_submit_message_tool_call_budget_exhausted_broadcasts_error(tmp_path: Pa
             _message_history: list[Any],
             *_args: Any,
             **_kwargs: Any,
-        ) -> tuple[list[Any], str, str]:
+        ) -> tuple[list[Any], str, str, None]:
             callback = deps.tool_call_callback
             assert callback is not None
             callback("read", {"path": "README.md"}, "[safe-list] auto-allowed", "safe-list", "allow", "ok")
             callback("read", {"path": "README.md"}, "[safe-list] auto-allowed", "safe-list", "allow", "ok")
-            return [], "done", ""
+            return [], "done", "", None
 
         with patch("carapace.session.engine.run_agent_turn", new=_fail_on_second_tool_call):
             await engine.submit_message(sid, "hello")
@@ -430,8 +430,8 @@ def test_submit_message_refreshes_sandbox_once_after_completed_turn(tmp_path: Pa
         sub = _FakeSubscriber()
         engine.subscribe(sid, sub)
 
-        async def _complete_turn(*_args: Any, **_kwargs: Any) -> tuple[list[Any], str, str]:
-            return [], "done", "thinking"
+        async def _complete_turn(*_args: Any, **_kwargs: Any) -> tuple[list[Any], str, str, None]:
+            return [], "done", "thinking", None
 
         with patch("carapace.session.engine.run_agent_turn", new=_complete_turn):
             await engine.submit_message(sid, "hello")
@@ -451,8 +451,8 @@ def test_submit_message_refresh_failure_does_not_block_completed_turn(tmp_path: 
         sub = _FakeSubscriber()
         engine.subscribe(sid, sub)
 
-        async def _complete_turn(*_args: Any, **_kwargs: Any) -> tuple[list[Any], str, str]:
-            return [], "done", "thinking"
+        async def _complete_turn(*_args: Any, **_kwargs: Any) -> tuple[list[Any], str, str, None]:
+            return [], "done", "thinking", None
 
         _sandbox_refresh_snapshot_mock(engine).side_effect = RuntimeError("snapshot refresh failed")
 
@@ -464,6 +464,28 @@ def test_submit_message_refresh_failure_does_not_block_completed_turn(tmp_path: 
         event = engine.session_mgr.load_events(sid)[-1]
         assert "timestamp" in event
         assert _without_timestamp(event) == {"role": "assistant", "content": "done"}
+
+    with _patch_sentinel():
+        asyncio.run(_run())
+
+
+def test_submit_message_persists_final_status_in_events(tmp_path: Path):
+    async def _run() -> None:
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session()
+        sid = state.session_id
+
+        async def _complete_turn(*_args: Any, **_kwargs: Any) -> tuple[list[Any], str, str, str]:
+            return [], "done", "thinking", "success"
+
+        with patch("carapace.session.engine.run_agent_turn", new=_complete_turn):
+            await engine.submit_message(sid, "hello")
+            await asyncio.sleep(0.1)
+
+        event = engine.session_mgr.load_events(sid)[-1]
+        assert event["role"] == "assistant"
+        assert event["content"] == "done"
+        assert event["final_status"] == "success"
 
     with _patch_sentinel():
         asyncio.run(_run())


### PR DESCRIPTION
## Summary
Add unattended session mode so sessions can run without user escalation and still be forked back into an attended flow.

## What changed
- persist an `unattended` session attribute through session create, fork, and API/frontend types
- make unattended security reviews deny instead of escalate when no user approval path exists
- switch unattended agent completion to explicit `task_done` / `task_failed` outputs
- normalize unattended output-tool history when forking back to attended mode
- disable idle input for unattended sessions while keeping stop available during a running turn
- add regression tests for prompt generation, agent output decoding, fork normalization, and API guards

## Validation
- `uv run pytest tests/test_agent_helpers.py tests/test_agent_loop.py tests/test_proxy_gating.py tests/test_session_engine_core.py tests/test_session_engine_models.py tests/test_server.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes core session lifecycle and security approval behavior (escalate vs deny) and introduces new agent output types that affect persistence, history parsing, and client rendering.
> 
> **Overview**
> Introduces an **`unattended` session attribute** across frontend + backend: sessions can now be created/forked as unattended, and the UI adds a split `NewSessionButton` plus visual indicators for unattended sessions.
> 
> In unattended mode, the agent is instructed to finish via structured `task_done`/`task_failed` outputs; the server persists a `final_status` on assistant events, exposes it in history/WS `done` messages, and the frontend renders a read-only notice for terminal turns.
> 
> Security gating is updated so unattended sessions **deny instead of escalate** when no user approval path exists (including sentinel fallback/batch/credential/push cases). Forking can toggle unattended→attended (but not in-place updates), and engine logic normalizes unattended tool-output history when forking back to attended.
> 
> Frontend disables input for unattended sessions after a real user message (while keeping stop/cancel), adjusts archive/delete confirmations based on `message_count`, and hides archive controls for empty sessions. Tests add coverage for prompts, agent output decoding, API guardrails, history `final_status`, and fork normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 004302d91a5a3ea12eeb5d4f7d2436a69e5c954e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->