### PR TITLE
🐛 fix(ci): add pnpm workspace configuration for sharp and unrs-resolver builds

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS builder
 RUN corepack enable pnpm
 WORKDIR /app
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY . .
 RUN pnpm run build

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  sharp: true
+  unrs-resolver: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk because it only adjusts dependency install/build configuration in the Docker image; main risk is unintended native dependency builds in CI images.
> 
> **Overview**
> Fixes frontend Docker builds by copying `pnpm-workspace.yaml` into the image so `pnpm install` honors workspace configuration.
> 
> Adds `pnpm-workspace.yaml` with `allowBuilds` entries for `sharp` and `unrs-resolver`, enabling these dependencies to build during CI/container installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71ff82f46b5e9daddd8f61c2a5538d022f70b8e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->