### PR TITLE
🐛 fix: unknown slash text routing

### DIFF
--- a/src/carapace/channels/matrix/channel.py
+++ b/src/carapace/channels/matrix/channel.py
@@ -499,7 +499,10 @@ class MatrixChannel:
             await self._handle_command(room_id, session_id, body, event.sender)
             return
 
-        # Delegate to SessionEngine
+        await self._submit_user_message(room_id, session_id, body)
+
+    async def _submit_user_message(self, room_id: str, session_id: str, body: str) -> None:
+        """Delegate a Matrix user message to SessionEngine."""
         sub = self._room_subscribers.get(room_id)
         if sub is None:
             sub = MatrixSubscriber(self, room_id)
@@ -571,7 +574,7 @@ class MatrixChannel:
             reply = format_command_result_text(result)
             await self._send_text(room_id, reply)
         else:
-            await self._send_text(room_id, f"Unknown command: `{cmd}`. Type `/help` for a list.")
+            await self._submit_user_message(room_id, session_id, text)
 
     async def _handle_reset(self, room_id: str, old_session_id: str) -> None:
         """Create a new session for this room."""

--- a/src/carapace/server.py
+++ b/src/carapace/server.py
@@ -1987,9 +1987,6 @@ async def chat_ws(
                         )
                     continue
 
-                await _send(websocket, ErrorMessage(detail=f"Unknown command: {user_input.split()[0]}"))
-                continue
-
             # --- Agent turn ---
             await _engine.submit_message(session_id, user_input, origin=sub)
 

--- a/src/carapace/session/titler.py
+++ b/src/carapace/session/titler.py
@@ -33,18 +33,19 @@ async def generate_title(
 ) -> str:
     """Build a short emoji-prefixed title from conversation events.
 
-    Only user and assistant messages are included. User lines that start with
-    ``/`` (slash commands) are skipped. Each line is truncated to 300 characters.
+    Only user and assistant messages are included. User lines followed by a
+    command-result event are skipped. Each line is truncated to 300 characters.
     The joined prompt is capped at ~2000 characters.
     """
     lines: list[str] = []
-    for e in events:
+    for index, e in enumerate(events):
         role = e.get("role")
         content = e.get("content", "")
         if role == "user":
             if not isinstance(content, str):
                 content = str(content)
-            if content.startswith("/"):
+            next_event = events[index + 1] if index + 1 < len(events) else None
+            if content.startswith("/") and isinstance(next_event, dict) and next_event.get("role") == "command":
                 continue
             lines.append(f"User: {content[:300]}")
         elif role == "assistant":

--- a/src/carapace/session/turns.py
+++ b/src/carapace/session/turns.py
@@ -46,14 +46,16 @@ _TURN_CANCELLED_TOOL_MESSAGE = "Tool call was canceled because the turn ended be
 
 
 def _non_slash_user_message_count(events: list[dict[str, Any]]) -> int:
-    """Count user lines that are not slash commands (matches server slash-command routing)."""
-    return sum(
-        1
-        for event in events
-        if event.get("role") == "user"
-        and isinstance(content := event.get("content"), str)
-        and not content.startswith("/")
-    )
+    """Count user lines that were routed to the agent, not command-result echoes."""
+    count = 0
+    for index, event in enumerate(events):
+        if event.get("role") != "user" or not isinstance(content := event.get("content"), str):
+            continue
+        next_event = events[index + 1] if index + 1 < len(events) else None
+        if content.startswith("/") and isinstance(next_event, dict) and next_event.get("role") == "command":
+            continue
+        count += 1
+    return count
 
 
 def _truncate_for_log(text: str, limit: int = 160) -> str:

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -237,20 +237,19 @@ async def test_handle_reset_creates_new_session(tmp_path: Path):
 
 
 @pytest.mark.anyio
-async def test_handle_command_unknown(tmp_path: Path):
+async def test_handle_command_unknown_submits_agent_message(tmp_path: Path):
     ch = _make_channel(tmp_path)
     room_id = "!room:example.com"
     ch._get_or_create_session(room_id)
     ch._client.room_send = AsyncMock(return_value=MagicMock(event_id="$evt1"))
