### PR TITLE
✨ feat: implement in-place unattended-attended toggles

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,4 +17,3 @@
 - [ ] warn user if deleting a session that has commits not pushed
 - [ ] replace pull / push slash commands (that aren't really tied to the session anyway) with a global indicator how many commits ahead/behind the backend's global repo is compared to the remote repo
 - [ ] speech input
-- [ ] alias setup must be written to the pod. right now an sts restart (externally) bricks aliases.

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -1692,16 +1692,18 @@ export function ChatView({
     }
   }
 
-  async function handleToggleSessionMode(mode: "ask" | "yolo") {
+  async function handleToggleSessionMode(mode: "ask" | "yolo" | "unattended") {
     if (!session || updatingSessionAttribute || deletingSession || !onUpdateSessionAttributes) return;
 
     const nextAttributes: SessionAttributesPatch = mode === "ask"
       ? session.attributes.ask_mode
         ? { ask_mode: false }
         : { ask_mode: true, yolo_mode: false }
-      : session.attributes.yolo_mode
-        ? { yolo_mode: false }
-        : { yolo_mode: true, ask_mode: false };
+      : mode === "yolo"
+        ? session.attributes.yolo_mode
+          ? { yolo_mode: false }
+          : { yolo_mode: true, ask_mode: false }
+        : { unattended: !session.attributes.unattended };
 
     if (Object.entries(nextAttributes).every(([key, value]) => session.attributes[key as keyof SessionAttributesPatch] === value)) {
       return;
@@ -2103,7 +2105,8 @@ export function ChatView({
               {
                 key: "unattended",
                 active: sessionUnattended,
-                disabled: true,
+                disabled: !session || deletingSession || !onUpdateSessionAttributes || updatingSessionAttribute !== null,
+                onClick: () => void handleToggleSessionMode("unattended"),
               },
             ]}
           />

--- a/src/carapace/security/sentinel.py
+++ b/src/carapace/security/sentinel.py
@@ -189,12 +189,18 @@ class Sentinel:
         self._model = model
         self._agent = self._create_agent()
 
-    def set_policy(self, *, ask_mode: bool) -> None:
+    def set_policy(self, *, ask_mode: bool | None = None, unattended: bool | None = None) -> None:
         """Update live mutable policy flags without discarding sentinel conversation state."""
-        if self._ask_mode == ask_mode:
-            return
-        self._ask_mode = ask_mode
-        self._agent = self._create_agent()
+        changed = False
+        if ask_mode is not None and self._ask_mode != ask_mode:
+            self._ask_mode = ask_mode
+            changed = True
+        if unattended is not None and self._unattended != unattended:
+            self._unattended = unattended
+            changed = True
+
+        if changed:
+            self._agent = self._create_agent()
 
     def _load_system_prompt(self, _ctx: RunContext[Path]) -> str:
         return _build_system_prompt(

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -36,6 +36,7 @@ from genai_prices import UpdatePrices
 from loguru import logger
 from pydantic import BaseModel, ValidationError, field_validator, model_validator
 from pydantic_ai.exceptions import UsageLimitExceeded
+from pydantic_ai.messages import ModelMessage
 
 from carapace import get_version
 from carapace.auth import get_token
@@ -1150,6 +1151,7 @@ async def update_session(
 
     next_attributes: SessionAttributes | None = None
     previous_attributes: SessionAttributes | None = None
+    previous_history: list[ModelMessage] | None = None
     archive_changed = False
     archive_now = False
 
@@ -1164,16 +1166,21 @@ async def update_session(
 
         unattended_changed = next_attributes.unattended != state.attributes.unattended
         if unattended_changed:
-            if _engine.is_agent_running(session_id):
-                raise HTTPException(
-                    status_code=409,
-                    detail="Cannot toggle unattended mode while an agent turn is actively running",
-                )
-            if state.attributes.unattended and not next_attributes.unattended:
-                # Transitioning unattended -> attended!
-                history = _engine.session_mgr.load_history(session_id)
-                normalized_history = _engine._normalize_unattended_output_history(history)
-                _engine.session_mgr.save_history(session_id, normalized_history)
+            active = _engine._active.get(session_id)
+            lock = active.lock if active else contextlib.nullcontext()
+            async with lock:
+                if _engine.is_agent_running(session_id):
+                    raise HTTPException(
+                        status_code=409,
+                        detail="Cannot toggle unattended mode while an agent turn is actively running",
+                    )
+                if state.attributes.unattended and not next_attributes.unattended:
+                    # Transitioning unattended -> attended!
+                    history = _engine.session_mgr.load_history(session_id)
+                    previous_history = history
+                    truncated_history = _engine._truncate_incomplete_model_history(history)
+                    normalized_history = _engine._normalize_unattended_output_history(truncated_history)
+                    _engine.session_mgr.save_history(session_id, normalized_history)
 
         archive_changed = next_attributes.archived != state.attributes.archived
         archive_now = next_attributes.archived
@@ -1219,6 +1226,8 @@ async def update_session(
                 state.attributes = previous_attributes
                 _engine.session_mgr.save_state(state)
                 _engine.update_active_state(session_id, attributes=previous_attributes)
+            if previous_history is not None:
+                _engine.session_mgr.save_history(session_id, previous_history)
             if model_changes:
                 state = _engine.update_session_model_overrides(session_id, **previous_models)
             raise

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -1164,10 +1164,16 @@ async def update_session(
 
         unattended_changed = next_attributes.unattended != state.attributes.unattended
         if unattended_changed:
-            raise HTTPException(
-                status_code=409,
-                detail="Cannot change unattended mode in place; fork the session instead",
-            )
+            if _engine.is_agent_running(session_id):
+                raise HTTPException(
+                    status_code=409,
+                    detail="Cannot toggle unattended mode while an agent turn is actively running",
+                )
+            if state.attributes.unattended and not next_attributes.unattended:
+                # Transitioning unattended -> attended!
+                history = _engine.session_mgr.load_history(session_id)
+                normalized_history = _engine._normalize_unattended_output_history(history)
+                _engine.session_mgr.save_history(session_id, normalized_history)
 
         archive_changed = next_attributes.archived != state.attributes.archived
         archive_now = next_attributes.archived

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -671,7 +671,10 @@ class SessionEngine(SessionTurnMixin):
                 yolo_mode=active.state.attributes.yolo_mode,
             )
         if active.sentinel is not None:
-            active.sentinel.set_policy(ask_mode=active.state.attributes.ask_mode)
+            active.sentinel.set_policy(
+                ask_mode=active.state.attributes.ask_mode,
+                unattended=active.state.attributes.unattended,
+            )
 
     def update_active_state(self, session_id: str, **changes: Any) -> None:
         """Apply explicit field updates to the in-memory state for a loaded session."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -766,7 +766,7 @@ def test_update_session_privacy_updates_active_session_state(client, auth_header
     assert active.state.activated_skills == ["demo-skill"]
 
 
-def test_update_session_rejects_unattended_mode_change(client, auth_headers):
+def test_update_session_allows_unattended_mode_change(client, auth_headers):
     create_resp = client.post("/api/sessions", headers=auth_headers)
     sid = create_resp.json()["session_id"]
 
@@ -776,8 +776,17 @@ def test_update_session_rejects_unattended_mode_change(client, auth_headers):
         json={"attributes": {"unattended": True}},
     )
 
-    assert resp.status_code == 409
-    assert "fork the session instead" in resp.json()["detail"]
+    assert resp.status_code == 200
+    assert resp.json()["attributes"]["unattended"] is True
+
+    # Toggle back to False
+    resp = client.patch(
+        f"/api/sessions/{sid}",
+        headers=auth_headers,
+        json={"attributes": {"unattended": False}},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["attributes"]["unattended"] is False
 
 
 def test_update_session_models_updates_active_session_state(client, auth_headers):


### PR DESCRIPTION
Implementing dynamic, in-place toggling between unattended and attended session modes.

### Key Changes
- **Sentinel:** Expanded `set_policy` in [src/carapace/security/sentinel.py](src/carapace/security/sentinel.py) to dynamically update `unattended` on the sentinel agent when changed.
- **Engine Policy:** Handled passing the updated `unattended` flag in `_sync_active_session_policy` inside [src/carapace/session/engine.py](src/carapace/session/engine.py).
- **In-place PATCH Route:** Modified [src/carapace/server.py](src/carapace/server.py) to allow dynamic toggling of the unattended mode on passive/idle active sessions. When switching from `unattended -> attended`, we cleanly normalize complete turn output histories from terminal task states back to conversational text.
- **Frontend Controls:** Unlocked the `unattended` live option tile under [frontend/src/components/chat-view.tsx](frontend/src/components/chat-view.tsx) allowing toggle actions in both directions.
- **Unit Tests:** Updated [tests/test_server.py](tests/test_server.py) with dynamic toggling validation coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables changing `unattended` on existing sessions and rewrites stored model history when switching back to attended, which could affect concurrency and persistence of conversation transcripts if edge cases slip through.
> 
> **Overview**
> Adds **in-place unattended/attended toggling** for sessions via `PATCH /api/sessions/{id}` instead of forcing a fork, with a guard that blocks toggles while an agent turn is running.
> 
> When switching **unattended → attended**, the server now truncates any incomplete model history and normalizes terminal `task_done`/`task_failed` tool output back into conversational assistant text, with rollback support if the update fails. The sentinel policy is updated to react to both `ask_mode` and `unattended` changes without dropping conversation state, and the frontend’s `unattended` option tile is enabled to trigger the new toggle flow. Tests were updated to expect the unattended attribute to be patchable both directions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81dc80cb88d847e182f2014a004ff51260d7645e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->