-    # Engine returns None for unknown commands
     ch._engine.handle_slash_command.return_value = None
+    ch._engine.submit_message = AsyncMock()
 
     await ch._handle_command(room_id, ch._room_sessions[room_id], "/foobar", "@alice:example.com")
 
-    # Should have sent an "Unknown command" message
-    ch._client.room_send.assert_called_once()
-    sent_body = ch._client.room_send.call_args[0][2]["body"]
-    assert "Unknown command" in sent_body
+    ch._client.room_send.assert_not_called()
+    ch._engine.submit_message.assert_awaited_once()
+    assert ch._engine.submit_message.await_args.args[:2] == (ch._room_sessions[room_id], "/foobar")
 
 
 @pytest.mark.anyio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1887,13 +1887,38 @@ def test_ws_skills_command(client, auth_headers, bearer):
         assert msg["command"] == "skills"
 
 
-def test_ws_unknown_command(client, auth_headers, bearer):
+def test_ws_unknown_command_is_agent_message(client, auth_headers, bearer, monkeypatch):
     create_resp = client.post("/api/sessions", headers=auth_headers)
     sid = create_resp.json()["session_id"]
 
+    async def _fake_run_turn(
+        user_input: str,
+        _deps: object,
+        message_history: list[object],
+        **_kwargs: object,
+    ) -> tuple[list[object], str, str, str]:
+        assert user_input == "/tmp"
+        return (
+            [
+                *message_history,
+                ModelRequest(parts=[UserPromptPart(content=user_input)]),
+                ModelResponse(parts=[TextPart(content="treated as text")]),
+            ],
+            "treated as text",
+            "",
+            "success",
+        )
+
+    monkeypatch.setattr(srv._engine.sandbox_mgr, "refresh_sandbox_snapshot", AsyncMock())
+    monkeypatch.setattr(srv._engine, "_generate_title", AsyncMock(return_value="title"))
+    monkeypatch.setattr("carapace.session.engine.run_agent_turn", _fake_run_turn)
+
     with client.websocket_connect(f"/api/chat/{sid}?token={bearer}") as ws:
         _consume_status(ws)
-        ws.send_json({"type": "message", "content": "/foobar"})
+        ws.send_json({"type": "message", "content": "/tmp"})
         msg = ws.receive_json()
-        assert msg["type"] == "error"
-        assert "Unknown command" in msg["detail"]
+        assert msg["type"] == "user_message"
+        assert msg["content"] == "/tmp"
+        msg = ws.receive_json()
+        assert msg["type"] == "done"
+        assert msg["content"] == "treated as text"

--- a/tests/test_session_engine_models.py
+++ b/tests/test_session_engine_models.py
@@ -448,11 +448,20 @@ def test_invalid_model_overrides_fall_back_on_restart(tmp_path: Path) -> None:
 
 def test_non_slash_user_message_count_ignores_slash_lines() -> None:
     events: list[dict[str, Any]] = [
-        {"role": "user", "content": "/model-agent openai:gpt-4o"},
-        {"role": "command", "command": "model-agent", "data": {}},
+        {"role": "user", "content": "/model openai:gpt-4o"},
+        {"role": "command", "command": "model", "data": {}},
         {"role": "user", "content": "hello"},
     ]
     assert _non_slash_user_message_count(events) == 1
+
+
+def test_non_slash_user_message_count_includes_unknown_slash_lines() -> None:
+    events: list[dict[str, Any]] = [
+        {"role": "user", "content": "/tmp"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "hello"},
+    ]
+    assert _non_slash_user_message_count(events) == 2
 
 
 def test_non_slash_user_message_count_plain_users() -> None:

--- a/tests/test_titler.py
+++ b/tests/test_titler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -11,10 +12,11 @@ from carapace.session.titler import generate_title
 
 @pytest.mark.asyncio
 async def test_generate_title_skips_slash_user_and_truncates() -> None:
-    """Slash user lines are omitted; user and assistant bodies are capped at 300 chars."""
+    """Command-result echoes are omitted; user and assistant bodies are capped at 300 chars."""
     long = "x" * 400
-    events: list[dict[str, str]] = [
-        {"role": "user", "content": "/memory"},
+    events: list[dict[str, Any]] = [
+        {"role": "user", "content": "/model openai:gpt-4o"},
+        {"role": "command", "command": "model", "data": {}},
         {"role": "user", "content": long},
         {"role": "assistant", "content": "ok"},
     ]
@@ -39,6 +41,34 @@ async def test_generate_title_skips_slash_user_and_truncates() -> None:
     assert out == "📌 t"
     assert len(prompts) == 1
     body = prompts[0]
-    assert "/memory" not in body
+    assert "/model" not in body
     assert "x" * 300 in body
     assert "x" * 301 not in body
+
+
+@pytest.mark.asyncio
+async def test_generate_title_includes_unknown_slash_message() -> None:
+    events: list[dict[str, str]] = [
+        {"role": "user", "content": "/tmp"},
+        {"role": "assistant", "content": "ok"},
+    ]
+    prompts: list[str] = []
+
+    async def _fake_run(*args: object, **_kw: object) -> MagicMock:
+        prompt = str(args[0]) if args else ""
+        prompts.append(prompt)
+        m = MagicMock()
+        m.output = "📌 t"
+        m.usage = MagicMock(return_value=MagicMock())
+        return m
+
+    with patch("carapace.session.titler.Agent") as agent_cls:
+        inst = MagicMock()
+        inst.run = AsyncMock(side_effect=_fake_run)
+        agent_cls.return_value = inst
+        out = await generate_title(
+            events, model="anthropic:claude-3-5-haiku-latest", model_factory=lambda _m: MagicMock()
+        )
+
+    assert out == "📌 t"
+    assert "User: /tmp" in prompts[0]


### PR DESCRIPTION
Unknown slash-prefixed input such as `/tmp` should be handled as normal user text instead of returning `Unknown command`.

Summary:
- Fall through to normal agent message handling when WebSocket slash command lookup returns no command result.
- Apply the same fallback in the Matrix channel.
- Update title generation and first-turn counting to skip only persisted command-result echoes, while keeping unknown slash text eligible as user messages.
- Cover the behavior with WebSocket, Matrix, transcript-counting, and titler tests.

Verification:
- `uv run pytest tests/test_server.py::test_ws_unknown_command_is_agent_message tests/test_server.py::test_ws_help_command tests/test_matrix.py::test_handle_command_unknown_submits_agent_message tests/test_matrix.py::test_handle_command_help tests/test_session_engine_models.py::test_non_slash_user_message_count_ignores_slash_lines tests/test_session_engine_models.py::test_non_slash_user_message_count_includes_unknown_slash_lines tests/test_titler.py`
- `uvx ruff check src/carapace/server.py src/carapace/channels/matrix/channel.py src/carapace/session/turns.py src/carapace/session/titler.py tests/test_server.py tests/test_matrix.py tests/test_session_engine_models.py tests/test_titler.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes slash-command routing in both WebSocket chat and the Matrix channel so unknown `/...` inputs now trigger agent turns instead of returning errors, which could alter user expectations and increase agent invocations.
> 
> **Overview**
> Unknown slash-prefixed inputs (e.g. `/tmp`) are no longer rejected as “Unknown command”; when `handle_slash_command` returns no result, the WebSocket chat loop and Matrix channel now fall through to normal `submit_message` agent handling.
> 
> Title generation and the “first/third user message” counter are updated to skip only *persisted* slash-command echoes (a `user` event immediately followed by a `command` event), ensuring unknown slash text still contributes to titling/turn counting. Tests are updated/added to cover the new fallback behavior across WebSocket, Matrix, titler, and transcript counting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd0f8a69359d030053e7e4d3a9a033f5f8212720. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->