### PR TITLE
✨ User Support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Required
 ANTHROPIC_API_KEY=sk-ant-...
-CARAPACE_TOKEN=pick-a-secret-bearer-token
+CARAPACE_TOKEN=pick-a-secret-admin-token
 
 # Optional — LLM providers
 # GOOGLE_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Required
 ANTHROPIC_API_KEY=sk-ant-...
-CARAPACE_TOKEN=pick-a-secret-admin-token
+CARAPACE_TOKEN=pick-a-bootstrap-admin-password
 
 # Optional — LLM providers
 # GOOGLE_API_KEY=

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ See [docs/security.md](docs/security.md), [docs/credentials.md](docs/credentials
 ```bash
 cp .env.example .env
 # fill in ANTHROPIC_API_KEY and CARAPACE_TOKEN
-# CARAPACE_TOKEN is the admin/bootstrap token, not the normal app login
+# CARAPACE_TOKEN is only the initial password for the bootstrap admin user
 
 docker compose build
 docker compose up -d
@@ -137,10 +137,7 @@ This starts:
 Optional CLI connection:
 
 ```bash
-curl -X POST http://localhost:8321/api/admin/users \
-  -H "Authorization: Bearer $CARAPACE_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"username":"thies","password":"change-me","display_name":"Thies"}'
+# First login to the web UI as admin with CARAPACE_TOKEN, then create your normal user.
 
 uv run carapace --user thies --password change-me
 ```

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ See [docs/security.md](docs/security.md), [docs/credentials.md](docs/credentials
 ```bash
 cp .env.example .env
 # fill in ANTHROPIC_API_KEY and CARAPACE_TOKEN
+# CARAPACE_TOKEN is the admin/bootstrap token, not the normal app login
 
 docker compose build
 docker compose up -d
@@ -136,12 +137,19 @@ This starts:
 Optional CLI connection:
 
 ```bash
-uv run carapace --token "$CARAPACE_TOKEN"
+curl -X POST http://localhost:8321/api/admin/users \
+  -H "Authorization: Bearer $CARAPACE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"thies","password":"change-me","display_name":"Thies"}'
+
+uv run carapace --user thies --password change-me
 ```
+
+The web UI uses the same username/password login and stores the session in an HttpOnly cookie.
 
 You can use whichever LLM backend fits your setup: hosted APIs, self-hosted `vllm`, `llama.cpp`, LM Studio, or anything else that exposes a compatible endpoint.
 
-For the full Docker Compose setup, model configuration, credential backends, Matrix integration, and knowledge-repo configuration, see [docs/quickstart.md](docs/quickstart.md). For Kubernetes deployment, see [docs/kubernetes.md](docs/kubernetes.md) and [charts/carapace/README.md](charts/carapace/README.md).
+For the full Docker Compose setup, auth model, model configuration, credential backends, Matrix integration, and knowledge-repo configuration, see [docs/quickstart.md](docs/quickstart.md) and [docs/auth.md](docs/auth.md). For Kubernetes deployment, see [docs/kubernetes.md](docs/kubernetes.md) and [charts/carapace/README.md](charts/carapace/README.md).
 
 ## Architecture
 

--- a/charts/carapace/README.md
+++ b/charts/carapace/README.md
@@ -27,11 +27,11 @@ Helm chart for deploying [carapace](https://github.com/thiesgerken/carapace) on 
 The chart is published to GHCR as an OCI artifact on every release:
 
 ```bash
-# Create the namespace and a secret with your API key and admin token
+# Create the namespace and a secret with your API key and bootstrap admin password
 kubectl create namespace carapace
 kubectl create secret generic carapace-secrets -n carapace \
   --from-literal=ANTHROPIC_API_KEY=sk-ant-... \
-  --from-literal=CARAPACE_TOKEN=my-secret-admin-token
+  --from-literal=CARAPACE_TOKEN=my-bootstrap-admin-password
 
 # Install from OCI registry
 helm install carapace oci://ghcr.io/thiesgerken/charts/carapace \
@@ -81,7 +81,7 @@ All images default to the chart's `appVersion` tag, which is kept in sync with t
 
 | What                   | How                                                                                                                         |
 | ---------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| **Admin token**        | Set `CARAPACE_TOKEN` in the Secret referenced via `envFrom`. It is only used for bootstrap/admin user-management API calls. |
+| **Bootstrap password** | Set `CARAPACE_TOKEN` in the Secret referenced via `envFrom`. It is only used as the initial password for the bootstrap `admin` user. |
 | **Anthropic API key**  | Set `ANTHROPIC_API_KEY` in the same Secret.                                                                                 |
 | **Ingress hostname**   | `--set ingress.hostname=carapace.example.com`                                                                               |
 | **Gateway parent ref** | `--set ingress.parentRefs[0].name=my-gateway` (defaults to `default-gateway`)                                               |

--- a/charts/carapace/README.md
+++ b/charts/carapace/README.md
@@ -81,7 +81,7 @@ All images default to the chart's `appVersion` tag, which is kept in sync with t
 
 | What                   | How                                                                                                                         |
 | ---------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| **Bootstrap password** | Set `CARAPACE_TOKEN` in the Secret referenced via `envFrom`. It is only used as the initial password for the bootstrap `admin` user. |
+| **Bootstrap password** | Set `CARAPACE_TOKEN` in the Secret referenced via `envFrom`. It is only used as the initial password for the bootstrap `admin` user when no enabled admin user exists. |
 | **Anthropic API key**  | Set `ANTHROPIC_API_KEY` in the same Secret.                                                                                 |
 | **Ingress hostname**   | `--set ingress.hostname=carapace.example.com`                                                                               |
 | **Gateway parent ref** | `--set ingress.parentRefs[0].name=my-gateway` (defaults to `default-gateway`)                                               |

--- a/charts/carapace/README.md
+++ b/charts/carapace/README.md
@@ -27,11 +27,11 @@ Helm chart for deploying [carapace](https://github.com/thiesgerken/carapace) on 
 The chart is published to GHCR as an OCI artifact on every release:
 
 ```bash
-# Create the namespace and a secret with your API key and bearer token
+# Create the namespace and a secret with your API key and admin token
 kubectl create namespace carapace
 kubectl create secret generic carapace-secrets -n carapace \
   --from-literal=ANTHROPIC_API_KEY=sk-ant-... \
-  --from-literal=CARAPACE_TOKEN=my-secret-token
+  --from-literal=CARAPACE_TOKEN=my-secret-admin-token
 
 # Install from OCI registry
 helm install carapace oci://ghcr.io/thiesgerken/charts/carapace \
@@ -79,12 +79,12 @@ All images default to the chart's `appVersion` tag, which is kept in sync with t
 
 ### Required configuration
 
-| What                   | How                                                                                                                            |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| **API bearer token**   | Set `CARAPACE_TOKEN` in the Secret referenced via `envFrom`. Both the server and CLI/frontend clients must use the same token. |
-| **Anthropic API key**  | Set `ANTHROPIC_API_KEY` in the same Secret.                                                                                    |
-| **Ingress hostname**   | `--set ingress.hostname=carapace.example.com`                                                                                  |
-| **Gateway parent ref** | `--set ingress.parentRefs[0].name=my-gateway` (defaults to `default-gateway`)                                                  |
+| What                   | How                                                                                                                         |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| **Admin token**        | Set `CARAPACE_TOKEN` in the Secret referenced via `envFrom`. It is only used for bootstrap/admin user-management API calls. |
+| **Anthropic API key**  | Set `ANTHROPIC_API_KEY` in the same Secret.                                                                                 |
+| **Ingress hostname**   | `--set ingress.hostname=carapace.example.com`                                                                               |
+| **Gateway parent ref** | `--set ingress.parentRefs[0].name=my-gateway` (defaults to `default-gateway`)                                               |
 
 ### Injecting secrets and environment variables
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,7 +98,7 @@ flowchart TD
 
 ### FastAPI Server
 
-The HTTP/WebSocket entry point. `src/carapace/server/__init__.py` is the public facade that exposes `app`, `sandbox_app`, and `main`, owns process startup/shutdown wiring, and keeps shared runtime state for compatibility with tests and route modules. Routes are split into focused modules: `server/auth.py` for bearer and WebSocket auth dependencies, `server/notifications.py` for notification and presence endpoints, `server/websocket.py` for chat WebSocket and small web-facing metadata routes, and `server/state.py` for accessing the mutable facade state from extracted routes.
+The HTTP/WebSocket entry point. `src/carapace/server/__init__.py` is the public facade that exposes `app`, `sandbox_app`, and `main`, owns process startup/shutdown wiring, and keeps shared runtime state for compatibility with tests and route modules. Routes are split into focused modules: `server/auth.py` for cookie-session auth and admin user-management routes, `server/notifications.py` for notification and presence endpoints, `server/websocket.py` for chat WebSocket and small web-facing metadata routes, and `server/state.py` for accessing the mutable facade state from extracted routes.
 
 ### Session Engine
 
@@ -168,7 +168,7 @@ This map describes the Python modules under `src/carapace/`. It is meant as a na
 | -------------- | --------------------------------------------------------------------------------------------- |
 | `__init__.py`  | Package version helper (`get_version`).                                                       |
 | `__main__.py`  | `python -m carapace` entry point; delegates to the server CLI entry point.                    |
-| `auth.py`      | Bearer token generation/loading used by API clients.                                          |
+| `auth.py`      | File-backed users, password hashing, signed session cookies, and admin token loading.         |
 | `bootstrap.py` | First-run data and knowledge directory seeding, including bundled knowledge files and skills. |
 | `cache.py`     | In-memory cache for paginated session-list responses.                                         |
 | `cli.py`       | Thin terminal client for REST and WebSocket session interaction.                              |
@@ -274,7 +274,7 @@ This map describes the Python modules under `src/carapace/`. It is meant as a na
 | Module                    | Responsibility                                                                                                                        |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `server/__init__.py`      | FastAPI app facade, startup/shutdown lifecycle, shared state, REST routes not yet split out, internal API, sandbox API, and `main()`. |
-| `server/auth.py`          | Bearer-token and WebSocket-token FastAPI dependencies.                                                                                |
+| `server/auth.py`          | Login/logout, cookie-session FastAPI dependencies, WebSocket auth, and admin user-management routes.                                  |
 | `server/notifications.py` | Notification subscription, test, and presence routes.                                                                                 |
 | `server/state.py`         | Helper for extracted route modules to access the mutable `carapace.server` facade.                                                    |
 | `server/websocket.py`     | Chat WebSocket route, `WebSocketSubscriber`, and small web-facing metadata/model routes.                                              |
@@ -317,7 +317,7 @@ carapace runs three separate listener ports for security isolation:
 
 | Port                | Bind address | Auth                                 | Purpose                                                                               |
 | ------------------- | ------------ | ------------------------------------ | ------------------------------------------------------------------------------------- |
-| 8321 (public API)   | `0.0.0.0`    | Bearer token                         | REST API, WebSocket — used by the frontend and CLI                                    |
+| 8321 (public API)   | `0.0.0.0`    | HttpOnly session cookie              | REST API, WebSocket — used by the frontend and CLI                                    |
 | 8322 (sandbox API)  | `0.0.0.0`    | HTTP Basic Auth (`session_id:token`) | Git HTTP backend + credential endpoints (`/credentials`) — used by sandbox containers |
 | 8320 (internal API) | `127.0.0.1`  | None (loopback only)                 | Sentinel callback — used by the pre-receive hook                                      |
 | 3128 (proxy)        | `0.0.0.0`    | Proxy-Authorization Basic Auth       | HTTP forward proxy — used by sandbox containers for outbound traffic                  |
@@ -392,7 +392,7 @@ services:
 
 For Kubernetes deployments, the Docker socket is replaced by in-cluster Kubernetes API access — see [kubernetes.md](kubernetes.md).
 
-The `$CARAPACE_DATA_DIR` environment variable (defaults to `./data`) points to the runtime data directory. Runtime state such as `config.yaml`, session files, notification state, and `jobs.yaml` lives there. The Git-backed knowledge repo lives in a separate `knowledge_dir` (default `./knowledge` relative to the config file, which resolves to `data/knowledge/` in the default setup).
+The `$CARAPACE_DATA_DIR` environment variable (defaults to `./data`) points to the runtime data directory. Runtime state such as `config.yaml`, auth files, session files, notification state, and `jobs.yaml` lives there. The Git-backed knowledge repo lives in a separate `knowledge_dir` (default `./knowledge` relative to the config file, which resolves to `data/knowledge/` in the default setup).
 
 ## Configuration
 
@@ -444,6 +444,15 @@ sessions:
 notifications:
   enabled: true
   presence_ttl_seconds: 60
+
+auth:
+  cookie:
+    name: carapace_session
+    ttl_seconds: 1209600
+    secure: false
+    same_site: lax
+  admin_token:
+    env: CARAPACE_TOKEN
 
 git:
   remote: https://gitea.example.com/user/knowledge.git

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -168,7 +168,7 @@ This map describes the Python modules under `src/carapace/`. It is meant as a na
 | -------------- | --------------------------------------------------------------------------------------------- |
 | `__init__.py`  | Package version helper (`get_version`).                                                       |
 | `__main__.py`  | `python -m carapace` entry point; delegates to the server CLI entry point.                    |
-| `auth.py`      | File-backed users, password hashing, signed session cookies, and admin token loading.         |
+| `auth.py`      | File-backed users, password hashing, signed session cookies, and bootstrap admin handling.    |
 | `bootstrap.py` | First-run data and knowledge directory seeding, including bundled knowledge files and skills. |
 | `cache.py`     | In-memory cache for paginated session-list responses.                                         |
 | `cli.py`       | Thin terminal client for REST and WebSocket session interaction.                              |
@@ -451,8 +451,6 @@ auth:
     ttl_seconds: 1209600
     secure: false
     same_site: lax
-  admin_token:
-    env: CARAPACE_TOKEN
 
 git:
   remote: https://gitea.example.com/user/knowledge.git

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -47,7 +47,7 @@ Usernames are normalized to lowercase and should be stable, hand-picked names fo
 
 Set `CARAPACE_TOKEN` to a random bootstrap password in the server environment, then start the server. If `auth/users.yaml` does not contain an `admin` user, carapace creates one with the `admin` role and this password. The password must be at least 16 characters long. If it is missing or too short while the bootstrap user is needed, the server exits and prints a suggested 24-character replacement.
 
-Log in as `admin` with that bootstrap password. In **Settings**, admin users see a **Platform** group with a **Users** tab. The users panel can create users, edit passwords and profile fields, enable or disable users, and assign existing single-user data to a selected user.
+Log in as `admin` with that bootstrap password. In **Settings**, admin users see an **Admin** group with a **Users** tab. The users panel can create users, edit passwords and profile fields, enable or disable users, and assign existing single-user data to a selected user.
 
 You can also create users through the admin API after logging in and storing the session cookie:
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -47,7 +47,7 @@ Usernames are normalized to lowercase and should be stable, hand-picked names fo
 
 Set `CARAPACE_TOKEN` to a random bootstrap password in the server environment, then start the server. If `auth/users.yaml` does not contain an `admin` user, carapace creates one with the `admin` role and this password. The password must be at least 16 characters long. If it is missing or too short while the bootstrap user is needed, the server exits and prints a suggested 24-character replacement.
 
-Log in as `admin` with that bootstrap password. In **Settings** → **Preferences**, admin users see a **Manage users** button. The admin users page can create users, edit passwords and profile fields, enable or disable users, and assign existing single-user data to a selected user.
+Log in as `admin` with that bootstrap password. In **Settings**, admin users see a **Platform** group with a **Users** tab. The users panel can create users, edit passwords and profile fields, enable or disable users, and assign existing single-user data to a selected user.
 
 You can also create users through the admin API after logging in and storing the session cookie:
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -45,7 +45,11 @@ Usernames are normalized to lowercase and should be stable, hand-picked names fo
 
 ## Creating Users
 
-Set `CARAPACE_TOKEN` to a random admin token in the server environment, start the server, then create users through the admin API:
+Set `CARAPACE_TOKEN` to a random admin token in the server environment, then start the server. The token must be at least 16 characters long. If it is missing or too short, the server exits and prints a suggested 24-character replacement token.
+
+Open the web UI, follow **Manage users** on the login screen, and enter the server URL plus `CARAPACE_TOKEN`. The admin users page can create users, edit passwords and profile fields, enable or disable users, and assign existing single-user data to a selected user.
+
+You can also create users through the admin API:
 
 ```bash
 curl -X POST http://localhost:8321/api/admin/users \
@@ -89,4 +93,4 @@ For an existing single-user instance, run:
 uv run carapace upgrade-data --user thies --data-dir data
 ```
 
-This creates a disabled placeholder user if needed, adds ownership metadata to sessions/jobs/notifications, moves `knowledge` to `knowledges/<user>`, and converts `matrix_token.json` and `sandbox_tokens.json` to YAML files with user fields. Set a real password through the admin API before using that user for normal login.
+This creates a disabled placeholder user if needed, adds ownership metadata to sessions/jobs/notifications, moves `knowledge` to `knowledges/<user>`, and converts `matrix_token.json` and `sandbox_tokens.json` to YAML files with user fields. Set a real password through the admin UI or admin API before using that user for normal login.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,6 +1,6 @@
 # Authentication
 
-carapace uses file-backed users and HttpOnly session cookies for the web UI, CLI, REST, WebSocket API, and admin API. `CARAPACE_TOKEN` is only used as the initial password for the bootstrap `admin` user when that user does not exist yet.
+carapace uses file-backed users and HttpOnly session cookies for the web UI, CLI, REST, WebSocket API, and admin API. `CARAPACE_TOKEN` is only used as the initial password for the bootstrap `admin` user when no enabled admin user exists yet.
 
 ## Files
 
@@ -45,9 +45,9 @@ Usernames are normalized to lowercase and should be stable, hand-picked names fo
 
 ## Creating Users
 
-Set `CARAPACE_TOKEN` to a random bootstrap password in the server environment, then start the server. If `auth/users.yaml` does not contain an `admin` user, carapace creates one with the `admin` role and this password. The password must be at least 16 characters long. If it is missing or too short while the bootstrap user is needed, the server exits and prints a suggested 24-character replacement.
+Set `CARAPACE_TOKEN` to a random bootstrap password in the server environment, then start the server. If `auth/users.yaml` does not contain any enabled user with the `admin` role, carapace creates an `admin` user with this password. The password must be at least 16 characters long. If it is missing or too short while the bootstrap user is needed, the server exits and prints a suggested 24-character replacement.
 
-Log in as `admin` with that bootstrap password. In **Settings**, admin users see an **Admin** group with a **Users** tab. The users panel can create users, edit passwords and profile fields, enable or disable users, and assign existing single-user data to a selected user.
+Log in as `admin` with that bootstrap password. In **Settings**, admin users see an **Admin** group with a **Users** tab. There is no standalone admin portal; user management lives inside Settings. The users panel can create users, edit passwords and profile fields, enable or disable users, and assign existing single-user data to a selected user.
 
 You can also create users through the admin API after logging in and storing the session cookie:
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,6 +1,6 @@
 # Authentication
 
-carapace uses file-backed users and HttpOnly session cookies for the normal web, CLI, REST, and WebSocket API. The old `CARAPACE_TOKEN` bearer token is no longer accepted by normal app endpoints. It remains an admin/bootstrap token for user management only.
+carapace uses file-backed users and HttpOnly session cookies for the web UI, CLI, REST, WebSocket API, and admin API. `CARAPACE_TOKEN` is only used as the initial password for the bootstrap `admin` user when that user does not exist yet.
 
 ## Files
 
@@ -45,15 +45,19 @@ Usernames are normalized to lowercase and should be stable, hand-picked names fo
 
 ## Creating Users
 
-Set `CARAPACE_TOKEN` to a random admin token in the server environment, then start the server. The token must be at least 16 characters long. If it is missing or too short, the server exits and prints a suggested 24-character replacement token.
+Set `CARAPACE_TOKEN` to a random bootstrap password in the server environment, then start the server. If `auth/users.yaml` does not contain an `admin` user, carapace creates one with the `admin` role and this password. The password must be at least 16 characters long. If it is missing or too short while the bootstrap user is needed, the server exits and prints a suggested 24-character replacement.
 
-Open the web UI, follow **Manage users** on the login screen, and enter the server URL plus `CARAPACE_TOKEN`. The admin users page can create users, edit passwords and profile fields, enable or disable users, and assign existing single-user data to a selected user.
+Log in as `admin` with that bootstrap password. In **Settings** → **Preferences**, admin users see a **Manage users** button. The admin users page can create users, edit passwords and profile fields, enable or disable users, and assign existing single-user data to a selected user.
 
-You can also create users through the admin API:
+You can also create users through the admin API after logging in and storing the session cookie:
 
 ```bash
+curl -c carapace.cookies -X POST http://localhost:8321/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","password":"'"$CARAPACE_TOKEN"'"}'
+
 curl -X POST http://localhost:8321/api/admin/users \
-  -H "Authorization: Bearer $CARAPACE_TOKEN" \
+  -b carapace.cookies \
   -H "Content-Type: application/json" \
   -d '{"username":"thies","password":"change-me","display_name":"Thies"}'
 ```

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,92 @@
+# Authentication
+
+carapace uses file-backed users and HttpOnly session cookies for the normal web, CLI, REST, and WebSocket API. The old `CARAPACE_TOKEN` bearer token is no longer accepted by normal app endpoints. It remains an admin/bootstrap token for user management only.
+
+## Files
+
+Auth state lives under `$CARAPACE_DATA_DIR/auth/`:
+
+| File             | Purpose                                                                |
+| ---------------- | ---------------------------------------------------------------------- |
+| `users.yaml`     | Stable local users, password hashes, roles, and user config references |
+| `sessions.yaml`  | Server-side session records used for logout and revocation             |
+| `session_secret` | HMAC signing secret for browser/CLI session JWT cookies                |
+
+One `users.yaml` entry looks like this:
+
+```yaml
+version: 1
+users:
+  thies:
+    password_hash: "$argon2id$v=19$..."
+    enabled: true
+    token_version: 1
+    display_name: Thies
+    email: thies@example.com
+    roles: []
+    created_at: "2026-05-24T12:00:00Z"
+    updated_at: "2026-05-24T12:00:00Z"
+    password_changed_at: "2026-05-24T12:00:00Z"
+    last_login_at: null
+    config:
+      credentials: {}
+      channels:
+        matrix:
+          enabled: false
+      git: {}
+      default_models:
+        agent: anthropic:claude-sonnet-4-6
+        sentinel: anthropic:claude-haiku-4-5
+        title: anthropic:claude-haiku-4-5
+      budgets: {}
+```
+
+Usernames are normalized to lowercase and should be stable, hand-picked names for the self-hosted users of an instance.
+
+## Creating Users
+
+Set `CARAPACE_TOKEN` to a random admin token in the server environment, start the server, then create users through the admin API:
+
+```bash
+curl -X POST http://localhost:8321/api/admin/users \
+  -H "Authorization: Bearer $CARAPACE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"thies","password":"change-me","display_name":"Thies"}'
+```
+
+The web UI logs in with username and password. The CLI does the same:
+
+```bash
+uv run carapace --user thies --password change-me
+```
+
+You can also set `CARAPACE_USER` and `CARAPACE_PASSWORD` for the CLI.
+
+## Session Cookies
+
+`POST /api/auth/login` verifies the password, creates a server-side session in `auth/sessions.yaml`, and sets the `carapace_session` HttpOnly cookie. The cookie contains a signed JWT with the username, session id, expiry, and token version. The server still checks the session file and user record on every request, so logout and disabled users take effect without waiting for cookie expiry.
+
+`POST /api/auth/logout` revokes the server-side session and deletes the cookie.
+
+Changing a password increments `token_version`, which invalidates older cookies for that user.
+
+## Owned Data
+
+User ownership is stored close to existing runtime files instead of changing the main directory structure:
+
+- `sessions/<session_id>/meta.yaml` contains `user: <username>`.
+- `jobs.yaml` job entries contain optional `user`.
+- notification subscription YAML files contain optional `user`.
+- legacy records without a user still parse, but authenticated app APIs hide them until migration assigns an owner.
+
+The knowledge repo migration moves `data/knowledge` to `data/knowledges/<username>`. Runtime use of per-user knowledge directories is tracked separately from this first auth/storage migration.
+
+## Upgrading Existing Data
+
+For an existing single-user instance, run:
+
+```bash
+uv run carapace upgrade-data --user thies --data-dir data
+```
+
+This creates a disabled placeholder user if needed, adds ownership metadata to sessions/jobs/notifications, moves `knowledge` to `knowledges/<user>`, and converts `matrix_token.json` and `sandbox_tokens.json` to YAML files with user fields. Set a real password through the admin API before using that user for normal login.

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -148,8 +148,13 @@ Job-linked sessions also show recent job metadata in the chat view.
 Example manual run:
 
 ```bash
+curl -c carapace-cookie.jar \
+  -H "Content-Type: application/json" \
+  http://localhost:8321/api/auth/login \
+  -d '{"username":"thies","password":"change-me"}'
+
 curl -X POST \
-  -H "Authorization: Bearer $CARAPACE_TOKEN" \
+  -b carapace-cookie.jar \
   -H "Content-Type: application/json" \
   http://localhost:8321/api/jobs/morning-briefing/run \
   -d '{"data":"Focus on production incidents only."}'

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -12,11 +12,11 @@ carapace supports Kubernetes as a sandbox runtime. Instead of Docker containers,
 ## Quick start
 
 ```bash
-# 1. Create a secret with your API key and bearer token (or use an ExternalSecret / SealedSecret)
+# 1. Create a secret with your API key and admin token (or use an ExternalSecret / SealedSecret)
 kubectl create namespace carapace
 kubectl create secret generic carapace-secrets -n carapace \
   --from-literal=ANTHROPIC_API_KEY=sk-ant-... \
-  --from-literal=CARAPACE_TOKEN=my-secret-token
+  --from-literal=CARAPACE_TOKEN=my-secret-admin-token
 
 # 2. Install from OCI registry, referencing the secret
 helm install carapace oci://ghcr.io/thiesgerken/charts/carapace \

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -12,11 +12,11 @@ carapace supports Kubernetes as a sandbox runtime. Instead of Docker containers,
 ## Quick start
 
 ```bash
-# 1. Create a secret with your API key and admin token (or use an ExternalSecret / SealedSecret)
+# 1. Create a secret with your API key and bootstrap admin password (or use an ExternalSecret / SealedSecret)
 kubectl create namespace carapace
 kubectl create secret generic carapace-secrets -n carapace \
   --from-literal=ANTHROPIC_API_KEY=sk-ant-... \
-  --from-literal=CARAPACE_TOKEN=my-secret-admin-token
+  --from-literal=CARAPACE_TOKEN=my-bootstrap-admin-password
 
 # 2. Install from OCI registry, referencing the secret
 helm install carapace oci://ghcr.io/thiesgerken/charts/carapace \

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -30,7 +30,8 @@ Push subscriptions are stored as YAML files at `$CARAPACE_DATA_DIR/notifications
 Each subscription records:
 
 - `id`
-- `owner_key`
+- `user`
+- `owner_key` (legacy, optional)
 - `device_name`
 - `endpoint`
 - `p256dh`
@@ -40,7 +41,7 @@ Each subscription records:
 - `last_heartbeat`
 - `expires_at`
 
-`owner_key` is derived from the authenticated bearer token in v1. That means subscriptions are currently grouped by `CARAPACE_TOKEN`, not by a separate user id. If you rotate the token, clients need to subscribe again.
+`user` is the normalized authenticated username. Legacy subscriptions with only `owner_key` still parse, but normal authenticated APIs list and update subscriptions owned by the current user.
 
 Default per-device preferences:
 
@@ -154,7 +155,7 @@ VAPID behavior:
 
 ## API
 
-Notification subscription and presence endpoints use the same bearer token auth as the rest of the server.
+Notification subscription and presence endpoints use the same `carapace_session` cookie auth as the rest of the server.
 
 ### Public config
 

--- a/docs/plans/images.md
+++ b/docs/plans/images.md
@@ -98,7 +98,7 @@ The `images` key is only present when images exist (backward compatible). The hi
 | Method | Path                                   | Purpose                                                                                       |
 | ------ | -------------------------------------- | --------------------------------------------------------------------------------------------- |
 | `POST` | `/api/sessions/{id}/images`            | Multipart upload; validates file type + size (20 MB cap); returns `{ images: [{ id, url }] }` |
-| `GET`  | `/api/sessions/{id}/images/{image_id}` | Serve stored image with correct `Content-Type`; bearer auth                                   |
+| `GET`  | `/api/sessions/{id}/images/{image_id}` | Serve stored image with correct `Content-Type`; session-cookie auth                           |
 
 Session cleanup: no changes needed — existing `DELETE /api/sessions/{id}` removes the session directory.
 
@@ -128,7 +128,7 @@ Session cleanup: no changes needed — existing `DELETE /api/sessions/{id}` remo
 
 **`frontend/src/lib/api.ts`**:
 
-- `uploadImages(sessionId, files): Promise<ImageRef[]>` — `FormData` upload with bearer auth
+- `uploadImages(sessionId, files): Promise<ImageRef[]>` — `FormData` upload with session-cookie auth
 - `imageUrl(sessionId, imageId): string` — construct serving URL
 
 **`frontend/src/lib/types.ts`**:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,7 +18,7 @@ Fill in the required values:
 ```env
 # Required
 ANTHROPIC_API_KEY=sk-ant-...
-CARAPACE_TOKEN=pick-a-secret-admin-token
+CARAPACE_TOKEN=pick-a-secret-admin-token-with-16-plus-chars
 
 # Optional — uncomment if needed
 # GOOGLE_API_KEY=...
@@ -26,7 +26,7 @@ CARAPACE_TOKEN=pick-a-secret-admin-token
 # CARAPACE_GIT_TOKEN=...
 ```
 
-`CARAPACE_TOKEN` is the admin/bootstrap token for managing users. Normal web UI, CLI, REST, and WebSocket access uses username/password login and an HttpOnly session cookie.
+`CARAPACE_TOKEN` is the admin/bootstrap token for managing users and must be at least 16 characters long. Normal web UI, CLI, REST, and WebSocket access uses username/password login and an HttpOnly session cookie.
 
 ## 2. Build and start
 
@@ -42,7 +42,7 @@ This starts:
 - **Redis** for mandatory session-list caching
 - **Sandbox image** is built automatically
 
-Create the first user with the admin token:
+Create the first user in the web UI by opening **Manage users** on the login screen, entering the server URL and admin token, and creating a user. You can also use the admin API:
 
 ```bash
 curl -X POST http://localhost:8321/api/admin/users \
@@ -144,7 +144,7 @@ If you already have data from a pre-user-auth version, assign it to a stable use
 uv run carapace upgrade-data --user thies --data-dir data
 ```
 
-The upgrade command adds ownership metadata to sessions, jobs, and notifications, moves `data/knowledge` to `data/knowledges/thies`, and converts Matrix/sandbox token JSON files to YAML with `user` fields. It creates a disabled placeholder user when needed; set a password through the admin API before logging in.
+The upgrade command adds ownership metadata to sessions, jobs, and notifications, moves `data/knowledge` to `data/knowledges/thies`, and converts Matrix/sandbox token JSON files to YAML with `user` fields. It creates a disabled placeholder user when needed; set a password through the admin UI or admin API before logging in.
 
 ## 6. Connect Matrix (optional)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,7 +18,7 @@ Fill in the required values:
 ```env
 # Required
 ANTHROPIC_API_KEY=sk-ant-...
-CARAPACE_TOKEN=pick-a-secret-bearer-token
+CARAPACE_TOKEN=pick-a-secret-admin-token
 
 # Optional — uncomment if needed
 # GOOGLE_API_KEY=...
@@ -26,7 +26,7 @@ CARAPACE_TOKEN=pick-a-secret-bearer-token
 # CARAPACE_GIT_TOKEN=...
 ```
 
-`CARAPACE_TOKEN` is the bearer token that authenticates CLI, web UI, and Matrix connections to the server. Pick any random string.
+`CARAPACE_TOKEN` is the admin/bootstrap token for managing users. Normal web UI, CLI, REST, and WebSocket access uses username/password login and an HttpOnly session cookie.
 
 ## 2. Build and start
 
@@ -42,13 +42,26 @@ This starts:
 - **Redis** for mandatory session-list caching
 - **Sandbox image** is built automatically
 
-The web UI prompts for the server URL and token on first connect.
+Create the first user with the admin token:
+
+```bash
+curl -X POST http://localhost:8321/api/admin/users \
+  -H "Authorization: Bearer $CARAPACE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"thies","password":"change-me","display_name":"Thies"}'
+```
+
+The web UI prompts for the server URL, username, and password on first connect.
+
+See [auth.md](auth.md) for the full user-file format, admin API, and session-cookie behavior.
 
 ## 3. Connect via CLI (optional)
 
 ```bash
-uv run carapace --token "$CARAPACE_TOKEN"
+uv run carapace --user thies --password change-me
 ```
+
+You can also set `CARAPACE_USER` and `CARAPACE_PASSWORD` for the CLI.
 
 ## 4. Configure `data/config.yaml`
 
@@ -121,9 +134,19 @@ Notes:
 - If `vapid_subject` is omitted, carapace uses `mailto:carapace@localhost`.
 - The public key is derived from the private key and exposed through `/api/config/vapid-public-key`.
 - Delivery also requires at least one client subscription registered through the `/api/notifications/*` endpoints.
-- Notification subscriptions are grouped by an `owner_key` derived from the current `CARAPACE_TOKEN`. If you rotate that token, existing notification subscriptions no longer match and clients must subscribe again.
+- Notification subscriptions are grouped by the authenticated username. Legacy `owner_key` values still parse for older files.
 
-## 5. Connect Matrix (optional)
+## 5. Upgrade an existing single-user data directory
+
+If you already have data from a pre-user-auth version, assign it to a stable username before normal use:
+
+```bash
+uv run carapace upgrade-data --user thies --data-dir data
+```
+
+The upgrade command adds ownership metadata to sessions, jobs, and notifications, moves `data/knowledge` to `data/knowledges/thies`, and converts Matrix/sandbox token JSON files to YAML with `user` fields. It creates a disabled placeholder user when needed; set a password through the admin API before logging in.
+
+## 6. Connect Matrix (optional)
 
 Create a Matrix account for carapace on your homeserver, then add to `data/config.yaml`:
 
@@ -145,7 +168,7 @@ Set `CARAPACE_MATRIX_PASSWORD` in your `.env` and restart. carapace will join th
 
 `allowed_rooms` and `allowed_users` are mandatory — without them the bot ignores all messages. This prevents accidental exposure if someone invites the bot to a public room.
 
-## 6. Set up credentials
+## 7. Set up credentials
 
 carapace can fetch credentials from a password manager on demand. The agent does not have blanket access — every credential request is evaluated by the sentinel agent and requires explicit user approval the first time it is used in a session. Credentials are intended to be consumed inside the sandbox (auto-injected via skill config or fetched with `ccred`) and must never be echoed or logged. Two backends are available.
 
@@ -231,7 +254,7 @@ credentials:
       #   - "deadbeef-..."
 ```
 
-## 7. Personalise
+## 8. Personalise
 
 Edit the workspace files in the knowledge repo to shape carapace's behaviour. With the default config, these live under `data/knowledge/`:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -42,7 +42,7 @@ This starts:
 - **Redis** for mandatory session-list caching
 - **Sandbox image** is built automatically
 
-Log in to the web UI as `admin` with the `CARAPACE_TOKEN` value, then open **Settings** → **Preferences** → **Manage users** to create your normal user. You can also use the admin API after logging in and storing the session cookie:
+Log in to the web UI as `admin` with the `CARAPACE_TOKEN` value, then open **Settings** → **Platform** → **Users** to create your normal user. You can also use the admin API after logging in and storing the session cookie:
 
 ```bash
 curl -c carapace.cookies -X POST http://localhost:8321/api/auth/login \

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -42,7 +42,7 @@ This starts:
 - **Redis** for mandatory session-list caching
 - **Sandbox image** is built automatically
 
-Log in to the web UI as `admin` with the `CARAPACE_TOKEN` value, then open **Settings** → **Platform** → **Users** to create your normal user. You can also use the admin API after logging in and storing the session cookie:
+Log in to the web UI as `admin` with the `CARAPACE_TOKEN` value, then open **Settings** → **Admin** → **Users** to create your normal user. You can also use the admin API after logging in and storing the session cookie:
 
 ```bash
 curl -c carapace.cookies -X POST http://localhost:8321/api/auth/login \

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,7 +18,7 @@ Fill in the required values:
 ```env
 # Required
 ANTHROPIC_API_KEY=sk-ant-...
-CARAPACE_TOKEN=pick-a-secret-admin-token-with-16-plus-chars
+CARAPACE_TOKEN=pick-a-bootstrap-admin-password
 
 # Optional — uncomment if needed
 # GOOGLE_API_KEY=...
@@ -26,7 +26,7 @@ CARAPACE_TOKEN=pick-a-secret-admin-token-with-16-plus-chars
 # CARAPACE_GIT_TOKEN=...
 ```
 
-`CARAPACE_TOKEN` is the admin/bootstrap token for managing users and must be at least 16 characters long. Normal web UI, CLI, REST, and WebSocket access uses username/password login and an HttpOnly session cookie.
+If no `admin` user exists yet, `CARAPACE_TOKEN` becomes that user's initial password and must be at least 16 characters long. After startup, normal web UI, CLI, REST, WebSocket, and admin access uses username/password login and an HttpOnly session cookie.
 
 ## 2. Build and start
 
@@ -42,11 +42,15 @@ This starts:
 - **Redis** for mandatory session-list caching
 - **Sandbox image** is built automatically
 
-Create the first user in the web UI by opening **Manage users** on the login screen, entering the server URL and admin token, and creating a user. You can also use the admin API:
+Log in to the web UI as `admin` with the `CARAPACE_TOKEN` value, then open **Settings** → **Preferences** → **Manage users** to create your normal user. You can also use the admin API after logging in and storing the session cookie:
 
 ```bash
+curl -c carapace.cookies -X POST http://localhost:8321/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","password":"'"$CARAPACE_TOKEN"'"}'
+
 curl -X POST http://localhost:8321/api/admin/users \
-  -H "Authorization: Bearer $CARAPACE_TOKEN" \
+  -b carapace.cookies \
   -H "Content-Type: application/json" \
   -d '{"username":"thies","password":"change-me","display_name":"Thies"}'
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,7 +26,7 @@ CARAPACE_TOKEN=pick-a-bootstrap-admin-password
 # CARAPACE_GIT_TOKEN=...
 ```
 
-If no `admin` user exists yet, `CARAPACE_TOKEN` becomes that user's initial password and must be at least 16 characters long. After startup, normal web UI, CLI, REST, WebSocket, and admin access uses username/password login and an HttpOnly session cookie.
+If no enabled admin user exists yet, `CARAPACE_TOKEN` becomes the bootstrap `admin` user's initial password and must be at least 16 characters long. After startup, normal web UI, CLI, REST, WebSocket, and admin access uses username/password login and an HttpOnly session cookie.
 
 ## 2. Build and start
 

--- a/docs/sessions-and-channels.md
+++ b/docs/sessions-and-channels.md
@@ -184,7 +184,7 @@ The primary interactive channel. A Next.js web app connects to the carapace serv
 
 Message `type` values, JSON fields, authentication, and what the server sends on a **fresh connect** (including replay of pending approvals and escalations) are documented in **[websocket-session.md](websocket-session.md)**.
 
-Authentication uses a bearer token (`CARAPACE_TOKEN` env var) passed as a query parameter or `Authorization: Bearer` header.
+Authentication uses the `carapace_session` cookie issued by `POST /api/auth/login`. The optional WebSocket query parameter is only `client_id`, used to keep interactive presence stable across reconnects.
 
 For presence tracking, the frontend also posts REST heartbeats and may attach a stable `client_id` query parameter to the WebSocket so reconnects map back to the same interactive client.
 

--- a/docs/websocket-session.md
+++ b/docs/websocket-session.md
@@ -8,11 +8,9 @@ For the broader notification backend, including presence, suppression, and push 
 
 - **URL:** `ws://<host>/api/chat/{session_id}` or `wss://…` for HTTPS deployments.
 - Optional query parameter: `client_id=<stable-client-id>` to let reconnects map to the same interactive presence source.
-- **Auth** (either works):
-  - Query: `?token=<server bearer token>`
-  - Header: `Authorization: Bearer <server bearer token>`
+- **Auth:** the same `carapace_session` HttpOnly cookie issued by `POST /api/auth/login` for the web UI and CLI.
 
-If the token is wrong, the server closes the socket with policy violation (`1008`) before accepting.
+If the cookie is missing, expired, revoked, or belongs to a different user than the session owner, the server closes the socket with policy violation (`1008`) before accepting.
 
 If `session_id` does not exist on disk, the server closes with code **4004** and reason `Session not found` before completing the handshake.
 

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -44,6 +44,7 @@
             "loading": "Benutzer werden geladen…",
             "empty": "Keine Benutzer gefunden",
             "selectUser": "Benutzer auswählen",
+            "you": "Du",
             "enabled": "Aktiv",
             "disabled": "Deaktiviert"
         },

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -31,6 +31,64 @@
             "connectionFailed": "Verbindung fehlgeschlagen"
         }
     },
+    "admin": {
+        "title": "Admin",
+        "backToApp": "Zurück zur App",
+        "serverLabel": "Server-URL",
+        "serverPlaceholder": "Kein Server ausgewählt",
+        "adminTokenLabel": "Admin-Token",
+        "adminTokenPlaceholder": "CARAPACE_TOKEN",
+        "users": {
+            "title": "Benutzer",
+            "savedUsers": "Benutzer",
+            "loading": "Benutzer werden geladen…",
+            "empty": "Keine Benutzer gefunden",
+            "selectUser": "Benutzer auswählen",
+            "enabled": "Aktiv",
+            "disabled": "Deaktiviert"
+        },
+        "create": {
+            "title": "Neuer Benutzer",
+            "subtitle": "Lokalen Benutzer anlegen"
+        },
+        "fields": {
+            "username": "Benutzername",
+            "password": "Passwort",
+            "newPassword": "Neues Passwort",
+            "keepPassword": "Aktuelles Passwort behalten",
+            "displayName": "Anzeigename",
+            "email": "E-Mail",
+            "roles": "Rollen",
+            "enabled": "Aktiv"
+        },
+        "actions": {
+            "load": "Laden",
+            "loading": "Lädt…",
+            "refresh": "Benutzer aktualisieren",
+            "new": "Neuer Benutzer",
+            "create": "Benutzer anlegen",
+            "creating": "Lege an…",
+            "save": "Änderungen speichern",
+            "saving": "Speichert…"
+        },
+        "notices": {
+            "loaded": "Benutzer geladen.",
+            "created": "{username} angelegt.",
+            "saved": "{username} gespeichert."
+        },
+        "errors": {
+            "missingCredentials": "Server-URL und Admin-Token sind erforderlich.",
+            "load": "Benutzer konnten nicht geladen werden.",
+            "create": "Benutzer konnte nicht angelegt werden.",
+            "save": "Benutzer konnte nicht gespeichert werden."
+        },
+        "meta": {
+            "tokenVersion": "Token v{version}",
+            "updated": "Aktualisiert {timestamp}",
+            "lastLogin": "Letzter Login {timestamp}",
+            "never": "nie"
+        }
+    },
     "preferences": {
         "title": "Einstellungen",
         "description": "Frontend-Einstellungen für Sprache und anderes app-weites Verhalten.",

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -17,7 +17,6 @@
         "menu": "Kontomenü",
         "openMenu": "Kontomenü öffnen",
         "unknown": "Unbekannter Benutzer",
-        "noRoles": "Keine Rollen",
         "logout": "Abmelden"
     },
     "home": {

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -8,8 +8,7 @@
         "settings": "Einstellungen",
         "jobs": "Jobs",
         "preferences": "Allgemein",
-        "personal": "Persönlich",
-        "platform": "Plattform",
+        "platform": "Admin",
         "users": "Benutzer",
         "disconnect": "Trennen",
         "github": "GitHub-Repository"

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -74,6 +74,7 @@
             "refresh": "Benutzer aktualisieren",
             "new": "Neuer Benutzer",
             "upgradeUser": "Daten für {username} upgraden",
+            "deleteUser": "{username} löschen",
             "create": "Benutzer anlegen",
             "creating": "Lege an…",
             "save": "Änderungen speichern",
@@ -83,6 +84,7 @@
             "loaded": "Benutzer geladen.",
             "created": "{username} angelegt.",
             "saved": "{username} gespeichert.",
+            "deleted": "{username} gelöscht.",
             "upgraded": "Daten für {username} aktualisiert: {count} Änderungen."
         },
         "errors": {
@@ -90,9 +92,11 @@
             "load": "Benutzer konnten nicht geladen werden.",
             "create": "Benutzer konnte nicht angelegt werden.",
             "save": "Benutzer konnte nicht gespeichert werden.",
+            "delete": "Benutzer konnte nicht gelöscht werden.",
             "upgrade": "Benutzerdaten konnten nicht aktualisiert werden."
         },
         "confirm": {
+            "deleteUser": "{username} löschen? Bestehende Daten dieses Benutzers bleiben erhalten.",
             "upgradeUser": "Bestehende Daten mit {username} aktualisieren?"
         },
         "meta": {

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -19,12 +19,14 @@
     "connect": {
         "description": "Mit deinem Server verbinden",
         "serverLabel": "Server-URL",
-        "tokenLabel": "Bearer-Token",
-        "tokenPlaceholder": "Token einfügen",
+        "usernameLabel": "Benutzername",
+        "usernamePlaceholder": "thies",
+        "passwordLabel": "Passwort",
+        "passwordPlaceholder": "Passwort",
         "connect": "Verbinden",
         "connecting": "Verbinde…",
+        "adminLink": "Benutzer verwalten",
         "errors": {
-            "invalidToken": "Ungültiger Token",
             "serverError": "Serverfehler: {status}",
             "connectionFailed": "Verbindung fehlgeschlagen"
         }

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -25,7 +25,6 @@
         "passwordPlaceholder": "Passwort",
         "connect": "Verbinden",
         "connecting": "Verbinde…",
-        "adminLink": "Benutzer verwalten",
         "errors": {
             "serverError": "Serverfehler: {status}",
             "connectionFailed": "Verbindung fehlgeschlagen"
@@ -36,8 +35,6 @@
         "backToApp": "Zurück zur App",
         "serverLabel": "Server-URL",
         "serverPlaceholder": "Kein Server ausgewählt",
-        "adminTokenLabel": "Admin-Token",
-        "adminTokenPlaceholder": "CARAPACE_TOKEN",
         "users": {
             "title": "Benutzer",
             "savedUsers": "Benutzer",
@@ -79,7 +76,7 @@
             "upgraded": "Daten für {username} aktualisiert: {count} Änderungen."
         },
         "errors": {
-            "missingCredentials": "Server-URL und Admin-Token sind erforderlich.",
+            "missingCredentials": "Server-URL ist erforderlich.",
             "load": "Benutzer konnten nicht geladen werden.",
             "create": "Benutzer konnte nicht angelegt werden.",
             "save": "Benutzer konnte nicht gespeichert werden.",
@@ -123,6 +120,11 @@
                 "label": "Archivierte Chats anzeigen",
                 "description": "Wenn deaktiviert, werden archivierte Chats ausgeblendet und bei Session-Listen direkt nicht vom Server angefragt."
             }
+        },
+        "admin": {
+            "label": "Administration",
+            "description": "Lokale Benutzer verwalten und bestehende Daten zuordnen.",
+            "open": "Benutzer verwalten"
         },
         "notifications": {
             "title": "Push-Benachrichtigungen",

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -8,6 +8,9 @@
         "settings": "Einstellungen",
         "jobs": "Jobs",
         "preferences": "Allgemein",
+        "personal": "Persönlich",
+        "platform": "Plattform",
+        "users": "Benutzer",
         "disconnect": "Trennen",
         "github": "GitHub-Repository"
     },
@@ -37,6 +40,7 @@
         "serverPlaceholder": "Kein Server ausgewählt",
         "users": {
             "title": "Benutzer",
+            "description": "Globale Plattform-Konten, Rollen und Datenzuordnung.",
             "savedUsers": "Benutzer",
             "loading": "Benutzer werden geladen…",
             "empty": "Keine Benutzer gefunden",
@@ -94,7 +98,7 @@
     },
     "preferences": {
         "title": "Einstellungen",
-        "description": "Frontend-Einstellungen für Sprache und anderes app-weites Verhalten.",
+        "description": "Persönliche Einstellungen für diesen Browser und deine Nutzung.",
         "currentLocale": "Aktuelle Oberflächensprache: {locale}",
         "language": {
             "label": "Sprache",
@@ -120,11 +124,6 @@
                 "label": "Archivierte Chats anzeigen",
                 "description": "Wenn deaktiviert, werden archivierte Chats ausgeblendet und bei Session-Listen direkt nicht vom Server angefragt."
             }
-        },
-        "admin": {
-            "label": "Administration",
-            "description": "Lokale Benutzer verwalten und bestehende Daten zuordnen.",
-            "open": "Benutzer verwalten"
         },
         "notifications": {
             "title": "Push-Benachrichtigungen",

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -11,7 +11,7 @@
         "platform": "Admin",
         "users": "Benutzer",
         "disconnect": "Trennen",
-        "github": "GitHub-Repository"
+        "github": "thiesgerken/carapace"
     },
     "account": {
         "menu": "Kontomenü",

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -51,6 +51,7 @@
             "empty": "Keine Benutzer gefunden",
             "selectUser": "Benutzer auswählen",
             "you": "Du",
+            "admin": "Admin",
             "enabled": "Aktiv",
             "disabled": "Deaktiviert"
         },

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -66,6 +66,7 @@
             "loading": "Lädt…",
             "refresh": "Benutzer aktualisieren",
             "new": "Neuer Benutzer",
+            "upgradeUser": "Daten für {username} upgraden",
             "create": "Benutzer anlegen",
             "creating": "Lege an…",
             "save": "Änderungen speichern",
@@ -74,13 +75,18 @@
         "notices": {
             "loaded": "Benutzer geladen.",
             "created": "{username} angelegt.",
-            "saved": "{username} gespeichert."
+            "saved": "{username} gespeichert.",
+            "upgraded": "Daten für {username} aktualisiert: {count} Änderungen."
         },
         "errors": {
             "missingCredentials": "Server-URL und Admin-Token sind erforderlich.",
             "load": "Benutzer konnten nicht geladen werden.",
             "create": "Benutzer konnte nicht angelegt werden.",
-            "save": "Benutzer konnte nicht gespeichert werden."
+            "save": "Benutzer konnte nicht gespeichert werden.",
+            "upgrade": "Benutzerdaten konnten nicht aktualisiert werden."
+        },
+        "confirm": {
+            "upgradeUser": "Bestehende Daten mit {username} aktualisieren?"
         },
         "meta": {
             "tokenVersion": "Token v{version}",

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -13,6 +13,13 @@
         "disconnect": "Trennen",
         "github": "GitHub-Repository"
     },
+    "account": {
+        "menu": "Kontomenü",
+        "openMenu": "Kontomenü öffnen",
+        "unknown": "Unbekannter Benutzer",
+        "noRoles": "Keine Rollen",
+        "logout": "Abmelden"
+    },
     "home": {
         "empty": {
             "description": "Wähle eine Sitzung aus oder starte eine neue"

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -51,6 +51,7 @@
             "empty": "No users found",
             "selectUser": "Select a user",
             "you": "You",
+            "admin": "Admin",
             "enabled": "Enabled",
             "disabled": "Disabled"
         },

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -11,7 +11,7 @@
         "platform": "Admin",
         "users": "Users",
         "disconnect": "Disconnect",
-        "github": "GitHub repository"
+        "github": "thiesgerken/carapace"
     },
     "account": {
         "menu": "Account menu",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -44,6 +44,7 @@
             "loading": "Loading users…",
             "empty": "No users found",
             "selectUser": "Select a user",
+            "you": "You",
             "enabled": "Enabled",
             "disabled": "Disabled"
         },

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -31,6 +31,64 @@
             "connectionFailed": "Connection failed"
         }
     },
+    "admin": {
+        "title": "Admin",
+        "backToApp": "Back to app",
+        "serverLabel": "Server URL",
+        "serverPlaceholder": "No server selected",
+        "adminTokenLabel": "Admin token",
+        "adminTokenPlaceholder": "CARAPACE_TOKEN",
+        "users": {
+            "title": "Users",
+            "savedUsers": "Users",
+            "loading": "Loading users…",
+            "empty": "No users found",
+            "selectUser": "Select a user",
+            "enabled": "Enabled",
+            "disabled": "Disabled"
+        },
+        "create": {
+            "title": "New user",
+            "subtitle": "Create a local user"
+        },
+        "fields": {
+            "username": "Username",
+            "password": "Password",
+            "newPassword": "New password",
+            "keepPassword": "Keep current password",
+            "displayName": "Display name",
+            "email": "Email",
+            "roles": "Roles",
+            "enabled": "Enabled"
+        },
+        "actions": {
+            "load": "Load",
+            "loading": "Loading…",
+            "refresh": "Refresh users",
+            "new": "New user",
+            "create": "Create user",
+            "creating": "Creating…",
+            "save": "Save changes",
+            "saving": "Saving…"
+        },
+        "notices": {
+            "loaded": "Users loaded.",
+            "created": "Created {username}.",
+            "saved": "Saved {username}."
+        },
+        "errors": {
+            "missingCredentials": "Server URL and admin token are required.",
+            "load": "Failed to load users.",
+            "create": "Failed to create user.",
+            "save": "Failed to save user."
+        },
+        "meta": {
+            "tokenVersion": "Token v{version}",
+            "updated": "Updated {timestamp}",
+            "lastLogin": "Last login {timestamp}",
+            "never": "never"
+        }
+    },
     "preferences": {
         "title": "Preferences",
         "description": "Frontend settings for language and other app-level behavior.",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -74,6 +74,7 @@
             "refresh": "Refresh users",
             "new": "New user",
             "upgradeUser": "Upgrade data for {username}",
+            "deleteUser": "Delete {username}",
             "create": "Create user",
             "creating": "Creating…",
             "save": "Save changes",
@@ -83,6 +84,7 @@
             "loaded": "Users loaded.",
             "created": "Created {username}.",
             "saved": "Saved {username}.",
+            "deleted": "Deleted {username}.",
             "upgraded": "Upgraded data for {username}: {count} changes."
         },
         "errors": {
@@ -90,9 +92,11 @@
             "load": "Failed to load users.",
             "create": "Failed to create user.",
             "save": "Failed to save user.",
+            "delete": "Failed to delete user.",
             "upgrade": "Failed to upgrade user data."
         },
         "confirm": {
+            "deleteUser": "Delete {username}? Existing data owned by this user is not deleted.",
             "upgradeUser": "Upgrade existing data using {username}?"
         },
         "meta": {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -8,8 +8,7 @@
         "settings": "Settings",
         "jobs": "Jobs",
         "preferences": "Preferences",
-        "personal": "Personal",
-        "platform": "Platform",
+        "platform": "Admin",
         "users": "Users",
         "disconnect": "Disconnect",
         "github": "GitHub repository"

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -17,7 +17,6 @@
         "menu": "Account menu",
         "openMenu": "Open account menu",
         "unknown": "Unknown user",
-        "noRoles": "No roles",
         "logout": "Log out"
     },
     "home": {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -25,7 +25,6 @@
         "passwordPlaceholder": "Password",
         "connect": "Connect",
         "connecting": "Connecting…",
-        "adminLink": "Manage users",
         "errors": {
             "serverError": "Server error: {status}",
             "connectionFailed": "Connection failed"
@@ -36,8 +35,6 @@
         "backToApp": "Back to app",
         "serverLabel": "Server URL",
         "serverPlaceholder": "No server selected",
-        "adminTokenLabel": "Admin token",
-        "adminTokenPlaceholder": "CARAPACE_TOKEN",
         "users": {
             "title": "Users",
             "savedUsers": "Users",
@@ -79,7 +76,7 @@
             "upgraded": "Upgraded data for {username}: {count} changes."
         },
         "errors": {
-            "missingCredentials": "Server URL and admin token are required.",
+            "missingCredentials": "Server URL is required.",
             "load": "Failed to load users.",
             "create": "Failed to create user.",
             "save": "Failed to save user.",
@@ -123,6 +120,11 @@
                 "label": "Show archived chats",
                 "description": "When disabled, archived chats are hidden and session list requests exclude them."
             }
+        },
+        "admin": {
+            "label": "Administration",
+            "description": "Manage local users and assign existing data.",
+            "open": "Manage users"
         },
         "notifications": {
             "title": "Push notifications",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -19,12 +19,14 @@
     "connect": {
         "description": "Connect to your server",
         "serverLabel": "Server URL",
-        "tokenLabel": "Bearer Token",
-        "tokenPlaceholder": "Paste your token",
+        "usernameLabel": "Username",
+        "usernamePlaceholder": "thies",
+        "passwordLabel": "Password",
+        "passwordPlaceholder": "Password",
         "connect": "Connect",
         "connecting": "Connecting…",
+        "adminLink": "Manage users",
         "errors": {
-            "invalidToken": "Invalid token",
             "serverError": "Server error: {status}",
             "connectionFailed": "Connection failed"
         }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -8,6 +8,9 @@
         "settings": "Settings",
         "jobs": "Jobs",
         "preferences": "Preferences",
+        "personal": "Personal",
+        "platform": "Platform",
+        "users": "Users",
         "disconnect": "Disconnect",
         "github": "GitHub repository"
     },
@@ -37,6 +40,7 @@
         "serverPlaceholder": "No server selected",
         "users": {
             "title": "Users",
+            "description": "Global platform accounts, roles, and data ownership.",
             "savedUsers": "Users",
             "loading": "Loading users…",
             "empty": "No users found",
@@ -94,7 +98,7 @@
     },
     "preferences": {
         "title": "Preferences",
-        "description": "Frontend settings for language and other app-level behavior.",
+        "description": "Personal settings for this browser and your account experience.",
         "currentLocale": "Current interface language: {locale}",
         "language": {
             "label": "Language",
@@ -120,11 +124,6 @@
                 "label": "Show archived chats",
                 "description": "When disabled, archived chats are hidden and session list requests exclude them."
             }
-        },
-        "admin": {
-            "label": "Administration",
-            "description": "Manage local users and assign existing data.",
-            "open": "Manage users"
         },
         "notifications": {
             "title": "Push notifications",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -66,6 +66,7 @@
             "loading": "Loading…",
             "refresh": "Refresh users",
             "new": "New user",
+            "upgradeUser": "Upgrade data for {username}",
             "create": "Create user",
             "creating": "Creating…",
             "save": "Save changes",
@@ -74,13 +75,18 @@
         "notices": {
             "loaded": "Users loaded.",
             "created": "Created {username}.",
-            "saved": "Saved {username}."
+            "saved": "Saved {username}.",
+            "upgraded": "Upgraded data for {username}: {count} changes."
         },
         "errors": {
             "missingCredentials": "Server URL and admin token are required.",
             "load": "Failed to load users.",
             "create": "Failed to create user.",
-            "save": "Failed to save user."
+            "save": "Failed to save user.",
+            "upgrade": "Failed to upgrade user data."
+        },
+        "confirm": {
+            "upgradeUser": "Upgrade existing data using {username}?"
         },
         "meta": {
             "tokenVersion": "Token v{version}",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -13,6 +13,13 @@
         "disconnect": "Disconnect",
         "github": "GitHub repository"
     },
+    "account": {
+        "menu": "Account menu",
+        "openMenu": "Open account menu",
+        "unknown": "Unknown user",
+        "noRoles": "No roles",
+        "logout": "Log out"
+    },
     "home": {
         "empty": {
             "description": "Select a session or start a new one"

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function AdminPage() {
+  redirect("/admin/users");
+}

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from "next/navigation";
-
-export default function AdminPage() {
-  redirect("/admin/users");
-}

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -1,5 +1,0 @@
-import { AdminUsersPage } from "@/components/admin-users-page";
-
-export default function UsersAdminRoute() {
-  return <AdminUsersPage />;
-}

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -1,0 +1,5 @@
+import { AdminUsersPage } from "@/components/admin-users-page";
+
+export default function UsersAdminRoute() {
+  return <AdminUsersPage />;
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -128,8 +128,8 @@ function HomeContent() {
   })();
   const initialSettingsTab: SettingsTab = (() => {
     const tab = searchParams.get("tab");
-    if (tab === "jobs") {
-      return "jobs";
+    if (tab === "jobs" || tab === "platform-users") {
+      return tab;
     }
     return "preferences";
   })();
@@ -175,7 +175,7 @@ function HomeContent() {
     const params = new URLSearchParams();
     if (activeView === "settings") {
       params.set("view", "settings");
-      if (settingsTab === "jobs") {
+      if (settingsTab !== "preferences") {
         params.set("tab", settingsTab);
       }
     } else if (activeSessionId) {
@@ -555,7 +555,9 @@ function HomeContent() {
     if (activeView === "settings") {
       const viewTitle = settingsTab === "jobs"
         ? t("navigation.jobs")
-        : t("navigation.settings");
+        : settingsTab === "platform-users"
+          ? t("navigation.users")
+          : t("navigation.settings");
       document.title = `${viewTitle} • ${appTitle}`;
       return;
     }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -10,7 +10,7 @@ import { NewSessionButton, type NewSessionOptions } from "@/components/new-sessi
 import { Sidebar } from "@/components/sidebar";
 import { ChatView } from "@/components/chat-view";
 import { VersionBadge } from "@/components/version-badge";
-import { createSession, deleteSession, getServerMeta, getSession, listSessions, logout, updateSession } from "@/lib/api";
+import { createSession, deleteSession, getCurrentUser, getServerMeta, getSession, listSessions, logout, updateSession, type AuthUserInfo } from "@/lib/api";
 import {
   clearConnection,
   getShowArchivedSessionsPreference,
@@ -138,6 +138,7 @@ function HomeContent() {
     server: "",
     token: "",
   });
+  const [currentUser, setCurrentUser] = useState<AuthUserInfo | null>(null);
   const [serverVersion, setServerVersion] = useState<string | null>(null);
   const [sessions, setSessions] = useState<SessionInfo[]>([]);
   const [activeSessionId, setActiveSessionId] = useState<string | null>(
@@ -162,6 +163,7 @@ function HomeContent() {
   const pendingSandboxUpdatesRef = useRef(new Map<string, SessionInfo["sandbox"]>());
 
   const { connected, server, token } = connection;
+  const isAdmin = currentUser?.roles.includes("admin") ?? false;
   const loading = creatingSession || refreshingSessions;
   const hasActiveSessionLoaded = activeSessionId != null
     && sessions.some((session) => session.session_id === activeSessionId);
@@ -270,6 +272,29 @@ function HomeContent() {
   useEffect(() => {
     let cancelled = false;
     const timer = setTimeout(() => {
+      if (!connected || !server) {
+        if (!cancelled) setCurrentUser(null);
+        return;
+      }
+
+      void getCurrentUser(server)
+        .then((user) => {
+          if (!cancelled) setCurrentUser(user);
+        })
+        .catch(() => {
+          if (!cancelled) setCurrentUser(null);
+        });
+    }, 0);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [connected, server, token]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const timer = setTimeout(() => {
       if (!connected || !server || !token) {
         if (!cancelled) {
           setServerVersion(null);
@@ -364,7 +389,7 @@ function HomeContent() {
     };
   }, [activeSessionId, connected, hasActiveSessionLoaded, server, sessionListInitialized, token]);
 
-  function handleConnect(srv: string, tok: string) {
+  function handleConnect(srv: string, user: AuthUserInfo) {
     refreshRequestIdRef.current += 1;
     loadingMoreSessionsRef.current = false;
     failedLoadMoreCursorRef.current = null;
@@ -375,8 +400,9 @@ function HomeContent() {
     setSessions([]);
     setSessionListCursor(null);
     setSessionListHasMore(false);
-    saveConnection(srv, tok);
-    setConnection({ connected: true, server: srv, token: tok });
+    saveConnection(srv, user.username);
+    setCurrentUser(user);
+    setConnection({ connected: true, server: srv, token: user.username });
   }
 
   function handleDisconnect() {
@@ -388,6 +414,7 @@ function HomeContent() {
     failedLoadMoreCursorRef.current = null;
     pendingSandboxUpdatesRef.current.clear();
     clearConnection();
+    setCurrentUser(null);
     setRefreshingSessions(false);
     setLoadingMoreSessions(false);
     setSessionListInitialized(false);
@@ -618,6 +645,7 @@ function HomeContent() {
           <JobsView
             server={server}
             token={token}
+            isAdmin={isAdmin}
             sessions={sessions}
             showArchivedSessions={showArchivedSessions}
             onShowArchivedSessionsChange={handleShowArchivedSessionsChange}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -10,7 +10,7 @@ import { NewSessionButton, type NewSessionOptions } from "@/components/new-sessi
 import { Sidebar } from "@/components/sidebar";
 import { ChatView } from "@/components/chat-view";
 import { VersionBadge } from "@/components/version-badge";
-import { createSession, deleteSession, getServerMeta, getSession, listSessions, updateSession } from "@/lib/api";
+import { createSession, deleteSession, getServerMeta, getSession, listSessions, logout, updateSession } from "@/lib/api";
 import {
   clearConnection,
   getShowArchivedSessionsPreference,
@@ -380,6 +380,9 @@ function HomeContent() {
   }
 
   function handleDisconnect() {
+    if (server) {
+      void logout(server).catch(() => undefined);
+    }
     refreshRequestIdRef.current += 1;
     loadingMoreSessionsRef.current = false;
     failedLoadMoreCursorRef.current = null;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -603,6 +603,7 @@ function HomeContent() {
           activeView={activeView}
           frontendVersion={BUILD_APP_VERSION}
           backendVersion={serverVersion}
+          currentUser={currentUser}
           onSelect={handleSelectSession}
           onNew={handleNewSession}
           onGoHome={handleGoHome}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -10,7 +10,7 @@ import { NewSessionButton, type NewSessionOptions } from "@/components/new-sessi
 import { Sidebar } from "@/components/sidebar";
 import { ChatView } from "@/components/chat-view";
 import { VersionBadge } from "@/components/version-badge";
-import { createSession, deleteSession, getCurrentUser, getServerMeta, getSession, listSessions, logout, updateSession, type AuthUserInfo } from "@/lib/api";
+import { AUTH_REQUIRED_EVENT, createSession, deleteSession, getCurrentUser, getServerMeta, getSession, listSessions, logout, updateSession, type AuthUserInfo } from "@/lib/api";
 import {
   clearConnection,
   getShowArchivedSessionsPreference,
@@ -292,6 +292,33 @@ function HomeContent() {
     };
   }, [connected, server, token]);
 
+  const requireLogin = useCallback(() => {
+    refreshRequestIdRef.current += 1;
+    loadingMoreSessionsRef.current = false;
+    failedLoadMoreCursorRef.current = null;
+    pendingSandboxUpdatesRef.current.clear();
+    setCurrentUser(null);
+    setRefreshingSessions(false);
+    setLoadingMoreSessions(false);
+    setSessionListInitialized(false);
+    setConnection({ connected: false, server: "", token: "" });
+    setServerVersion(null);
+    setSessions([]);
+    setSessionListCursor(null);
+    setSessionListHasMore(false);
+    setRequestedJobId(null);
+    setActiveSessionId(null);
+    setActiveView("chat");
+    setSidebarOpen(false);
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener(AUTH_REQUIRED_EVENT, requireLogin);
+    return () => {
+      window.removeEventListener(AUTH_REQUIRED_EVENT, requireLogin);
+    };
+  }, [requireLogin]);
+
   useEffect(() => {
     let cancelled = false;
     const timer = setTimeout(() => {
@@ -409,23 +436,8 @@ function HomeContent() {
     if (server) {
       void logout(server).catch(() => undefined);
     }
-    refreshRequestIdRef.current += 1;
-    loadingMoreSessionsRef.current = false;
-    failedLoadMoreCursorRef.current = null;
-    pendingSandboxUpdatesRef.current.clear();
     clearConnection();
-    setCurrentUser(null);
-    setRefreshingSessions(false);
-    setLoadingMoreSessions(false);
-    setSessionListInitialized(false);
-    setConnection({ connected: false, server: "", token: "" });
-    setServerVersion(null);
-    setSessions([]);
-    setSessionListCursor(null);
-    setSessionListHasMore(false);
-    setRequestedJobId(null);
-    setActiveSessionId(null);
-    setActiveView("chat");
+    requireLogin();
   }
 
   async function handleNewSession(options: NewSessionOptions = {}) {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -648,6 +648,7 @@ function HomeContent() {
             server={server}
             token={token}
             isAdmin={isAdmin}
+            currentUsername={currentUser?.username ?? null}
             sessions={sessions}
             showArchivedSessions={showArchivedSessions}
             onShowArchivedSessionsChange={handleShowArchivedSessionsChange}

--- a/frontend/src/components/admin-users-page.tsx
+++ b/frontend/src/components/admin-users-page.tsx
@@ -92,7 +92,6 @@ export function AdminUsersPage() {
     const params = new URLSearchParams(window.location.search);
     return normalizeServer(params.get("server") ?? getServer() ?? defaultServer());
   });
-  const [adminToken, setAdminToken] = useState("");
   const [users, setUsers] = useState<AdminUserInfo[]>([]);
   const [selectedUsername, setSelectedUsername] = useState<string | "new">("new");
   const [editDraft, setEditDraft] = useState<UserDraft | null>(null);
@@ -111,7 +110,7 @@ export function AdminUsersPage() {
 
   async function refreshUsers(preferredUsername: string | "new" = selectedUsername, message?: string): Promise<void> {
     const normalizedServer = normalizeServer(server);
-    if (!normalizedServer || !adminToken.trim()) {
+    if (!normalizedServer) {
       setError(t("errors.missingCredentials"));
       setNotice(null);
       return;
@@ -120,7 +119,7 @@ export function AdminUsersPage() {
     setLoading(true);
     setError(null);
     try {
-      const loadedUsers = await listAdminUsers(normalizedServer, adminToken.trim());
+      const loadedUsers = await listAdminUsers(normalizedServer);
       setServer(normalizedServer);
       setUsers(loadedUsers);
       if (preferredUsername === "new") {
@@ -146,7 +145,7 @@ export function AdminUsersPage() {
   async function handleCreateUser(event: React.FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();
     const normalizedServer = normalizeServer(server);
-    if (!normalizedServer || !adminToken.trim()) {
+    if (!normalizedServer) {
       setError(t("errors.missingCredentials"));
       setNotice(null);
       return;
@@ -155,7 +154,7 @@ export function AdminUsersPage() {
     setCreating(true);
     setError(null);
     try {
-      const created = await createAdminUser(normalizedServer, adminToken.trim(), {
+      const created = await createAdminUser(normalizedServer, {
         username: createDraft.username.trim(),
         password: createDraft.password,
         display_name: createDraft.displayName.trim(),
@@ -176,7 +175,7 @@ export function AdminUsersPage() {
     event.preventDefault();
     if (selectedUser === null || editDraft === null) return;
     const normalizedServer = normalizeServer(server);
-    if (!normalizedServer || !adminToken.trim()) {
+    if (!normalizedServer) {
       setError(t("errors.missingCredentials"));
       setNotice(null);
       return;
@@ -185,7 +184,7 @@ export function AdminUsersPage() {
     setSaving(true);
     setError(null);
     try {
-      const updated = await updateAdminUser(normalizedServer, adminToken.trim(), selectedUser.username, {
+      const updated = await updateAdminUser(normalizedServer, selectedUser.username, {
         display_name: editDraft.displayName.trim(),
         email: editDraft.email.trim() || null,
         roles: rolesFromText(editDraft.roles),
@@ -203,7 +202,7 @@ export function AdminUsersPage() {
 
   async function handleUpgradeUser(username: string): Promise<void> {
     const normalizedServer = normalizeServer(server);
-    if (!normalizedServer || !adminToken.trim()) {
+    if (!normalizedServer) {
       setError(t("errors.missingCredentials"));
       setNotice(null);
       return;
@@ -216,7 +215,7 @@ export function AdminUsersPage() {
     setError(null);
     setNotice(null);
     try {
-      const result = await upgradeAdminUserData(normalizedServer, adminToken.trim(), username);
+      const result = await upgradeAdminUserData(normalizedServer, username);
       const changedCount = Object.values(result.summary).reduce((total, entries) => total + entries.length, 0);
       await refreshUsers(result.username, t("notices.upgraded", { username: result.username, count: changedCount }));
     } catch (upgradeError) {
@@ -274,7 +273,7 @@ export function AdminUsersPage() {
                 event.preventDefault();
                 void refreshUsers();
               }}
-              className="grid gap-2 sm:grid-cols-[minmax(13rem,1fr)_minmax(12rem,1fr)_auto] lg:w-[42rem]"
+              className="grid gap-2 sm:grid-cols-[minmax(13rem,1fr)_auto] lg:w-[28rem]"
             >
               <label className="space-y-1">
                 <span className="text-xs font-medium text-muted-foreground">{t("serverLabel")}</span>
@@ -286,19 +285,9 @@ export function AdminUsersPage() {
                   className={inputClassName}
                 />
               </label>
-              <label className="space-y-1">
-                <span className="text-xs font-medium text-muted-foreground">{t("adminTokenLabel")}</span>
-                <input
-                  type="password"
-                  value={adminToken}
-                  onChange={(event) => setAdminToken(event.target.value)}
-                  placeholder={t("adminTokenPlaceholder")}
-                  className={inputClassName}
-                />
-              </label>
               <button
                 type="submit"
-                disabled={loading || !server.trim() || !adminToken.trim()}
+                disabled={loading || !server.trim()}
                 className="inline-flex min-h-10 items-center justify-center gap-2 self-end rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
@@ -326,7 +315,7 @@ export function AdminUsersPage() {
                   title={t("actions.refresh")}
                   aria-label={t("actions.refresh")}
                   className={iconButtonClassName}
-                  disabled={loading || !server.trim() || !adminToken.trim()}
+                  disabled={loading || !server.trim()}
                 >
                   <RefreshCw className={cn("h-4 w-4", loading && "animate-spin")} />
                 </button>
@@ -397,7 +386,7 @@ export function AdminUsersPage() {
                           title={t("actions.upgradeUser", { username: user.username })}
                           aria-label={t("actions.upgradeUser", { username: user.username })}
                           className={iconButtonClassName}
-                          disabled={upgradingUsername !== null || loading || !server.trim() || !adminToken.trim()}
+                          disabled={upgradingUsername !== null || loading || !server.trim()}
                         >
                           {upgrading ? <Loader2 className="h-4 w-4 animate-spin" /> : <DatabaseBackup className="h-4 w-4" />}
                         </button>
@@ -467,7 +456,7 @@ export function AdminUsersPage() {
 
                 <button
                   type="submit"
-                  disabled={creating || !createDraft.username.trim() || !createDraft.password || !server.trim() || !adminToken.trim()}
+                  disabled={creating || !createDraft.username.trim() || !createDraft.password || !server.trim()}
                   className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <UserPlus className="h-4 w-4" />}
@@ -535,7 +524,7 @@ export function AdminUsersPage() {
                 <div className="flex flex-wrap items-center gap-2">
                   <button
                     type="submit"
-                    disabled={saving || !server.trim() || !adminToken.trim()}
+                    disabled={saving || !server.trim()}
                     className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}

--- a/frontend/src/components/admin-users-page.tsx
+++ b/frontend/src/components/admin-users-page.tsx
@@ -378,6 +378,7 @@ export function AdminUsersPage({ embedded = false, server: serverProp, currentUs
                     const upgrading = upgradingUsername === user.username;
                     const isCurrentUser = user.username === visibleCurrentUsername;
                     const deleting = deletingUsername === user.username;
+                    const isAdminUser = user.roles.some((role) => role.trim().toLowerCase() === "admin");
                     return (
                       <div key={user.username} className="flex items-stretch gap-1">
                         <button
@@ -410,12 +411,22 @@ export function AdminUsersPage({ embedded = false, server: serverProp, currentUs
                                 {user.username}
                               </div>
                             </div>
-                            <span className={cn(
-                              "shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium",
-                              user.enabled ? "bg-emerald-100 text-emerald-700" : "bg-amber-100 text-amber-700",
-                            )}>
-                              {user.enabled ? t("users.enabled") : t("users.disabled")}
-                            </span>
+                            <div className="flex shrink-0 flex-wrap justify-end gap-1">
+                              <span className={cn(
+                                "rounded-full px-2 py-0.5 text-[11px] font-medium",
+                                user.enabled ? "bg-emerald-100 text-emerald-700" : "bg-amber-100 text-amber-700",
+                              )}>
+                                {user.enabled ? t("users.enabled") : t("users.disabled")}
+                              </span>
+                              {isAdminUser ? (
+                                <span className={cn(
+                                  "rounded-full px-2 py-0.5 text-[11px] font-medium",
+                                  selected ? "bg-accent-foreground/15 text-accent-foreground" : "bg-accent text-accent-foreground",
+                                )}>
+                                  {t("users.admin")}
+                                </span>
+                              ) : null}
+                            </div>
                           </div>
                         </button>
                         <button

--- a/frontend/src/components/admin-users-page.tsx
+++ b/frontend/src/components/admin-users-page.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 
 import { createAdminUser, deleteAdminUser, getCurrentUser, listAdminUsers, updateAdminUser, upgradeAdminUserData, type AdminUserInfo } from "@/lib/api";
+import { defaultServer, normalizeServer } from "@/lib/server-url";
 import { getServer } from "@/lib/storage";
 import { cn } from "@/lib/utils";
 
@@ -32,19 +33,6 @@ const emptyCreateDraft: CreateDraft = {
   email: "",
   roles: "",
 };
-
-function defaultServer(): string {
-  if (typeof window === "undefined") return "http://127.0.0.1:8321";
-  const url = new URL(window.location.origin);
-  if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
-    return `${url.protocol}//${url.hostname}:8321`;
-  }
-  return window.location.origin;
-}
-
-function normalizeServer(server: string): string {
-  return server.trim().replace(/\/$/, "");
-}
 
 function rolesFromText(value: string): string[] {
   return [...new Set(value.split(/[\n,]/).map((role) => role.trim()).filter(Boolean))];

--- a/frontend/src/components/admin-users-page.tsx
+++ b/frontend/src/components/admin-users-page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowLeft, Check, DatabaseBackup, Loader2, Plus, RefreshCw, Save, ShieldCheck, UserPlus, Users } from "lucide-react";
+import { ArrowLeft, Check, DatabaseBackup, Loader2, Plus, RefreshCw, Save, ShieldCheck, Trash2, UserPlus, Users } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 
-import { createAdminUser, getCurrentUser, listAdminUsers, updateAdminUser, upgradeAdminUserData, type AdminUserInfo } from "@/lib/api";
+import { createAdminUser, deleteAdminUser, getCurrentUser, listAdminUsers, updateAdminUser, upgradeAdminUserData, type AdminUserInfo } from "@/lib/api";
 import { getServer } from "@/lib/storage";
 import { cn } from "@/lib/utils";
 
@@ -107,6 +107,7 @@ export function AdminUsersPage({ embedded = false, server: serverProp, currentUs
   const [saving, setSaving] = useState(false);
   const [creating, setCreating] = useState(false);
   const [upgradingUsername, setUpgradingUsername] = useState<string | null>(null);
+  const [deletingUsername, setDeletingUsername] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [resolvedCurrentUsername, setResolvedCurrentUsername] = useState<string | null>(currentUsername);
@@ -247,6 +248,34 @@ export function AdminUsersPage({ embedded = false, server: serverProp, currentUs
     }
   }
 
+  async function handleDeleteUser(username: string): Promise<void> {
+    const normalizedServer = normalizeServer(server);
+    if (!normalizedServer) {
+      setError(t("errors.missingCredentials"));
+      setNotice(null);
+      return;
+    }
+    if (username === (currentUsername ?? resolvedCurrentUsername)) {
+      return;
+    }
+    if (!window.confirm(t("confirm.deleteUser", { username }))) {
+      return;
+    }
+
+    setDeletingUsername(username);
+    setError(null);
+    setNotice(null);
+    try {
+      await deleteAdminUser(normalizedServer, username);
+      await refreshUsers("new", t("notices.deleted", { username }));
+    } catch (deleteError) {
+      setError(deleteError instanceof Error ? deleteError.message : t("errors.delete"));
+      setNotice(null);
+    } finally {
+      setDeletingUsername(null);
+    }
+  }
+
   const selectedIsNew = selectedUsername === "new";
   const visibleCurrentUsername = currentUsername ?? resolvedCurrentUsername;
   const ContentElement = embedded ? "section" : "main";
@@ -348,6 +377,7 @@ export function AdminUsersPage({ embedded = false, server: serverProp, currentUs
                     const selected = selectedUsername === user.username;
                     const upgrading = upgradingUsername === user.username;
                     const isCurrentUser = user.username === visibleCurrentUsername;
+                    const deleting = deletingUsername === user.username;
                     return (
                       <div key={user.username} className="flex items-stretch gap-1">
                         <button
@@ -398,6 +428,18 @@ export function AdminUsersPage({ embedded = false, server: serverProp, currentUs
                         >
                           {upgrading ? <Loader2 className="h-4 w-4 animate-spin" /> : <DatabaseBackup className="h-4 w-4" />}
                         </button>
+                        {!isCurrentUser ? (
+                          <button
+                            type="button"
+                            onClick={() => void handleDeleteUser(user.username)}
+                            title={t("actions.deleteUser", { username: user.username })}
+                            aria-label={t("actions.deleteUser", { username: user.username })}
+                            className={cn(iconButtonClassName, "hover:bg-destructive/10 hover:text-destructive")}
+                            disabled={deletingUsername !== null || upgradingUsername !== null || loading || !server.trim()}
+                          >
+                            {deleting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+                          </button>
+                        ) : null}
                       </div>
                     );
                   })}

--- a/frontend/src/components/admin-users-page.tsx
+++ b/frontend/src/components/admin-users-page.tsx
@@ -5,7 +5,7 @@ import { ArrowLeft, Check, DatabaseBackup, Loader2, Plus, RefreshCw, Save, Shiel
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 
-import { createAdminUser, listAdminUsers, updateAdminUser, upgradeAdminUserData, type AdminUserInfo } from "@/lib/api";
+import { createAdminUser, getCurrentUser, listAdminUsers, updateAdminUser, upgradeAdminUserData, type AdminUserInfo } from "@/lib/api";
 import { getServer } from "@/lib/storage";
 import { cn } from "@/lib/utils";
 
@@ -88,9 +88,10 @@ const iconButtonClassName = cn(
 interface AdminUsersPageProps {
   embedded?: boolean;
   server?: string;
+  currentUsername?: string | null;
 }
 
-export function AdminUsersPage({ embedded = false, server: serverProp }: AdminUsersPageProps = {}) {
+export function AdminUsersPage({ embedded = false, server: serverProp, currentUsername = null }: AdminUsersPageProps = {}) {
   const t = useTranslations("admin");
   const [server, setServer] = useState(() => {
     if (serverProp !== undefined) return normalizeServer(serverProp);
@@ -108,6 +109,7 @@ export function AdminUsersPage({ embedded = false, server: serverProp }: AdminUs
   const [upgradingUsername, setUpgradingUsername] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const [resolvedCurrentUsername, setResolvedCurrentUsername] = useState<string | null>(currentUsername);
   const loadedServerRef = useRef<string | null>(null);
   const lockedServer = embedded && serverProp !== undefined;
 
@@ -127,9 +129,13 @@ export function AdminUsersPage({ embedded = false, server: serverProp }: AdminUs
     setLoading(true);
     setError(null);
     try {
-      const loadedUsers = await listAdminUsers(normalizedServer);
+      const [loadedUsers, loadedCurrentUser] = await Promise.all([
+        listAdminUsers(normalizedServer),
+        currentUsername === null ? getCurrentUser(normalizedServer).catch(() => null) : Promise.resolve(null),
+      ]);
       setServer(normalizedServer);
       setUsers(loadedUsers);
+      setResolvedCurrentUsername(currentUsername ?? loadedCurrentUser?.username ?? null);
       if (preferredUsername === "new") {
         setSelectedUsername("new");
         setEditDraft(null);
@@ -148,7 +154,7 @@ export function AdminUsersPage({ embedded = false, server: serverProp }: AdminUs
     } finally {
       setLoading(false);
     }
-  }, [selectedUsername, server, t]);
+  }, [currentUsername, selectedUsername, server, t]);
 
   useEffect(() => {
     if (!embedded) return;
@@ -243,7 +249,8 @@ export function AdminUsersPage({ embedded = false, server: serverProp }: AdminUs
   }
 
   const selectedIsNew = selectedUsername === "new";
-    const ContentElement = embedded ? "section" : "main";
+  const visibleCurrentUsername = currentUsername ?? resolvedCurrentUsername;
+  const ContentElement = embedded ? "section" : "main";
 
   const mainContent = (
       <ContentElement className={cn("flex min-w-0 flex-1 flex-col overflow-hidden", embedded && "bg-background/65")}>
@@ -344,6 +351,7 @@ export function AdminUsersPage({ embedded = false, server: serverProp }: AdminUs
                   {users.map((user) => {
                     const selected = selectedUsername === user.username;
                     const upgrading = upgradingUsername === user.username;
+                    const isCurrentUser = user.username === visibleCurrentUsername;
                     return (
                       <div key={user.username} className="flex items-stretch gap-1">
                         <button
@@ -361,7 +369,17 @@ export function AdminUsersPage({ embedded = false, server: serverProp }: AdminUs
                         >
                           <div className="flex items-start justify-between gap-3">
                             <div className="min-w-0">
-                              <div className="truncate text-sm font-semibold">{user.display_name || user.username}</div>
+                              <div className="flex min-w-0 items-center gap-2">
+                                <span className="truncate text-sm font-semibold">{user.display_name || user.username}</span>
+                                {isCurrentUser ? (
+                                  <span className={cn(
+                                    "shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium",
+                                    selected ? "bg-accent-foreground/15 text-accent-foreground" : "bg-muted text-muted-foreground",
+                                  )}>
+                                    {t("users.you")}
+                                  </span>
+                                ) : null}
+                              </div>
                               <div className={cn("mt-0.5 truncate font-mono text-xs", selected ? "text-accent-foreground/70" : "text-foreground/70")}>
                                 {user.username}
                               </div>

--- a/frontend/src/components/admin-users-page.tsx
+++ b/frontend/src/components/admin-users-page.tsx
@@ -111,7 +111,6 @@ export function AdminUsersPage({ embedded = false, server: serverProp, currentUs
   const [notice, setNotice] = useState<string | null>(null);
   const [resolvedCurrentUsername, setResolvedCurrentUsername] = useState<string | null>(currentUsername);
   const loadedServerRef = useRef<string | null>(null);
-  const lockedServer = embedded && serverProp !== undefined;
 
   const selectedUser = useMemo(
     () => users.find((user) => user.username === selectedUsername) ?? null,
@@ -253,28 +252,25 @@ export function AdminUsersPage({ embedded = false, server: serverProp, currentUs
   const ContentElement = embedded ? "section" : "main";
 
   const mainContent = (
-      <ContentElement className={cn("flex min-w-0 flex-1 flex-col overflow-hidden", embedded && "bg-background/65")}>
-        <header className="border-b border-border/80 bg-background/70 px-4 py-3 backdrop-blur sm:px-6">
-          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-            <div>
-              <div className={cn(
-                "flex items-center gap-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground",
-                !embedded && "md:hidden",
-              )}>
-                <ShieldCheck className="h-4 w-4" />
-                {t("title")}
+    <ContentElement className={cn("flex min-w-0 flex-1 flex-col overflow-hidden", embedded && "bg-background/65")}>
+        {!embedded ? (
+          <header className="border-b border-border/80 bg-background/70 px-4 py-3 backdrop-blur sm:px-6">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground md:hidden">
+                  <ShieldCheck className="h-4 w-4" />
+                  {t("title")}
+                </div>
+                <h1 className="mt-1 text-2xl font-semibold tracking-tight md:mt-0">{t("users.title")}</h1>
+                <p className="mt-1 max-w-2xl text-sm text-muted-foreground">{t("users.description")}</p>
               </div>
-              <h1 className="mt-1 text-2xl font-semibold tracking-tight md:mt-0">{t("users.title")}</h1>
-              <p className="mt-1 max-w-2xl text-sm text-muted-foreground">{t("users.description")}</p>
-            </div>
-            <form
-              onSubmit={(event) => {
-                event.preventDefault();
-                void refreshUsers();
-              }}
-              className={cn("grid gap-2", lockedServer ? "sm:grid-cols-[auto]" : "sm:grid-cols-[minmax(13rem,1fr)_auto] lg:w-[28rem]")}
-            >
-              {!lockedServer ? (
+              <form
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  void refreshUsers();
+                }}
+                className="grid gap-2 sm:grid-cols-[minmax(13rem,1fr)_auto] lg:w-[28rem]"
+              >
                 <label className="space-y-1">
                   <span className="text-xs font-medium text-muted-foreground">{t("serverLabel")}</span>
                   <input
@@ -285,23 +281,23 @@ export function AdminUsersPage({ embedded = false, server: serverProp, currentUs
                     className={inputClassName}
                   />
                 </label>
-              ) : null}
-              <button
-                type="submit"
-                disabled={loading || !server.trim()}
-                className="inline-flex min-h-10 items-center justify-center gap-2 self-end rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
-                {loading ? t("actions.loading") : t("actions.load")}
-              </button>
-            </form>
-          </div>
-          {(error || notice) && (
-            <div className={cn("mt-3 text-sm", error ? "text-destructive" : "text-muted-foreground")}>
-              {error ?? notice}
+                <button
+                  type="submit"
+                  disabled={loading || !server.trim()}
+                  className="inline-flex min-h-10 items-center justify-center gap-2 self-end rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                  {loading ? t("actions.loading") : t("actions.load")}
+                </button>
+              </form>
             </div>
-          )}
-        </header>
+            {(error || notice) && (
+              <div className={cn("mt-3 text-sm", error ? "text-destructive" : "text-muted-foreground")}>
+                {error ?? notice}
+              </div>
+            )}
+          </header>
+        ) : null}
 
         <div className="grid min-h-0 flex-1 lg:grid-cols-[22rem_minmax(0,1fr)]">
           <section className="min-h-0 border-b border-border/80 bg-background/55 lg:border-r lg:border-b-0">
@@ -411,6 +407,11 @@ export function AdminUsersPage({ embedded = false, server: serverProp, currentUs
           </section>
 
           <section className="min-h-0 overflow-y-auto px-4 py-5 sm:px-6">
+            {embedded && error ? (
+              <div className="mx-auto mb-4 max-w-3xl rounded-2xl border border-border bg-background/88 px-4 py-3 text-sm shadow-sm">
+                <p className="text-destructive">{error}</p>
+              </div>
+            ) : null}
             {selectedIsNew ? (
               <form onSubmit={(event) => void handleCreateUser(event)} className="mx-auto max-w-3xl space-y-5">
                 <div className="flex items-center gap-3">

--- a/frontend/src/components/admin-users-page.tsx
+++ b/frontend/src/components/admin-users-page.tsx
@@ -1,0 +1,532 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft, Check, Loader2, Plus, RefreshCw, Save, ShieldCheck, UserPlus, Users } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+
+import { createAdminUser, listAdminUsers, updateAdminUser, type AdminUserInfo } from "@/lib/api";
+import { getServer } from "@/lib/storage";
+import { cn } from "@/lib/utils";
+
+type UserDraft = {
+  displayName: string;
+  email: string;
+  roles: string;
+  enabled: boolean;
+  password: string;
+};
+
+type CreateDraft = {
+  username: string;
+  password: string;
+  displayName: string;
+  email: string;
+  roles: string;
+};
+
+const emptyCreateDraft: CreateDraft = {
+  username: "",
+  password: "",
+  displayName: "",
+  email: "",
+  roles: "",
+};
+
+function defaultServer(): string {
+  if (typeof window === "undefined") return "http://127.0.0.1:8321";
+  const url = new URL(window.location.origin);
+  if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
+    return `${url.protocol}//${url.hostname}:8321`;
+  }
+  return window.location.origin;
+}
+
+function normalizeServer(server: string): string {
+  return server.trim().replace(/\/$/, "");
+}
+
+function rolesFromText(value: string): string[] {
+  return [...new Set(value.split(/[\n,]/).map((role) => role.trim()).filter(Boolean))];
+}
+
+function textFromRoles(roles: string[]): string {
+  return roles.join(", ");
+}
+
+function draftFromUser(user: AdminUserInfo): UserDraft {
+  return {
+    displayName: user.display_name,
+    email: user.email ?? "",
+    roles: textFromRoles(user.roles),
+    enabled: user.enabled,
+    password: "",
+  };
+}
+
+function formatTimestamp(value: string | null, fallback: string): string {
+  if (!value) return fallback;
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) return value;
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(parsed);
+}
+
+const inputClassName = cn(
+  "w-full rounded-lg border border-border bg-background px-3 py-2 text-base sm:text-sm",
+  "outline-none transition-colors placeholder:text-muted-foreground/50",
+  "focus:border-ring focus:ring-2 focus:ring-ring/30",
+);
+
+const iconButtonClassName = cn(
+  "inline-flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition-colors",
+  "hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50",
+);
+
+export function AdminUsersPage() {
+  const t = useTranslations("admin");
+  const [server, setServer] = useState(() => {
+    if (typeof window === "undefined") return defaultServer();
+    const params = new URLSearchParams(window.location.search);
+    return normalizeServer(params.get("server") ?? getServer() ?? defaultServer());
+  });
+  const [adminToken, setAdminToken] = useState("");
+  const [users, setUsers] = useState<AdminUserInfo[]>([]);
+  const [selectedUsername, setSelectedUsername] = useState<string | "new">("new");
+  const [editDraft, setEditDraft] = useState<UserDraft | null>(null);
+  const [createDraft, setCreateDraft] = useState<CreateDraft>(emptyCreateDraft);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const selectedUser = useMemo(
+    () => users.find((user) => user.username === selectedUsername) ?? null,
+    [selectedUsername, users],
+  );
+
+  async function refreshUsers(preferredUsername: string | "new" = selectedUsername, message?: string): Promise<void> {
+    const normalizedServer = normalizeServer(server);
+    if (!normalizedServer || !adminToken.trim()) {
+      setError(t("errors.missingCredentials"));
+      setNotice(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const loadedUsers = await listAdminUsers(normalizedServer, adminToken.trim());
+      setServer(normalizedServer);
+      setUsers(loadedUsers);
+      if (preferredUsername === "new") {
+        setSelectedUsername("new");
+        setEditDraft(null);
+      } else if (loadedUsers.some((user) => user.username === preferredUsername)) {
+        setSelectedUsername(preferredUsername);
+        setEditDraft(draftFromUser(loadedUsers.find((user) => user.username === preferredUsername)!));
+      } else {
+        const fallbackUser = loadedUsers[0] ?? null;
+        setSelectedUsername(fallbackUser?.username ?? "new");
+        setEditDraft(fallbackUser === null ? null : draftFromUser(fallbackUser));
+      }
+      setNotice(message ?? t("notices.loaded"));
+    } catch (refreshError) {
+      setError(refreshError instanceof Error ? refreshError.message : t("errors.load"));
+      setNotice(null);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleCreateUser(event: React.FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    const normalizedServer = normalizeServer(server);
+    if (!normalizedServer || !adminToken.trim()) {
+      setError(t("errors.missingCredentials"));
+      setNotice(null);
+      return;
+    }
+
+    setCreating(true);
+    setError(null);
+    try {
+      const created = await createAdminUser(normalizedServer, adminToken.trim(), {
+        username: createDraft.username.trim(),
+        password: createDraft.password,
+        display_name: createDraft.displayName.trim(),
+        email: createDraft.email.trim() || null,
+        roles: rolesFromText(createDraft.roles),
+      });
+      setCreateDraft(emptyCreateDraft);
+      await refreshUsers(created.username, t("notices.created", { username: created.username }));
+    } catch (createError) {
+      setError(createError instanceof Error ? createError.message : t("errors.create"));
+      setNotice(null);
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleSaveUser(event: React.FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    if (selectedUser === null || editDraft === null) return;
+    const normalizedServer = normalizeServer(server);
+    if (!normalizedServer || !adminToken.trim()) {
+      setError(t("errors.missingCredentials"));
+      setNotice(null);
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await updateAdminUser(normalizedServer, adminToken.trim(), selectedUser.username, {
+        display_name: editDraft.displayName.trim(),
+        email: editDraft.email.trim() || null,
+        roles: rolesFromText(editDraft.roles),
+        enabled: editDraft.enabled,
+        ...(editDraft.password ? { password: editDraft.password } : {}),
+      });
+      await refreshUsers(updated.username, t("notices.saved", { username: updated.username }));
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : t("errors.save"));
+      setNotice(null);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const selectedIsNew = selectedUsername === "new";
+
+  return (
+    <div className="flex h-dvh overflow-hidden bg-[radial-gradient(circle_at_top_left,_color-mix(in_oklch,var(--accent)_55%,transparent),transparent_35%),linear-gradient(180deg,color-mix(in_oklch,var(--background)_96%,var(--muted))_0%,var(--background)_100%)]">
+      <aside className="hidden w-72 shrink-0 border-r border-border bg-background/88 md:flex md:flex-col">
+        <div className="border-b border-border px-5 py-4">
+          <div className="flex items-center gap-2 text-sm font-semibold tracking-tight">
+            <ShieldCheck className="h-4 w-4 text-muted-foreground" />
+            {t("title")}
+          </div>
+          <div className="mt-1 truncate text-xs text-muted-foreground">{server || t("serverPlaceholder")}</div>
+        </div>
+        <nav className="flex-1 p-3">
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 rounded-lg bg-accent px-3 py-2 text-sm font-medium text-accent-foreground"
+          >
+            <Users className="h-4 w-4" />
+            {t("users.title")}
+          </button>
+        </nav>
+        <div className="border-t border-border p-3">
+          <Link
+            href="/"
+            className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            {t("backToApp")}
+          </Link>
+        </div>
+      </aside>
+
+      <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
+        <header className="border-b border-border/80 bg-background/70 px-4 py-3 backdrop-blur sm:px-6">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground md:hidden">
+                <ShieldCheck className="h-4 w-4" />
+                {t("title")}
+              </div>
+              <h1 className="mt-1 text-2xl font-semibold tracking-tight md:mt-0">{t("users.title")}</h1>
+            </div>
+            <form
+              onSubmit={(event) => {
+                event.preventDefault();
+                void refreshUsers();
+              }}
+              className="grid gap-2 sm:grid-cols-[minmax(13rem,1fr)_minmax(12rem,1fr)_auto] lg:w-[42rem]"
+            >
+              <label className="space-y-1">
+                <span className="text-xs font-medium text-muted-foreground">{t("serverLabel")}</span>
+                <input
+                  type="url"
+                  value={server}
+                  onChange={(event) => setServer(event.target.value)}
+                  placeholder="http://127.0.0.1:8321"
+                  className={inputClassName}
+                />
+              </label>
+              <label className="space-y-1">
+                <span className="text-xs font-medium text-muted-foreground">{t("adminTokenLabel")}</span>
+                <input
+                  type="password"
+                  value={adminToken}
+                  onChange={(event) => setAdminToken(event.target.value)}
+                  placeholder={t("adminTokenPlaceholder")}
+                  className={inputClassName}
+                />
+              </label>
+              <button
+                type="submit"
+                disabled={loading || !server.trim() || !adminToken.trim()}
+                className="inline-flex min-h-10 items-center justify-center gap-2 self-end rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                {loading ? t("actions.loading") : t("actions.load")}
+              </button>
+            </form>
+          </div>
+          {(error || notice) && (
+            <div className={cn("mt-3 text-sm", error ? "text-destructive" : "text-muted-foreground")}>
+              {error ?? notice}
+            </div>
+          )}
+        </header>
+
+        <div className="grid min-h-0 flex-1 lg:grid-cols-[22rem_minmax(0,1fr)]">
+          <section className="min-h-0 border-b border-border/80 bg-background/55 lg:border-r lg:border-b-0">
+            <div className="flex items-center justify-between gap-3 border-b border-border/70 px-4 py-3 sm:px-5">
+              <div className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                {t("users.savedUsers")}
+              </div>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => void refreshUsers(selectedUsername, t("notices.loaded"))}
+                  title={t("actions.refresh")}
+                  aria-label={t("actions.refresh")}
+                  className={iconButtonClassName}
+                  disabled={loading || !server.trim() || !adminToken.trim()}
+                >
+                  <RefreshCw className={cn("h-4 w-4", loading && "animate-spin")} />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSelectedUsername("new");
+                    setEditDraft(null);
+                    setError(null);
+                    setNotice(null);
+                  }}
+                  title={t("actions.new")}
+                  aria-label={t("actions.new")}
+                  className={iconButtonClassName}
+                >
+                  <Plus className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+            <div className="max-h-72 min-h-0 overflow-y-auto p-3 lg:max-h-none lg:h-full">
+              {loading ? (
+                <div className="flex items-center gap-2 rounded-lg border border-dashed border-border px-4 py-5 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  {t("users.loading")}
+                </div>
+              ) : users.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-border bg-background/80 px-4 py-6 text-sm text-muted-foreground">
+                  {t("users.empty")}
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {users.map((user) => {
+                    const selected = selectedUsername === user.username;
+                    return (
+                      <button
+                        key={user.username}
+                        type="button"
+                        onClick={() => {
+                          setSelectedUsername(user.username);
+                          setEditDraft(draftFromUser(user));
+                          setError(null);
+                          setNotice(null);
+                        }}
+                        className={cn(
+                          "w-full rounded-lg px-3 py-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                          selected ? "bg-accent text-accent-foreground" : "text-foreground/80 hover:bg-muted",
+                        )}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <div className="truncate text-sm font-semibold">{user.display_name || user.username}</div>
+                            <div className={cn("mt-0.5 truncate font-mono text-xs", selected ? "text-accent-foreground/70" : "text-foreground/70")}>
+                              {user.username}
+                            </div>
+                          </div>
+                          <span className={cn(
+                            "shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium",
+                            user.enabled ? "bg-emerald-100 text-emerald-700" : "bg-amber-100 text-amber-700",
+                          )}>
+                            {user.enabled ? t("users.enabled") : t("users.disabled")}
+                          </span>
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </section>
+
+          <section className="min-h-0 overflow-y-auto px-4 py-5 sm:px-6">
+            {selectedIsNew ? (
+              <form onSubmit={(event) => void handleCreateUser(event)} className="mx-auto max-w-3xl space-y-5">
+                <div className="flex items-center gap-3">
+                  <div className="rounded-lg border border-border bg-background p-2 text-muted-foreground">
+                    <UserPlus className="h-4 w-4" />
+                  </div>
+                  <div>
+                    <h2 className="text-lg font-semibold tracking-tight">{t("create.title")}</h2>
+                    <p className="text-sm text-muted-foreground">{t("create.subtitle")}</p>
+                  </div>
+                </div>
+
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <Field label={t("fields.username")}>
+                    <input
+                      value={createDraft.username}
+                      onChange={(event) => setCreateDraft((draft) => ({ ...draft, username: event.target.value }))}
+                      className={inputClassName}
+                      required
+                    />
+                  </Field>
+                  <Field label={t("fields.password")}>
+                    <input
+                      type="password"
+                      value={createDraft.password}
+                      onChange={(event) => setCreateDraft((draft) => ({ ...draft, password: event.target.value }))}
+                      className={inputClassName}
+                      required
+                    />
+                  </Field>
+                  <Field label={t("fields.displayName")}>
+                    <input
+                      value={createDraft.displayName}
+                      onChange={(event) => setCreateDraft((draft) => ({ ...draft, displayName: event.target.value }))}
+                      className={inputClassName}
+                    />
+                  </Field>
+                  <Field label={t("fields.email")}>
+                    <input
+                      type="email"
+                      value={createDraft.email}
+                      onChange={(event) => setCreateDraft((draft) => ({ ...draft, email: event.target.value }))}
+                      className={inputClassName}
+                    />
+                  </Field>
+                  <Field label={t("fields.roles")} className="sm:col-span-2">
+                    <input
+                      value={createDraft.roles}
+                      onChange={(event) => setCreateDraft((draft) => ({ ...draft, roles: event.target.value }))}
+                      placeholder="admin, matrix"
+                      className={inputClassName}
+                    />
+                  </Field>
+                </div>
+
+                <button
+                  type="submit"
+                  disabled={creating || !createDraft.username.trim() || !createDraft.password || !server.trim() || !adminToken.trim()}
+                  className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <UserPlus className="h-4 w-4" />}
+                  {creating ? t("actions.creating") : t("actions.create")}
+                </button>
+              </form>
+            ) : selectedUser && editDraft ? (
+              <form onSubmit={(event) => void handleSaveUser(event)} className="mx-auto max-w-3xl space-y-5">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <div className="font-mono text-xs text-muted-foreground">{selectedUser.username}</div>
+                    <h2 className="mt-1 text-2xl font-semibold tracking-tight">{selectedUser.display_name || selectedUser.username}</h2>
+                    <div className="mt-2 flex flex-wrap gap-2 text-xs text-muted-foreground">
+                      <span>{t("meta.tokenVersion", { version: selectedUser.token_version })}</span>
+                      <span>{t("meta.updated", { timestamp: formatTimestamp(selectedUser.updated_at, t("meta.never")) })}</span>
+                      <span>{t("meta.lastLogin", { timestamp: formatTimestamp(selectedUser.last_login_at, t("meta.never")) })}</span>
+                    </div>
+                  </div>
+                  <label className="inline-flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm font-medium">
+                    <input
+                      type="checkbox"
+                      checked={editDraft.enabled}
+                      onChange={(event) => setEditDraft((draft) => draft ? { ...draft, enabled: event.target.checked } : draft)}
+                      className="h-4 w-4 rounded border-border accent-foreground"
+                    />
+                    {t("fields.enabled")}
+                  </label>
+                </div>
+
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <Field label={t("fields.displayName")}>
+                    <input
+                      value={editDraft.displayName}
+                      onChange={(event) => setEditDraft((draft) => draft ? { ...draft, displayName: event.target.value } : draft)}
+                      className={inputClassName}
+                    />
+                  </Field>
+                  <Field label={t("fields.email")}>
+                    <input
+                      type="email"
+                      value={editDraft.email}
+                      onChange={(event) => setEditDraft((draft) => draft ? { ...draft, email: event.target.value } : draft)}
+                      className={inputClassName}
+                    />
+                  </Field>
+                  <Field label={t("fields.roles")}>
+                    <input
+                      value={editDraft.roles}
+                      onChange={(event) => setEditDraft((draft) => draft ? { ...draft, roles: event.target.value } : draft)}
+                      placeholder="admin, matrix"
+                      className={inputClassName}
+                    />
+                  </Field>
+                  <Field label={t("fields.newPassword")}>
+                    <input
+                      type="password"
+                      value={editDraft.password}
+                      onChange={(event) => setEditDraft((draft) => draft ? { ...draft, password: event.target.value } : draft)}
+                      placeholder={t("fields.keepPassword")}
+                      className={inputClassName}
+                    />
+                  </Field>
+                </div>
+
+                <div className="flex flex-wrap items-center gap-2">
+                  <button
+                    type="submit"
+                    disabled={saving || !server.trim() || !adminToken.trim()}
+                    className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+                    {saving ? t("actions.saving") : t("actions.save")}
+                  </button>
+                  {notice && !error && (
+                    <span className="inline-flex items-center gap-1 text-sm text-muted-foreground">
+                      <Check className="h-4 w-4" />
+                      {notice}
+                    </span>
+                  )}
+                </div>
+              </form>
+            ) : (
+              <div className="mx-auto max-w-3xl rounded-lg border border-dashed border-border bg-background/75 px-4 py-6 text-sm text-muted-foreground">
+                {t("users.selectUser")}
+              </div>
+            )}
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function Field({ label, children, className }: { label: string; children: React.ReactNode; className?: string }) {
+  return (
+    <label className={cn("space-y-1.5", className)}>
+      <span className="text-xs font-medium text-muted-foreground">{label}</span>
+      {children}
+    </label>
+  );
+}

--- a/frontend/src/components/admin-users-page.tsx
+++ b/frontend/src/components/admin-users-page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { ArrowLeft, Check, DatabaseBackup, Loader2, Plus, RefreshCw, Save, ShieldCheck, UserPlus, Users } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 
 import { createAdminUser, listAdminUsers, updateAdminUser, upgradeAdminUserData, type AdminUserInfo } from "@/lib/api";
@@ -85,9 +85,15 @@ const iconButtonClassName = cn(
   "hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50",
 );
 
-export function AdminUsersPage() {
+interface AdminUsersPageProps {
+  embedded?: boolean;
+  server?: string;
+}
+
+export function AdminUsersPage({ embedded = false, server: serverProp }: AdminUsersPageProps = {}) {
   const t = useTranslations("admin");
   const [server, setServer] = useState(() => {
+    if (serverProp !== undefined) return normalizeServer(serverProp);
     if (typeof window === "undefined") return defaultServer();
     const params = new URLSearchParams(window.location.search);
     return normalizeServer(params.get("server") ?? getServer() ?? defaultServer());
@@ -102,13 +108,15 @@ export function AdminUsersPage() {
   const [upgradingUsername, setUpgradingUsername] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const loadedServerRef = useRef<string | null>(null);
+  const lockedServer = embedded && serverProp !== undefined;
 
   const selectedUser = useMemo(
     () => users.find((user) => user.username === selectedUsername) ?? null,
     [selectedUsername, users],
   );
 
-  async function refreshUsers(preferredUsername: string | "new" = selectedUsername, message?: string): Promise<void> {
+  const refreshUsers = useCallback(async (preferredUsername: string | "new" = selectedUsername, message?: string): Promise<void> => {
     const normalizedServer = normalizeServer(server);
     if (!normalizedServer) {
       setError(t("errors.missingCredentials"));
@@ -140,7 +148,15 @@ export function AdminUsersPage() {
     } finally {
       setLoading(false);
     }
-  }
+  }, [selectedUsername, server, t]);
+
+  useEffect(() => {
+    if (!embedded) return;
+    const normalizedServer = normalizeServer(server);
+    if (!normalizedServer || loadedServerRef.current === normalizedServer) return;
+    loadedServerRef.current = normalizedServer;
+    void refreshUsers(selectedUsername);
+  }, [embedded, refreshUsers, selectedUsername, server]);
 
   async function handleCreateUser(event: React.FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();
@@ -227,64 +243,42 @@ export function AdminUsersPage() {
   }
 
   const selectedIsNew = selectedUsername === "new";
+    const ContentElement = embedded ? "section" : "main";
 
-  return (
-    <div className="flex h-dvh overflow-hidden bg-[radial-gradient(circle_at_top_left,_color-mix(in_oklch,var(--accent)_55%,transparent),transparent_35%),linear-gradient(180deg,color-mix(in_oklch,var(--background)_96%,var(--muted))_0%,var(--background)_100%)]">
-      <aside className="hidden w-72 shrink-0 border-r border-border bg-background/88 md:flex md:flex-col">
-        <div className="border-b border-border px-5 py-4">
-          <div className="flex items-center gap-2 text-sm font-semibold tracking-tight">
-            <ShieldCheck className="h-4 w-4 text-muted-foreground" />
-            {t("title")}
-          </div>
-          <div className="mt-1 truncate text-xs text-muted-foreground">{server || t("serverPlaceholder")}</div>
-        </div>
-        <nav className="flex-1 p-3">
-          <button
-            type="button"
-            className="flex w-full items-center gap-2 rounded-lg bg-accent px-3 py-2 text-sm font-medium text-accent-foreground"
-          >
-            <Users className="h-4 w-4" />
-            {t("users.title")}
-          </button>
-        </nav>
-        <div className="border-t border-border p-3">
-          <Link
-            href="/"
-            className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            {t("backToApp")}
-          </Link>
-        </div>
-      </aside>
-
-      <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
+  const mainContent = (
+      <ContentElement className={cn("flex min-w-0 flex-1 flex-col overflow-hidden", embedded && "bg-background/65")}>
         <header className="border-b border-border/80 bg-background/70 px-4 py-3 backdrop-blur sm:px-6">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
             <div>
-              <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground md:hidden">
+              <div className={cn(
+                "flex items-center gap-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground",
+                !embedded && "md:hidden",
+              )}>
                 <ShieldCheck className="h-4 w-4" />
                 {t("title")}
               </div>
               <h1 className="mt-1 text-2xl font-semibold tracking-tight md:mt-0">{t("users.title")}</h1>
+              <p className="mt-1 max-w-2xl text-sm text-muted-foreground">{t("users.description")}</p>
             </div>
             <form
               onSubmit={(event) => {
                 event.preventDefault();
                 void refreshUsers();
               }}
-              className="grid gap-2 sm:grid-cols-[minmax(13rem,1fr)_auto] lg:w-[28rem]"
+              className={cn("grid gap-2", lockedServer ? "sm:grid-cols-[auto]" : "sm:grid-cols-[minmax(13rem,1fr)_auto] lg:w-[28rem]")}
             >
-              <label className="space-y-1">
-                <span className="text-xs font-medium text-muted-foreground">{t("serverLabel")}</span>
-                <input
-                  type="url"
-                  value={server}
-                  onChange={(event) => setServer(event.target.value)}
-                  placeholder="http://127.0.0.1:8321"
-                  className={inputClassName}
-                />
-              </label>
+              {!lockedServer ? (
+                <label className="space-y-1">
+                  <span className="text-xs font-medium text-muted-foreground">{t("serverLabel")}</span>
+                  <input
+                    type="url"
+                    value={server}
+                    onChange={(event) => setServer(event.target.value)}
+                    placeholder="http://127.0.0.1:8321"
+                    className={inputClassName}
+                  />
+                </label>
+              ) : null}
               <button
                 type="submit"
                 disabled={loading || !server.trim()}
@@ -545,7 +539,44 @@ export function AdminUsersPage() {
             )}
           </section>
         </div>
-      </main>
+        </ContentElement>
+  );
+
+  if (embedded) {
+    return mainContent;
+  }
+
+  return (
+    <div className="flex h-dvh overflow-hidden bg-[radial-gradient(circle_at_top_left,_color-mix(in_oklch,var(--accent)_55%,transparent),transparent_35%),linear-gradient(180deg,color-mix(in_oklch,var(--background)_96%,var(--muted))_0%,var(--background)_100%)]">
+      <aside className="hidden w-72 shrink-0 border-r border-border bg-background/88 md:flex md:flex-col">
+        <div className="border-b border-border px-5 py-4">
+          <div className="flex items-center gap-2 text-sm font-semibold tracking-tight">
+            <ShieldCheck className="h-4 w-4 text-muted-foreground" />
+            {t("title")}
+          </div>
+          <div className="mt-1 truncate text-xs text-muted-foreground">{server || t("serverPlaceholder")}</div>
+        </div>
+        <nav className="flex-1 p-3">
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 rounded-lg bg-accent px-3 py-2 text-sm font-medium text-accent-foreground"
+          >
+            <Users className="h-4 w-4" />
+            {t("users.title")}
+          </button>
+        </nav>
+        <div className="border-t border-border p-3">
+          <Link
+            href="/"
+            className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            {t("backToApp")}
+          </Link>
+        </div>
+      </aside>
+
+      {mainContent}
     </div>
   );
 }

--- a/frontend/src/components/admin-users-page.tsx
+++ b/frontend/src/components/admin-users-page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowLeft, Check, Loader2, Plus, RefreshCw, Save, ShieldCheck, UserPlus, Users } from "lucide-react";
+import { ArrowLeft, Check, DatabaseBackup, Loader2, Plus, RefreshCw, Save, ShieldCheck, UserPlus, Users } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 
-import { createAdminUser, listAdminUsers, updateAdminUser, type AdminUserInfo } from "@/lib/api";
+import { createAdminUser, listAdminUsers, updateAdminUser, upgradeAdminUserData, type AdminUserInfo } from "@/lib/api";
 import { getServer } from "@/lib/storage";
 import { cn } from "@/lib/utils";
 
@@ -100,6 +100,7 @@ export function AdminUsersPage() {
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [creating, setCreating] = useState(false);
+  const [upgradingUsername, setUpgradingUsername] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
 
@@ -197,6 +198,32 @@ export function AdminUsersPage() {
       setNotice(null);
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function handleUpgradeUser(username: string): Promise<void> {
+    const normalizedServer = normalizeServer(server);
+    if (!normalizedServer || !adminToken.trim()) {
+      setError(t("errors.missingCredentials"));
+      setNotice(null);
+      return;
+    }
+    if (!window.confirm(t("confirm.upgradeUser", { username }))) {
+      return;
+    }
+
+    setUpgradingUsername(username);
+    setError(null);
+    setNotice(null);
+    try {
+      const result = await upgradeAdminUserData(normalizedServer, adminToken.trim(), username);
+      const changedCount = Object.values(result.summary).reduce((total, entries) => total + entries.length, 0);
+      await refreshUsers(result.username, t("notices.upgraded", { username: result.username, count: changedCount }));
+    } catch (upgradeError) {
+      setError(upgradeError instanceof Error ? upgradeError.message : t("errors.upgrade"));
+      setNotice(null);
+    } finally {
+      setUpgradingUsername(null);
     }
   }
 
@@ -333,36 +360,48 @@ export function AdminUsersPage() {
                 <div className="space-y-2">
                   {users.map((user) => {
                     const selected = selectedUsername === user.username;
+                    const upgrading = upgradingUsername === user.username;
                     return (
-                      <button
-                        key={user.username}
-                        type="button"
-                        onClick={() => {
-                          setSelectedUsername(user.username);
-                          setEditDraft(draftFromUser(user));
-                          setError(null);
-                          setNotice(null);
-                        }}
-                        className={cn(
-                          "w-full rounded-lg px-3 py-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                          selected ? "bg-accent text-accent-foreground" : "text-foreground/80 hover:bg-muted",
-                        )}
-                      >
-                        <div className="flex items-start justify-between gap-3">
-                          <div className="min-w-0">
-                            <div className="truncate text-sm font-semibold">{user.display_name || user.username}</div>
-                            <div className={cn("mt-0.5 truncate font-mono text-xs", selected ? "text-accent-foreground/70" : "text-foreground/70")}>
-                              {user.username}
+                      <div key={user.username} className="flex items-stretch gap-1">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setSelectedUsername(user.username);
+                            setEditDraft(draftFromUser(user));
+                            setError(null);
+                            setNotice(null);
+                          }}
+                          className={cn(
+                            "min-w-0 flex-1 rounded-lg px-3 py-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                            selected ? "bg-accent text-accent-foreground" : "text-foreground/80 hover:bg-muted",
+                          )}
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0">
+                              <div className="truncate text-sm font-semibold">{user.display_name || user.username}</div>
+                              <div className={cn("mt-0.5 truncate font-mono text-xs", selected ? "text-accent-foreground/70" : "text-foreground/70")}>
+                                {user.username}
+                              </div>
                             </div>
+                            <span className={cn(
+                              "shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium",
+                              user.enabled ? "bg-emerald-100 text-emerald-700" : "bg-amber-100 text-amber-700",
+                            )}>
+                              {user.enabled ? t("users.enabled") : t("users.disabled")}
+                            </span>
                           </div>
-                          <span className={cn(
-                            "shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium",
-                            user.enabled ? "bg-emerald-100 text-emerald-700" : "bg-amber-100 text-amber-700",
-                          )}>
-                            {user.enabled ? t("users.enabled") : t("users.disabled")}
-                          </span>
-                        </div>
-                      </button>
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void handleUpgradeUser(user.username)}
+                          title={t("actions.upgradeUser", { username: user.username })}
+                          aria-label={t("actions.upgradeUser", { username: user.username })}
+                          className={iconButtonClassName}
+                          disabled={upgradingUsername !== null || loading || !server.trim() || !adminToken.trim()}
+                        >
+                          {upgrading ? <Loader2 className="h-4 w-4 animate-spin" /> : <DatabaseBackup className="h-4 w-4" />}
+                        </button>
+                      </div>
                     );
                   })}
                 </div>

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -16,6 +16,7 @@ import {
   fetchSandbox,
   fetchModels,
   forkSession,
+  getWebSocketTicket,
   type SlashCommand,
   startSandbox,
   stopSandbox,
@@ -1392,7 +1393,22 @@ export function ChatView({
     setWaiting(false);
   }, [clearToolLoading]);
   const presenceClientId = useRef(getPresenceClientId()).current;
-  const url = wsUrl(server, sessionId, token, presenceClientId);
+  const [webSocketTicket, setWebSocketTicket] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    setWebSocketTicket(null);
+    getWebSocketTicket(server, token)
+      .then((ticket) => {
+        if (!cancelled) setWebSocketTicket(ticket);
+      })
+      .catch(() => {
+        if (!cancelled) setWebSocketTicket(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [server, token]);
+  const url = webSocketTicket ? wsUrl(server, sessionId, token, presenceClientId, webSocketTicket) : null;
   const { status, send } = useWebSocket(url, onMessage, onWsDisconnect);
   useSessionPresence(server, token, sessionId, status, presenceClientId);
   useEffect(() => {

--- a/frontend/src/components/connect-form.tsx
+++ b/frontend/src/components/connect-form.tsx
@@ -2,11 +2,11 @@
 
 import { useTranslations } from "next-intl";
 import { useState } from "react";
-import { login } from "@/lib/api";
+import { login, type AuthUserInfo } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
 interface ConnectFormProps {
-  onConnect: (server: string, username: string) => void;
+  onConnect: (server: string, user: AuthUserInfo) => void;
 }
 
 function defaultServer(): string {
@@ -34,7 +34,7 @@ export function ConnectForm({ onConnect }: ConnectFormProps) {
     try {
       const normalizedServer = server.replace(/\/$/, "");
       const user = await login(normalizedServer, username, password);
-      onConnect(normalizedServer, user.username);
+      onConnect(normalizedServer, user);
     } catch (err) {
       setError(err instanceof Error ? err.message : t("errors.connectionFailed"));
     } finally {
@@ -137,12 +137,6 @@ export function ConnectForm({ onConnect }: ConnectFormProps) {
         >
           {loading ? t("connecting") : t("connect")}
         </button>
-        <a
-          href={`/admin/users?server=${encodeURIComponent(server.replace(/\/$/, ""))}`}
-          className="block text-center text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-        >
-          {t("adminLink")}
-        </a>
       </form>
     </div>
   );

--- a/frontend/src/components/connect-form.tsx
+++ b/frontend/src/components/connect-form.tsx
@@ -138,7 +138,7 @@ export function ConnectForm({ onConnect }: ConnectFormProps) {
           {loading ? t("connecting") : t("connect")}
         </button>
         <a
-          href={`${server.replace(/\/$/, "")}/api/admin/users`}
+          href={`/admin/users?server=${encodeURIComponent(server.replace(/\/$/, ""))}`}
           className="block text-center text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
         >
           {t("adminLink")}

--- a/frontend/src/components/connect-form.tsx
+++ b/frontend/src/components/connect-form.tsx
@@ -2,10 +2,11 @@
 
 import { useTranslations } from "next-intl";
 import { useState } from "react";
+import { login } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
 interface ConnectFormProps {
-  onConnect: (server: string, token: string) => void;
+  onConnect: (server: string, username: string) => void;
 }
 
 function defaultServer(): string {
@@ -20,7 +21,8 @@ function defaultServer(): string {
 export function ConnectForm({ onConnect }: ConnectFormProps) {
   const t = useTranslations("connect");
   const [server, setServer] = useState(defaultServer);
-  const [token, setToken] = useState("");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -30,16 +32,9 @@ export function ConnectForm({ onConnect }: ConnectFormProps) {
     setLoading(true);
 
     try {
-      const res = await fetch(`${server.replace(/\/$/, "")}/api/sessions`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok)
-        throw new Error(
-          res.status === 401
-            ? t("errors.invalidToken")
-            : t("errors.serverError", { status: res.status }),
-        );
-      onConnect(server.replace(/\/$/, ""), token);
+      const normalizedServer = server.replace(/\/$/, "");
+      const user = await login(normalizedServer, username, password);
+      onConnect(normalizedServer, user.username);
     } catch (err) {
       setError(err instanceof Error ? err.message : t("errors.connectionFailed"));
     } finally {
@@ -83,20 +78,43 @@ export function ConnectForm({ onConnect }: ConnectFormProps) {
 
           <div className="space-y-1.5">
             <label
-              htmlFor="token"
+              htmlFor="username"
               className="text-xs font-medium text-muted-foreground"
             >
-              {t("tokenLabel")}
+              {t("usernameLabel")}
             </label>
             <input
-              id="token"
-              type="password"
-              value={token}
-              onChange={(e) => setToken(e.target.value)}
-              placeholder={t("tokenPlaceholder")}
+              id="username"
+              type="text"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              placeholder={t("usernamePlaceholder")}
               required
               className={cn(
-                "w-full rounded-lg border border-border bg-background px-3 py-2.5 text-base sm:text-sm font-mono",
+                "w-full rounded-lg border border-border bg-background px-3 py-2.5 text-base sm:text-sm",
+                "outline-none transition-colors",
+                "focus:ring-2 focus:ring-ring/30 focus:border-ring",
+                "placeholder:text-muted-foreground/50",
+              )}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label
+              htmlFor="password"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              {t("passwordLabel")}
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder={t("passwordPlaceholder")}
+              required
+              className={cn(
+                "w-full rounded-lg border border-border bg-background px-3 py-2.5 text-base sm:text-sm",
                 "outline-none transition-colors",
                 "focus:ring-2 focus:ring-ring/30 focus:border-ring",
                 "placeholder:text-muted-foreground/50",
@@ -109,7 +127,7 @@ export function ConnectForm({ onConnect }: ConnectFormProps) {
 
         <button
           type="submit"
-          disabled={loading || !token}
+          disabled={loading || !username || !password}
           className={cn(
             "w-full rounded-lg px-4 py-2 text-sm font-medium transition-colors",
             "bg-foreground text-background",
@@ -119,6 +137,12 @@ export function ConnectForm({ onConnect }: ConnectFormProps) {
         >
           {loading ? t("connecting") : t("connect")}
         </button>
+        <a
+          href={`${server.replace(/\/$/, "")}/api/admin/users`}
+          className="block text-center text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+        >
+          {t("adminLink")}
+        </a>
       </form>
     </div>
   );

--- a/frontend/src/components/connect-form.tsx
+++ b/frontend/src/components/connect-form.tsx
@@ -3,19 +3,11 @@
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { login, type AuthUserInfo } from "@/lib/api";
+import { defaultServer, normalizeServer } from "@/lib/server-url";
 import { cn } from "@/lib/utils";
 
 interface ConnectFormProps {
   onConnect: (server: string, user: AuthUserInfo) => void;
-}
-
-function defaultServer(): string {
-  if (typeof window === "undefined") return "http://127.0.0.1:8321";
-  const url = new URL(window.location.origin);
-  if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
-    return `${url.protocol}//${url.hostname}:8321`;
-  }
-  return window.location.origin;
 }
 
 export function ConnectForm({ onConnect }: ConnectFormProps) {
@@ -32,7 +24,7 @@ export function ConnectForm({ onConnect }: ConnectFormProps) {
     setLoading(true);
 
     try {
-      const normalizedServer = server.replace(/\/$/, "");
+      const normalizedServer = normalizeServer(server);
       const user = await login(normalizedServer, username, password);
       onConnect(normalizedServer, user);
     } catch (err) {

--- a/frontend/src/components/connect-form.tsx
+++ b/frontend/src/components/connect-form.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { login, type AuthUserInfo } from "@/lib/api";
 import { defaultServer, normalizeServer } from "@/lib/server-url";
+import { getServer, getToken } from "@/lib/storage";
 import { cn } from "@/lib/utils";
 
 interface ConnectFormProps {
@@ -12,8 +13,8 @@ interface ConnectFormProps {
 
 export function ConnectForm({ onConnect }: ConnectFormProps) {
   const t = useTranslations("connect");
-  const [server, setServer] = useState(defaultServer);
-  const [username, setUsername] = useState("");
+  const [server, setServer] = useState(() => getServer() || defaultServer());
+  const [username, setUsername] = useState(getToken);
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);

--- a/frontend/src/components/jobs-view.tsx
+++ b/frontend/src/components/jobs-view.tsx
@@ -27,6 +27,7 @@ interface JobsViewProps {
   server: string;
   token: string;
   isAdmin: boolean;
+  currentUsername: string | null;
   sessions: SessionInfo[];
   showArchivedSessions: boolean;
   onShowArchivedSessionsChange: (showArchivedSessions: boolean) => void;
@@ -136,6 +137,7 @@ export function JobsView({
   server,
   token,
   isAdmin,
+  currentUsername,
   sessions,
   showArchivedSessions,
   onShowArchivedSessionsChange,
@@ -1258,7 +1260,7 @@ export function JobsView({
           aria-labelledby="settings-tab-platform-users"
           className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background/65"
         >
-          <AdminUsersPage key={server} embedded server={server} />
+          <AdminUsersPage key={server} embedded server={server} currentUsername={currentUsername} />
         </div>
       ) : (
         <div

--- a/frontend/src/components/jobs-view.tsx
+++ b/frontend/src/components/jobs-view.tsx
@@ -25,6 +25,7 @@ import { cn } from "@/lib/utils";
 interface JobsViewProps {
   server: string;
   token: string;
+  isAdmin: boolean;
   sessions: SessionInfo[];
   showArchivedSessions: boolean;
   onShowArchivedSessionsChange: (showArchivedSessions: boolean) => void;
@@ -133,6 +134,7 @@ function toKebabCaseId(value: string): string {
 export function JobsView({
   server,
   token,
+  isAdmin,
   sessions,
   showArchivedSessions,
   onShowArchivedSessionsChange,
@@ -1238,6 +1240,7 @@ export function JobsView({
             embedded
             server={server}
             token={token}
+            isAdmin={isAdmin}
             showArchivedSessions={showArchivedSessions}
             onShowArchivedSessionsChange={onShowArchivedSessionsChange}
           />

--- a/frontend/src/components/jobs-view.tsx
+++ b/frontend/src/components/jobs-view.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/lib/api";
 import { useAppLocale } from "@/components/locale-provider";
 import { ModelPicker, withSelectedModelOption } from "@/components/model-picker";
+import { AdminUsersPage } from "@/components/admin-users-page";
 import { PreferencesView } from "@/components/preferences-view";
 import { SESSION_OPTION_ORDER, SessionOptionTiles, type SessionOptionKey } from "@/components/session-option-tiles";
 import { SwitchRow } from "@/components/switch-row";
@@ -35,7 +36,7 @@ interface JobsViewProps {
   onTabChange: (tab: SettingsTab) => void;
 }
 
-export type SettingsTab = "jobs" | "preferences";
+export type SettingsTab = "jobs" | "platform-users" | "preferences";
 
 const CRON_EXAMPLE_EXPRESSIONS = [
   "*/15 * * * *",
@@ -627,7 +628,16 @@ export function JobsView({
   const usePersistentSession = draft.persistent_session_id !== null;
   const hasPersistentSessionId = Boolean(draft.persistent_session_id?.trim());
   const defaultModelLabel = tRoot("commandResult.models.default");
-  const isJobsTab = activeTab === "jobs";
+  const effectiveActiveTab = activeTab === "platform-users" && !isAdmin ? "preferences" : activeTab;
+  const isJobsTab = effectiveActiveTab === "jobs";
+  const isPlatformUsersTab = effectiveActiveTab === "platform-users";
+  const isPreferencesTab = effectiveActiveTab === "preferences";
+  const tabButtonClassName = (selected: boolean): string => cn(
+    "rounded-t-lg border border-b-0 px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+    selected
+      ? "relative z-10 -mb-px border-border bg-background text-foreground"
+      : "border-transparent text-muted-foreground hover:border-border/60 hover:bg-background/70 hover:text-foreground",
+  );
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-[radial-gradient(circle_at_top_left,_color-mix(in_oklch,var(--accent)_55%,transparent),transparent_35%),linear-gradient(180deg,color-mix(in_oklch,var(--background)_96%,var(--muted))_0%,var(--background)_100%)]">
@@ -640,42 +650,57 @@ export function JobsView({
           <div
             role="tablist"
             aria-label={t("settingsSections")}
-            className="flex items-end gap-1 border-b border-border/80"
+            className="flex flex-wrap items-end gap-x-4 gap-y-2 border-b border-border/80"
           >
-            <button
-              id="settings-tab-preferences"
-              type="button"
-              role="tab"
-              aria-selected={!isJobsTab}
-              aria-controls="settings-panel-preferences"
-              tabIndex={!isJobsTab ? 0 : -1}
-              onClick={() => onTabChange("preferences")}
-              className={cn(
-                "rounded-t-lg border border-b-0 px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                !isJobsTab
-                  ? "relative z-10 -mb-px border-border bg-background text-foreground"
-                  : "border-transparent text-muted-foreground hover:border-border/60 hover:bg-background/70 hover:text-foreground",
-              )}
-            >
-              {tRoot("navigation.preferences")}
-            </button>
-            <button
-              id="settings-tab-jobs"
-              type="button"
-              role="tab"
-              aria-selected={isJobsTab}
-              aria-controls="settings-panel-jobs"
-              tabIndex={isJobsTab ? 0 : -1}
-              onClick={() => onTabChange("jobs")}
-              className={cn(
-                "rounded-t-lg border border-b-0 px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                isJobsTab
-                  ? "relative z-10 -mb-px border-border bg-background text-foreground"
-                  : "border-transparent text-muted-foreground hover:border-border/60 hover:bg-background/70 hover:text-foreground",
-              )}
-            >
-              {tRoot("navigation.jobs")}
-            </button>
+            <div className="flex items-end gap-1">
+              <span className="pb-2 pr-1 text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                {tRoot("navigation.personal")}
+              </span>
+              <button
+                id="settings-tab-preferences"
+                type="button"
+                role="tab"
+                aria-selected={isPreferencesTab}
+                aria-controls="settings-panel-preferences"
+                tabIndex={isPreferencesTab ? 0 : -1}
+                onClick={() => onTabChange("preferences")}
+                className={tabButtonClassName(isPreferencesTab)}
+              >
+                {tRoot("navigation.preferences")}
+              </button>
+              <button
+                id="settings-tab-jobs"
+                type="button"
+                role="tab"
+                aria-selected={isJobsTab}
+                aria-controls="settings-panel-jobs"
+                tabIndex={isJobsTab ? 0 : -1}
+                onClick={() => onTabChange("jobs")}
+                className={tabButtonClassName(isJobsTab)}
+              >
+                {tRoot("navigation.jobs")}
+              </button>
+            </div>
+
+            {isAdmin ? (
+              <div className="flex items-end gap-1 border-l border-border/80 pl-4">
+                <span className="pb-2 pr-1 text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                  {tRoot("navigation.platform")}
+                </span>
+                <button
+                  id="settings-tab-platform-users"
+                  type="button"
+                  role="tab"
+                  aria-selected={isPlatformUsersTab}
+                  aria-controls="settings-panel-platform-users"
+                  tabIndex={isPlatformUsersTab ? 0 : -1}
+                  onClick={() => onTabChange("platform-users")}
+                  className={tabButtonClassName(isPlatformUsersTab)}
+                >
+                  {tRoot("navigation.users")}
+                </button>
+              </div>
+            ) : null}
           </div>
 
         </div>
@@ -1229,6 +1254,15 @@ export function JobsView({
           </div>
         </section>
         </div>
+      ) : isPlatformUsersTab ? (
+        <div
+          id="settings-panel-platform-users"
+          role="tabpanel"
+          aria-labelledby="settings-tab-platform-users"
+          className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background/65"
+        >
+          <AdminUsersPage key={server} embedded server={server} />
+        </div>
       ) : (
         <div
           id="settings-panel-preferences"
@@ -1240,7 +1274,6 @@ export function JobsView({
             embedded
             server={server}
             token={token}
-            isAdmin={isAdmin}
             showArchivedSessions={showArchivedSessions}
             onShowArchivedSessionsChange={onShowArchivedSessionsChange}
           />

--- a/frontend/src/components/jobs-view.tsx
+++ b/frontend/src/components/jobs-view.tsx
@@ -653,9 +653,6 @@ export function JobsView({
             className="flex flex-wrap items-end gap-x-4 gap-y-2 border-b border-border/80"
           >
             <div className="flex items-end gap-1">
-              <span className="pb-2 pr-1 text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
-                {tRoot("navigation.personal")}
-              </span>
               <button
                 id="settings-tab-preferences"
                 type="button"

--- a/frontend/src/components/preferences-view.tsx
+++ b/frontend/src/components/preferences-view.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import Link from "next/link";
-import { Globe2, ShieldCheck } from "lucide-react";
+import { Globe2 } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useTranslations } from "next-intl";
 import { useSyncExternalStore } from "react";
@@ -17,14 +16,12 @@ export function PreferencesView({
   embedded = false,
   server,
   token,
-  isAdmin,
   showArchivedSessions,
   onShowArchivedSessionsChange,
 }: {
   embedded?: boolean;
   server: string;
   token: string;
-  isAdmin: boolean;
   showArchivedSessions: boolean;
   onShowArchivedSessionsChange: (showArchivedSessions: boolean) => void;
 }) {
@@ -149,25 +146,6 @@ export function PreferencesView({
             <NotificationSubscription server={server} token={token} />
           </div>
 
-          {isAdmin ? (
-            <div className="mt-4 rounded-2xl border border-border bg-background/88 p-4 shadow-sm">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <div>
-                  <div className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                    {t("admin.label")}
-                  </div>
-                  <p className="mt-1 text-sm text-muted-foreground">{t("admin.description")}</p>
-                </div>
-                <Link
-                  href={`/admin/users?server=${encodeURIComponent(server)}`}
-                  className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-foreground/90"
-                >
-                  <ShieldCheck className="h-4 w-4" />
-                  {t("admin.open")}
-                </Link>
-              </div>
-            </div>
-          ) : null}
         </section>
       </div>
     </div>

--- a/frontend/src/components/preferences-view.tsx
+++ b/frontend/src/components/preferences-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Globe2 } from "lucide-react";
+import Link from "next/link";
+import { Globe2, ShieldCheck } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useTranslations } from "next-intl";
 import { useSyncExternalStore } from "react";
@@ -16,12 +17,14 @@ export function PreferencesView({
   embedded = false,
   server,
   token,
+  isAdmin,
   showArchivedSessions,
   onShowArchivedSessionsChange,
 }: {
   embedded?: boolean;
   server: string;
   token: string;
+  isAdmin: boolean;
   showArchivedSessions: boolean;
   onShowArchivedSessionsChange: (showArchivedSessions: boolean) => void;
 }) {
@@ -145,6 +148,26 @@ export function PreferencesView({
           <div className="mt-4">
             <NotificationSubscription server={server} token={token} />
           </div>
+
+          {isAdmin ? (
+            <div className="mt-4 rounded-2xl border border-border bg-background/88 p-4 shadow-sm">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <div className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                    {t("admin.label")}
+                  </div>
+                  <p className="mt-1 text-sm text-muted-foreground">{t("admin.description")}</p>
+                </div>
+                <Link
+                  href={`/admin/users?server=${encodeURIComponent(server)}`}
+                  className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-foreground/90"
+                >
+                  <ShieldCheck className="h-4 w-4" />
+                  {t("admin.open")}
+                </Link>
+              </div>
+            </div>
+          ) : null}
         </section>
       </div>
     </div>

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -579,24 +579,21 @@ export function Sidebar({
     <div className="flex h-full flex-col">
       {/* Header */}
       <div className="flex items-center justify-between border-b border-border px-4 py-3">
-        <button
-          type="button"
-          onClick={onGoHome}
-          title={t("navigation.home")}
-          aria-label={t("navigation.home")}
-          className={cn(
-            "flex min-w-0 items-center gap-2 rounded-md px-1.5 py-1 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-            activeView === "chat" && activeSessionId === null
-              ? "bg-accent text-accent-foreground"
-              : "hover:bg-muted",
-          )}
-        >
-          <span className="flex min-w-0 items-center gap-1.5 leading-none">
+        <div className="flex min-w-0 items-center gap-2">
+          <div className="flex min-w-0 items-center gap-1.5 leading-none">
             <Image src="/icon.svg" alt="" width={18} height={18} aria-hidden="true" className="shrink-0" />
-            <span className="text-sm font-semibold tracking-tight">{t("app.name")}</span>
-          </span>
+            <button
+              type="button"
+              onClick={onGoHome}
+              title={t("navigation.home")}
+              aria-label={t("navigation.home")}
+              className="cursor-pointer rounded-sm text-sm font-semibold tracking-tight focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              {t("app.name")}
+            </button>
+          </div>
           <VersionBadge frontendVersion={frontendVersion} backendVersion={backendVersion} />
-        </button>
+        </div>
         <div className="flex items-center gap-0.5">
           <div ref={accountMenuRef} className="relative">
             <button

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -2,12 +2,13 @@
 
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
-import { Archive, ArchiveRestore, Bot, Home, Loader2, Lock, LogOut, Mail, MessageSquare, Pin, Save, Settings2, Star, Trash2 } from "lucide-react";
+import { Archive, ArchiveRestore, Bot, Home, Loader2, Lock, LogOut, Mail, MessageSquare, Pin, Save, Settings2, Star, Trash2, User } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { EmojiText } from "@/components/emoji-text";
 import { useAppLocale } from "@/components/locale-provider";
 import { NewSessionButton, type NewSessionOptions } from "@/components/new-session-button";
 import { VersionBadge } from "@/components/version-badge";
+import type { AuthUserInfo } from "@/lib/api";
 import type { SessionAttributesPatch, SessionInfo, SessionSandboxSnapshot } from "@/lib/types";
 import {
   canArchiveSession,
@@ -26,6 +27,7 @@ interface SidebarProps {
   activeView?: "chat" | "settings";
   frontendVersion?: string | null;
   backendVersion?: string | null;
+  currentUser?: AuthUserInfo | null;
   onSelect: (sessionId: string) => void;
   onNew: (options?: NewSessionOptions) => void;
   onGoHome: () => void;
@@ -70,6 +72,11 @@ function runSidebarAttributeUpdate(promise: Promise<SessionInfo>): void {
   });
 }
 
+function accountInitial(user: AuthUserInfo | null | undefined): string {
+  const label = user?.display_name?.trim() || user?.username.trim() || "?";
+  return label.slice(0, 1).toLocaleUpperCase();
+}
+
 function GitHubIcon({ className }: { className?: string }) {
   return (
     <svg
@@ -90,6 +97,7 @@ export function Sidebar({
   activeView = "chat",
   frontendVersion = null,
   backendVersion = null,
+  currentUser = null,
   onSelect,
   onNew,
   onGoHome,
@@ -108,11 +116,15 @@ export function Sidebar({
   const { locale } = useAppLocale();
   const scrollRootRef = useRef<HTMLDivElement | null>(null);
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
+  const accountMenuRef = useRef<HTMLDivElement | null>(null);
   const [referenceTime, setReferenceTime] = useState<number>(() => Date.now());
+  const [accountMenuOpen, setAccountMenuOpen] = useState(false);
   const activeSessions = sessions.filter((session) => !session.attributes.archived);
   const archivedSessions = showArchivedSessions
     ? sessions.filter((session) => session.attributes.archived)
     : [];
+  const accountName = currentUser?.display_name?.trim() || currentUser?.username || t("account.unknown");
+  const accountRoles = currentUser?.roles.length ? currentUser.roles.join(", ") : t("account.noRoles");
 
   useEffect(() => {
     const updateReferenceTime = (): void => {
@@ -125,6 +137,31 @@ export function Sidebar({
       window.clearInterval(intervalId);
     };
   }, []);
+
+  useEffect(() => {
+    if (!accountMenuOpen) return;
+
+    function handlePointerDown(event: MouseEvent): void {
+      const target = event.target;
+      if (!(target instanceof Node) || accountMenuRef.current?.contains(target)) {
+        return;
+      }
+      setAccountMenuOpen(false);
+    }
+
+    function handleKeyDown(event: KeyboardEvent): void {
+      if (event.key === "Escape") {
+        setAccountMenuOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [accountMenuOpen]);
 
   function calendarDayNumber(date: Date): number {
     return Math.floor(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) / 86_400_000);
@@ -564,38 +601,87 @@ export function Sidebar({
           >
             <Home className="h-4 w-4" />
           </button>
-          <button
-            type="button"
-            onClick={onOpenSettings}
-            title={t("navigation.settings")}
-            aria-label={t("navigation.settings")}
-            className={cn(
-              "rounded-md p-1.5 transition-colors",
-              activeView === "settings"
-                ? "bg-accent text-accent-foreground"
-                : "text-muted-foreground hover:bg-muted hover:text-foreground",
-            )}
-          >
-            <Settings2 className="h-4 w-4" />
-          </button>
-          <button
-            onClick={onDisconnect}
-            title={t("navigation.disconnect")}
-            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          >
-            <LogOut className="h-4 w-4" />
-          </button>
-          <span className="mx-0.5 h-5 w-px bg-border" aria-hidden="true" />
-          <a
-            href={githubUrl}
-            target="_blank"
-            rel="noreferrer"
-            title={t("navigation.github")}
-            aria-label={t("navigation.github")}
-            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          >
-            <GitHubIcon className="h-4 w-4" />
-          </a>
+          <div ref={accountMenuRef} className="relative">
+            <button
+              type="button"
+              onClick={() => setAccountMenuOpen((open) => !open)}
+              title={t("account.openMenu")}
+              aria-label={t("account.openMenu")}
+              aria-haspopup="menu"
+              aria-expanded={accountMenuOpen}
+              className={cn(
+                "inline-flex h-8 w-8 items-center justify-center rounded-full border border-border text-xs font-semibold transition-colors",
+                activeView === "settings" || accountMenuOpen
+                  ? "bg-accent text-accent-foreground"
+                  : "bg-background text-muted-foreground hover:bg-muted hover:text-foreground",
+              )}
+            >
+              {accountInitial(currentUser)}
+            </button>
+
+            {accountMenuOpen ? (
+              <div
+                role="menu"
+                aria-label={t("account.menu")}
+                className="absolute right-0 top-full z-50 mt-2 w-64 overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-lg"
+              >
+                <div className="border-b border-border/80 px-3 py-3">
+                  <div className="flex min-w-0 items-center gap-2.5">
+                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-accent text-sm font-semibold text-accent-foreground">
+                      {accountInitial(currentUser)}
+                    </div>
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium" title={accountName}>{accountName}</div>
+                      <div className="truncate text-xs text-muted-foreground" title={currentUser?.username ?? undefined}>
+                        {currentUser?.username ?? t("account.unknown")}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="mt-2 flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <User className="h-3.5 w-3.5" />
+                    <span className="truncate" title={accountRoles}>{accountRoles}</span>
+                  </div>
+                </div>
+                <div className="p-1">
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      setAccountMenuOpen(false);
+                      onOpenSettings();
+                    }}
+                    className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm text-foreground transition-colors hover:bg-muted"
+                  >
+                    <Settings2 className="h-4 w-4 text-muted-foreground" />
+                    {t("navigation.settings")}
+                  </button>
+                  <a
+                    role="menuitem"
+                    href={githubUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    onClick={() => setAccountMenuOpen(false)}
+                    className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm text-foreground transition-colors hover:bg-muted"
+                  >
+                    <GitHubIcon className="h-4 w-4 text-muted-foreground" />
+                    {t("navigation.github")}
+                  </a>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      setAccountMenuOpen(false);
+                      onDisconnect();
+                    }}
+                    className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm text-destructive transition-colors hover:bg-destructive/10"
+                  >
+                    <LogOut className="h-4 w-4" />
+                    {t("account.logout")}
+                  </button>
+                </div>
+              </div>
+            ) : null}
+          </div>
         </div>
       </div>
 

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -124,6 +124,7 @@ export function Sidebar({
     ? sessions.filter((session) => session.attributes.archived)
     : [];
   const accountName = currentUser?.display_name?.trim() || currentUser?.username || t("account.unknown");
+  const accountUsername = currentUser?.username ?? t("account.unknown");
 
   useEffect(() => {
     const updateReferenceTime = (): void => {
@@ -603,13 +604,16 @@ export function Sidebar({
               aria-haspopup="menu"
               aria-expanded={accountMenuOpen}
               className={cn(
-                "inline-flex h-8 w-8 items-center justify-center rounded-full border border-border text-xs font-semibold transition-colors",
+                "inline-flex h-8 max-w-[9.5rem] items-center gap-2 rounded-full border border-border px-2 text-xs font-medium transition-colors",
                 activeView === "settings" || accountMenuOpen
                   ? "bg-accent text-accent-foreground"
                   : "bg-background text-muted-foreground hover:bg-muted hover:text-foreground",
               )}
             >
-              {accountInitial(currentUser)}
+              <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted text-[11px] font-semibold text-muted-foreground">
+                {accountInitial(currentUser)}
+              </span>
+              <span className="truncate">{accountName}</span>
             </button>
 
             {accountMenuOpen ? (
@@ -625,8 +629,8 @@ export function Sidebar({
                     </div>
                     <div className="min-w-0">
                       <div className="truncate text-sm font-medium" title={accountName}>{accountName}</div>
-                      <div className="truncate text-xs text-muted-foreground" title={currentUser?.username ?? undefined}>
-                        {currentUser?.username ?? t("account.unknown")}
+                      <div className="truncate text-xs text-muted-foreground" title={accountUsername}>
+                        {accountUsername}
                       </div>
                     </div>
                   </div>

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -603,14 +603,16 @@ export function Sidebar({
               aria-label={t("account.openMenu")}
               aria-haspopup="menu"
               aria-expanded={accountMenuOpen}
-              className={cn(
-                "inline-flex h-8 max-w-[9.5rem] items-center gap-2 rounded-full border border-border px-2 text-xs font-medium transition-colors",
-                activeView === "settings" || accountMenuOpen
-                  ? "bg-accent text-accent-foreground"
-                  : "bg-background text-muted-foreground hover:bg-muted hover:text-foreground",
-              )}
+              className="inline-flex h-8 max-w-[9.5rem] cursor-pointer items-center gap-2 rounded-sm text-xs font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             >
-              <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted text-[11px] font-semibold text-muted-foreground">
+              <span
+                className={cn(
+                  "flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-border text-[11px] font-semibold transition-colors",
+                  activeView === "settings" || accountMenuOpen
+                    ? "bg-accent text-accent-foreground"
+                    : "bg-background text-muted-foreground",
+                )}
+              >
                 {accountInitial(currentUser)}
               </span>
               <span className="truncate">{accountName}</span>

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
-import { Archive, ArchiveRestore, Bot, Loader2, Lock, LogOut, Mail, MessageSquare, Pin, Save, Settings2, Star, Trash2, User } from "lucide-react";
+import { Archive, ArchiveRestore, Bot, Loader2, Lock, LogOut, Mail, MessageSquare, Pin, Save, Settings2, Star, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { EmojiText } from "@/components/emoji-text";
 import { useAppLocale } from "@/components/locale-provider";
@@ -124,7 +124,6 @@ export function Sidebar({
     ? sessions.filter((session) => session.attributes.archived)
     : [];
   const accountName = currentUser?.display_name?.trim() || currentUser?.username || t("account.unknown");
-  const accountRoles = currentUser?.roles.length ? currentUser.roles.join(", ") : t("account.noRoles");
 
   useEffect(() => {
     const updateReferenceTime = (): void => {
@@ -630,10 +629,6 @@ export function Sidebar({
                         {currentUser?.username ?? t("account.unknown")}
                       </div>
                     </div>
-                  </div>
-                  <div className="mt-2 flex items-center gap-1.5 text-xs text-muted-foreground">
-                    <User className="h-3.5 w-3.5" />
-                    <span className="truncate" title={accountRoles}>{accountRoles}</span>
                   </div>
                 </div>
                 <div className="p-1">

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -620,7 +620,7 @@ export function Sidebar({
               <div
                 role="menu"
                 aria-label={t("account.menu")}
-                className="absolute right-0 top-full z-50 mt-2 w-64 overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-lg"
+                className="absolute right-0 top-full z-50 mt-2 w-64 overflow-hidden rounded-lg border border-border bg-background text-foreground shadow-lg"
               >
                 <div className="border-b border-border/80 px-3 py-3">
                   <div className="flex min-w-0 items-center gap-2.5">

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -629,12 +629,25 @@ export function Sidebar({
                     <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-accent text-sm font-semibold text-accent-foreground">
                       {accountInitial(currentUser)}
                     </div>
-                    <div className="min-w-0">
+                    <div className="min-w-0 flex-1">
                       <div className="truncate text-sm font-medium" title={accountName}>{accountName}</div>
                       <div className="truncate text-xs text-muted-foreground" title={accountUsername}>
                         {accountUsername}
                       </div>
                     </div>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      title={t("account.logout")}
+                      aria-label={t("account.logout")}
+                      onClick={() => {
+                        setAccountMenuOpen(false);
+                        onDisconnect();
+                      }}
+                      className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-destructive transition-colors hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    >
+                      <LogOut className="h-4 w-4" />
+                    </button>
                   </div>
                 </div>
                 <div className="p-1">
@@ -661,18 +674,6 @@ export function Sidebar({
                     <GitHubIcon className="h-4 w-4 text-muted-foreground" />
                     {t("navigation.github")}
                   </a>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    onClick={() => {
-                      setAccountMenuOpen(false);
-                      onDisconnect();
-                    }}
-                    className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm text-destructive transition-colors hover:bg-destructive/10"
-                  >
-                    <LogOut className="h-4 w-4" />
-                    {t("account.logout")}
-                  </button>
                 </div>
               </div>
             ) : null}

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
-import { Archive, ArchiveRestore, Bot, Home, Loader2, Lock, LogOut, Mail, MessageSquare, Pin, Save, Settings2, Star, Trash2, User } from "lucide-react";
+import { Archive, ArchiveRestore, Bot, Loader2, Lock, LogOut, Mail, MessageSquare, Pin, Save, Settings2, Star, Trash2, User } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { EmojiText } from "@/components/emoji-text";
 import { useAppLocale } from "@/components/locale-provider";
@@ -579,28 +579,25 @@ export function Sidebar({
     <div className="flex h-full flex-col">
       {/* Header */}
       <div className="flex items-center justify-between border-b border-border px-4 py-3">
-        <div className="flex items-center gap-2">
-          <div className="flex items-center gap-1.5 leading-none">
+        <button
+          type="button"
+          onClick={onGoHome}
+          title={t("navigation.home")}
+          aria-label={t("navigation.home")}
+          className={cn(
+            "flex min-w-0 items-center gap-2 rounded-md px-1.5 py-1 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+            activeView === "chat" && activeSessionId === null
+              ? "bg-accent text-accent-foreground"
+              : "hover:bg-muted",
+          )}
+        >
+          <span className="flex min-w-0 items-center gap-1.5 leading-none">
             <Image src="/icon.svg" alt="" width={18} height={18} aria-hidden="true" className="shrink-0" />
             <span className="text-sm font-semibold tracking-tight">{t("app.name")}</span>
-          </div>
+          </span>
           <VersionBadge frontendVersion={frontendVersion} backendVersion={backendVersion} />
-        </div>
+        </button>
         <div className="flex items-center gap-0.5">
-          <button
-            type="button"
-            onClick={onGoHome}
-            title={t("navigation.home")}
-            aria-label={t("navigation.home")}
-            className={cn(
-              "rounded-md p-1.5 transition-colors",
-              activeView === "chat" && activeSessionId === null
-                ? "bg-accent text-accent-foreground"
-                : "text-muted-foreground hover:bg-muted hover:text-foreground",
-            )}
-          >
-            <Home className="h-4 w-4" />
-          </button>
           <div ref={accountMenuRef} className="relative">
             <button
               type="button"

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   createAdminUser,
   deleteNotificationSubscription,
+  getCurrentUser,
   getVapidPublicKey,
   listAdminUsers,
   sendTestNotification,
@@ -139,7 +140,23 @@ test("sendTestNotification surfaces backend detail messages on failure", async (
   );
 });
 
-test("admin user helpers send bearer token and parse users", async () => {
+test("getCurrentUser parses authenticated user roles", async () => {
+  let capturedRequest: Request | null = null;
+  setFetch(async (input, init) => {
+    capturedRequest = new Request(input, init);
+    return new Response(
+      JSON.stringify({ username: "admin", display_name: "Admin", roles: ["admin"] }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+
+  const user = await getCurrentUser("https://carapace.example.test");
+
+  assert.equal(capturedRequest?.url, "https://carapace.example.test/api/auth/me");
+  assert.deepEqual(user.roles, ["admin"]);
+});
+
+test("admin user helpers use cookie auth and parse users", async () => {
   const calls: Request[] = [];
   setFetch(async (input, init) => {
     const request = new Request(input, init);
@@ -164,12 +181,9 @@ test("admin user helpers send bearer token and parse users", async () => {
     );
   });
 
-  const users = await listAdminUsers(
-    "https://carapace.example.test",
-    "admin-token",
-  );
+  const users = await listAdminUsers("https://carapace.example.test");
 
-  assert.equal(calls[0].headers.get("Authorization"), "Bearer admin-token");
+  assert.equal(calls[0].headers.get("Authorization"), null);
   assert.equal(users[0].username, "thies");
   assert.equal(users[0].roles[0], "admin");
 });
@@ -197,15 +211,11 @@ test("createAdminUser posts admin payload", async () => {
     );
   });
 
-  const user = await createAdminUser(
-    "https://carapace.example.test",
-    "admin-token",
-    {
-      username: "ada",
-      password: "secret",
-      display_name: "Ada",
-    },
-  );
+  const user = await createAdminUser("https://carapace.example.test", {
+    username: "ada",
+    password: "secret",
+    display_name: "Ada",
+  });
 
   assert.equal(JSON.parse(capturedBody).username, "ada");
   assert.equal(user.username, "ada");
@@ -226,7 +236,6 @@ test("updateAdminUser encodes username and surfaces backend errors", async () =>
     () =>
       updateAdminUser(
         "https://carapace.example.test",
-        "admin-token",
         "ada lovelace",
         { enabled: false },
       ),
@@ -251,20 +260,13 @@ test("upgradeAdminUserData posts to the selected user's upgrade endpoint", async
     );
   });
 
-  const result = await upgradeAdminUserData(
-    "https://carapace.example.test",
-    "admin-token",
-    "thies",
-  );
+  const result = await upgradeAdminUserData("https://carapace.example.test", "thies");
 
   assert.equal(capturedRequest?.method, "POST");
   assert.equal(
     capturedRequest?.url,
     "https://carapace.example.test/api/admin/users/thies/upgrade-data",
   );
-  assert.equal(
-    capturedRequest?.headers.get("Authorization"),
-    "Bearer admin-token",
-  );
+  assert.equal(capturedRequest?.headers.get("Authorization"), null);
   assert.deepEqual(result.summary.sessions, ["set owner for session-1"]);
 });

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   createAdminUser,
+  deleteAdminUser,
   deleteNotificationSubscription,
   getCurrentUser,
   getVapidPublicKey,
@@ -141,9 +142,9 @@ test("sendTestNotification surfaces backend detail messages on failure", async (
 });
 
 test("getCurrentUser parses authenticated user roles", async () => {
-  let capturedRequest: Request | null = null;
+  const calls: Request[] = [];
   setFetch(async (input, init) => {
-    capturedRequest = new Request(input, init);
+    calls.push(new Request(input, init));
     return new Response(
       JSON.stringify({ username: "admin", display_name: "Admin", roles: ["admin"] }),
       { status: 200, headers: { "Content-Type": "application/json" } },
@@ -152,7 +153,7 @@ test("getCurrentUser parses authenticated user roles", async () => {
 
   const user = await getCurrentUser("https://carapace.example.test");
 
-  assert.equal(capturedRequest?.url, "https://carapace.example.test/api/auth/me");
+  assert.equal(calls[0]?.url, "https://carapace.example.test/api/auth/me");
   assert.deepEqual(user.roles, ["admin"]);
 });
 
@@ -247,10 +248,27 @@ test("updateAdminUser encodes username and surfaces backend errors", async () =>
   );
 });
 
-test("upgradeAdminUserData posts to the selected user's upgrade endpoint", async () => {
-  let capturedRequest: Request | null = null;
+test("deleteAdminUser deletes the selected user", async () => {
+  const calls: Request[] = [];
   setFetch(async (input, init) => {
-    capturedRequest = new Request(input, init);
+    calls.push(new Request(input, init));
+    return new Response(null, { status: 204 });
+  });
+
+  await deleteAdminUser("https://carapace.example.test", "ada lovelace");
+
+  assert.equal(calls[0]?.method, "DELETE");
+  assert.equal(
+    calls[0]?.url,
+    "https://carapace.example.test/api/admin/users/ada%20lovelace",
+  );
+  assert.equal(calls[0]?.headers.get("Authorization"), null);
+});
+
+test("upgradeAdminUserData posts to the selected user's upgrade endpoint", async () => {
+  const calls: Request[] = [];
+  setFetch(async (input, init) => {
+    calls.push(new Request(input, init));
     return new Response(
       JSON.stringify({
         username: "thies",
@@ -262,11 +280,11 @@ test("upgradeAdminUserData posts to the selected user's upgrade endpoint", async
 
   const result = await upgradeAdminUserData("https://carapace.example.test", "thies");
 
-  assert.equal(capturedRequest?.method, "POST");
+  assert.equal(calls[0]?.method, "POST");
   assert.equal(
-    capturedRequest?.url,
+    calls[0]?.url,
     "https://carapace.example.test/api/admin/users/thies/upgrade-data",
   );
-  assert.equal(capturedRequest?.headers.get("Authorization"), null);
+  assert.equal(calls[0]?.headers.get("Authorization"), null);
   assert.deepEqual(result.summary.sessions, ["set owner for session-1"]);
 });

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -120,7 +120,6 @@ test("postNotificationSubscriptionPresence rejects failed heartbeats", async () 
   );
 });
 
-
 test("sendTestNotification surfaces backend detail messages on failure", async () => {
   setFetch(
     async () =>
@@ -135,11 +134,7 @@ test("sendTestNotification surfaces backend detail messages on failure", async (
 
   await assert.rejects(
     () =>
-      sendTestNotification(
-        "https://carapace.example.test",
-        "token-1",
-        "sub-1",
-      ),
+      sendTestNotification("https://carapace.example.test", "token-1", "sub-1"),
     /Failed to deliver test notification/,
   );
 });
@@ -169,7 +164,10 @@ test("admin user helpers send bearer token and parse users", async () => {
     );
   });
 
-  const users = await listAdminUsers("https://carapace.example.test", "admin-token");
+  const users = await listAdminUsers(
+    "https://carapace.example.test",
+    "admin-token",
+  );
 
   assert.equal(calls[0].headers.get("Authorization"), "Bearer admin-token");
   assert.equal(users[0].username, "thies");
@@ -199,11 +197,15 @@ test("createAdminUser posts admin payload", async () => {
     );
   });
 
-  const user = await createAdminUser("https://carapace.example.test", "admin-token", {
-    username: "ada",
-    password: "secret",
-    display_name: "Ada",
-  });
+  const user = await createAdminUser(
+    "https://carapace.example.test",
+    "admin-token",
+    {
+      username: "ada",
+      password: "secret",
+      display_name: "Ada",
+    },
+  );
 
   assert.equal(JSON.parse(capturedBody).username, "ada");
   assert.equal(user.username, "ada");
@@ -221,10 +223,19 @@ test("updateAdminUser encodes username and surfaces backend errors", async () =>
   });
 
   await assert.rejects(
-    () => updateAdminUser("https://carapace.example.test", "admin-token", "ada lovelace", { enabled: false }),
+    () =>
+      updateAdminUser(
+        "https://carapace.example.test",
+        "admin-token",
+        "ada lovelace",
+        { enabled: false },
+      ),
     /User not found/,
   );
-  assert.equal(capturedUrl, "https://carapace.example.test/api/admin/users/ada%20lovelace");
+  assert.equal(
+    capturedUrl,
+    "https://carapace.example.test/api/admin/users/ada%20lovelace",
+  );
 });
 
 test("upgradeAdminUserData posts to the selected user's upgrade endpoint", async () => {
@@ -232,15 +243,28 @@ test("upgradeAdminUserData posts to the selected user's upgrade endpoint", async
   setFetch(async (input, init) => {
     capturedRequest = new Request(input, init);
     return new Response(
-      JSON.stringify({ username: "thies", summary: { sessions: ["set owner for session-1"] } }),
+      JSON.stringify({
+        username: "thies",
+        summary: { sessions: ["set owner for session-1"] },
+      }),
       { status: 200, headers: { "Content-Type": "application/json" } },
     );
   });
 
-  const result = await upgradeAdminUserData("https://carapace.example.test", "admin-token", "thies");
+  const result = await upgradeAdminUserData(
+    "https://carapace.example.test",
+    "admin-token",
+    "thies",
+  );
 
   assert.equal(capturedRequest?.method, "POST");
-  assert.equal(capturedRequest?.url, "https://carapace.example.test/api/admin/users/thies/upgrade-data");
-  assert.equal(capturedRequest?.headers.get("Authorization"), "Bearer admin-token");
+  assert.equal(
+    capturedRequest?.url,
+    "https://carapace.example.test/api/admin/users/thies/upgrade-data",
+  );
+  assert.equal(
+    capturedRequest?.headers.get("Authorization"),
+    "Bearer admin-token",
+  );
   assert.deepEqual(result.summary.sessions, ["set owner for session-1"]);
 });

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,12 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  AUTH_REQUIRED_EVENT,
   createAdminUser,
   deleteAdminUser,
   deleteNotificationSubscription,
   getWebSocketTicket,
   getCurrentUser,
   getVapidPublicKey,
+  login,
   listAdminUsers,
   sendTestNotification,
   updateAdminUser,
@@ -19,6 +21,7 @@ import {
 } from "./api";
 
 const originalFetch = globalThis.fetch;
+const originalWindow = globalThis.window;
 
 function setFetch(handler: typeof fetch): void {
   Object.defineProperty(globalThis, "fetch", {
@@ -34,7 +37,22 @@ test.afterEach(() => {
     writable: true,
     value: originalFetch,
   });
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    writable: true,
+    value: originalWindow,
+  });
 });
+
+function setWindowTarget(): EventTarget {
+  const windowTarget = new EventTarget();
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    writable: true,
+    value: windowTarget,
+  });
+  return windowTarget;
+}
 
 test("getVapidPublicKey returns configured key", async () => {
   setFetch(
@@ -157,6 +175,38 @@ test("getCurrentUser parses authenticated user roles", async () => {
 
   assert.equal(calls[0]?.url, "https://carapace.example.test/api/auth/me");
   assert.deepEqual(user.roles, ["admin"]);
+});
+
+test("authenticated API 401 dispatches auth-required event", async () => {
+  const windowTarget = setWindowTarget();
+  let authRequiredEvents = 0;
+  windowTarget.addEventListener(AUTH_REQUIRED_EVENT, () => {
+    authRequiredEvents += 1;
+  });
+  setFetch(async () => new Response(JSON.stringify({ detail: "Invalid session" }), { status: 401 }));
+
+  await assert.rejects(
+    () => getCurrentUser("https://carapace.example.test"),
+    /Invalid session/,
+  );
+
+  assert.equal(authRequiredEvents, 1);
+});
+
+test("login 401 does not dispatch auth-required event", async () => {
+  const windowTarget = setWindowTarget();
+  let authRequiredEvents = 0;
+  windowTarget.addEventListener(AUTH_REQUIRED_EVENT, () => {
+    authRequiredEvents += 1;
+  });
+  setFetch(async () => new Response(JSON.stringify({ detail: "Invalid username or password" }), { status: 401 }));
+
+  await assert.rejects(
+    () => login("https://carapace.example.test", "thies", "wrong"),
+    /Invalid username or password/,
+  );
+
+  assert.equal(authRequiredEvents, 0);
 });
 
 test("admin user helpers use cookie auth and parse users", async () => {

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -7,6 +7,7 @@ import {
   listAdminUsers,
   sendTestNotification,
   updateAdminUser,
+  upgradeAdminUserData,
 } from "./api";
 import {
   listNotificationSubscriptions,
@@ -224,4 +225,22 @@ test("updateAdminUser encodes username and surfaces backend errors", async () =>
     /User not found/,
   );
   assert.equal(capturedUrl, "https://carapace.example.test/api/admin/users/ada%20lovelace");
+});
+
+test("upgradeAdminUserData posts to the selected user's upgrade endpoint", async () => {
+  let capturedRequest: Request | null = null;
+  setFetch(async (input, init) => {
+    capturedRequest = new Request(input, init);
+    return new Response(
+      JSON.stringify({ username: "thies", summary: { sessions: ["set owner for session-1"] } }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+
+  const result = await upgradeAdminUserData("https://carapace.example.test", "admin-token", "thies");
+
+  assert.equal(capturedRequest?.method, "POST");
+  assert.equal(capturedRequest?.url, "https://carapace.example.test/api/admin/users/thies/upgrade-data");
+  assert.equal(capturedRequest?.headers.get("Authorization"), "Bearer admin-token");
+  assert.deepEqual(result.summary.sessions, ["set owner for session-1"]);
 });

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -4,12 +4,14 @@ import {
   createAdminUser,
   deleteAdminUser,
   deleteNotificationSubscription,
+  getWebSocketTicket,
   getCurrentUser,
   getVapidPublicKey,
   listAdminUsers,
   sendTestNotification,
   updateAdminUser,
   upgradeAdminUserData,
+  wsUrl,
 } from "./api";
 import {
   listNotificationSubscriptions,
@@ -187,6 +189,31 @@ test("admin user helpers use cookie auth and parse users", async () => {
   assert.equal(calls[0].headers.get("Authorization"), null);
   assert.equal(users[0].username, "thies");
   assert.equal(users[0].roles[0], "admin");
+});
+
+test("getWebSocketTicket posts with cookie credentials", async () => {
+  const calls: Request[] = [];
+  setFetch(async (input, init) => {
+    calls.push(new Request(input, init));
+    return new Response(JSON.stringify({ ticket: "ws-ticket-1" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+
+  const ticket = await getWebSocketTicket("https://carapace.example.test", "");
+
+  assert.equal(ticket, "ws-ticket-1");
+  assert.equal(calls[0]?.method, "POST");
+  assert.equal(calls[0]?.credentials, "include");
+  assert.equal(calls[0]?.url, "https://carapace.example.test/api/auth/ws-ticket");
+});
+
+test("wsUrl includes client id and websocket ticket", () => {
+  assert.equal(
+    wsUrl("https://carapace.example.test", "session-1", "", "web tab", "ticket.1"),
+    "wss://carapace.example.test/api/chat/session-1?client_id=web+tab&ticket=ticket.1",
+  );
 });
 
 test("createAdminUser posts admin payload", async () => {

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,9 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  createAdminUser,
   deleteNotificationSubscription,
   getVapidPublicKey,
+  listAdminUsers,
   sendTestNotification,
+  updateAdminUser,
 } from "./api";
 import {
   listNotificationSubscriptions,
@@ -138,4 +141,87 @@ test("sendTestNotification surfaces backend detail messages on failure", async (
       ),
     /Failed to deliver test notification/,
   );
+});
+
+test("admin user helpers send bearer token and parse users", async () => {
+  const calls: Request[] = [];
+  setFetch(async (input, init) => {
+    const request = new Request(input, init);
+    calls.push(request);
+    return new Response(
+      JSON.stringify([
+        {
+          username: "thies",
+          enabled: true,
+          token_version: 2,
+          display_name: "Thies",
+          email: "thies@example.test",
+          roles: ["admin"],
+          created_at: "2026-05-24T12:00:00Z",
+          updated_at: "2026-05-24T12:00:00Z",
+          password_changed_at: "2026-05-24T12:00:00Z",
+          last_login_at: null,
+          config: {},
+        },
+      ]),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+
+  const users = await listAdminUsers("https://carapace.example.test", "admin-token");
+
+  assert.equal(calls[0].headers.get("Authorization"), "Bearer admin-token");
+  assert.equal(users[0].username, "thies");
+  assert.equal(users[0].roles[0], "admin");
+});
+
+test("createAdminUser posts admin payload", async () => {
+  let capturedBody = "";
+  setFetch(async (input, init) => {
+    const request = new Request(input, init);
+    capturedBody = await request.text();
+    return new Response(
+      JSON.stringify({
+        username: "ada",
+        enabled: true,
+        token_version: 1,
+        display_name: "Ada",
+        email: null,
+        roles: [],
+        created_at: "2026-05-24T12:00:00Z",
+        updated_at: "2026-05-24T12:00:00Z",
+        password_changed_at: "2026-05-24T12:00:00Z",
+        last_login_at: null,
+        config: {},
+      }),
+      { status: 201, headers: { "Content-Type": "application/json" } },
+    );
+  });
+
+  const user = await createAdminUser("https://carapace.example.test", "admin-token", {
+    username: "ada",
+    password: "secret",
+    display_name: "Ada",
+  });
+
+  assert.equal(JSON.parse(capturedBody).username, "ada");
+  assert.equal(user.username, "ada");
+});
+
+test("updateAdminUser encodes username and surfaces backend errors", async () => {
+  let capturedUrl = "";
+  setFetch(async (input, init) => {
+    const request = new Request(input, init);
+    capturedUrl = request.url;
+    return new Response(JSON.stringify({ detail: "User not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+
+  await assert.rejects(
+    () => updateAdminUser("https://carapace.example.test", "admin-token", "ada lovelace", { enabled: false }),
+    /User not found/,
+  );
+  assert.equal(capturedUrl, "https://carapace.example.test/api/admin/users/ada%20lovelace");
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -31,7 +31,7 @@ function headers(_session: string): HeadersInit {
 function adminHeaders(adminToken: string): HeadersInit {
   return {
     "Content-Type": "application/json",
-    "Authorization": `Bearer ${adminToken}`,
+    Authorization: `Bearer ${adminToken}`,
   };
 }
 
@@ -105,13 +105,13 @@ function decodeAdminUser(raw: unknown): AdminUserInfo | null {
   const passwordChangedAt = readString(raw, "password_changed_at");
   const tokenVersion = readNumber(raw, "token_version");
   if (
-    !username
-    || displayName === undefined
-    || !createdAt
-    || !updatedAt
-    || !passwordChangedAt
-    || tokenVersion === undefined
-    || typeof raw.enabled !== "boolean"
+    !username ||
+    displayName === undefined ||
+    !createdAt ||
+    !updatedAt ||
+    !passwordChangedAt ||
+    tokenVersion === undefined ||
+    typeof raw.enabled !== "boolean"
   ) {
     return null;
   }
@@ -214,11 +214,14 @@ export async function updateAdminUser(
   username: string,
   body: AdminUserUpdateInput,
 ): Promise<AdminUserInfo> {
-  const res = await fetch(`${server}/api/admin/users/${encodeURIComponent(username)}`, {
-    method: "PATCH",
-    headers: adminHeaders(adminToken),
-    body: JSON.stringify(body),
-  });
+  const res = await fetch(
+    `${server}/api/admin/users/${encodeURIComponent(username)}`,
+    {
+      method: "PATCH",
+      headers: adminHeaders(adminToken),
+      body: JSON.stringify(body),
+    },
+  );
   if (!res.ok) {
     throw new Error(await readErrorMessage(res, "Failed to update user"));
   }
@@ -234,20 +237,30 @@ export async function upgradeAdminUserData(
   adminToken: string,
   username: string,
 ): Promise<AdminDataUpgradeResult> {
-  const res = await fetch(`${server}/api/admin/users/${encodeURIComponent(username)}/upgrade-data`, {
-    method: "POST",
-    headers: adminHeaders(adminToken),
-  });
+  const res = await fetch(
+    `${server}/api/admin/users/${encodeURIComponent(username)}/upgrade-data`,
+    {
+      method: "POST",
+      headers: adminHeaders(adminToken),
+    },
+  );
   if (!res.ok) {
     throw new Error(await readErrorMessage(res, "Failed to upgrade user data"));
   }
   const raw: unknown = await res.json();
-  if (!isRecord(raw) || !readString(raw, "username") || !isRecord(raw.summary)) {
+  if (
+    !isRecord(raw) ||
+    !readString(raw, "username") ||
+    !isRecord(raw.summary)
+  ) {
     throw new Error("Invalid upgrade response");
   }
   const summary: Record<string, string[]> = {};
   for (const [key, value] of Object.entries(raw.summary)) {
-    if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
+    if (
+      Array.isArray(value) &&
+      value.every((item) => typeof item === "string")
+    ) {
       summary[key] = value;
     }
   }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -14,9 +14,16 @@ import type {
 } from "./types";
 import { isRecord, readNumber, readString } from "./decoding";
 
-function headers(token: string): HeadersInit {
+async function fetch(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+): Promise<Response> {
+  return globalThis.fetch(input, { ...init, credentials: "include" });
+}
+
+function headers(_session: string): HeadersInit {
+  void _session;
   return {
-    Authorization: `Bearer ${token}`,
     "Content-Type": "application/json",
   };
 }
@@ -39,6 +46,48 @@ async function readErrorMessage(
 
 export interface ServerMeta {
   version: string;
+}
+
+export interface AuthUserInfo {
+  username: string;
+  display_name: string | null;
+}
+
+export async function login(
+  server: string,
+  username: string,
+  password: string,
+): Promise<AuthUserInfo> {
+  const res = await fetch(`${server}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password }),
+  });
+  if (!res.ok) {
+    throw new Error(await readErrorMessage(res, "Login failed"));
+  }
+  const body: unknown = await res.json();
+  if (!isRecord(body) || !isRecord(body.user)) {
+    throw new Error("Invalid login response");
+  }
+  const parsedUsername = readString(body.user, "username");
+  if (!parsedUsername) {
+    throw new Error("Invalid login response");
+  }
+  return {
+    username: parsedUsername,
+    display_name: readString(body.user, "display_name") ?? null,
+  };
+}
+
+export async function logout(server: string): Promise<void> {
+  const res = await fetch(`${server}/api/auth/logout`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!res.ok && res.status !== 401) {
+    throw new Error(await readErrorMessage(res, "Logout failed"));
+  }
 }
 
 export async function getServerMeta(
@@ -576,13 +625,15 @@ export async function runJob(
 export function wsUrl(
   server: string,
   sessionId: string,
-  token: string,
+  _session: string,
   clientId?: string,
 ): string {
+  void _session;
   const base = server.replace("http://", "ws://").replace("https://", "wss://");
-  const params = new URLSearchParams({ token });
+  const params = new URLSearchParams();
   if (clientId) {
     params.set("client_id", clientId);
   }
-  return `${base}/api/chat/${sessionId}?${params.toString()}`;
+  const query = params.toString();
+  return `${base}/api/chat/${sessionId}${query ? `?${query}` : ""}`;
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -12,7 +12,7 @@ import type {
   SessionListPage,
   SessionSandboxSnapshot,
 } from "./types";
-import { isRecord, readNumber, readString } from "./decoding";
+import { isRecord, readNumber, readString, readStringArray } from "./decoding";
 
 async function fetch(
   input: RequestInfo | URL,
@@ -25,6 +25,13 @@ function headers(_session: string): HeadersInit {
   void _session;
   return {
     "Content-Type": "application/json",
+  };
+}
+
+function adminHeaders(adminToken: string): HeadersInit {
+  return {
+    "Content-Type": "application/json",
+    "Authorization": `Bearer ${adminToken}`,
   };
 }
 
@@ -51,6 +58,79 @@ export interface ServerMeta {
 export interface AuthUserInfo {
   username: string;
   display_name: string | null;
+}
+
+export interface AdminUserInfo {
+  username: string;
+  enabled: boolean;
+  token_version: number;
+  display_name: string;
+  email: string | null;
+  roles: string[];
+  created_at: string;
+  updated_at: string;
+  password_changed_at: string;
+  last_login_at: string | null;
+  config: unknown;
+}
+
+export interface AdminUserCreateInput {
+  username: string;
+  password: string;
+  display_name?: string;
+  email?: string | null;
+  roles?: string[];
+}
+
+export interface AdminUserUpdateInput {
+  display_name?: string;
+  email?: string | null;
+  roles?: string[];
+  enabled?: boolean;
+  password?: string;
+}
+
+function decodeAdminUser(raw: unknown): AdminUserInfo | null {
+  if (!isRecord(raw)) return null;
+
+  const username = readString(raw, "username");
+  const displayName = readString(raw, "display_name");
+  const createdAt = readString(raw, "created_at");
+  const updatedAt = readString(raw, "updated_at");
+  const passwordChangedAt = readString(raw, "password_changed_at");
+  const tokenVersion = readNumber(raw, "token_version");
+  if (
+    !username
+    || displayName === undefined
+    || !createdAt
+    || !updatedAt
+    || !passwordChangedAt
+    || tokenVersion === undefined
+    || typeof raw.enabled !== "boolean"
+  ) {
+    return null;
+  }
+
+  return {
+    username,
+    enabled: raw.enabled,
+    token_version: tokenVersion,
+    display_name: displayName,
+    email: readString(raw, "email") ?? null,
+    roles: readStringArray(raw, "roles") ?? [],
+    created_at: createdAt,
+    updated_at: updatedAt,
+    password_changed_at: passwordChangedAt,
+    last_login_at: readString(raw, "last_login_at") ?? null,
+    config: raw.config,
+  };
+}
+
+function decodeAdminUsers(raw: unknown): AdminUserInfo[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((item) => decodeAdminUser(item))
+    .filter((item): item is AdminUserInfo => item !== null);
 }
 
 export async function login(
@@ -88,6 +168,60 @@ export async function logout(server: string): Promise<void> {
   if (!res.ok && res.status !== 401) {
     throw new Error(await readErrorMessage(res, "Logout failed"));
   }
+}
+
+export async function listAdminUsers(
+  server: string,
+  adminToken: string,
+): Promise<AdminUserInfo[]> {
+  const res = await fetch(`${server}/api/admin/users`, {
+    headers: adminHeaders(adminToken),
+  });
+  if (!res.ok) {
+    throw new Error(await readErrorMessage(res, "Failed to list users"));
+  }
+  return decodeAdminUsers(await res.json());
+}
+
+export async function createAdminUser(
+  server: string,
+  adminToken: string,
+  body: AdminUserCreateInput,
+): Promise<AdminUserInfo> {
+  const res = await fetch(`${server}/api/admin/users`, {
+    method: "POST",
+    headers: adminHeaders(adminToken),
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(await readErrorMessage(res, "Failed to create user"));
+  }
+  const user = decodeAdminUser(await res.json());
+  if (user === null) {
+    throw new Error("Invalid user response");
+  }
+  return user;
+}
+
+export async function updateAdminUser(
+  server: string,
+  adminToken: string,
+  username: string,
+  body: AdminUserUpdateInput,
+): Promise<AdminUserInfo> {
+  const res = await fetch(`${server}/api/admin/users/${encodeURIComponent(username)}`, {
+    method: "PATCH",
+    headers: adminHeaders(adminToken),
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(await readErrorMessage(res, "Failed to update user"));
+  }
+  const user = decodeAdminUser(await res.json());
+  if (user === null) {
+    throw new Error("Invalid user response");
+  }
+  return user;
 }
 
 export async function getServerMeta(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -28,13 +28,6 @@ function headers(_session: string): HeadersInit {
   };
 }
 
-function adminHeaders(adminToken: string): HeadersInit {
-  return {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${adminToken}`,
-  };
-}
-
 async function readErrorMessage(
   res: Response,
   fallback: string,
@@ -58,6 +51,7 @@ export interface ServerMeta {
 export interface AuthUserInfo {
   username: string;
   display_name: string | null;
+  roles: string[];
 }
 
 export interface AdminUserInfo {
@@ -138,6 +132,17 @@ function decodeAdminUsers(raw: unknown): AdminUserInfo[] {
     .filter((item): item is AdminUserInfo => item !== null);
 }
 
+function decodeAuthUser(raw: unknown): AuthUserInfo | null {
+  if (!isRecord(raw)) return null;
+  const username = readString(raw, "username");
+  if (!username) return null;
+  return {
+    username,
+    display_name: readString(raw, "display_name") ?? null,
+    roles: readStringArray(raw, "roles") ?? [],
+  };
+}
+
 export async function login(
   server: string,
   username: string,
@@ -155,14 +160,25 @@ export async function login(
   if (!isRecord(body) || !isRecord(body.user)) {
     throw new Error("Invalid login response");
   }
-  const parsedUsername = readString(body.user, "username");
-  if (!parsedUsername) {
+  const user = decodeAuthUser(body.user);
+  if (user === null) {
     throw new Error("Invalid login response");
   }
-  return {
-    username: parsedUsername,
-    display_name: readString(body.user, "display_name") ?? null,
-  };
+  return user;
+}
+
+export async function getCurrentUser(server: string): Promise<AuthUserInfo> {
+  const res = await fetch(`${server}/api/auth/me`, {
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!res.ok) {
+    throw new Error(await readErrorMessage(res, "Failed to fetch current user"));
+  }
+  const user = decodeAuthUser(await res.json());
+  if (user === null) {
+    throw new Error("Invalid user response");
+  }
+  return user;
 }
 
 export async function logout(server: string): Promise<void> {
@@ -175,12 +191,9 @@ export async function logout(server: string): Promise<void> {
   }
 }
 
-export async function listAdminUsers(
-  server: string,
-  adminToken: string,
-): Promise<AdminUserInfo[]> {
+export async function listAdminUsers(server: string): Promise<AdminUserInfo[]> {
   const res = await fetch(`${server}/api/admin/users`, {
-    headers: adminHeaders(adminToken),
+    headers: { "Content-Type": "application/json" },
   });
   if (!res.ok) {
     throw new Error(await readErrorMessage(res, "Failed to list users"));
@@ -190,12 +203,11 @@ export async function listAdminUsers(
 
 export async function createAdminUser(
   server: string,
-  adminToken: string,
   body: AdminUserCreateInput,
 ): Promise<AdminUserInfo> {
   const res = await fetch(`${server}/api/admin/users`, {
     method: "POST",
-    headers: adminHeaders(adminToken),
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
   if (!res.ok) {
@@ -210,7 +222,6 @@ export async function createAdminUser(
 
 export async function updateAdminUser(
   server: string,
-  adminToken: string,
   username: string,
   body: AdminUserUpdateInput,
 ): Promise<AdminUserInfo> {
@@ -218,7 +229,7 @@ export async function updateAdminUser(
     `${server}/api/admin/users/${encodeURIComponent(username)}`,
     {
       method: "PATCH",
-      headers: adminHeaders(adminToken),
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     },
   );
@@ -234,14 +245,13 @@ export async function updateAdminUser(
 
 export async function upgradeAdminUserData(
   server: string,
-  adminToken: string,
   username: string,
 ): Promise<AdminDataUpgradeResult> {
   const res = await fetch(
     `${server}/api/admin/users/${encodeURIComponent(username)}/upgrade-data`,
     {
       method: "POST",
-      headers: adminHeaders(adminToken),
+      headers: { "Content-Type": "application/json" },
     },
   );
   if (!res.ok) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -54,6 +54,10 @@ export interface AuthUserInfo {
   roles: string[];
 }
 
+export interface WebSocketTicketResponse {
+  ticket: string;
+}
+
 export interface AdminUserInfo {
   username: string;
   enabled: boolean;
@@ -179,6 +183,16 @@ export async function getCurrentUser(server: string): Promise<AuthUserInfo> {
     throw new Error("Invalid user response");
   }
   return user;
+}
+
+export async function getWebSocketTicket(server: string, token: string): Promise<string> {
+  const res = await fetch(`${server}/api/auth/ws-ticket`, {
+    method: "POST",
+    headers: headers(token),
+  });
+  if (!res.ok) throw new Error(await readErrorMessage(res, "Failed to create websocket ticket"));
+  const body = await res.json() as WebSocketTicketResponse;
+  return body.ticket;
 }
 
 export async function logout(server: string): Promise<void> {
@@ -830,12 +844,16 @@ export function wsUrl(
   sessionId: string,
   _session: string,
   clientId?: string,
+  ticket?: string,
 ): string {
   void _session;
   const base = server.replace("http://", "ws://").replace("https://", "wss://");
   const params = new URLSearchParams();
   if (clientId) {
     params.set("client_id", clientId);
+  }
+  if (ticket) {
+    params.set("ticket", ticket);
   }
   const query = params.toString();
   return `${base}/api/chat/${sessionId}${query ? `?${query}` : ""}`;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -14,11 +14,33 @@ import type {
 } from "./types";
 import { isRecord, readNumber, readString, readStringArray } from "./decoding";
 
+export const AUTH_REQUIRED_EVENT = "carapace:auth-required";
+
+function requestPath(input: RequestInfo | URL): string {
+  if (input instanceof Request) return new URL(input.url).pathname;
+  if (input instanceof URL) return input.pathname;
+  return new URL(input, "http://carapace.local").pathname;
+}
+
+function shouldEmitAuthRequired(input: RequestInfo | URL): boolean {
+  const path = requestPath(input);
+  return path !== "/api/auth/login" && path !== "/api/auth/logout";
+}
+
+function emitAuthRequired(input: RequestInfo | URL): void {
+  if (typeof window === "undefined" || !shouldEmitAuthRequired(input)) return;
+  window.dispatchEvent(new Event(AUTH_REQUIRED_EVENT));
+}
+
 async function fetch(
   input: RequestInfo | URL,
   init: RequestInit = {},
 ): Promise<Response> {
-  return globalThis.fetch(input, { ...init, credentials: "include" });
+  const response = await globalThis.fetch(input, { ...init, credentials: "include" });
+  if (response.status === 401) {
+    emitAuthRequired(input);
+  }
+  return response;
 }
 
 function headers(_session: string): HeadersInit {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -90,6 +90,11 @@ export interface AdminUserUpdateInput {
   password?: string;
 }
 
+export interface AdminDataUpgradeResult {
+  username: string;
+  summary: Record<string, string[]>;
+}
+
 function decodeAdminUser(raw: unknown): AdminUserInfo | null {
   if (!isRecord(raw)) return null;
 
@@ -222,6 +227,31 @@ export async function updateAdminUser(
     throw new Error("Invalid user response");
   }
   return user;
+}
+
+export async function upgradeAdminUserData(
+  server: string,
+  adminToken: string,
+  username: string,
+): Promise<AdminDataUpgradeResult> {
+  const res = await fetch(`${server}/api/admin/users/${encodeURIComponent(username)}/upgrade-data`, {
+    method: "POST",
+    headers: adminHeaders(adminToken),
+  });
+  if (!res.ok) {
+    throw new Error(await readErrorMessage(res, "Failed to upgrade user data"));
+  }
+  const raw: unknown = await res.json();
+  if (!isRecord(raw) || !readString(raw, "username") || !isRecord(raw.summary)) {
+    throw new Error("Invalid upgrade response");
+  }
+  const summary: Record<string, string[]> = {};
+  for (const [key, value] of Object.entries(raw.summary)) {
+    if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
+      summary[key] = value;
+    }
+  }
+  return { username: readString(raw, "username")!, summary };
 }
 
 export async function getServerMeta(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -243,6 +243,22 @@ export async function updateAdminUser(
   return user;
 }
 
+export async function deleteAdminUser(
+  server: string,
+  username: string,
+): Promise<void> {
+  const res = await fetch(
+    `${server}/api/admin/users/${encodeURIComponent(username)}`,
+    {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+  if (!res.ok) {
+    throw new Error(await readErrorMessage(res, "Failed to delete user"));
+  }
+}
+
 export async function upgradeAdminUserData(
   server: string,
   username: string,

--- a/frontend/src/lib/server-url.ts
+++ b/frontend/src/lib/server-url.ts
@@ -1,0 +1,12 @@
+export function defaultServer(): string {
+  if (typeof window === "undefined") return "http://127.0.0.1:8321";
+  const url = new URL(window.location.origin);
+  if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
+    return `${url.protocol}//${url.hostname}:8321`;
+  }
+  return window.location.origin;
+}
+
+export function normalizeServer(server: string): string {
+  return server.trim().replace(/\/$/, "");
+}

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -1,5 +1,6 @@
 const SERVER_KEY = "carapace_server";
-const TOKEN_KEY = "carapace_token";
+const USERNAME_KEY = "carapace_username";
+const LEGACY_TOKEN_KEY = "carapace_token";
 const LOCALE_OVERRIDE_KEY = "carapace_locale_override";
 const SHOW_ARCHIVED_SESSIONS_KEY = "carapace_show_archived_sessions";
 const PRESENCE_CLIENT_ID_KEY = "carapace_presence_client_id";
@@ -16,17 +17,19 @@ export function getServer(): string {
 
 export function getToken(): string {
   if (typeof window === "undefined") return "";
-  return localStorage.getItem(TOKEN_KEY) ?? "";
+  return localStorage.getItem(USERNAME_KEY) ?? "";
 }
 
-export function saveConnection(server: string, token: string) {
+export function saveConnection(server: string, username: string) {
   localStorage.setItem(SERVER_KEY, server);
-  localStorage.setItem(TOKEN_KEY, token);
+  localStorage.setItem(USERNAME_KEY, username);
+  localStorage.removeItem(LEGACY_TOKEN_KEY);
 }
 
 export function clearConnection() {
   localStorage.removeItem(SERVER_KEY);
-  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(USERNAME_KEY);
+  localStorage.removeItem(LEGACY_TOKEN_KEY);
 }
 
 export function hasConnection(): boolean {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ dependencies = [
     "tiktoken>=0.8,<1",
     "redis>=7.4,<8",
     "pywebpush>=2,<3",
+    "joserfc>=1.6.5",
+    "pwdlib[argon2]>=0.3.0",
 ]
 
 [project.scripts]

--- a/src/carapace/auth.py
+++ b/src/carapace/auth.py
@@ -157,17 +157,40 @@ class AuthStore:
         return self.load_users().users.get(normalize_username(username))
 
     def ensure_bootstrap_admin(self) -> AuthUser | None:
-        users_file = self.load_users()
-        if any(user.enabled and has_admin_role(user.roles) for user in users_file.users.values()):
-            return None
-        if ADMIN_USERNAME in users_file.users:
-            return None
-        return self.create_user(
-            username=ADMIN_USERNAME,
-            password=validate_bootstrap_admin_password(),
-            display_name="Administrator",
-            roles=[ADMIN_ROLE],
-        )
+        now = datetime.now(tz=UTC)
+        with self._lock:
+            users_file = self.load_users()
+            if any(user.enabled and has_admin_role(user.roles) for user in users_file.users.values()):
+                return None
+
+            password = validate_bootstrap_admin_password()
+            existing = users_file.users.get(ADMIN_USERNAME)
+            if existing is None:
+                user = AuthUser(
+                    password_hash=hash_password(password),
+                    display_name="Administrator",
+                    roles=[ADMIN_ROLE],
+                    created_at=now,
+                    updated_at=now,
+                    password_changed_at=now,
+                )
+            else:
+                payload = existing.model_dump(mode="python")
+                payload.update(
+                    {
+                        "password_hash": hash_password(password),
+                        "enabled": True,
+                        "display_name": existing.display_name or "Administrator",
+                        "roles": normalize_roles([*existing.roles, ADMIN_ROLE]),
+                        "token_version": existing.token_version + 1,
+                        "updated_at": now,
+                        "password_changed_at": now,
+                    }
+                )
+                user = AuthUser.model_validate(payload)
+            users_file.users[ADMIN_USERNAME] = user
+            self.save_users(users_file)
+            return user
 
     def create_user(
         self,

--- a/src/carapace/auth.py
+++ b/src/carapace/auth.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import secrets
+import string
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from threading import RLock
@@ -17,6 +18,9 @@ from pydantic import BaseModel, Field, model_validator
 from .models.config import AuthConfig, UserConfig
 
 _password_hash = PasswordHash.recommended()
+ADMIN_TOKEN_MIN_LENGTH = 16
+ADMIN_TOKEN_SUGGESTED_LENGTH = 24
+_ADMIN_TOKEN_ALPHABET = string.ascii_letters + string.digits
 
 
 class UserIdentity(BaseModel):
@@ -358,9 +362,25 @@ def verify_password(password: str, password_hash: str) -> bool:
     return _password_hash.verify(password, password_hash)
 
 
-def get_token() -> str:
-    """Return the admin token from the CARAPACE_TOKEN environment variable."""
-    token = os.environ.get("CARAPACE_TOKEN", "").strip()
+def suggest_admin_token() -> str:
+    return "".join(secrets.choice(_ADMIN_TOKEN_ALPHABET) for _ in range(ADMIN_TOKEN_SUGGESTED_LENGTH))
+
+
+def validate_admin_token(token: str | None = None) -> str:
+    """Return a validated admin token or raise with a replacement suggestion."""
+    if token is None:
+        token = os.environ.get("CARAPACE_TOKEN", "")
+    token = token.strip()
     if not token:
         raise RuntimeError("CARAPACE_TOKEN environment variable is required but not set")
+    if len(token) < ADMIN_TOKEN_MIN_LENGTH:
+        raise RuntimeError(
+            "CARAPACE_TOKEN must be at least "
+            f"{ADMIN_TOKEN_MIN_LENGTH} characters long. Suggested replacement: {suggest_admin_token()}"
+        )
     return token
+
+
+def get_token() -> str:
+    """Return the admin token from the CARAPACE_TOKEN environment variable."""
+    return validate_admin_token()

--- a/src/carapace/auth.py
+++ b/src/carapace/auth.py
@@ -159,7 +159,7 @@ class AuthStore:
             return None
         return self.create_user(
             username=ADMIN_USERNAME,
-            password=get_token(),
+            password=validate_bootstrap_admin_password(),
             display_name="Administrator",
             roles=[ADMIN_ROLE],
         )
@@ -402,8 +402,3 @@ def validate_bootstrap_admin_password(password: str | None = None) -> str:
             f"Suggested replacement: {suggest_bootstrap_admin_password()}"
         )
     return password
-
-
-def get_token() -> str:
-    """Return the bootstrap admin password from the CARAPACE_TOKEN environment variable."""
-    return validate_bootstrap_admin_password()

--- a/src/carapace/auth.py
+++ b/src/carapace/auth.py
@@ -18,9 +18,11 @@ from pydantic import BaseModel, Field, model_validator
 from .models.config import AuthConfig, UserConfig
 
 _password_hash = PasswordHash.recommended()
-ADMIN_TOKEN_MIN_LENGTH = 16
-ADMIN_TOKEN_SUGGESTED_LENGTH = 24
-_ADMIN_TOKEN_ALPHABET = string.ascii_letters + string.digits
+ADMIN_ROLE = "admin"
+ADMIN_USERNAME = "admin"
+BOOTSTRAP_ADMIN_PASSWORD_MIN_LENGTH = 16
+BOOTSTRAP_ADMIN_PASSWORD_SUGGESTED_LENGTH = 24
+_BOOTSTRAP_ADMIN_PASSWORD_ALPHABET = string.ascii_letters + string.digits
 
 
 class UserIdentity(BaseModel):
@@ -48,7 +50,7 @@ class AuthUser(BaseModel):
     def _normalize(self) -> AuthUser:
         self.display_name = self.display_name.strip()
         self.email = self.email.strip() or None if self.email is not None else None
-        self.roles = [role.strip() for role in self.roles if role.strip()]
+        self.roles = normalize_roles(self.roles)
         if self.token_version < 1:
             raise ValueError("token_version must be >= 1")
         return self
@@ -151,6 +153,16 @@ class AuthStore:
 
     def get_user(self, username: str) -> AuthUser | None:
         return self.load_users().users.get(normalize_username(username))
+
+    def ensure_bootstrap_admin(self) -> AuthUser | None:
+        if self.get_user(ADMIN_USERNAME) is not None:
+            return None
+        return self.create_user(
+            username=ADMIN_USERNAME,
+            password=get_token(),
+            display_name="Administrator",
+            roles=[ADMIN_ROLE],
+        )
 
     def create_user(
         self,
@@ -350,6 +362,14 @@ def normalize_username(username: str) -> str:
     return username.strip().lower()
 
 
+def normalize_roles(roles: list[str]) -> list[str]:
+    return [role.strip().lower() for role in roles if role.strip()]
+
+
+def has_admin_role(roles: list[str]) -> bool:
+    return ADMIN_ROLE in normalize_roles(roles)
+
+
 def hash_password(password: str) -> str:
     if not password:
         raise ValueError("password must not be empty")
@@ -362,25 +382,28 @@ def verify_password(password: str, password_hash: str) -> bool:
     return _password_hash.verify(password, password_hash)
 
 
-def suggest_admin_token() -> str:
-    return "".join(secrets.choice(_ADMIN_TOKEN_ALPHABET) for _ in range(ADMIN_TOKEN_SUGGESTED_LENGTH))
+def suggest_bootstrap_admin_password() -> str:
+    return "".join(
+        secrets.choice(_BOOTSTRAP_ADMIN_PASSWORD_ALPHABET) for _ in range(BOOTSTRAP_ADMIN_PASSWORD_SUGGESTED_LENGTH)
+    )
 
 
-def validate_admin_token(token: str | None = None) -> str:
-    """Return a validated admin token or raise with a replacement suggestion."""
-    if token is None:
-        token = os.environ.get("CARAPACE_TOKEN", "")
-    token = token.strip()
-    if not token:
+def validate_bootstrap_admin_password(password: str | None = None) -> str:
+    """Return a validated bootstrap admin password or raise with a replacement suggestion."""
+    if password is None:
+        password = os.environ.get("CARAPACE_TOKEN", "")
+    password = password.strip()
+    if not password:
         raise RuntimeError("CARAPACE_TOKEN environment variable is required but not set")
-    if len(token) < ADMIN_TOKEN_MIN_LENGTH:
+    if len(password) < BOOTSTRAP_ADMIN_PASSWORD_MIN_LENGTH:
         raise RuntimeError(
             "CARAPACE_TOKEN must be at least "
-            f"{ADMIN_TOKEN_MIN_LENGTH} characters long. Suggested replacement: {suggest_admin_token()}"
+            f"{BOOTSTRAP_ADMIN_PASSWORD_MIN_LENGTH} characters long. "
+            f"Suggested replacement: {suggest_bootstrap_admin_password()}"
         )
-    return token
+    return password
 
 
 def get_token() -> str:
-    """Return the admin token from the CARAPACE_TOKEN environment variable."""
-    return validate_admin_token()
+    """Return the bootstrap admin password from the CARAPACE_TOKEN environment variable."""
+    return validate_bootstrap_admin_password()

--- a/src/carapace/auth.py
+++ b/src/carapace/auth.py
@@ -211,6 +211,16 @@ class AuthStore:
             self.save_users(users_file)
             return updated
 
+    def delete_user(self, username: str) -> None:
+        key = normalize_username(username)
+        with self._lock:
+            users_file = self.load_users()
+            if key not in users_file.users:
+                raise KeyError(key)
+            del users_file.users[key]
+            self.save_users(users_file)
+            self.revoke_user_sessions(key)
+
     def set_password(self, username: str, password: str) -> AuthUser:
         key = normalize_username(username)
         password_hash = hash_password(password)
@@ -285,6 +295,21 @@ class AuthStore:
             sessions_file.sessions[session_id] = session.model_copy(update={"revoked_at": datetime.now(tz=UTC)})
             self.save_sessions(sessions_file)
             return True
+
+    def revoke_user_sessions(self, username: str) -> int:
+        key = normalize_username(username)
+        now = datetime.now(tz=UTC)
+        revoked = 0
+        with self._lock:
+            sessions_file = self.load_sessions()
+            for session_id, session in sessions_file.sessions.items():
+                if session.user != key or session.revoked_at is not None:
+                    continue
+                sessions_file.sessions[session_id] = session.model_copy(update={"revoked_at": now})
+                revoked += 1
+            if revoked:
+                self.save_sessions(sessions_file)
+        return revoked
 
     def signing_secret(self) -> str:
         with self._lock:

--- a/src/carapace/auth.py
+++ b/src/carapace/auth.py
@@ -157,7 +157,10 @@ class AuthStore:
         return self.load_users().users.get(normalize_username(username))
 
     def ensure_bootstrap_admin(self) -> AuthUser | None:
-        if self.get_user(ADMIN_USERNAME) is not None:
+        users_file = self.load_users()
+        if any(user.enabled and has_admin_role(user.roles) for user in users_file.users.values()):
+            return None
+        if ADMIN_USERNAME in users_file.users:
             return None
         return self.create_user(
             username=ADMIN_USERNAME,

--- a/src/carapace/auth.py
+++ b/src/carapace/auth.py
@@ -1,10 +1,354 @@
 from __future__ import annotations
 
 import os
+import secrets
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from threading import RLock
+from typing import Any
+
+import yaml
+from joserfc import jwt
+from joserfc.errors import JoseError
+from joserfc.jwk import OctKey
+from pwdlib import PasswordHash
+from pydantic import BaseModel, Field, model_validator
+
+from .models.config import AuthConfig, UserConfig
+
+_password_hash = PasswordHash.recommended()
+
+
+class UserIdentity(BaseModel):
+    username: str
+    display_name: str = ""
+    email: str | None = None
+    roles: list[str] = []
+    config: UserConfig = UserConfig()
+
+
+class AuthUser(BaseModel):
+    password_hash: str
+    enabled: bool = True
+    token_version: int = 1
+    display_name: str = ""
+    email: str | None = None
+    roles: list[str] = []
+    created_at: datetime = Field(default_factory=lambda: datetime.now(tz=UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(tz=UTC))
+    password_changed_at: datetime = Field(default_factory=lambda: datetime.now(tz=UTC))
+    last_login_at: datetime | None = None
+    config: UserConfig = UserConfig()
+
+    @model_validator(mode="after")
+    def _normalize(self) -> AuthUser:
+        self.display_name = self.display_name.strip()
+        self.email = self.email.strip() or None if self.email is not None else None
+        self.roles = [role.strip() for role in self.roles if role.strip()]
+        if self.token_version < 1:
+            raise ValueError("token_version must be >= 1")
+        return self
+
+    def identity(self, username: str) -> UserIdentity:
+        return UserIdentity(
+            username=username,
+            display_name=self.display_name or username,
+            email=self.email,
+            roles=list(self.roles),
+            config=self.config.model_copy(deep=True),
+        )
+
+
+class UsersFile(BaseModel):
+    version: int = 1
+    users: dict[str, AuthUser] = {}
+
+    @model_validator(mode="after")
+    def _normalize(self) -> UsersFile:
+        normalized: dict[str, AuthUser] = {}
+        for username, user in self.users.items():
+            key = normalize_username(username)
+            if key in normalized:
+                raise ValueError(f"duplicate username after normalization: {username!r}")
+            normalized[key] = user
+        self.users = normalized
+        return self
+
+
+class AuthSession(BaseModel):
+    id: str
+    user: str
+    created_at: datetime = Field(default_factory=lambda: datetime.now(tz=UTC))
+    expires_at: datetime
+    revoked_at: datetime | None = None
+    user_agent: str = ""
+
+    @model_validator(mode="after")
+    def _normalize(self) -> AuthSession:
+        self.id = self.id.strip()
+        if not self.id:
+            raise ValueError("session id must not be empty")
+        self.user = normalize_username(self.user)
+        if self.expires_at <= self.created_at:
+            raise ValueError("session expires_at must be after created_at")
+        return self
+
+    def is_active(self, *, now: datetime | None = None) -> bool:
+        current = now or datetime.now(tz=UTC)
+        return self.revoked_at is None and self.expires_at > current
+
+
+class SessionsFile(BaseModel):
+    version: int = 1
+    sessions: dict[str, AuthSession] = {}
+
+
+class SessionTokenClaims(BaseModel):
+    iss: str
+    aud: str
+    typ: str
+    sub: str
+    sid: str
+    iat: int
+    exp: int
+    ver: int
+
+
+class AuthStore:
+    def __init__(self, data_dir: Path, config: AuthConfig):
+        self._dir = data_dir / "auth"
+        self._users_path = self._dir / "users.yaml"
+        self._sessions_path = self._dir / "sessions.yaml"
+        self._secret_path = self._dir / "session_secret"
+        self._config = config
+        self._lock = RLock()
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def users_path(self) -> Path:
+        return self._users_path
+
+    @property
+    def sessions_path(self) -> Path:
+        return self._sessions_path
+
+    def load_users(self) -> UsersFile:
+        with self._lock:
+            if not self._users_path.exists():
+                return UsersFile()
+            raw = yaml.safe_load(self._users_path.read_text(encoding="utf-8")) or {}
+        return UsersFile.model_validate(raw)
+
+    def save_users(self, users_file: UsersFile) -> UsersFile:
+        payload = users_file.model_dump(mode="json", exclude_none=True)
+        with self._lock:
+            self._write_yaml(self._users_path, payload)
+        return users_file
+
+    def get_user(self, username: str) -> AuthUser | None:
+        return self.load_users().users.get(normalize_username(username))
+
+    def create_user(
+        self,
+        *,
+        username: str,
+        password: str,
+        display_name: str = "",
+        email: str | None = None,
+        roles: list[str] | None = None,
+        config: UserConfig | None = None,
+    ) -> AuthUser:
+        key = normalize_username(username)
+        if not key:
+            raise ValueError("username must not be empty")
+        now = datetime.now(tz=UTC)
+        with self._lock:
+            users_file = self.load_users()
+            if key in users_file.users:
+                raise ValueError(f"User {key!r} already exists")
+            user = AuthUser(
+                password_hash=hash_password(password),
+                display_name=display_name or key,
+                email=email,
+                roles=roles or [],
+                created_at=now,
+                updated_at=now,
+                password_changed_at=now,
+                config=config or UserConfig(),
+            )
+            users_file.users[key] = user
+            self.save_users(users_file)
+            return user
+
+    def update_user(self, username: str, updates: dict[str, Any]) -> AuthUser:
+        key = normalize_username(username)
+        with self._lock:
+            users_file = self.load_users()
+            existing = users_file.users.get(key)
+            if existing is None:
+                raise KeyError(key)
+            payload = existing.model_dump(mode="python")
+            payload.update(updates)
+            payload["updated_at"] = datetime.now(tz=UTC)
+            updated = AuthUser.model_validate(payload)
+            users_file.users[key] = updated
+            self.save_users(users_file)
+            return updated
+
+    def set_password(self, username: str, password: str) -> AuthUser:
+        user = self.get_user(username)
+        return self.update_user(
+            username,
+            {
+                "password_hash": hash_password(password),
+                "password_changed_at": datetime.now(tz=UTC),
+                "token_version": user.token_version + 1 if user is not None else 1,
+            },
+        )
+
+    def verify_password(self, username: str, password: str) -> AuthUser | None:
+        user = self.get_user(username)
+        if user is None or not user.enabled:
+            return None
+        if not verify_password(password, user.password_hash):
+            return None
+        return user
+
+    def load_sessions(self) -> SessionsFile:
+        with self._lock:
+            if not self._sessions_path.exists():
+                return SessionsFile()
+            raw = yaml.safe_load(self._sessions_path.read_text(encoding="utf-8")) or {}
+        return SessionsFile.model_validate(raw)
+
+    def save_sessions(self, sessions_file: SessionsFile) -> SessionsFile:
+        payload = sessions_file.model_dump(mode="json", exclude_none=True)
+        with self._lock:
+            self._write_yaml(self._sessions_path, payload)
+        return sessions_file
+
+    def create_session(self, *, username: str, user_agent: str = "") -> AuthSession:
+        user = self.get_user(username)
+        if user is None or not user.enabled:
+            raise ValueError("User not found or disabled")
+        now = datetime.now(tz=UTC)
+        session = AuthSession(
+            id=secrets.token_urlsafe(32),
+            user=normalize_username(username),
+            created_at=now,
+            expires_at=now + timedelta(seconds=self._config.cookie.ttl_seconds),
+            user_agent=user_agent,
+        )
+        with self._lock:
+            sessions_file = self.load_sessions()
+            sessions_file.sessions[session.id] = session
+            self.save_sessions(sessions_file)
+            self.update_user(username, {"last_login_at": now})
+        return session
+
+    def get_session(self, session_id: str) -> AuthSession | None:
+        return self.load_sessions().sessions.get(session_id)
+
+    def revoke_session(self, session_id: str) -> bool:
+        with self._lock:
+            sessions_file = self.load_sessions()
+            session = sessions_file.sessions.get(session_id)
+            if session is None:
+                return False
+            sessions_file.sessions[session_id] = session.model_copy(update={"revoked_at": datetime.now(tz=UTC)})
+            self.save_sessions(sessions_file)
+            return True
+
+    def signing_secret(self) -> str:
+        with self._lock:
+            if self._secret_path.exists():
+                return self._secret_path.read_text(encoding="utf-8").strip()
+            secret = secrets.token_urlsafe(48)
+            self._secret_path.write_text(secret, encoding="utf-8")
+            self._secret_path.chmod(0o600)
+            return secret
+
+    def issue_session_token(self, session: AuthSession) -> str:
+        user = self.get_user(session.user)
+        if user is None:
+            raise ValueError("User not found")
+        claims = {
+            "iss": self._config.cookie.issuer,
+            "aud": self._config.cookie.audience,
+            "typ": "session",
+            "sub": session.user,
+            "sid": session.id,
+            "iat": int(session.created_at.timestamp()),
+            "exp": int(session.expires_at.timestamp()),
+            "ver": user.token_version,
+        }
+        return jwt.encode({"alg": "HS256"}, claims, self._signing_key())
+
+    def validate_session_token(self, token: str) -> UserIdentity | None:
+        claims = self._decode_session_claims(token)
+        if claims is None:
+            return None
+
+        now = datetime.now(tz=UTC)
+        if datetime.fromtimestamp(claims.exp, tz=UTC) <= now:
+            return None
+
+        session = self.get_session(claims.sid)
+        if session is None or not session.is_active(now=now) or session.user != normalize_username(claims.sub):
+            return None
+        user = self.get_user(session.user)
+        if user is None or not user.enabled or user.token_version != claims.ver:
+            return None
+        return user.identity(session.user)
+
+    def revoke_token(self, token: str) -> bool:
+        claims = self._decode_session_claims(token)
+        if claims is None:
+            return False
+        return self.revoke_session(claims.sid)
+
+    def _decode_session_claims(self, token: str) -> SessionTokenClaims | None:
+        try:
+            token_obj = jwt.decode(token, self._signing_key(), algorithms=["HS256"])
+            claims = SessionTokenClaims.model_validate(token_obj.claims)
+        except (JoseError, ValueError):
+            return None
+        if claims.iss != self._config.cookie.issuer:
+            return None
+        if claims.aud != self._config.cookie.audience:
+            return None
+        if claims.typ != "session":
+            return None
+        return claims
+
+    def _signing_key(self) -> OctKey:
+        return OctKey.import_key(self.signing_secret())
+
+    def _write_yaml(self, path: Path, payload: dict[str, Any]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = path.with_suffix(f"{path.suffix}.tmp")
+        tmp_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+        tmp_path.replace(path)
+
+
+def normalize_username(username: str) -> str:
+    return username.strip().lower()
+
+
+def hash_password(password: str) -> str:
+    if not password:
+        raise ValueError("password must not be empty")
+    return _password_hash.hash(password)
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    if not password or not password_hash:
+        return False
+    return _password_hash.verify(password, password_hash)
 
 
 def get_token() -> str:
-    """Return the bearer token from the CARAPACE_TOKEN environment variable."""
+    """Return the admin token from the CARAPACE_TOKEN environment variable."""
     token = os.environ.get("CARAPACE_TOKEN", "").strip()
     if not token:
         raise RuntimeError("CARAPACE_TOKEN environment variable is required but not set")

--- a/src/carapace/auth.py
+++ b/src/carapace/auth.py
@@ -196,15 +196,26 @@ class AuthStore:
             return updated
 
     def set_password(self, username: str, password: str) -> AuthUser:
-        user = self.get_user(username)
-        return self.update_user(
-            username,
-            {
-                "password_hash": hash_password(password),
-                "password_changed_at": datetime.now(tz=UTC),
-                "token_version": user.token_version + 1 if user is not None else 1,
-            },
-        )
+        key = normalize_username(username)
+        password_hash = hash_password(password)
+        with self._lock:
+            users_file = self.load_users()
+            existing = users_file.users.get(key)
+            if existing is None:
+                raise KeyError(key)
+            payload = existing.model_dump(mode="python")
+            payload.update(
+                {
+                    "password_hash": password_hash,
+                    "password_changed_at": datetime.now(tz=UTC),
+                    "token_version": existing.token_version + 1,
+                    "updated_at": datetime.now(tz=UTC),
+                }
+            )
+            updated = AuthUser.model_validate(payload)
+            users_file.users[key] = updated
+            self.save_users(users_file)
+            return updated
 
     def verify_password(self, username: str, password: str) -> AuthUser | None:
         user = self.get_user(username)

--- a/src/carapace/auth.py
+++ b/src/carapace/auth.py
@@ -128,6 +128,8 @@ class AuthStore:
         self._secret_path = self._dir / "session_secret"
         self._config = config
         self._lock = RLock()
+        self._cached_signing_secret: str | None = None
+        self._cached_signing_key: OctKey | None = None
         self._dir.mkdir(parents=True, exist_ok=True)
 
     @property
@@ -278,6 +280,7 @@ class AuthStore:
         )
         with self._lock:
             sessions_file = self.load_sessions()
+            self._prune_sessions_file(sessions_file, now=now)
             sessions_file.sessions[session.id] = session
             self.save_sessions(sessions_file)
             self.update_user(username, {"last_login_at": now})
@@ -311,13 +314,26 @@ class AuthStore:
                 self.save_sessions(sessions_file)
         return revoked
 
+    def prune_sessions(self, *, now: datetime | None = None) -> int:
+        current = now or datetime.now(tz=UTC)
+        with self._lock:
+            sessions_file = self.load_sessions()
+            removed = self._prune_sessions_file(sessions_file, now=current)
+            if removed:
+                self.save_sessions(sessions_file)
+            return removed
+
     def signing_secret(self) -> str:
         with self._lock:
+            if self._cached_signing_secret is not None:
+                return self._cached_signing_secret
             if self._secret_path.exists():
-                return self._secret_path.read_text(encoding="utf-8").strip()
+                self._cached_signing_secret = self._secret_path.read_text(encoding="utf-8").strip()
+                return self._cached_signing_secret
             secret = secrets.token_urlsafe(48)
             self._secret_path.write_text(secret, encoding="utf-8")
             self._secret_path.chmod(0o600)
+            self._cached_signing_secret = secret
             return secret
 
     def issue_session_token(self, session: AuthSession) -> str:
@@ -336,11 +352,43 @@ class AuthStore:
         }
         return jwt.encode({"alg": "HS256"}, claims, self._signing_key())
 
+    def issue_websocket_token(self, session_token: str) -> str | None:
+        session_claims = self._decode_token_claims(session_token, expected_type="session")
+        if session_claims is None:
+            return None
+        if self._identity_from_claims(session_claims) is None:
+            return None
+
+        now = datetime.now(tz=UTC)
+        user = self.get_user(session_claims.sub)
+        if user is None:
+            return None
+        claims = {
+            "iss": self._config.cookie.issuer,
+            "aud": self._config.cookie.audience,
+            "typ": "websocket",
+            "sub": session_claims.sub,
+            "sid": session_claims.sid,
+            "iat": int(now.timestamp()),
+            "exp": session_claims.exp,
+            "ver": user.token_version,
+        }
+        return jwt.encode({"alg": "HS256"}, claims, self._signing_key())
+
     def validate_session_token(self, token: str) -> UserIdentity | None:
-        claims = self._decode_session_claims(token)
+        claims = self._decode_token_claims(token, expected_type="session")
         if claims is None:
             return None
 
+        return self._identity_from_claims(claims)
+
+    def validate_websocket_token(self, token: str) -> UserIdentity | None:
+        claims = self._decode_token_claims(token, expected_type="websocket")
+        if claims is None:
+            return None
+        return self._identity_from_claims(claims)
+
+    def _identity_from_claims(self, claims: SessionTokenClaims) -> UserIdentity | None:
         now = datetime.now(tz=UTC)
         if datetime.fromtimestamp(claims.exp, tz=UTC) <= now:
             return None
@@ -354,12 +402,12 @@ class AuthStore:
         return user.identity(session.user)
 
     def revoke_token(self, token: str) -> bool:
-        claims = self._decode_session_claims(token)
+        claims = self._decode_token_claims(token, expected_type="session")
         if claims is None:
             return False
         return self.revoke_session(claims.sid)
 
-    def _decode_session_claims(self, token: str) -> SessionTokenClaims | None:
+    def _decode_token_claims(self, token: str, *, expected_type: str) -> SessionTokenClaims | None:
         try:
             token_obj = jwt.decode(token, self._signing_key(), algorithms=["HS256"])
             claims = SessionTokenClaims.model_validate(token_obj.claims)
@@ -369,12 +417,22 @@ class AuthStore:
             return None
         if claims.aud != self._config.cookie.audience:
             return None
-        if claims.typ != "session":
+        if claims.typ != expected_type:
             return None
         return claims
 
     def _signing_key(self) -> OctKey:
-        return OctKey.import_key(self.signing_secret())
+        with self._lock:
+            if self._cached_signing_key is None:
+                self._cached_signing_key = OctKey.import_key(self.signing_secret())
+            return self._cached_signing_key
+
+    def _prune_sessions_file(self, sessions_file: SessionsFile, *, now: datetime) -> int:
+        before = len(sessions_file.sessions)
+        sessions_file.sessions = {
+            session_id: session for session_id, session in sessions_file.sessions.items() if session.is_active(now=now)
+        }
+        return before - len(sessions_file.sessions)
 
     def _write_yaml(self, path: Path, payload: dict[str, Any]) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/carapace/cache.py
+++ b/src/carapace/cache.py
@@ -74,7 +74,7 @@ class SessionListCache:
         loop.call_soon_threadsafe(lambda: loop.create_task(self.invalidate()))
 
     def _cache_key(self, include_archived: bool, include_message_count: bool, *, user: str | None = None) -> str:
-        owner = user or "all"
+        owner = f"user:{user}" if user is not None else "scope:all"
         return f"carapace:sessions:list:{owner}:{int(include_archived)}:{int(include_message_count)}"
 
     async def _redis_get(self, cache_key: str) -> list[dict[str, Any]] | None:

--- a/src/carapace/cache.py
+++ b/src/carapace/cache.py
@@ -42,11 +42,12 @@ class SessionListCache:
     async def get_session_infos(
         self,
         *,
+        user: str | None = None,
         include_archived: bool,
         include_message_count: bool,
         loader: Callable[[], list[dict[str, Any]]],
     ) -> list[dict[str, Any]]:
-        cache_key = self._cache_key(include_archived, include_message_count)
+        cache_key = self._cache_key(include_archived, include_message_count, user=user)
 
         redis_cached = await self._redis_get(cache_key)
         if redis_cached is not None:
@@ -60,12 +61,9 @@ class SessionListCache:
         if self._redis_client is None:
             raise RuntimeError("Session list cache has not been started")
         try:
-            await self._redis_client.delete(
-                self._cache_key(False, False),
-                self._cache_key(False, True),
-                self._cache_key(True, False),
-                self._cache_key(True, True),
-            )
+            keys = [key async for key in self._redis_client.scan_iter("carapace:sessions:list:*")]
+            if keys:
+                await self._redis_client.delete(*keys)
         except (OSError, RedisError) as exc:
             logger.warning(f"Failed to invalidate Redis session list cache: {exc}")
 
@@ -75,8 +73,9 @@ class SessionListCache:
         loop = self._loop
         loop.call_soon_threadsafe(lambda: loop.create_task(self.invalidate()))
 
-    def _cache_key(self, include_archived: bool, include_message_count: bool) -> str:
-        return f"carapace:sessions:list:{int(include_archived)}:{int(include_message_count)}"
+    def _cache_key(self, include_archived: bool, include_message_count: bool, *, user: str | None = None) -> str:
+        owner = user or "all"
+        return f"carapace:sessions:list:{owner}:{int(include_archived)}:{int(include_message_count)}"
 
     async def _redis_get(self, cache_key: str) -> list[dict[str, Any]] | None:
         if self._redis_client is None:

--- a/src/carapace/channels/matrix/channel.py
+++ b/src/carapace/channels/matrix/channel.py
@@ -10,13 +10,16 @@ from pathlib import Path
 from typing import Any, Protocol, cast
 
 import nio
+import yaml
 from loguru import logger
 
-from ...models.config import Config, MatrixChannelConfig, MatrixTokenFile
+from ...auth import normalize_username
+from ...models.config import Config, MatrixChannelConfig, MatrixTokenFile, MatrixTokensFile
 from ...models.skills import SkillInfo
 from ...notifications.presence import NotificationPresenceRegistry
 from ...sandbox.manager import SandboxManager
 from ...session import SessionEngine, SessionManager
+from ...session.manager import SessionMeta
 from ...ws_models import ApprovalResponse, CommandResult, EscalationResponse
 from .approval import (
     APPROVE_COMMANDS,
@@ -106,6 +109,7 @@ class MatrixChannel:
         self._sandbox_mgr = sandbox_mgr
         self._engine = engine
         self._presence_registry = presence_registry
+        self._owner_user: str | None = None
 
         self._client = cast(MatrixClientProtocol, nio.AsyncClient(config.homeserver, config.user_id))
 
@@ -137,7 +141,7 @@ class MatrixChannel:
     async def start(self) -> None:
         """Authenticate and start the sync loop."""
         data_dir = self._session_mgr.sessions_dir.parent
-        token_file = data_dir / "matrix_token.json"
+        token_file = data_dir / "matrix_token.yaml"
 
         await self._authenticate(token_file)
         logger.info(f"Matrix channel logged in as {self._config.user_id} on {self._config.homeserver}")
@@ -207,18 +211,24 @@ class MatrixChannel:
         """Return (access_token, device_id) from persisted file or env var, or ("", None)."""
         if token_file.exists():
             try:
-                stored = MatrixTokenFile.model_validate_json(token_file.read_text())
-                if stored.user_id != self._config.user_id:
-                    logger.warning(
-                        f"Matrix: persisted token belongs to {stored.user_id!r}, "
-                        f"but config has {self._config.user_id!r} — discarding stale token"
-                    )
-                    token_file.unlink(missing_ok=True)
-                else:
+                stored = self._load_persisted_token(token_file)
+                if stored is not None:
                     logger.debug("Matrix: using persisted access token")
+                    self._set_owner_user(stored.user)
                     return stored.access_token, stored.device_id
             except Exception as exc:
                 logger.warning(f"Matrix: could not read persisted token file: {exc}")
+
+        legacy_token_file = token_file.with_suffix(".json") if token_file.suffix in {".yaml", ".yml"} else None
+        if legacy_token_file is not None and legacy_token_file.exists():
+            try:
+                stored = self._load_persisted_token(legacy_token_file)
+                if stored is not None:
+                    logger.debug("Matrix: using persisted legacy access token")
+                    self._set_owner_user(stored.user)
+                    return stored.access_token, stored.device_id
+            except Exception as exc:
+                logger.warning(f"Matrix: could not read persisted legacy token file: {exc}")
 
         raw = self._config.token.resolve().get_secret_value() if self._config.token else ""
         if raw:
@@ -229,6 +239,35 @@ class MatrixChannel:
             return raw, device_id
 
         return "", None
+
+    def _load_persisted_token(self, token_file: Path) -> MatrixTokenFile | None:
+        if token_file.suffix in {".yaml", ".yml"}:
+            raw = yaml.safe_load(token_file.read_text(encoding="utf-8")) or {}
+            tokens_file = MatrixTokensFile.model_validate(raw)
+            for stored in tokens_file.tokens:
+                if stored.user_id == self._config.user_id:
+                    return stored
+            logger.warning(
+                f"Matrix: no persisted token for {self._config.user_id!r} in {token_file} — ignoring token file"
+            )
+            return None
+
+        stored = MatrixTokenFile.model_validate_json(token_file.read_text(encoding="utf-8"))
+        if stored.user_id != self._config.user_id:
+            logger.warning(
+                f"Matrix: persisted token belongs to {stored.user_id!r}, "
+                f"but config has {self._config.user_id!r} — discarding stale token"
+            )
+            token_file.unlink(missing_ok=True)
+            return None
+        return stored
+
+    def _set_owner_user(self, user: str | None) -> None:
+        if not user:
+            return
+        normalized = normalize_username(user)
+        if normalized:
+            self._owner_user = normalized
 
     async def _password_login(self, token_file: Path) -> None:
         """Log in with the configured password secret and persist the new token. Raises on failure."""
@@ -241,9 +280,18 @@ class MatrixChannel:
             raise RuntimeError(f"Matrix password login failed: {resp.message}")
 
         persisted = MatrixTokenFile(
-            access_token=resp.access_token, device_id=resp.device_id, user_id=self._config.user_id
+            access_token=resp.access_token,
+            device_id=resp.device_id,
+            user_id=self._config.user_id,
+            user=self._owner_user,
         )
-        token_file.write_text(persisted.model_dump_json())
+        if token_file.suffix in {".yaml", ".yml"}:
+            token_file.write_text(
+                yaml.safe_dump(MatrixTokensFile(tokens=[persisted]).model_dump(mode="json", exclude_none=True)),
+                encoding="utf-8",
+            )
+        else:
+            token_file.write_text(persisted.model_dump_json(exclude_none=True), encoding="utf-8")
         logger.info(f"Matrix: password login successful, token persisted to {token_file}")
 
     async def _authenticate(self, token_file: Path) -> None:
@@ -294,6 +342,7 @@ class MatrixChannel:
             return self._room_sessions[room_id]
         existing = self._session_mgr.find_session("matrix", room_id)
         if existing:
+            self._ensure_session_owner(existing)
             self._room_sessions[room_id] = existing
             logger.debug(f"Matrix: resuming session {existing} for room {room_id}")
         else:
@@ -301,11 +350,19 @@ class MatrixChannel:
                 "matrix",
                 room_id,
                 budget=self._engine.config.agent.default_session_budget,
+                user=self._owner_user,
                 private=False,
             )
             self._room_sessions[room_id] = state.session_id
             logger.info(f"Matrix: created session {state.session_id} for room {room_id}")
         return self._room_sessions[room_id]
+
+    def _ensure_session_owner(self, session_id: str) -> None:
+        if self._owner_user is None:
+            return
+        meta = self._session_mgr.load_meta(session_id)
+        if meta.user is None:
+            self._session_mgr.save_meta(session_id, SessionMeta(user=self._owner_user))
 
     def _is_allowed(self, room: nio.MatrixRoom, sender: str) -> bool:
         """Return True if the message should be processed."""
@@ -590,6 +647,7 @@ class MatrixChannel:
             "matrix",
             room_id,
             budget=self._engine.config.agent.default_session_budget,
+            user=self._owner_user,
             private=False,
         )
         self._room_sessions[room_id] = new_state.session_id

--- a/src/carapace/cli.py
+++ b/src/carapace/cli.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 from datetime import datetime
-from typing import Any
+from pathlib import Path
+from typing import Annotated, Any
 
 import httpx
 import typer
@@ -18,6 +18,7 @@ from rich.table import Table
 from websockets.exceptions import ConnectionClosed, InvalidHandshake
 
 from .payloads import dict_of_dicts, dict_or_empty, list_of_dicts, string_dict
+from .upgrade import upgrade_data_dir
 
 load_dotenv()
 
@@ -38,25 +39,35 @@ def _fmt_dt(iso: str) -> str:
         return iso
 
 
-def _get_token(data_dir: str | None, token: str | None) -> str:
-    """Resolve bearer token from flag or env var."""
-    if token:
-        return token
-    env_token = os.environ.get("CARAPACE_TOKEN")
-    if env_token:
-        return env_token
-    console.print("[red]No auth token found. Set --token or CARAPACE_TOKEN.[/red]")
-    raise typer.Exit(1)
+def _login_client(server: str, username: str | None, password: str | None) -> httpx.Client:
+    resolved_username = username.strip() if username else console.input("Username: ").strip()
+    if not resolved_username:
+        console.print("[red]Username is required.[/red]")
+        raise typer.Exit(1)
+    resolved_password = password if password is not None else typer.prompt("Password", hide_input=True)
+    client = httpx.Client(base_url=server)
+    try:
+        resp = client.post("/api/auth/login", json={"username": resolved_username, "password": resolved_password})
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        client.close()
+        if exc.response.status_code == 401:
+            console.print("[red]Invalid username or password.[/red]")
+        else:
+            console.print(f"[red]Login failed: {exc.response.status_code}[/red]")
+        raise typer.Exit(1) from None
+    return client
 
 
-def _auth_headers(bearer: str) -> dict[str, str]:
-    return {"Authorization": f"Bearer {bearer}"}
+def _cookie_headers(client: httpx.Client) -> dict[str, str]:
+    cookie_header = "; ".join(f"{cookie.name}={cookie.value}" for cookie in client.cookies.jar)
+    return {"Cookie": cookie_header} if cookie_header else {}
 
 
-def _ws_url(server: str, session_id: str, bearer: str) -> str:
-    """Build WebSocket URL with token query param."""
+def _ws_url(server: str, session_id: str) -> str:
+    """Build WebSocket URL for a session."""
     base = server.replace("http://", "ws://").replace("https://", "wss://")
-    return f"{base}/api/chat/{session_id}?token={bearer}"
+    return f"{base}/api/chat/{session_id}"
 
 
 def _replay_history(server: str, session_id: str, headers: dict[str, str], limit: int) -> None:
@@ -514,21 +525,26 @@ async def _read_until_done(ws) -> None:
             return
 
 
-async def _connect_ws(ws_url: str, *, max_backoff: float = 30.0) -> websockets.asyncio.client.ClientConnection:
+async def _connect_ws(
+    ws_url: str,
+    *,
+    headers: dict[str, str],
+    max_backoff: float = 30.0,
+) -> websockets.asyncio.client.ClientConnection:
     """Connect to the WebSocket, retrying with exponential backoff on failure."""
     delay = 1.0
     while True:
         try:
-            return await websockets.asyncio.client.connect(ws_url)
+            return await websockets.asyncio.client.connect(ws_url, additional_headers=headers)
         except (OSError, ConnectionClosed, InvalidHandshake) as exc:
             console.print(f"[dim]Connection failed ({exc}), retrying in {delay:.0f}s…[/dim]")
             await asyncio.sleep(delay)
             delay = min(delay * 2, max_backoff)
 
 
-async def _chat_loop(ws_url: str) -> None:
+async def _chat_loop(ws_url: str, *, headers: dict[str, str]) -> None:
     """Connect to the server WebSocket and run the interactive REPL."""
-    ws = await _connect_ws(ws_url)
+    ws = await _connect_ws(ws_url, headers=headers)
     pending_message: str | None = None
     show_tool_events = True
     try:
@@ -565,7 +581,7 @@ async def _chat_loop(ws_url: str) -> None:
             except ConnectionClosed:
                 console.print("[dim]Server disconnected — reconnecting…[/dim]")
                 pending_message = user_input
-                ws = await _connect_ws(ws_url)
+                ws = await _connect_ws(ws_url, headers=headers)
                 console.print("[green]Reconnected.[/green]")
                 continue
 
@@ -573,7 +589,7 @@ async def _chat_loop(ws_url: str) -> None:
                 await _read_server_responses(ws, show_tool_events=show_tool_events)
             except ConnectionClosed:
                 console.print("[dim]Server disconnected while reading response — reconnecting…[/dim]")
-                ws = await _connect_ws(ws_url)
+                ws = await _connect_ws(ws_url, headers=headers)
                 console.print("[green]Reconnected.[/green]")
             except KeyboardInterrupt:
                 console.print("\n[yellow]Cancelling…[/yellow]")
@@ -721,16 +737,16 @@ async def _read_server_responses(ws, *, show_tool_events: bool = True) -> None:
 def chat(
     session: str | None = typer.Option(None, "--session", "-s", help="Resume a session by ID"),
     server: str = typer.Option(DEFAULT_SERVER, "--server", envvar="CARAPACE_SERVER", help="Server URL"),
-    data_dir: str | None = typer.Option(None, "--data-dir", "-d", help="Data directory (for token lookup)"),
-    token: str | None = typer.Option(None, "--token", envvar="CARAPACE_TOKEN", help="Bearer token"),
+    username: str | None = typer.Option(None, "--user", "-u", envvar="CARAPACE_USER", help="Username"),
+    password: str | None = typer.Option(None, "--password", envvar="CARAPACE_PASSWORD", help="Password"),
     list_sessions: bool = typer.Option(False, "--list", "-l", help="List existing sessions"),
     history: int = typer.Option(
         -1, "--history", "-H", help="Number of past messages to show on resume (-1 = all, 0 = none)"
     ),
 ):
     """Start an interactive chat session with the carapace server."""
-    bearer = _get_token(data_dir, token)
-    headers = _auth_headers(bearer)
+    client = _login_client(server, username, password)
+    headers = _cookie_headers(client)
 
     if list_sessions:
         sessions: list[dict[str, Any]] = []
@@ -741,7 +757,7 @@ def chat(
             if cursor is not None:
                 params["cursor"] = cursor
 
-            resp = httpx.get(f"{server}/api/sessions", headers=headers, params=params)
+            resp = client.get("/api/sessions", params=params)
             resp.raise_for_status()
             payload = resp.json()
 
@@ -777,12 +793,13 @@ def chat(
                     str(s.get("message_count", 0)),
                 )
             console.print(table)
+        client.close()
         raise typer.Exit()
 
     # Create or resume session
     if session:
         try:
-            resp = httpx.get(f"{server}/api/sessions/{session}", headers=headers)
+            resp = client.get(f"/api/sessions/{session}")
             resp.raise_for_status()
             session_data = resp.json()
             session_id = session_data["session_id"]
@@ -794,7 +811,7 @@ def chat(
                 console.print(f"[red]Server error: {exc.response.status_code}[/red]")
             raise typer.Exit(1) from None
     else:
-        resp = httpx.post(f"{server}/api/sessions", headers=headers)
+        resp = client.post("/api/sessions")
         resp.raise_for_status()
         session_data = resp.json()
         session_id = session_data["session_id"]
@@ -806,11 +823,29 @@ def chat(
     if session and history != 0:
         _replay_history(server, session_id, headers, history)
 
-    url = _ws_url(server, session_id, bearer)
+    url = _ws_url(server, session_id)
     try:
-        asyncio.run(_chat_loop(url))
+        asyncio.run(_chat_loop(url, headers=headers))
     except Exception as e:
         console.print(f"[red]Connection error: {e}[/red]")
+    finally:
+        client.close()
+
+
+@app.command("upgrade-data")
+def upgrade_data(
+    username: Annotated[str, typer.Option("--user", "-u", help="Stable username that owns existing data")],
+    data_dir: Annotated[Path, typer.Option("--data-dir", "-d", help="Data directory to upgrade")] = Path("data"),
+) -> None:
+    """Upgrade an existing single-user data directory to user-owned storage."""
+    summary = upgrade_data_dir(data_dir, username)
+    if not summary:
+        console.print("[green]Data directory already matched the new layout.[/green]")
+        return
+    for section, entries in summary.items():
+        console.print(f"[bold]{section}[/bold]")
+        for entry in entries:
+            console.print(f"  - {entry}")
 
 
 if __name__ == "__main__":

--- a/src/carapace/cli.py
+++ b/src/carapace/cli.py
@@ -70,11 +70,11 @@ def _ws_url(server: str, session_id: str) -> str:
     return f"{base}/api/chat/{session_id}"
 
 
-def _replay_history(server: str, session_id: str, headers: dict[str, str], limit: int) -> None:
+def _replay_history(client: httpx.Client, session_id: str, limit: int) -> None:
     """Fetch and display past conversation messages."""
     params = {} if limit < 0 else {"limit": limit}
     try:
-        resp = httpx.get(f"{server}/api/sessions/{session_id}/history", headers=headers, params=params)
+        resp = client.get(f"/api/sessions/{session_id}/history", params=params)
         resp.raise_for_status()
     except httpx.HTTPStatusError:
         return
@@ -821,7 +821,7 @@ def chat(
     console.print()
 
     if session and history != 0:
-        _replay_history(server, session_id, headers, history)
+        _replay_history(client, session_id, history)
 
     url = _ws_url(server, session_id)
     try:

--- a/src/carapace/jobs.py
+++ b/src/carapace/jobs.py
@@ -83,8 +83,17 @@ class JobsStore:
     def list_jobs(self) -> list[JobDefinition]:
         return self.load().jobs
 
+    def list_jobs_for_user(self, user: str) -> list[JobDefinition]:
+        return [job for job in self.load().jobs if job.user == user]
+
     def get_job(self, job_id: str) -> JobDefinition | None:
         return next((job for job in self.load().jobs if job.id == job_id), None)
+
+    def get_job_for_user(self, job_id: str, user: str) -> JobDefinition | None:
+        job = self.get_job(job_id)
+        if job is None or job.user != user:
+            return None
+        return job
 
     def create_job(self, job: JobDefinition) -> JobDefinition:
         jobs_file = self.load()

--- a/src/carapace/models/config.py
+++ b/src/carapace/models/config.py
@@ -88,6 +88,28 @@ class ChannelsConfig(BaseModel):
     cron: CronChannelConfig = CronChannelConfig()
 
 
+class UserConfig(BaseModel):
+    credentials: dict[str, Any] = {}
+    channels: ChannelsConfig = ChannelsConfig()
+    git: dict[str, Any] = {}
+    default_models: dict[str, str] = {}
+    budgets: dict[str, Any] = {}
+
+
+class JwtCookieConfig(BaseModel):
+    name: str = "carapace_session"
+    issuer: str = "carapace"
+    audience: str = "carapace-web"
+    ttl_seconds: int = Field(default=60 * 60 * 24 * 14, ge=60)
+    secure: bool = False
+    same_site: Literal["lax", "strict", "none"] = "lax"
+
+
+class AuthConfig(BaseModel):
+    cookie: JwtCookieConfig = JwtCookieConfig()
+    admin_token: Secret | None = Secret(env="CARAPACE_TOKEN")
+
+
 class AvailableModelEntry(BaseModel):
     """One row in ``agent.available_models``: shorthand ``provider:name`` string or a mapping."""
 
@@ -325,6 +347,7 @@ class Config(BaseModel):
     carapace: CarapaceConfig = CarapaceConfig()
     cache: CacheConfig = CacheConfig()
     server: ServerConfig = ServerConfig()
+    auth: AuthConfig = AuthConfig()
     notifications: NotificationsConfig = NotificationsConfig()
     channels: ChannelsConfig = ChannelsConfig()
     agent: AgentConfig = AgentConfig()

--- a/src/carapace/models/config.py
+++ b/src/carapace/models/config.py
@@ -53,11 +53,19 @@ class Secret(BaseModel):
 
 
 class MatrixTokenFile(BaseModel):
-    """Schema for the persisted ``matrix_token.json`` file."""
+    """Schema for one persisted Matrix access token."""
 
     access_token: str
     device_id: str | None = None
     user_id: str | None = None
+    user: str | None = None
+
+
+class MatrixTokensFile(BaseModel):
+    """Schema for the persisted ``matrix_token.yaml`` file."""
+
+    version: int = 1
+    tokens: list[MatrixTokenFile] = []
 
 
 class MatrixChannelConfig(BaseModel):

--- a/src/carapace/models/config.py
+++ b/src/carapace/models/config.py
@@ -115,7 +115,6 @@ class JwtCookieConfig(BaseModel):
 
 class AuthConfig(BaseModel):
     cookie: JwtCookieConfig = JwtCookieConfig()
-    admin_token: Secret | None = Secret(env="CARAPACE_TOKEN")
 
 
 class AvailableModelEntry(BaseModel):

--- a/src/carapace/models/jobs.py
+++ b/src/carapace/models/jobs.py
@@ -44,6 +44,7 @@ class JobCronTrigger(BaseModel):
 
 class JobDefinition(BaseModel):
     id: str
+    user: str | None = None
     name: str
     enabled: bool = True
     triggers: Annotated[list[JobCronTrigger], Field(default_factory=list)]
@@ -68,6 +69,9 @@ class JobDefinition(BaseModel):
         self.id = self.id.strip()
         if not self.id:
             raise ValueError("job id must not be empty")
+
+        if self.user is not None:
+            self.user = self.user.strip().lower() or None
 
         self.name = self.name.strip()
         if not self.name:

--- a/src/carapace/notifications/models.py
+++ b/src/carapace/notifications/models.py
@@ -18,7 +18,8 @@ class NotificationPreferences(BaseModel):
 
 class NotificationSubscription(BaseModel):
     id: str
-    owner_key: str
+    owner_key: str = ""
+    user: str | None = None
     device_name: str = ""
     endpoint: str
     p256dh: str
@@ -34,8 +35,8 @@ class NotificationSubscription(BaseModel):
         if not self.id:
             raise ValueError("notification subscription id must not be empty")
         self.owner_key = self.owner_key.strip()
-        if not self.owner_key:
-            raise ValueError("notification subscription owner_key must not be empty")
+        if self.user is not None:
+            self.user = self.user.strip().lower() or None
         self.device_name = self.device_name.strip()
         self.endpoint = self.endpoint.strip()
         if not self.endpoint:

--- a/src/carapace/notifications/router.py
+++ b/src/carapace/notifications/router.py
@@ -140,12 +140,7 @@ class NotificationRouter:
         notif_id: str,
         subscription_ids: set[str] | None = None,
     ) -> NotificationDeliveryResult:
-        owner = self._owner_for_session(session_id) if self._owner_for_session is not None else None
-        subscriptions = (
-            self._store.list_subscriptions(user=owner)
-            if owner
-            else self._store.list_subscriptions(owner_key=self._owner_key)
-        )
+        subscriptions = self._subscriptions_for_session(session_id)
         if subscription_ids is not None:
             subscriptions = [subscription for subscription in subscriptions if subscription.id in subscription_ids]
         if not subscriptions:
@@ -204,12 +199,7 @@ class NotificationRouter:
             )
             return NotificationDeliveryResult(attempted_subscription_ids=set(), delivered_subscription_ids=set())
 
-        owner = self._owner_for_session(session_id) if self._owner_for_session is not None else None
-        all_subscriptions = (
-            self._store.list_subscriptions(user=owner)
-            if owner
-            else self._store.list_subscriptions(owner_key=self._owner_key)
-        )
+        all_subscriptions = self._subscriptions_for_session(session_id)
         subscriptions = [
             subscription
             for subscription in all_subscriptions
@@ -226,6 +216,16 @@ class NotificationRouter:
             + f" subscriptions={len(delivery.attempted_subscription_ids)}"
         )
         return delivery
+
+    def _subscriptions_for_session(self, session_id: str) -> list[NotificationSubscription]:
+        if self._owner_for_session is None:
+            return self._store.list_subscriptions(owner_key=self._owner_key)
+
+        owner = self._owner_for_session(session_id)
+        if owner is None:
+            logger.warning(f"Notification skipped session={session_id} reason=missing_owner")
+            return []
+        return self._store.list_subscriptions(user=owner)
 
 
 def _delivery_result(

--- a/src/carapace/notifications/router.py
+++ b/src/carapace/notifications/router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from typing import Literal, Protocol
 
@@ -77,11 +78,13 @@ class NotificationRouter:
         presence: NotificationPresenceRegistry,
         sender: NotificationSender,
         owner_key: str,
+        owner_for_session: Callable[[str], str | None] | None = None,
     ) -> None:
         self._store = store
         self._presence = presence
         self._sender = sender
         self._owner_key = owner_key
+        self._owner_for_session = owner_for_session
 
     async def dispatch_escalation(
         self,
@@ -137,7 +140,12 @@ class NotificationRouter:
         notif_id: str,
         subscription_ids: set[str] | None = None,
     ) -> NotificationDeliveryResult:
-        subscriptions = self._store.list_subscriptions(owner_key=self._owner_key)
+        owner = self._owner_for_session(session_id) if self._owner_for_session is not None else None
+        subscriptions = (
+            self._store.list_subscriptions(user=owner)
+            if owner
+            else self._store.list_subscriptions(owner_key=self._owner_key)
+        )
         if subscription_ids is not None:
             subscriptions = [subscription for subscription in subscriptions if subscription.id in subscription_ids]
         if not subscriptions:
@@ -196,9 +204,15 @@ class NotificationRouter:
             )
             return NotificationDeliveryResult(attempted_subscription_ids=set(), delivered_subscription_ids=set())
 
+        owner = self._owner_for_session(session_id) if self._owner_for_session is not None else None
+        all_subscriptions = (
+            self._store.list_subscriptions(user=owner)
+            if owner
+            else self._store.list_subscriptions(owner_key=self._owner_key)
+        )
         subscriptions = [
             subscription
-            for subscription in self._store.list_subscriptions(owner_key=self._owner_key)
+            for subscription in all_subscriptions
             if _preferences_allow(subscription.notification_prefs, kind)
         ]
         if not subscriptions:

--- a/src/carapace/notifications/store.py
+++ b/src/carapace/notifications/store.py
@@ -36,19 +36,28 @@ class NotificationStore:
             raw = yaml.safe_load(f) or {}
         return NotificationSubscription.model_validate(raw)
 
-    def list_subscriptions(self, *, owner_key: str | None = None) -> list[NotificationSubscription]:
+    def list_subscriptions(
+        self,
+        *,
+        owner_key: str | None = None,
+        user: str | None = None,
+    ) -> list[NotificationSubscription]:
         with self._lock:
             subscriptions = [
                 NotificationSubscription.model_validate(yaml.safe_load(path.read_text(encoding="utf-8")) or {})
                 for path in sorted(self._dir.glob("*.yaml"))
             ]
         if owner_key is None:
-            return subscriptions
+            if user is None:
+                return subscriptions
+            return [subscription for subscription in subscriptions if subscription.user == user]
         return [subscription for subscription in subscriptions if subscription.owner_key == owner_key]
 
-    def find_by_endpoint(self, *, owner_key: str, endpoint: str) -> NotificationSubscription | None:
+    def find_by_endpoint(
+        self, *, owner_key: str = "", user: str | None = None, endpoint: str
+    ) -> NotificationSubscription | None:
         normalized_endpoint = endpoint.strip()
-        for subscription in self.list_subscriptions(owner_key=owner_key):
+        for subscription in self.list_subscriptions(owner_key=owner_key or None, user=user):
             if subscription.endpoint == normalized_endpoint:
                 return subscription
         return None
@@ -81,7 +90,8 @@ class NotificationStore:
     def upsert_subscription(
         self,
         *,
-        owner_key: str,
+        owner_key: str = "",
+        user: str | None = None,
         endpoint: str,
         p256dh: str,
         auth: str,
@@ -91,11 +101,12 @@ class NotificationStore:
         now: datetime | None = None,
     ) -> NotificationSubscription:
         current = now or datetime.now(tz=UTC)
-        existing = self.find_by_endpoint(owner_key=owner_key, endpoint=endpoint)
+        existing = self.find_by_endpoint(owner_key=owner_key, user=user, endpoint=endpoint)
         if existing is None:
             subscription = NotificationSubscription(
                 id=uuid.uuid4().hex,
                 owner_key=owner_key,
+                user=user,
                 device_name=device_name,
                 endpoint=endpoint,
                 p256dh=p256dh,

--- a/src/carapace/notifications/store.py
+++ b/src/carapace/notifications/store.py
@@ -57,7 +57,10 @@ class NotificationStore:
         self, *, owner_key: str = "", user: str | None = None, endpoint: str
     ) -> NotificationSubscription | None:
         normalized_endpoint = endpoint.strip()
-        for subscription in self.list_subscriptions(owner_key=owner_key or None, user=user):
+        normalized_owner_key = owner_key or None
+        if normalized_owner_key is None and user is None:
+            return None
+        for subscription in self.list_subscriptions(owner_key=normalized_owner_key, user=user):
             if subscription.endpoint == normalized_endpoint:
                 return subscription
         return None

--- a/src/carapace/server/__init__.py
+++ b/src/carapace/server/__init__.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel
 from pydantic_ai.exceptions import UsageLimitExceeded
 
 from .. import get_version
-from ..auth import AuthStore
+from ..auth import AuthStore, validate_admin_token
 from ..bootstrap import ensure_data_dir, ensure_knowledge_dir
 from ..cache import SessionListCache
 from ..config import _resolve_data_dir, _resolve_knowledge_dir, get_config_path, get_data_dir, load_config
@@ -190,6 +190,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
         _auth_store
 
     # 1. Load config
+    validate_admin_token()
     config_path = get_config_path()
     _config = load_config()
     _data_dir = _resolve_data_dir(config_path, _config)
@@ -522,6 +523,7 @@ def main() -> None:
     data_dir = get_data_dir()
     ensure_data_dir(data_dir)
     config = load_config(data_dir)
+    validate_admin_token()
     _setup_logging(config.carapace.log_level)
     logger.info(f"Starting carapace server on {config.server.host}:{config.server.port}")
     logger.info(f"Sandbox API on 0.0.0.0:{config.server.sandbox_port}")

--- a/src/carapace/server/__init__.py
+++ b/src/carapace/server/__init__.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel
 from pydantic_ai.exceptions import UsageLimitExceeded
 
 from .. import get_version
-from ..auth import AuthStore, validate_admin_token
+from ..auth import AuthStore
 from ..bootstrap import ensure_data_dir, ensure_knowledge_dir
 from ..cache import SessionListCache
 from ..config import _resolve_data_dir, _resolve_knowledge_dir, get_config_path, get_data_dir, load_config
@@ -190,7 +190,6 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
         _auth_store
 
     # 1. Load config
-    validate_admin_token()
     config_path = get_config_path()
     _config = load_config()
     _data_dir = _resolve_data_dir(config_path, _config)
@@ -199,6 +198,8 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     # 2. Bootstrap directories
     ensure_data_dir(_data_dir)
     _auth_store = AuthStore(_data_dir, _config.auth)
+    if _auth_store.ensure_bootstrap_admin() is not None:
+        logger.warning("Created bootstrap admin user 'admin' with password from CARAPACE_TOKEN")
 
     # 3. Git-backed knowledge store
     git_store = GitStore(
@@ -523,7 +524,6 @@ def main() -> None:
     data_dir = get_data_dir()
     ensure_data_dir(data_dir)
     config = load_config(data_dir)
-    validate_admin_token()
     _setup_logging(config.carapace.log_level)
     logger.info(f"Starting carapace server on {config.server.host}:{config.server.port}")
     logger.info(f"Sandbox API on 0.0.0.0:{config.server.sandbox_port}")

--- a/src/carapace/server/__init__.py
+++ b/src/carapace/server/__init__.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel
 from pydantic_ai.exceptions import UsageLimitExceeded
 
 from .. import get_version
-from ..auth import get_token
+from ..auth import AuthStore
 from ..bootstrap import ensure_data_dir, ensure_knowledge_dir
 from ..cache import SessionListCache
 from ..config import _resolve_data_dir, _resolve_knowledge_dir, get_config_path, get_data_dir, load_config
@@ -41,7 +41,7 @@ from ..models.config import Config
 from ..notifications.presence import NotificationPresenceRegistry
 from ..notifications.router import NotificationRouter
 from ..notifications.sender import WebPushSender
-from ..notifications.store import NotificationStore, derive_owner_key
+from ..notifications.store import NotificationStore
 from ..notifications.vapid import ensure_vapid_config
 from ..sandbox.manager import SandboxManager
 from ..sandbox.proxy import ProxyServer
@@ -50,6 +50,7 @@ from ..session import SessionEngine, SessionManager
 from ..session.archive import SessionArchiveService
 from ..skills import SkillRegistry
 from ..usage import SessionBudgetExceededError
+from .auth import router as auth_router
 from .auth import verify_ws_token
 from .history import router as history_router
 from .jobs import _jobs_scheduler_loop
@@ -81,6 +82,7 @@ _jobs_scheduler: JobsScheduler
 _notification_store: NotificationStore
 _notification_presence: NotificationPresenceRegistry
 _notification_router: NotificationRouter
+_auth_store: AuthStore
 
 _SESSION_COMMIT_SWEEP_SECONDS = 15 * 60
 _APP_VERSION = get_version()
@@ -184,7 +186,8 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
         _jobs_scheduler, \
         _notification_store, \
         _notification_presence, \
-        _notification_router
+        _notification_router, \
+        _auth_store
 
     # 1. Load config
     config_path = get_config_path()
@@ -194,6 +197,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     # 2. Bootstrap directories
     ensure_data_dir(_data_dir)
+    _auth_store = AuthStore(_data_dir, _config.auth)
 
     # 3. Git-backed knowledge store
     git_store = GitStore(
@@ -295,7 +299,6 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     _config.notifications = ensure_vapid_config(_config.notifications, _data_dir)
 
-    token = get_token()
     _notification_store = NotificationStore(_data_dir)
     _notification_presence = NotificationPresenceRegistry(
         ttl=timedelta(seconds=_config.notifications.presence_ttl_seconds)
@@ -313,7 +316,8 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
             max_payload_bytes=_config.notifications.max_payload_bytes,
             delivery_ttl_seconds=_config.notifications.delivery_ttl_seconds,
         ),
-        owner_key=derive_owner_key(token),
+        owner_key="",
+        owner_for_session=lambda session_id: session_mgr.load_meta(session_id).user,
     )
 
     _engine = SessionEngine(
@@ -410,7 +414,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     logger.info(
         f"carapace server ready — model={_config.agent.model}, "
-        f"skills={len(skill_catalog)}, proxy_port={proxy_port}, token={token[:8]}…"
+        f"skills={len(skill_catalog)}, proxy_port={proxy_port}"
         + (f", matrix=on ({_config.channels.matrix.homeserver})" if _config.channels.matrix.enabled else "")
     )
     yield
@@ -519,12 +523,9 @@ def main() -> None:
     ensure_data_dir(data_dir)
     config = load_config(data_dir)
     _setup_logging(config.carapace.log_level)
-    token = get_token()
-
     logger.info(f"Starting carapace server on {config.server.host}:{config.server.port}")
     logger.info(f"Sandbox API on 0.0.0.0:{config.server.sandbox_port}")
     logger.info(f"Internal API on 127.0.0.1:{config.server.internal_port}")
-    logger.info(f"Bearer token: {token[:8]}…")
 
     uvicorn.run(
         "carapace.server:app",
@@ -589,6 +590,7 @@ router.include_router(jobs_router)
 router.include_router(session_sandbox_router)
 router.include_router(notifications_router)
 router.include_router(websocket_router)
+router.include_router(auth_router)
 app.include_router(router)
 
 

--- a/src/carapace/server/auth.py
+++ b/src/carapace/server/auth.py
@@ -24,6 +24,10 @@ class LoginResponse(BaseModel):
     user: UserIdentity
 
 
+class WebSocketTicketResponse(BaseModel):
+    ticket: str
+
+
 class AdminUserCreateRequest(BaseModel):
     username: str
     password: str
@@ -106,9 +110,13 @@ async def current_user(request: Request) -> UserIdentity:
 async def current_ws_user(websocket: WebSocket) -> UserIdentity:
     cookie_name = server._config.auth.cookie.name
     token = websocket.cookies.get(cookie_name)
-    if not token:
-        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
-    identity = _auth_store().validate_session_token(token)
+    ticket = websocket.query_params.get("ticket")
+    if token:
+        identity = _auth_store().validate_session_token(token)
+    elif ticket:
+        identity = _auth_store().validate_websocket_token(ticket)
+    else:
+        identity = None
     if identity is None:
         raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
     return identity
@@ -205,6 +213,20 @@ async def logout(
 @router.get("/auth/me", response_model=UserIdentity)
 async def me(user: Annotated[UserIdentity, Depends(current_user)]) -> UserIdentity:
     return user
+
+
+@router.post("/auth/ws-ticket", response_model=WebSocketTicketResponse)
+async def create_websocket_ticket(
+    request: Request,
+    _user: Annotated[UserIdentity, Depends(current_user)],
+) -> WebSocketTicketResponse:
+    session_cookie = request.cookies.get(server._config.auth.cookie.name)
+    if not session_cookie:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
+    ticket = _auth_store().issue_websocket_token(session_cookie)
+    if ticket is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid session")
+    return WebSocketTicketResponse(ticket=ticket)
 
 
 @router.get("/admin/users", response_model=list[AdminUserResponse])

--- a/src/carapace/server/auth.py
+++ b/src/carapace/server/auth.py
@@ -152,6 +152,19 @@ def _assert_not_removing_last_admin(username: str, updates: dict[str, object]) -
         raise HTTPException(status_code=400, detail="Cannot remove the last enabled admin")
 
 
+def _assert_user_can_be_deleted(username: str, admin_user: UserIdentity) -> None:
+    normalized_username = normalize_username(username)
+    if normalized_username == normalize_username(admin_user.username):
+        raise HTTPException(status_code=400, detail="Cannot delete your own user")
+
+    existing = _auth_store().get_user(normalized_username)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if existing.enabled and has_admin_role(existing.roles) and len(_enabled_admin_usernames()) <= 1:
+        raise HTTPException(status_code=400, detail="Cannot remove the last enabled admin")
+
+
 @router.post("/auth/login", response_model=LoginResponse)
 async def login(request: Request, response: Response, body: LoginRequest) -> LoginResponse:
     store = _auth_store()
@@ -239,6 +252,20 @@ async def update_admin_user(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return _user_response(username)
+
+
+@router.delete("/admin/users/{username}", status_code=204)
+async def delete_admin_user(
+    username: str,
+    admin_user: Annotated[UserIdentity, Depends(verify_admin_user)],
+) -> Response:
+    normalized_username = normalize_username(username)
+    _assert_user_can_be_deleted(normalized_username, admin_user)
+    try:
+        _auth_store().delete_user(normalized_username)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="User not found") from exc
+    return Response(status_code=204)
 
 
 @router.post("/admin/users/{username}/upgrade-data", response_model=AdminUserUpgradeResponse)

--- a/src/carapace/server/auth.py
+++ b/src/carapace/server/auth.py
@@ -2,32 +2,215 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import Depends, HTTPException, Query, WebSocket, WebSocketException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, WebSocket, WebSocketException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel
 
-from ..auth import get_token
+from ..auth import AuthStore, UserIdentity, get_token, normalize_username
+from ..models.config import UserConfig
+from .state import server_module
 
-_bearer_scheme = HTTPBearer()
+server = server_module()
+
+router = APIRouter()
+_bearer_scheme = HTTPBearer(auto_error=False)
 
 
-async def verify_token(
-    credentials: Annotated[HTTPAuthorizationCredentials, Depends(_bearer_scheme)],
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class LoginResponse(BaseModel):
+    user: UserIdentity
+
+
+class AdminUserCreateRequest(BaseModel):
+    username: str
+    password: str
+    display_name: str = ""
+    email: str | None = None
+    roles: list[str] = []
+    config: UserConfig = UserConfig()
+
+
+class AdminUserUpdateRequest(BaseModel):
+    display_name: str | None = None
+    email: str | None = None
+    roles: list[str] | None = None
+    enabled: bool | None = None
+    password: str | None = None
+    config: UserConfig | None = None
+
+
+class AdminUserResponse(BaseModel):
+    username: str
+    enabled: bool
+    token_version: int
+    display_name: str
+    email: str | None = None
+    roles: list[str] = []
+    created_at: str
+    updated_at: str
+    password_changed_at: str
+    last_login_at: str | None = None
+    config: UserConfig
+
+
+def _auth_store() -> AuthStore:
+    store = getattr(server, "_auth_store", None)
+    if isinstance(store, AuthStore):
+        return store
+    data_dir = getattr(server, "_data_dir", None)
+    config = getattr(server, "_config", None)
+    if data_dir is None or config is None:
+        raise HTTPException(status_code=503, detail="Auth store is not initialized")
+    store = AuthStore(data_dir, config.auth)
+    server._auth_store = store  # type: ignore[attr-defined]
+    return store
+
+
+def _user_response(username: str) -> AdminUserResponse:
+    user = _auth_store().get_user(username)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return AdminUserResponse(
+        username=normalize_username(username),
+        enabled=user.enabled,
+        token_version=user.token_version,
+        display_name=user.display_name,
+        email=user.email,
+        roles=user.roles,
+        created_at=user.created_at.isoformat(),
+        updated_at=user.updated_at.isoformat(),
+        password_changed_at=user.password_changed_at.isoformat(),
+        last_login_at=user.last_login_at.isoformat() if user.last_login_at is not None else None,
+        config=user.config,
+    )
+
+
+async def current_user(request: Request) -> UserIdentity:
+    session_cookie = request.cookies.get(server._config.auth.cookie.name)
+    if not session_cookie:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
+    identity = _auth_store().validate_session_token(session_cookie)
+    if identity is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid session")
+    return identity
+
+
+async def current_ws_user(websocket: WebSocket) -> UserIdentity:
+    cookie_name = server._config.auth.cookie.name
+    token = websocket.cookies.get(cookie_name)
+    if not token:
+        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
+    identity = _auth_store().validate_session_token(token)
+    if identity is None:
+        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
+    return identity
+
+
+async def verify_token(user: Annotated[UserIdentity, Depends(current_user)]) -> UserIdentity:
+    return user
+
+
+async def verify_ws_token(websocket: WebSocket) -> UserIdentity:
+    return await current_ws_user(websocket)
+
+
+async def verify_admin_token(
+    credentials: Annotated[HTTPAuthorizationCredentials | None, Depends(_bearer_scheme)],
 ) -> str:
+    if credentials is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Admin token required")
     expected = get_token()
     if credentials.credentials != expected:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid admin token")
     return credentials.credentials
 
 
-async def verify_ws_token(
-    websocket: WebSocket,
-    token: Annotated[str | None, Query()] = None,
-) -> str:
-    expected = get_token()
-    if token and token == expected:
-        return token
-    auth = websocket.headers.get("authorization", "")
-    if auth.startswith("Bearer ") and auth.removeprefix("Bearer ") == expected:
-        return expected
-    await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
-    raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
+@router.post("/auth/login", response_model=LoginResponse)
+async def login(request: Request, response: Response, body: LoginRequest) -> LoginResponse:
+    store = _auth_store()
+    username = normalize_username(body.username)
+    user = store.verify_password(username, body.password)
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid username or password")
+    auth_session = store.create_session(username=username, user_agent=request.headers.get("user-agent", ""))
+    token = store.issue_session_token(auth_session)
+    cookie = server._config.auth.cookie
+    response.set_cookie(
+        key=cookie.name,
+        value=token,
+        max_age=cookie.ttl_seconds,
+        expires=cookie.ttl_seconds,
+        httponly=True,
+        secure=cookie.secure,
+        samesite=cookie.same_site,
+        path="/",
+    )
+    return LoginResponse(user=user.identity(username))
+
+
+@router.post("/auth/logout", status_code=204)
+async def logout(
+    request: Request,
+    response: Response,
+) -> Response:
+    session_cookie = request.cookies.get(server._config.auth.cookie.name)
+    if session_cookie:
+        _auth_store().revoke_token(session_cookie)
+    cookie = server._config.auth.cookie
+    response.delete_cookie(key=cookie.name, path="/")
+    response.status_code = 204
+    return response
+
+
+@router.get("/auth/me", response_model=UserIdentity)
+async def me(user: Annotated[UserIdentity, Depends(current_user)]) -> UserIdentity:
+    return user
+
+
+@router.get("/admin/users", response_model=list[AdminUserResponse])
+async def list_admin_users(_admin_token: Annotated[str, Depends(verify_admin_token)]) -> list[AdminUserResponse]:
+    users = _auth_store().load_users().users
+    return [_user_response(username) for username in sorted(users)]
+
+
+@router.post("/admin/users", response_model=AdminUserResponse, status_code=201)
+async def create_admin_user(
+    body: AdminUserCreateRequest,
+    _admin_token: Annotated[str, Depends(verify_admin_token)],
+) -> AdminUserResponse:
+    try:
+        _auth_store().create_user(
+            username=body.username,
+            password=body.password,
+            display_name=body.display_name,
+            email=body.email,
+            roles=body.roles,
+            config=body.config,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return _user_response(body.username)
+
+
+@router.patch("/admin/users/{username}", response_model=AdminUserResponse)
+async def update_admin_user(
+    username: str,
+    body: AdminUserUpdateRequest,
+    _admin_token: Annotated[str, Depends(verify_admin_token)],
+) -> AdminUserResponse:
+    updates = body.model_dump(exclude_none=True)
+    password = updates.pop("password", None)
+    try:
+        if updates:
+            _auth_store().update_user(username, updates)
+        if password is not None:
+            _auth_store().set_password(username, password)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="User not found") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return _user_response(username)

--- a/src/carapace/server/auth.py
+++ b/src/carapace/server/auth.py
@@ -123,7 +123,13 @@ async def verify_admin_token(
 ) -> str:
     if credentials is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Admin token required")
-    expected = get_token()
+    try:
+        expected = get_token()
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Admin token is not configured",
+        ) from exc
     if credentials.credentials != expected:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid admin token")
     return credentials.credentials

--- a/src/carapace/server/auth.py
+++ b/src/carapace/server/auth.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 from ..auth import AuthStore, UserIdentity, get_token, normalize_username
 from ..models.config import UserConfig
+from ..upgrade import upgrade_data_dir
 from .state import server_module
 
 server = server_module()
@@ -55,6 +56,11 @@ class AdminUserResponse(BaseModel):
     password_changed_at: str
     last_login_at: str | None = None
     config: UserConfig
+
+
+class AdminUserUpgradeResponse(BaseModel):
+    username: str
+    summary: dict[str, list[str]]
 
 
 def _auth_store() -> AuthStore:
@@ -220,3 +226,24 @@ async def update_admin_user(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return _user_response(username)
+
+
+@router.post("/admin/users/{username}/upgrade-data", response_model=AdminUserUpgradeResponse)
+async def upgrade_admin_user_data(
+    username: str,
+    _admin_token: Annotated[str, Depends(verify_admin_token)],
+) -> AdminUserUpgradeResponse:
+    normalized_username = normalize_username(username)
+    if _auth_store().get_user(normalized_username) is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    data_dir = getattr(server, "_data_dir", None)
+    if data_dir is None:
+        raise HTTPException(status_code=503, detail="Data directory is not initialized")
+    try:
+        summary = upgrade_data_dir(data_dir, normalized_username)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    session_list_cache = getattr(server, "_session_list_cache", None)
+    if session_list_cache is not None:
+        session_list_cache.invalidate_sync()
+    return AdminUserUpgradeResponse(username=normalized_username, summary=dict(summary))

--- a/src/carapace/server/auth.py
+++ b/src/carapace/server/auth.py
@@ -214,7 +214,7 @@ async def update_admin_user(
     body: AdminUserUpdateRequest,
     _admin_token: Annotated[str, Depends(verify_admin_token)],
 ) -> AdminUserResponse:
-    updates = body.model_dump(exclude_none=True)
+    updates = body.model_dump(exclude_unset=True)
     password = updates.pop("password", None)
     try:
         if updates:

--- a/src/carapace/server/auth.py
+++ b/src/carapace/server/auth.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, WebSocket, WebSocketException, status
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 
-from ..auth import AuthStore, UserIdentity, get_token, normalize_username
+from ..auth import AuthStore, UserIdentity, has_admin_role, normalize_username
 from ..models.config import UserConfig
 from ..upgrade import upgrade_data_dir
 from .state import server_module
@@ -14,7 +13,6 @@ from .state import server_module
 server = server_module()
 
 router = APIRouter()
-_bearer_scheme = HTTPBearer(auto_error=False)
 
 
 class LoginRequest(BaseModel):
@@ -124,21 +122,34 @@ async def verify_ws_token(websocket: WebSocket) -> UserIdentity:
     return await current_ws_user(websocket)
 
 
-async def verify_admin_token(
-    credentials: Annotated[HTTPAuthorizationCredentials | None, Depends(_bearer_scheme)],
-) -> str:
-    if credentials is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Admin token required")
-    try:
-        expected = get_token()
-    except RuntimeError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Admin token is not configured",
-        ) from exc
-    if credentials.credentials != expected:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid admin token")
-    return credentials.credentials
+async def verify_admin_user(user: Annotated[UserIdentity, Depends(current_user)]) -> UserIdentity:
+    if not has_admin_role(user.roles):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin role required")
+    return user
+
+
+def _enabled_admin_usernames() -> set[str]:
+    return {
+        username
+        for username, user in _auth_store().load_users().users.items()
+        if user.enabled and has_admin_role(user.roles)
+    }
+
+
+def _assert_not_removing_last_admin(username: str, updates: dict[str, object]) -> None:
+    normalized_username = normalize_username(username)
+    enabled_admins = _enabled_admin_usernames()
+    if normalized_username not in enabled_admins or len(enabled_admins) > 1:
+        return
+
+    existing = _auth_store().get_user(normalized_username)
+    if existing is None:
+        return
+
+    next_enabled = updates.get("enabled", existing.enabled)
+    next_roles = updates.get("roles", existing.roles)
+    if next_enabled is False or not (isinstance(next_roles, list) and has_admin_role(next_roles)):
+        raise HTTPException(status_code=400, detail="Cannot remove the last enabled admin")
 
 
 @router.post("/auth/login", response_model=LoginResponse)
@@ -184,7 +195,7 @@ async def me(user: Annotated[UserIdentity, Depends(current_user)]) -> UserIdenti
 
 
 @router.get("/admin/users", response_model=list[AdminUserResponse])
-async def list_admin_users(_admin_token: Annotated[str, Depends(verify_admin_token)]) -> list[AdminUserResponse]:
+async def list_admin_users(_admin_user: Annotated[UserIdentity, Depends(verify_admin_user)]) -> list[AdminUserResponse]:
     users = _auth_store().load_users().users
     return [_user_response(username) for username in sorted(users)]
 
@@ -192,7 +203,7 @@ async def list_admin_users(_admin_token: Annotated[str, Depends(verify_admin_tok
 @router.post("/admin/users", response_model=AdminUserResponse, status_code=201)
 async def create_admin_user(
     body: AdminUserCreateRequest,
-    _admin_token: Annotated[str, Depends(verify_admin_token)],
+    _admin_user: Annotated[UserIdentity, Depends(verify_admin_user)],
 ) -> AdminUserResponse:
     try:
         _auth_store().create_user(
@@ -212,11 +223,13 @@ async def create_admin_user(
 async def update_admin_user(
     username: str,
     body: AdminUserUpdateRequest,
-    _admin_token: Annotated[str, Depends(verify_admin_token)],
+    _admin_user: Annotated[UserIdentity, Depends(verify_admin_user)],
 ) -> AdminUserResponse:
     updates = body.model_dump(exclude_unset=True)
     password = updates.pop("password", None)
     try:
+        if updates:
+            _assert_not_removing_last_admin(username, updates)
         if updates:
             _auth_store().update_user(username, updates)
         if password is not None:
@@ -231,7 +244,7 @@ async def update_admin_user(
 @router.post("/admin/users/{username}/upgrade-data", response_model=AdminUserUpgradeResponse)
 async def upgrade_admin_user_data(
     username: str,
-    _admin_token: Annotated[str, Depends(verify_admin_token)],
+    _admin_user: Annotated[UserIdentity, Depends(verify_admin_user)],
 ) -> AdminUserUpgradeResponse:
     normalized_username = normalize_username(username)
     if _auth_store().get_user(normalized_username) is None:

--- a/src/carapace/server/history.py
+++ b/src/carapace/server/history.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, model_validator
 from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, ThinkingPart, ToolCallPart, UserPromptPart
 
+from ..auth import UserIdentity
 from ..models.tooling import normalize_tool_call_args
 from ..security.context import ApprovalSource, ApprovalVerdict
 from ..ws_models import FinalStatus
@@ -82,10 +83,12 @@ class HistoryMessage(BaseModel):
 @router.get("/sessions/{session_id}/history", response_model=list[HistoryMessage])
 async def get_session_history(
     session_id: str,
+    user: Annotated[UserIdentity, Depends(verify_token)],
     limit: Annotated[int, Query()] = -1,
-    _token: str = Depends(verify_token),
 ) -> list[HistoryMessage]:
-    if server._engine.session_mgr.load_state(session_id) is None:
+    if server._engine.session_mgr.load_state(session_id) is None or not server._engine.session_mgr.is_owned_by(
+        session_id, user.username
+    ):
         raise HTTPException(status_code=404, detail="Session not found")
 
     events = server._engine.session_mgr.load_events(session_id)

--- a/src/carapace/server/jobs.py
+++ b/src/carapace/server/jobs.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
-from typing import Literal
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Response
 from loguru import logger
 from pydantic import BaseModel
 
+from ..auth import UserIdentity
 from ..jobs import build_job_run_message
 from ..models.jobs import JobDefinition, JobsFile
 from ..models.session import SessionJobRunContext
@@ -74,10 +75,13 @@ async def _run_job_definition(
     effective_triggered_at = triggered_at or datetime.now(tz=UTC)
 
     if job.persistent_session_id is None:
+        if job.user is None:
+            raise HTTPException(status_code=409, detail="Job has no owner; run the data upgrade first")
         state = server._engine.session_mgr.create_session(
             channel_type="job",
             channel_ref=f"job:{job.id}",
             budget=server._engine.config.agent.default_session_budget,
+            user=job.user,
             private=job.private,
             unattended=job.unattended,
             ask_mode=job.ask_mode,
@@ -89,7 +93,7 @@ async def _run_job_definition(
         created_new_session = True
     else:
         state = server._engine.session_mgr.load_state(job.persistent_session_id)
-        if state is None:
+        if state is None or job.user is None or not server._engine.session_mgr.is_owned_by(state.session_id, job.user):
             raise HTTPException(status_code=409, detail="Configured persistent session was not found")
         if state.attributes.unattended:
             raise HTTPException(status_code=409, detail="Configured persistent session must be attended")
@@ -141,15 +145,16 @@ async def _run_job_definition(
 
 
 @router.get("/jobs", response_model=JobsFile)
-async def list_jobs(_token: str = Depends(verify_token)) -> JobsFile:
-    return server._jobs_store.load()
+async def list_jobs(user: Annotated[UserIdentity, Depends(verify_token)]) -> JobsFile:
+    return JobsFile(jobs=server._jobs_store.list_jobs_for_user(user.username))
 
 
 @router.post("/jobs", response_model=JobDefinition, status_code=201)
 async def create_job(
     body: JobDefinition,
-    _token: str = Depends(verify_token),
+    user: Annotated[UserIdentity, Depends(verify_token)],
 ) -> JobDefinition:
+    body = body.model_copy(update={"user": user.username})
     try:
         return server._jobs_store.create_job(body)
     except ValueError as exc:
@@ -157,8 +162,8 @@ async def create_job(
 
 
 @router.get("/jobs/{job_id}", response_model=JobDefinition)
-async def get_job(job_id: str, _token: str = Depends(verify_token)) -> JobDefinition:
-    job = server._jobs_store.get_job(job_id)
+async def get_job(job_id: str, user: Annotated[UserIdentity, Depends(verify_token)]) -> JobDefinition:
+    job = server._jobs_store.get_job_for_user(job_id, user.username)
     if job is None:
         raise HTTPException(status_code=404, detail="Job not found")
     return job
@@ -168,10 +173,14 @@ async def get_job(job_id: str, _token: str = Depends(verify_token)) -> JobDefini
 async def update_job(
     job_id: str,
     body: JobDefinition,
-    _token: str = Depends(verify_token),
+    user: Annotated[UserIdentity, Depends(verify_token)],
 ) -> JobDefinition:
     if body.id != job_id:
         raise HTTPException(status_code=400, detail="Job id in path and body must match")
+    existing = server._jobs_store.get_job_for_user(job_id, user.username)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    body = body.model_copy(update={"user": user.username})
     try:
         return server._jobs_store.update_job(job_id, body)
     except KeyError as exc:
@@ -179,7 +188,9 @@ async def update_job(
 
 
 @router.delete("/jobs/{job_id}", status_code=204)
-async def delete_job(job_id: str, _token: str = Depends(verify_token)) -> Response:
+async def delete_job(job_id: str, user: Annotated[UserIdentity, Depends(verify_token)]) -> Response:
+    if server._jobs_store.get_job_for_user(job_id, user.username) is None:
+        raise HTTPException(status_code=404, detail="Job not found")
     deleted = server._jobs_store.delete_job(job_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Job not found")
@@ -189,10 +200,10 @@ async def delete_job(job_id: str, _token: str = Depends(verify_token)) -> Respon
 @router.post("/jobs/{job_id}/run", response_model=JobRunResult)
 async def run_job(
     job_id: str,
+    user: Annotated[UserIdentity, Depends(verify_token)],
     body: JobRunRequest | None = None,
-    _token: str = Depends(verify_token),
 ) -> JobRunResult:
-    job = server._jobs_store.get_job(job_id)
+    job = server._jobs_store.get_job_for_user(job_id, user.username)
     if job is None:
         raise HTTPException(status_code=404, detail="Job not found")
 

--- a/src/carapace/server/jobs.py
+++ b/src/carapace/server/jobs.py
@@ -55,8 +55,8 @@ async def _run_due_jobs_once(*, now: datetime | None = None) -> int:
                 cron_expression=due_run.trigger.expression,
                 trigger_timezone=due_run.trigger.timezone,
             )
-        except HTTPException as exc:
-            logger.warning(f"Scheduled job {due_run.job.id} skipped: {exc.detail}")
+        except ValueError as exc:
+            logger.warning(f"Scheduled job {due_run.job.id} skipped: {exc}")
         except Exception as exc:
             logger.warning(f"Scheduled job {due_run.job.id} failed: {exc}")
     return len(due_runs)
@@ -74,9 +74,14 @@ async def _run_job_definition(
     created_new_session = False
     effective_triggered_at = triggered_at or datetime.now(tz=UTC)
 
+    def raise_job_conflict(detail: str) -> None:
+        if trigger_kind == "api":
+            raise HTTPException(status_code=409, detail=detail)
+        raise ValueError(detail)
+
     if job.persistent_session_id is None:
         if job.user is None:
-            raise HTTPException(status_code=409, detail="Job has no owner; run the data upgrade first")
+            raise_job_conflict("Job has no owner; run the data upgrade first")
         state = server._engine.session_mgr.create_session(
             channel_type="job",
             channel_ref=f"job:{job.id}",
@@ -94,14 +99,14 @@ async def _run_job_definition(
     else:
         state = server._engine.session_mgr.load_state(job.persistent_session_id)
         if state is None or job.user is None or not server._engine.session_mgr.is_owned_by(state.session_id, job.user):
-            raise HTTPException(status_code=409, detail="Configured persistent session was not found")
+            raise_job_conflict("Configured persistent session was not found")
         if state.attributes.unattended:
-            raise HTTPException(status_code=409, detail="Configured persistent session must be attended")
+            raise_job_conflict("Configured persistent session must be attended")
         if state.attributes.archived:
-            raise HTTPException(status_code=409, detail="Configured persistent session must not be archived")
+            raise_job_conflict("Configured persistent session must not be archived")
 
     if server._engine.is_agent_running(state.session_id):
-        raise HTTPException(status_code=409, detail="Target session is busy")
+        raise_job_conflict("Target session is busy")
 
     job_run_context = SessionJobRunContext(
         job_id=job.id,

--- a/src/carapace/server/notifications.py
+++ b/src/carapace/server/notifications.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Response
 from pydantic import BaseModel, field_validator
 
+from ..auth import UserIdentity
 from ..notifications.models import (
     NotificationClientType,
     NotificationFocusState,
     NotificationPreferences,
     NotificationSubscription,
 )
-from ..notifications.store import derive_owner_key
 from .auth import verify_token
 from .state import server_module
 
@@ -103,9 +104,9 @@ def _notification_response(subscription: NotificationSubscription) -> Notificati
     )
 
 
-def _owned_notification_subscription(subscription_id: str, token: str) -> NotificationSubscription:
+def _owned_notification_subscription(subscription_id: str, user: UserIdentity) -> NotificationSubscription:
     subscription = server._notification_store.get_subscription(subscription_id)
-    if subscription is None or subscription.owner_key != derive_owner_key(token):
+    if subscription is None or subscription.user != user.username:
         raise HTTPException(status_code=404, detail="Notification subscription not found")
     return subscription
 
@@ -134,25 +135,24 @@ async def _set_notification_presence(
 
 @router.get("/notifications/subscriptions", response_model=list[NotificationSubscriptionResponse])
 async def list_notification_subscriptions(
-    _token: str = Depends(verify_token),
+    user: Annotated[UserIdentity, Depends(verify_token)],
 ) -> list[NotificationSubscriptionResponse]:
     server._notification_store.cleanup_expired()
-    owner_key = derive_owner_key(_token)
-    subscriptions = server._notification_store.list_subscriptions(owner_key=owner_key)
+    subscriptions = server._notification_store.list_subscriptions(user=user.username)
     return [_notification_response(subscription) for subscription in subscriptions]
 
 
 @router.post("/notifications/subscriptions", response_model=NotificationSubscriptionResponse)
 async def upsert_notification_subscription(
     request: NotificationSubscriptionCreateRequest,
-    _token: str = Depends(verify_token),
+    user: Annotated[UserIdentity, Depends(verify_token)],
 ) -> NotificationSubscriptionResponse:
     server._notification_store.cleanup_expired()
     prefs = _default_notification_preferences()
     if request.preferences is not None:
         prefs = request.preferences.apply(prefs)
     subscription = server._notification_store.upsert_subscription(
-        owner_key=derive_owner_key(_token),
+        user=user.username,
         endpoint=request.endpoint,
         p256dh=request.p256dh,
         auth=request.auth,
@@ -164,8 +164,11 @@ async def upsert_notification_subscription(
 
 
 @router.delete("/notifications/subscriptions/{subscription_id}", status_code=204)
-async def delete_notification_subscription(subscription_id: str, _token: str = Depends(verify_token)) -> Response:
-    subscription = _owned_notification_subscription(subscription_id, _token)
+async def delete_notification_subscription(
+    subscription_id: str,
+    user: Annotated[UserIdentity, Depends(verify_token)],
+) -> Response:
+    subscription = _owned_notification_subscription(subscription_id, user)
     server._notification_store.delete_subscription(subscription.id)
     return Response(status_code=204)
 
@@ -177,9 +180,9 @@ async def delete_notification_subscription(subscription_id: str, _token: str = D
 async def patch_notification_subscription_preferences(
     subscription_id: str,
     request: NotificationPreferencesPatch,
-    _token: str = Depends(verify_token),
+    user: Annotated[UserIdentity, Depends(verify_token)],
 ) -> NotificationSubscriptionResponse:
-    subscription = _owned_notification_subscription(subscription_id, _token)
+    subscription = _owned_notification_subscription(subscription_id, user)
     updated = subscription.model_copy(update={"notification_prefs": request.apply(subscription.notification_prefs)})
     server._notification_store.save_subscription(updated)
     return _notification_response(updated)
@@ -191,10 +194,10 @@ async def patch_notification_subscription_preferences(
 )
 async def test_notification_subscription(
     subscription_id: str,
-    _token: str = Depends(verify_token),
+    user: Annotated[UserIdentity, Depends(verify_token)],
 ) -> NotificationTestResponse:
     server._notification_store.cleanup_expired()
-    subscription = _owned_notification_subscription(subscription_id, _token)
+    subscription = _owned_notification_subscription(subscription_id, user)
     delivered = await server._notification_router.dispatch_test(subscription=subscription)
     if not delivered:
         raise HTTPException(status_code=502, detail="Failed to deliver test notification")
@@ -205,9 +208,11 @@ async def test_notification_subscription(
 async def update_notification_presence(
     subscription_id: str,
     request: NotificationPresenceRequest,
-    _token: str = Depends(verify_token),
+    user: Annotated[UserIdentity, Depends(verify_token)],
 ) -> dict[str, bool]:
-    subscription = _owned_notification_subscription(subscription_id, _token)
+    subscription = _owned_notification_subscription(subscription_id, user)
+    if not server._engine.session_mgr.is_owned_by(request.session_id, user.username):
+        raise HTTPException(status_code=404, detail="Session not found")
     now = datetime.now(tz=UTC)
     updated = subscription.model_copy(update={"last_heartbeat": now, "expires_at": now + _notification_ttl()})
     server._notification_store.save_subscription(updated)
@@ -224,8 +229,10 @@ async def update_notification_presence(
 @router.post("/notifications/presence")
 async def update_interactive_presence(
     request: InteractivePresenceRequest,
-    _token: str = Depends(verify_token),
+    user: Annotated[UserIdentity, Depends(verify_token)],
 ) -> dict[str, bool]:
+    if not server._engine.session_mgr.is_owned_by(request.session_id, user.username):
+        raise HTTPException(status_code=404, detail="Session not found")
     await _set_notification_presence(
         session_id=request.session_id,
         source_id=request.source_id,

--- a/src/carapace/server/session_sandbox.py
+++ b/src/carapace/server/session_sandbox.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, HTTPException
 
+from ..auth import UserIdentity
 from ..sandbox.state import SessionSandboxSnapshot
 from .auth import verify_token
 from .state import server_module
@@ -11,20 +14,29 @@ server = server_module()
 router = APIRouter()
 
 
-@router.get("/sessions/{session_id}/sandbox", response_model=SessionSandboxSnapshot)
-async def get_session_sandbox(session_id: str, _token: str = Depends(verify_token)) -> SessionSandboxSnapshot:
+def _load_owned_session(session_id: str, user: UserIdentity):
     state = server._engine.session_mgr.load_state(session_id)
-    if state is None:
+    if state is None or not server._engine.session_mgr.is_owned_by(session_id, user.username):
         raise HTTPException(status_code=404, detail="Session not found")
+    return state
+
+
+@router.get("/sessions/{session_id}/sandbox", response_model=SessionSandboxSnapshot)
+async def get_session_sandbox(
+    session_id: str,
+    user: Annotated[UserIdentity, Depends(verify_token)],
+) -> SessionSandboxSnapshot:
+    _load_owned_session(session_id, user)
     snapshot = server._engine.session_mgr.load_sandbox_snapshot(session_id)
     return snapshot or SessionSandboxSnapshot()
 
 
 @router.post("/sessions/{session_id}/sandbox/up", response_model=SessionSandboxSnapshot)
-async def start_session_sandbox(session_id: str, _token: str = Depends(verify_token)) -> SessionSandboxSnapshot:
-    state = server._engine.session_mgr.load_state(session_id)
-    if state is None:
-        raise HTTPException(status_code=404, detail="Session not found")
+async def start_session_sandbox(
+    session_id: str,
+    user: Annotated[UserIdentity, Depends(verify_token)],
+) -> SessionSandboxSnapshot:
+    state = _load_owned_session(session_id, user)
     if state.attributes.archived:
         raise HTTPException(status_code=409, detail="Archived sessions must be unarchived before use")
     if server._engine.is_agent_running(session_id):
@@ -35,10 +47,11 @@ async def start_session_sandbox(session_id: str, _token: str = Depends(verify_to
 
 
 @router.post("/sessions/{session_id}/sandbox/down", response_model=SessionSandboxSnapshot)
-async def stop_session_sandbox(session_id: str, _token: str = Depends(verify_token)) -> SessionSandboxSnapshot:
-    state = server._engine.session_mgr.load_state(session_id)
-    if state is None:
-        raise HTTPException(status_code=404, detail="Session not found")
+async def stop_session_sandbox(
+    session_id: str,
+    user: Annotated[UserIdentity, Depends(verify_token)],
+) -> SessionSandboxSnapshot:
+    state = _load_owned_session(session_id, user)
     if state.attributes.archived:
         raise HTTPException(status_code=409, detail="Archived sessions must be unarchived before use")
     if server._engine.is_agent_running(session_id):
@@ -49,10 +62,11 @@ async def stop_session_sandbox(session_id: str, _token: str = Depends(verify_tok
 
 
 @router.post("/sessions/{session_id}/sandbox/wipe", response_model=SessionSandboxSnapshot)
-async def wipe_session_sandbox(session_id: str, _token: str = Depends(verify_token)) -> SessionSandboxSnapshot:
-    state = server._engine.session_mgr.load_state(session_id)
-    if state is None:
-        raise HTTPException(status_code=404, detail="Session not found")
+async def wipe_session_sandbox(
+    session_id: str,
+    user: Annotated[UserIdentity, Depends(verify_token)],
+) -> SessionSandboxSnapshot:
+    state = _load_owned_session(session_id, user)
     if state.attributes.archived:
         raise HTTPException(status_code=409, detail="Archived sessions must be unarchived before use")
     if server._engine.is_agent_running(session_id):

--- a/src/carapace/server/sessions.py
+++ b/src/carapace/server/sessions.py
@@ -2,15 +2,17 @@ from __future__ import annotations
 
 import contextlib
 from decimal import Decimal
-from typing import Any, Self
+from typing import Annotated, Any, Self
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from loguru import logger
 from pydantic import BaseModel, ValidationError, field_validator, model_validator
 from pydantic_ai.messages import ModelMessage
 
+from ..auth import UserIdentity
 from ..models.session import SessionAttributes, SessionJobRunContext, SessionState
 from ..sandbox.state import SessionSandboxSnapshot
+from ..session.manager import SessionMeta
 from .auth import verify_token
 from .history import _history_from_messages
 from .state import server_module
@@ -157,9 +159,16 @@ def _session_message_count(session_id: str) -> int:
     return sum(1 for message in history if message.role in {"user", "assistant"})
 
 
-def _compute_sorted_session_states(*, include_archived: bool) -> list[SessionState]:
+def _load_owned_state(session_id: str, user: UserIdentity) -> SessionState:
+    state = server._engine.session_mgr.load_state(session_id)
+    if state is None or not server._engine.session_mgr.is_owned_by(session_id, user.username):
+        raise HTTPException(status_code=404, detail="Session not found")
+    return state
+
+
+def _compute_sorted_session_states(*, include_archived: bool, user: UserIdentity) -> list[SessionState]:
     states: list[SessionState] = []
-    for session_id in server._engine.session_mgr.list_sessions():
+    for session_id in server._engine.session_mgr.list_sessions(user=user.username):
         state = server._engine.session_mgr.load_state(session_id)
         if state is None:
             continue
@@ -177,9 +186,11 @@ def _compute_sorted_session_states(*, include_archived: bool) -> list[SessionSta
     return states
 
 
-def _build_session_list_items(*, include_archived: bool, include_message_count: bool) -> list[dict[str, Any]]:
+def _build_session_list_items(
+    *, include_archived: bool, include_message_count: bool, user: UserIdentity
+) -> list[dict[str, Any]]:
     items: list[dict[str, Any]] = []
-    for state in _compute_sorted_session_states(include_archived=include_archived):
+    for state in _compute_sorted_session_states(include_archived=include_archived, user=user):
         session_info = _session_info_from_state(state, include_message_count=include_message_count)
         items.append(session_info.model_dump(mode="json"))
     return items
@@ -221,14 +232,17 @@ async def _list_session_page(
     include_archived: bool,
     limit: int | None,
     cursor: str | None,
+    user: UserIdentity,
 ) -> SessionListPage:
     offset = _parse_session_cursor(cursor)
     cached_items = await server._session_list_cache.get_session_infos(
+        user=user.username,
         include_archived=include_archived,
         include_message_count=include_message_count,
         loader=lambda: _build_session_list_items(
             include_archived=include_archived,
             include_message_count=include_message_count,
+            user=user,
         ),
     )
     page_items = cached_items[offset:] if limit is None else cached_items[offset : offset + limit]
@@ -243,14 +257,15 @@ async def _list_session_page(
 
 @router.post("/sessions", response_model=SessionInfo)
 async def create_session(
+    user: Annotated[UserIdentity, Depends(verify_token)],
     body: SessionCreateRequest | None = None,
-    _token: str = Depends(verify_token),
 ) -> SessionInfo:
     body = body or SessionCreateRequest()
     state = server._engine.session_mgr.create_session(
         body.channel_type,
         body.channel_ref,
         budget=server._engine.config.agent.default_session_budget,
+        user=user.username,
         private=False if body.private is None else body.private,
         unattended=False if body.unattended is None else body.unattended,
         ask_mode=False if body.ask_mode is None else body.ask_mode,
@@ -261,25 +276,24 @@ async def create_session(
 
 @router.get("/sessions", response_model=SessionListPage)
 async def list_sessions(
+    user: Annotated[UserIdentity, Depends(verify_token)],
     include_message_count: bool = False,
     include_archived: bool = False,
     limit: int = Query(default=50, ge=1, le=200),
     cursor: str | None = None,
-    _token: str = Depends(verify_token),
 ) -> SessionListPage:
     return await _list_session_page(
         include_message_count=include_message_count,
         include_archived=include_archived,
         limit=limit,
         cursor=cursor,
+        user=user,
     )
 
 
 @router.get("/sessions/{session_id}", response_model=SessionInfo)
-async def get_session(session_id: str, _token: str = Depends(verify_token)) -> SessionInfo:
-    state = server._engine.session_mgr.load_state(session_id)
-    if state is None:
-        raise HTTPException(status_code=404, detail="Session not found")
+async def get_session(session_id: str, user: Annotated[UserIdentity, Depends(verify_token)]) -> SessionInfo:
+    state = _load_owned_state(session_id, user)
     sandbox = server._engine.session_mgr.load_sandbox_snapshot(session_id)
     return SessionInfo.from_state(
         state,
@@ -293,11 +307,9 @@ async def get_session(session_id: str, _token: str = Depends(verify_token)) -> S
 async def update_session(
     session_id: str,
     body: SessionUpdateRequest,
-    _token: str = Depends(verify_token),
+    user: Annotated[UserIdentity, Depends(verify_token)],
 ) -> SessionInfo:
-    state = server._engine.session_mgr.load_state(session_id)
-    if state is None:
-        raise HTTPException(status_code=404, detail="Session not found")
+    state = _load_owned_state(session_id, user)
 
     next_attributes: SessionAttributes | None = None
     previous_attributes: SessionAttributes | None = None
@@ -398,11 +410,9 @@ async def update_session(
 async def fork_session(
     session_id: str,
     body: SessionForkRequest,
-    _token: str = Depends(verify_token),
+    user: Annotated[UserIdentity, Depends(verify_token)],
 ) -> SessionInfo:
-    state = server._engine.session_mgr.load_state(session_id)
-    if state is None:
-        raise HTTPException(status_code=404, detail="Session not found")
+    _load_owned_state(session_id, user)
 
     try:
         forked = server._engine.fork_session(
@@ -421,6 +431,7 @@ async def fork_session(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
+    server._engine.session_mgr.save_meta(forked.session_id, SessionMeta(user=user.username))
     return SessionInfo.from_state(
         forked,
         message_count=_session_message_count(forked.session_id),
@@ -431,11 +442,9 @@ async def fork_session(
 @router.post("/sessions/{session_id}/knowledge/commit", response_model=SessionArchiveCommitResponse)
 async def commit_session_knowledge(
     session_id: str,
-    _token: str = Depends(verify_token),
+    user: Annotated[UserIdentity, Depends(verify_token)],
 ) -> SessionArchiveCommitResponse:
-    state = server._engine.session_mgr.load_state(session_id)
-    if state is None:
-        raise HTTPException(status_code=404, detail="Session not found")
+    state = _load_owned_state(session_id, user)
     if not server._session_archive.enabled:
         raise HTTPException(status_code=503, detail="Session archive is disabled")
     if state.attributes.private:
@@ -468,10 +477,8 @@ async def commit_session_knowledge(
 
 
 @router.delete("/sessions/{session_id}", status_code=204)
-async def delete_session(session_id: str, _token: str = Depends(verify_token)) -> None:
-    state = server._engine.session_mgr.load_state(session_id)
-    if state is None:
-        raise HTTPException(status_code=404, detail="Session not found")
+async def delete_session(session_id: str, user: Annotated[UserIdentity, Depends(verify_token)]) -> None:
+    state = _load_owned_state(session_id, user)
     server._engine.deactivate(session_id)
     await server._engine.sandbox_mgr.destroy_session(session_id)
     if server._session_archive.enabled and server._config.sessions.commit.delete_from_knowledge_on_session_delete:

--- a/src/carapace/server/websocket.py
+++ b/src/carapace/server/websocket.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, Query, WebSocket, WebSocketDisconnect
 from loguru import logger
 from pydantic import BaseModel
 
+from ..auth import UserIdentity
 from ..models.tooling import ToolResult, normalize_tool_call_args
 from ..notifications.models import NotificationClientType
 from ..notifications.vapid import derive_vapid_public_key
@@ -80,12 +81,12 @@ def _llm_activity_payload(activity: LlmRequestState | None) -> LlmActivity | Non
 
 
 @router.get("/commands")
-async def list_commands(_token: str = Depends(verify_token)) -> list[dict[str, str]]:
+async def list_commands(_user: Annotated[UserIdentity, Depends(verify_token)]) -> list[dict[str, str]]:
     return SLASH_COMMANDS
 
 
 @router.get("/meta", response_model=ServerMeta)
-async def get_meta(_token: str = Depends(verify_token)) -> ServerMeta:
+async def get_meta(_user: Annotated[UserIdentity, Depends(verify_token)]) -> ServerMeta:
     return ServerMeta(version=server._APP_VERSION)
 
 
@@ -98,7 +99,7 @@ async def get_vapid_public_key() -> VapidPublicKeyResponse:
 
 
 @router.get("/models")
-async def list_models(_token: str = Depends(verify_token)) -> list[dict[str, Any]]:
+async def list_models(_user: Annotated[UserIdentity, Depends(verify_token)]) -> list[dict[str, Any]]:
     return [e.model_dump(mode="json", by_alias=True) for e in server._engine.available_model_entries]
 
 
@@ -292,11 +293,11 @@ class WebSocketSubscriber:
 async def chat_ws(
     websocket: WebSocket,
     session_id: str,
-    _token: Annotated[str, Depends(verify_ws_token)],
+    user: Annotated[UserIdentity, Depends(verify_ws_token)],
     client_id: Annotated[str | None, Query()] = None,
 ) -> None:
     current_state = server._engine.session_mgr.load_state(session_id)
-    if current_state is None:
+    if current_state is None or not server._engine.session_mgr.is_owned_by(session_id, user.username):
         logger.warning(f"WebSocket rejected — session {session_id} not found")
         await websocket.close(code=4004, reason="Session not found")
         return

--- a/src/carapace/session/manager.py
+++ b/src/carapace/session/manager.py
@@ -148,14 +148,15 @@ class SessionManager:
         if not self.sessions_dir.exists():
             return []
         self._log_disk_read("session directory listing", self.sessions_dir)
-        session_ids = [d.name for d in self.sessions_dir.iterdir() if d.is_dir()]
-        if user is not None:
-            session_ids = [session_id for session_id in session_ids if self.is_owned_by(session_id, user)]
-        return sorted(
-            session_ids,
-            key=lambda s: self._get_mtime(s),
-            reverse=True,
-        )
+        candidates: list[tuple[float, str]] = []
+        for session_dir in self.sessions_dir.iterdir():
+            if not session_dir.is_dir():
+                continue
+            session_id = session_dir.name
+            if user is not None and self.load_meta(session_id).user != user:
+                continue
+            candidates.append((self._get_mtime(session_id), session_id))
+        return [session_id for _, session_id in sorted(candidates, reverse=True)]
 
     def find_session(self, channel_type: str, channel_ref: str) -> str | None:
         """Return the most recently active session ID for the given channel, or None."""

--- a/src/carapace/session/manager.py
+++ b/src/carapace/session/manager.py
@@ -23,6 +23,10 @@ from ..sandbox.state import (
 from ..usage import LlmRequestLog, LlmRequestState, UsageTracker
 
 
+class SessionMeta(BaseModel):
+    user: str | None = None
+
+
 def _to_yaml_safe(value: Any) -> Any:
     if isinstance(value, BaseModel):
         return value.model_dump(mode="json")
@@ -73,6 +77,7 @@ class SessionManager:
         channel_ref: str = "",
         budget: SessionBudget | None = None,
         *,
+        user: str | None = None,
         private: bool = False,
         unattended: bool = False,
         ask_mode: bool = False,
@@ -99,8 +104,29 @@ class SessionManager:
         )
         session_dir = self.sessions_dir / session_id
         session_dir.mkdir(parents=True, exist_ok=True)
+        if user is not None:
+            self.save_meta(session_id, SessionMeta(user=user))
         self._save_state(state)
         return state
+
+    def load_meta(self, session_id: str) -> SessionMeta:
+        meta_path = self.sessions_dir / session_id / "meta.yaml"
+        if not meta_path.exists():
+            return SessionMeta()
+        self._log_disk_read("session metadata", meta_path, session_id=session_id)
+        with open(meta_path) as f:
+            raw = yaml.safe_load(f) or {}
+        return SessionMeta.model_validate(raw)
+
+    def save_meta(self, session_id: str, meta: SessionMeta) -> None:
+        session_dir = self.sessions_dir / session_id
+        session_dir.mkdir(parents=True, exist_ok=True)
+        meta_path = session_dir / "meta.yaml"
+        with open(meta_path, "w") as f:
+            yaml.dump(meta.model_dump(mode="json", exclude_none=True), f, default_flow_style=False)
+
+    def is_owned_by(self, session_id: str, user: str) -> bool:
+        return self.load_meta(session_id).user == user
 
     def load_state(self, session_id: str) -> SessionState | None:
         """Load session state without mutating last_active."""
@@ -118,12 +144,15 @@ class SessionManager:
             state.last_active = datetime.now(tz=UTC)
         return state
 
-    def list_sessions(self) -> list[str]:
+    def list_sessions(self, *, user: str | None = None) -> list[str]:
         if not self.sessions_dir.exists():
             return []
         self._log_disk_read("session directory listing", self.sessions_dir)
+        session_ids = [d.name for d in self.sessions_dir.iterdir() if d.is_dir()]
+        if user is not None:
+            session_ids = [session_id for session_id in session_ids if self.is_owned_by(session_id, user)]
         return sorted(
-            [d.name for d in self.sessions_dir.iterdir() if d.is_dir()],
+            session_ids,
             key=lambda s: self._get_mtime(s),
             reverse=True,
         )

--- a/src/carapace/upgrade.py
+++ b/src/carapace/upgrade.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .auth import AuthStore, AuthUser, normalize_username
+from .config import load_config
+from .models.config import UserConfig
+from .session.manager import SessionMeta
+
+
+class UpgradeSummary(dict[str, list[str]]):
+    def add(self, key: str, value: str) -> None:
+        self.setdefault(key, []).append(value)
+
+
+def upgrade_data_dir(data_dir: Path, username: str) -> UpgradeSummary:
+    user = normalize_username(username)
+    if not user:
+        raise ValueError("username must not be empty")
+    data_dir = data_dir.resolve()
+    summary = UpgradeSummary()
+
+    config = load_config(data_dir)
+    _upsert_user_config(data_dir, user, _user_config_from_global_config(config), summary)
+    _upgrade_sessions(data_dir, user, summary)
+    _upgrade_knowledge(data_dir, user, summary)
+    _upgrade_jobs(data_dir, user, summary)
+    _upgrade_notifications(data_dir, user, summary)
+    _upgrade_matrix_token(data_dir, user, summary)
+    _upgrade_sandbox_tokens(data_dir, user, summary)
+    return summary
+
+
+def _user_config_from_global_config(config: Any) -> UserConfig:
+    return UserConfig(
+        credentials=config.credentials.model_dump(mode="json", exclude_none=True),
+        channels=config.channels.model_copy(deep=True),
+        git=config.git.model_dump(mode="json", exclude_none=True),
+        default_models={
+            "agent": config.agent.model,
+            "sentinel": config.agent.sentinel_model,
+            "title": config.agent.title_model,
+        },
+        budgets=config.agent.default_session_budget.model_dump(mode="json", exclude_none=True),
+    )
+
+
+def _upsert_user_config(data_dir: Path, user: str, user_config: UserConfig, summary: UpgradeSummary) -> None:
+    store = AuthStore(data_dir, load_config(data_dir).auth)
+    users_file = store.load_users()
+    now = datetime.now(tz=UTC)
+    existing = users_file.users.get(user)
+    if existing is None:
+        users_file.users[user] = AuthUser(
+            password_hash="",
+            enabled=False,
+            display_name=user,
+            created_at=now,
+            updated_at=now,
+            password_changed_at=now,
+            config=user_config,
+        )
+        summary.add("users", f"created disabled placeholder user {user!r}")
+    else:
+        users_file.users[user] = existing.model_copy(update={"config": user_config, "updated_at": now})
+        summary.add("users", f"updated config for user {user!r}")
+    store.save_users(users_file)
+
+
+def _upgrade_sessions(data_dir: Path, user: str, summary: UpgradeSummary) -> None:
+    sessions_dir = data_dir / "sessions"
+    if not sessions_dir.exists():
+        return
+    for session_dir in sorted(path for path in sessions_dir.iterdir() if path.is_dir()):
+        meta_path = session_dir / "meta.yaml"
+        if meta_path.exists():
+            raw = yaml.safe_load(meta_path.read_text(encoding="utf-8")) or {}
+            meta = SessionMeta.model_validate(raw)
+            if meta.user is not None:
+                continue
+        _write_yaml(meta_path, SessionMeta(user=user).model_dump(mode="json", exclude_none=True))
+        summary.add("sessions", f"set owner for {session_dir.name}")
+
+
+def _upgrade_knowledge(data_dir: Path, user: str, summary: UpgradeSummary) -> None:
+    source = data_dir / "knowledge"
+    target = data_dir / "knowledges" / user
+    if not source.exists():
+        target.mkdir(parents=True, exist_ok=True)
+        return
+    if target.exists():
+        summary.add("knowledge", f"left existing {source} in place because {target} already exists")
+        return
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(source), str(target))
+    summary.add("knowledge", f"moved knowledge to {target}")
+
+
+def _upgrade_jobs(data_dir: Path, user: str, summary: UpgradeSummary) -> None:
+    path = data_dir / "jobs.yaml"
+    if not path.exists():
+        return
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    jobs = raw.get("jobs")
+    if not isinstance(jobs, list):
+        return
+    changed = False
+    for job in jobs:
+        if isinstance(job, dict) and not job.get("user"):
+            job["user"] = user
+            changed = True
+    if changed:
+        _write_yaml(path, raw)
+        summary.add("jobs", "added user to unowned jobs")
+
+
+def _upgrade_notifications(data_dir: Path, user: str, summary: UpgradeSummary) -> None:
+    subscriptions_dir = data_dir / "notifications" / "subscriptions"
+    if not subscriptions_dir.exists():
+        return
+    for path in sorted(subscriptions_dir.glob("*.yaml")):
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        if not isinstance(raw, dict) or raw.get("user"):
+            continue
+        raw["user"] = user
+        _write_yaml(path, raw)
+        summary.add("notifications", f"added user to {path.name}")
+
+
+def _upgrade_matrix_token(data_dir: Path, user: str, summary: UpgradeSummary) -> None:
+    json_path = data_dir / "matrix_token.json"
+    yaml_path = data_dir / "matrix_token.yaml"
+    if not json_path.exists() and yaml_path.exists():
+        raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
+        tokens = raw.get("tokens") if isinstance(raw, dict) else None
+        if isinstance(tokens, list):
+            changed = False
+            for token in tokens:
+                if isinstance(token, dict) and not token.get("user"):
+                    token["user"] = user
+                    changed = True
+            if changed:
+                _write_yaml(yaml_path, raw)
+                summary.add("matrix", "added user to existing matrix_token.yaml")
+        return
+    if not json_path.exists():
+        return
+    raw_json = json.loads(json_path.read_text(encoding="utf-8"))
+    token_record = dict(raw_json) if isinstance(raw_json, dict) else {}
+    token_record["user"] = user
+    payload = {"version": 1, "tokens": [token_record]}
+    _write_yaml(yaml_path, payload)
+    _backup_or_remove(json_path)
+    summary.add("matrix", "converted matrix_token.json to matrix_token.yaml")
+
+
+def _upgrade_sandbox_tokens(data_dir: Path, user: str, summary: UpgradeSummary) -> None:
+    json_path = data_dir / "sandbox_tokens.json"
+    yaml_path = data_dir / "sandbox_tokens.yaml"
+    if not json_path.exists() and yaml_path.exists():
+        raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
+        _add_user_to_token_mapping(raw, user)
+        _write_yaml(yaml_path, raw)
+        summary.add("sandbox", "ensured user in existing sandbox_tokens.yaml")
+        return
+    if not json_path.exists():
+        return
+    raw_json = json.loads(json_path.read_text(encoding="utf-8"))
+    payload: dict[str, Any] = (
+        {"version": 1, "tokens": raw_json} if isinstance(raw_json, dict) else {"version": 1, "tokens": []}
+    )
+    _add_user_to_token_mapping(payload, user)
+    _write_yaml(yaml_path, payload)
+    _backup_or_remove(json_path)
+    summary.add("sandbox", "converted sandbox_tokens.json to sandbox_tokens.yaml")
+
+
+def _add_user_to_token_mapping(raw: Any, user: str) -> None:
+    if not isinstance(raw, dict):
+        return
+    tokens = raw.get("tokens")
+    if isinstance(tokens, dict):
+        for session_id, token_value in list(tokens.items()):
+            if isinstance(token_value, dict):
+                token_value.setdefault("user", user)
+                continue
+            tokens[session_id] = {"token": token_value, "user": user}
+    elif isinstance(tokens, list):
+        for token_record in tokens:
+            if isinstance(token_record, dict):
+                token_record.setdefault("user", user)
+
+
+def _write_yaml(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(f"{path.suffix}.tmp")
+    tmp_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    tmp_path.replace(path)
+
+
+def _backup_or_remove(path: Path) -> None:
+    backup = path.with_suffix(f"{path.suffix}.bak")
+    if backup.exists():
+        path.unlink()
+    else:
+        path.replace(backup)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,41 +14,43 @@ from carapace.auth import (
     AuthSession,
     AuthStore,
     SessionsFile,
-    get_token,
     hash_password,
     normalize_username,
+    validate_bootstrap_admin_password,
     verify_password,
 )
 from carapace.models.config import AuthConfig, JwtCookieConfig, UserConfig
 
 
-def test_get_token_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_validate_bootstrap_admin_password_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CARAPACE_TOKEN", "test-token-12345")
-    assert get_token() == "test-token-12345"
+    assert validate_bootstrap_admin_password() == "test-token-12345"
 
 
-def test_get_token_strips_whitespace(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_validate_bootstrap_admin_password_strips_whitespace(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CARAPACE_TOKEN", "  my-token-is-long  ")
-    assert get_token() == "my-token-is-long"
+    assert validate_bootstrap_admin_password() == "my-token-is-long"
 
 
-def test_get_token_raises_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_validate_bootstrap_admin_password_raises_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CARAPACE_TOKEN", raising=False)
     with pytest.raises(RuntimeError, match="CARAPACE_TOKEN"):
-        get_token()
+        validate_bootstrap_admin_password()
 
 
-def test_get_token_raises_when_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_validate_bootstrap_admin_password_raises_when_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CARAPACE_TOKEN", "")
     with pytest.raises(RuntimeError, match="CARAPACE_TOKEN"):
-        get_token()
+        validate_bootstrap_admin_password()
 
 
-def test_get_token_raises_when_too_short_with_suggestion(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_validate_bootstrap_admin_password_raises_when_too_short_with_suggestion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("CARAPACE_TOKEN", "short")
 
     with pytest.raises(RuntimeError, match=rf"at least {BOOTSTRAP_ADMIN_PASSWORD_MIN_LENGTH} characters") as exc_info:
-        get_token()
+        validate_bootstrap_admin_password()
 
     suggestion = str(exc_info.value).split("Suggested replacement: ", maxsplit=1)[1]
     assert len(suggestion) == BOOTSTRAP_ADMIN_PASSWORD_SUGGESTED_LENGTH

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -7,8 +7,10 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from carapace.auth import (
-    ADMIN_TOKEN_MIN_LENGTH,
-    ADMIN_TOKEN_SUGGESTED_LENGTH,
+    ADMIN_ROLE,
+    ADMIN_USERNAME,
+    BOOTSTRAP_ADMIN_PASSWORD_MIN_LENGTH,
+    BOOTSTRAP_ADMIN_PASSWORD_SUGGESTED_LENGTH,
     AuthSession,
     AuthStore,
     SessionsFile,
@@ -45,11 +47,11 @@ def test_get_token_raises_when_empty(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_get_token_raises_when_too_short_with_suggestion(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CARAPACE_TOKEN", "short")
 
-    with pytest.raises(RuntimeError, match=rf"at least {ADMIN_TOKEN_MIN_LENGTH} characters") as exc_info:
+    with pytest.raises(RuntimeError, match=rf"at least {BOOTSTRAP_ADMIN_PASSWORD_MIN_LENGTH} characters") as exc_info:
         get_token()
 
     suggestion = str(exc_info.value).split("Suggested replacement: ", maxsplit=1)[1]
-    assert len(suggestion) == ADMIN_TOKEN_SUGGESTED_LENGTH
+    assert len(suggestion) == BOOTSTRAP_ADMIN_PASSWORD_SUGGESTED_LENGTH
     assert suggestion.isalnum()
 
 
@@ -78,7 +80,7 @@ def test_create_user_normalizes_persists_and_verifies_password(tmp_path) -> None
         password="secret",
         display_name=" Thies Gerken ",
         email=" thies@example.com ",
-        roles=[" admin ", ""],
+        roles=[" Admin ", ""],
         config=config,
     )
 
@@ -104,6 +106,21 @@ def test_create_user_rejects_empty_and_duplicate_normalized_usernames(tmp_path) 
 
     with pytest.raises(ValueError, match="already exists"):
         store.create_user(username=" thies ", password="secret")
+
+
+def test_ensure_bootstrap_admin_creates_admin_from_env(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CARAPACE_TOKEN", "bootstrap-secret-123")
+    store = AuthStore(tmp_path, AuthConfig())
+
+    created = store.ensure_bootstrap_admin()
+    repeated = store.ensure_bootstrap_admin()
+
+    assert created is not None
+    assert repeated is None
+    assert store.verify_password(ADMIN_USERNAME, "bootstrap-secret-123") is not None
+    admin = store.get_user(ADMIN_USERNAME)
+    assert admin is not None
+    assert admin.roles == [ADMIN_ROLE]
 
 
 def test_disabled_users_cannot_login_or_keep_existing_sessions(tmp_path) -> None:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,28 +2,201 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 
-from carapace.auth import get_token
+from carapace.auth import (
+    AuthSession,
+    AuthStore,
+    SessionsFile,
+    get_token,
+    hash_password,
+    normalize_username,
+    verify_password,
+)
+from carapace.models.config import AuthConfig, JwtCookieConfig, UserConfig
 
 
-def test_get_token_from_env(monkeypatch):
+def test_get_token_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CARAPACE_TOKEN", "test-token-123")
     assert get_token() == "test-token-123"
 
 
-def test_get_token_strips_whitespace(monkeypatch):
+def test_get_token_strips_whitespace(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CARAPACE_TOKEN", "  my-token  ")
     assert get_token() == "my-token"
 
 
-def test_get_token_raises_when_missing(monkeypatch):
+def test_get_token_raises_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CARAPACE_TOKEN", raising=False)
     with pytest.raises(RuntimeError, match="CARAPACE_TOKEN"):
         get_token()
 
 
-def test_get_token_raises_when_empty(monkeypatch):
+def test_get_token_raises_when_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CARAPACE_TOKEN", "")
     with pytest.raises(RuntimeError, match="CARAPACE_TOKEN"):
         get_token()
+
+
+def test_normalize_username_strips_and_lowercases() -> None:
+    assert normalize_username(" Thies ") == "thies"
+
+
+def test_password_hashing_never_accepts_plaintext_hashes() -> None:
+    password_hash = hash_password("correct-horse-battery")
+
+    assert password_hash != "correct-horse-battery"
+    assert verify_password("correct-horse-battery", password_hash) is True
+    assert verify_password("wrong", password_hash) is False
+    assert verify_password("correct-horse-battery", "") is False
+
+    with pytest.raises(ValueError, match="password must not be empty"):
+        hash_password("")
+
+
+def test_create_user_normalizes_persists_and_verifies_password(tmp_path) -> None:
+    store = AuthStore(tmp_path, AuthConfig())
+    config = UserConfig(default_models={"agent": "anthropic:test"})
+
+    user = store.create_user(
+        username=" Thies ",
+        password="secret",
+        display_name=" Thies Gerken ",
+        email=" thies@example.com ",
+        roles=[" admin ", ""],
+        config=config,
+    )
+
+    assert user.password_hash != "secret"
+    assert store.users_path.exists()
+    persisted = store.load_users().users
+    assert list(persisted) == ["thies"]
+    assert persisted["thies"].display_name == "Thies Gerken"
+    assert persisted["thies"].email == "thies@example.com"
+    assert persisted["thies"].roles == ["admin"]
+    assert persisted["thies"].config.default_models == {"agent": "anthropic:test"}
+    assert store.verify_password("THIES", "secret") is not None
+    assert store.verify_password("thies", "wrong") is None
+
+
+def test_create_user_rejects_empty_and_duplicate_normalized_usernames(tmp_path) -> None:
+    store = AuthStore(tmp_path, AuthConfig())
+
+    with pytest.raises(ValueError, match="username must not be empty"):
+        store.create_user(username=" ", password="secret")
+
+    store.create_user(username="Thies", password="secret")
+
+    with pytest.raises(ValueError, match="already exists"):
+        store.create_user(username=" thies ", password="secret")
+
+
+def test_disabled_users_cannot_login_or_keep_existing_sessions(tmp_path) -> None:
+    store = AuthStore(tmp_path, AuthConfig())
+    store.create_user(username="thies", password="secret")
+    auth_session = store.create_session(username="thies")
+    token = store.issue_session_token(auth_session)
+
+    assert store.validate_session_token(token) is not None
+
+    store.update_user("thies", {"enabled": False})
+
+    assert store.verify_password("thies", "secret") is None
+    assert store.validate_session_token(token) is None
+
+
+def test_session_token_roundtrip_persists_session_and_identity(tmp_path) -> None:
+    store = AuthStore(tmp_path, AuthConfig(cookie=JwtCookieConfig(ttl_seconds=3600)))
+    store.create_user(username="thies", password="secret", display_name="Thies")
+
+    auth_session = store.create_session(username="THIES", user_agent="pytest")
+    token = store.issue_session_token(auth_session)
+    identity = store.validate_session_token(token)
+
+    assert auth_session.user == "thies"
+    assert store.sessions_path.exists()
+    persisted_session = store.get_session(auth_session.id)
+    assert persisted_session is not None
+    assert persisted_session.user_agent == "pytest"
+    persisted_user = store.get_user("thies")
+    assert persisted_user is not None
+    assert persisted_user.last_login_at is not None
+    assert identity is not None
+    assert identity.username == "thies"
+    assert identity.display_name == "Thies"
+
+
+def test_revoke_token_invalidates_session(tmp_path) -> None:
+    store = AuthStore(tmp_path, AuthConfig())
+    store.create_user(username="thies", password="secret")
+    auth_session = store.create_session(username="thies")
+    token = store.issue_session_token(auth_session)
+
+    assert store.revoke_token(token) is True
+    assert store.validate_session_token(token) is None
+    revoked_session = store.get_session(auth_session.id)
+    assert revoked_session is not None
+    assert revoked_session.revoked_at is not None
+    assert store.revoke_token("not-a-token") is False
+
+
+def test_password_change_increments_token_version_and_invalidates_old_tokens(tmp_path) -> None:
+    store = AuthStore(tmp_path, AuthConfig())
+    store.create_user(username="thies", password="old-secret")
+    old_session = store.create_session(username="thies")
+    old_token = store.issue_session_token(old_session)
+
+    updated = store.set_password("thies", "new-secret")
+    new_session = store.create_session(username="thies")
+    new_token = store.issue_session_token(new_session)
+
+    assert updated.token_version == 2
+    assert store.verify_password("thies", "old-secret") is None
+    assert store.verify_password("thies", "new-secret") is not None
+    assert store.validate_session_token(old_token) is None
+    assert store.validate_session_token(new_token) is not None
+
+
+def test_expired_token_is_rejected(tmp_path) -> None:
+    store = AuthStore(tmp_path, AuthConfig())
+    store.create_user(username="thies", password="secret")
+    now = datetime.now(tz=UTC)
+    expired_session = AuthSession(
+        id="expired-session",
+        user="thies",
+        created_at=now - timedelta(minutes=2),
+        expires_at=now - timedelta(minutes=1),
+    )
+    store.save_sessions(SessionsFile(sessions={expired_session.id: expired_session}))
+    token = store.issue_session_token(expired_session)
+
+    assert store.validate_session_token(token) is None
+
+
+def test_token_signed_for_different_auth_config_is_rejected(tmp_path) -> None:
+    store = AuthStore(
+        tmp_path,
+        AuthConfig(cookie=JwtCookieConfig(issuer="carapace-a", audience="web-a")),
+    )
+    store.create_user(username="thies", password="secret")
+    auth_session = store.create_session(username="thies")
+    token = store.issue_session_token(auth_session)
+
+    other_config_store = AuthStore(
+        tmp_path,
+        AuthConfig(cookie=JwtCookieConfig(issuer="carapace-b", audience="web-b")),
+    )
+
+    assert other_config_store.validate_session_token(token) is None
+
+
+def test_signing_secret_is_reused_across_store_instances(tmp_path) -> None:
+    store = AuthStore(tmp_path, AuthConfig())
+    first_secret = store.signing_secret()
+
+    reloaded_store = AuthStore(tmp_path, AuthConfig())
+
+    assert reloaded_store.signing_secret() == first_secret
+    assert (tmp_path / "auth" / "session_secret").stat().st_mode & 0o777 == 0o600

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -159,6 +159,13 @@ def test_password_change_increments_token_version_and_invalidates_old_tokens(tmp
     assert store.validate_session_token(new_token) is not None
 
 
+def test_set_password_raises_for_missing_user(tmp_path) -> None:
+    store = AuthStore(tmp_path, AuthConfig())
+
+    with pytest.raises(KeyError):
+        store.set_password("missing", "new-secret")
+
+
 def test_expired_token_is_rejected(tmp_path) -> None:
     store = AuthStore(tmp_path, AuthConfig())
     store.create_user(username="thies", password="secret")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -125,6 +125,20 @@ def test_ensure_bootstrap_admin_creates_admin_from_env(tmp_path, monkeypatch: py
     assert admin.roles == [ADMIN_ROLE]
 
 
+def test_ensure_bootstrap_admin_skips_when_another_admin_exists(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CARAPACE_TOKEN", raising=False)
+    store = AuthStore(tmp_path, AuthConfig())
+    store.create_user(username="thies", password="secret", roles=[ADMIN_ROLE])
+
+    created = store.ensure_bootstrap_admin()
+
+    assert created is None
+    assert store.get_user(ADMIN_USERNAME) is None
+
+
 def test_disabled_users_cannot_login_or_keep_existing_sessions(tmp_path) -> None:
     store = AuthStore(tmp_path, AuthConfig())
     store.create_user(username="thies", password="secret")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -174,6 +174,55 @@ def test_revoke_token_invalidates_session(tmp_path) -> None:
     assert store.revoke_token("not-a-token") is False
 
 
+def test_create_session_prunes_expired_and_revoked_sessions(tmp_path) -> None:
+    store = AuthStore(tmp_path, AuthConfig(cookie=JwtCookieConfig(ttl_seconds=3600)))
+    store.create_user(username="thies", password="secret")
+    now = datetime.now(tz=UTC)
+    expired_session = AuthSession(
+        id="expired-session",
+        user="thies",
+        created_at=now - timedelta(hours=2),
+        expires_at=now - timedelta(hours=1),
+    )
+    revoked_session = AuthSession(
+        id="revoked-session",
+        user="thies",
+        created_at=now - timedelta(minutes=30),
+        expires_at=now + timedelta(minutes=30),
+        revoked_at=now - timedelta(minutes=1),
+    )
+    store.save_sessions(
+        SessionsFile(
+            sessions={
+                expired_session.id: expired_session,
+                revoked_session.id: revoked_session,
+            }
+        )
+    )
+
+    fresh_session = store.create_session(username="thies")
+
+    persisted_sessions = store.load_sessions().sessions
+    assert list(persisted_sessions) == [fresh_session.id]
+
+
+def test_websocket_token_is_scoped_to_session_and_revocation(tmp_path) -> None:
+    store = AuthStore(tmp_path, AuthConfig(cookie=JwtCookieConfig(ttl_seconds=3600)))
+    store.create_user(username="thies", password="secret")
+    auth_session = store.create_session(username="thies")
+    session_token = store.issue_session_token(auth_session)
+
+    websocket_token = store.issue_websocket_token(session_token)
+
+    assert websocket_token is not None
+    identity = store.validate_websocket_token(websocket_token)
+    assert identity is not None
+    assert identity.username == "thies"
+    assert store.validate_session_token(websocket_token) is None
+    store.revoke_token(session_token)
+    assert store.validate_websocket_token(websocket_token) is None
+
+
 def test_password_change_increments_token_version_and_invalidates_old_tokens(tmp_path) -> None:
     store = AuthStore(tmp_path, AuthConfig())
     store.create_user(username="thies", password="old-secret")
@@ -238,4 +287,12 @@ def test_signing_secret_is_reused_across_store_instances(tmp_path) -> None:
     reloaded_store = AuthStore(tmp_path, AuthConfig())
 
     assert reloaded_store.signing_secret() == first_secret
+
+
+def test_signing_secret_is_cached_per_store_instance(tmp_path) -> None:
+    store = AuthStore(tmp_path, AuthConfig())
+    first_secret = store.signing_secret()
+    store._secret_path.write_text("changed-on-disk", encoding="utf-8")
+
+    assert store.signing_secret() == first_secret
     assert (tmp_path / "auth" / "session_secret").stat().st_mode & 0o777 == 0o600

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -139,6 +139,24 @@ def test_ensure_bootstrap_admin_skips_when_another_admin_exists(
     assert store.get_user(ADMIN_USERNAME) is None
 
 
+def test_ensure_bootstrap_admin_repairs_disabled_admin_placeholder(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CARAPACE_TOKEN", "bootstrap-secret-123")
+    store = AuthStore(tmp_path, AuthConfig())
+    store.create_user(username=ADMIN_USERNAME, password="temporary-secret")
+    placeholder = store.update_user(ADMIN_USERNAME, {"enabled": False, "password_hash": ""})
+
+    created = store.ensure_bootstrap_admin()
+
+    assert created is not None
+    assert created.enabled is True
+    assert created.roles == [ADMIN_ROLE]
+    assert created.token_version == placeholder.token_version + 1
+    assert store.verify_password(ADMIN_USERNAME, "bootstrap-secret-123") is not None
+
+
 def test_disabled_users_cannot_login_or_keep_existing_sessions(tmp_path) -> None:
     store = AuthStore(tmp_path, AuthConfig())
     store.create_user(username="thies", password="secret")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -7,6 +7,8 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from carapace.auth import (
+    ADMIN_TOKEN_MIN_LENGTH,
+    ADMIN_TOKEN_SUGGESTED_LENGTH,
     AuthSession,
     AuthStore,
     SessionsFile,
@@ -19,13 +21,13 @@ from carapace.models.config import AuthConfig, JwtCookieConfig, UserConfig
 
 
 def test_get_token_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("CARAPACE_TOKEN", "test-token-123")
-    assert get_token() == "test-token-123"
+    monkeypatch.setenv("CARAPACE_TOKEN", "test-token-12345")
+    assert get_token() == "test-token-12345"
 
 
 def test_get_token_strips_whitespace(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("CARAPACE_TOKEN", "  my-token  ")
-    assert get_token() == "my-token"
+    monkeypatch.setenv("CARAPACE_TOKEN", "  my-token-is-long  ")
+    assert get_token() == "my-token-is-long"
 
 
 def test_get_token_raises_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -38,6 +40,17 @@ def test_get_token_raises_when_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CARAPACE_TOKEN", "")
     with pytest.raises(RuntimeError, match="CARAPACE_TOKEN"):
         get_token()
+
+
+def test_get_token_raises_when_too_short_with_suggestion(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CARAPACE_TOKEN", "short")
+
+    with pytest.raises(RuntimeError, match=rf"at least {ADMIN_TOKEN_MIN_LENGTH} characters") as exc_info:
+        get_token()
+
+    suggestion = str(exc_info.value).split("Suggested replacement: ", maxsplit=1)[1]
+    assert len(suggestion) == ADMIN_TOKEN_SUGGESTED_LENGTH
+    assert suggestion.isalnum()
 
 
 def test_normalize_username_strips_and_lowercases() -> None:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from carapace.cache import SessionListCache
+from carapace.models.config import CacheConfig
+
+
+def test_session_list_cache_key_distinguishes_user_all_from_global_scope() -> None:
+    cache = SessionListCache(CacheConfig())
+
+    global_key = cache._cache_key(False, False)
+    user_all_key = cache._cache_key(False, False, user="all")
+
+    assert global_key == "carapace:sessions:list:scope:all:0:0"
+    assert user_all_key == "carapace:sessions:list:user:all:0:0"
+    assert user_all_key != global_key

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ import pytest
 from typer.testing import CliRunner
 
 import carapace.cli as cli_module
-from carapace.cli import _render_escalation_request, app
+from carapace.cli import _render_escalation_request, _replay_history, app
 
 runner = CliRunner()
 
@@ -137,3 +137,21 @@ def test_chat_list_fetches_all_session_pages(monkeypatch: pytest.MonkeyPatch) ->
         {"include_message_count": "true", "limit": "200"},
         {"include_message_count": "true", "limit": "200", "cursor": "1"},
     ]
+
+
+def test_replay_history_uses_authenticated_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen_requests: list[tuple[str, dict[str, int]]] = []
+
+    class _FakeClient:
+        def get(self, url: str, *, params: dict[str, int] | None = None):
+            seen_requests.append((url, dict(params or {})))
+            return _FakeHttpResponse([{"role": "user", "content": "hello"}])
+
+    def fail_module_get(*args: object, **kwargs: object) -> None:
+        raise AssertionError("module-level httpx.get should not be used")
+
+    monkeypatch.setattr(cli_module.httpx, "get", fail_module_get)
+
+    _replay_history(_FakeClient(), "session-1", 25)  # type: ignore[arg-type]
+
+    assert seen_requests == [("/api/sessions/session-1/history", {"limit": 25})]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,7 +31,8 @@ def test_chat_help():
     output = _strip_ansi(result.output)
     assert "--session" in output
     assert "--server" in output
-    assert "--token" in output
+    assert "--user" in output
+    assert "--password" in output
 
 
 @pytest.mark.parametrize(
@@ -95,15 +96,38 @@ def test_chat_list_fetches_all_session_pages(monkeypatch: pytest.MonkeyPatch) ->
     )
     seen_params: list[dict[str, str]] = []
 
-    def fake_get(url: str, *, headers: dict[str, str] | None = None, params: dict[str, str] | None = None):
-        assert url == "http://example.test/api/sessions"
-        assert headers == {"Authorization": "Bearer test-token"}
-        seen_params.append(dict(params or {}))
-        return _FakeHttpResponse(next(responses))
+    class _Cookie:
+        name = "carapace_session"
+        value = "session-token"
 
-    monkeypatch.setattr(cli_module.httpx, "get", fake_get)
+    class _Cookies:
+        def __init__(self) -> None:
+            self.jar = [_Cookie()]
 
-    result = runner.invoke(app, ["--server", "http://example.test", "--token", "test-token", "--list"])
+    class _FakeClient:
+        def __init__(self, base_url: str):
+            assert base_url == "http://example.test"
+            self.cookies = _Cookies()
+
+        def post(self, url: str, *, json: dict[str, str] | None = None):
+            assert url == "/api/auth/login"
+            assert json == {"username": "thies", "password": "secret"}
+            return _FakeHttpResponse({"user": {"username": "thies"}})
+
+        def get(self, url: str, *, params: dict[str, str] | None = None):
+            assert url == "/api/sessions"
+            seen_params.append(dict(params or {}))
+            return _FakeHttpResponse(next(responses))
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(cli_module.httpx, "Client", _FakeClient)
+
+    result = runner.invoke(
+        app,
+        ["chat", "--server", "http://example.test", "--user", "thies", "--password", "secret", "--list"],
+    )
 
     assert result.exit_code == 0
     output = _strip_ansi(result.output)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -44,7 +44,7 @@ def test_import_llm():
 
 
 def test_import_auth():
-    from carapace.auth import get_token  # noqa: F401
+    from carapace.auth import validate_bootstrap_admin_password  # noqa: F401
 
 
 def test_import_ws_models():

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import nio
 import pytest
+import yaml
 
 from carapace.bootstrap import ensure_data_dir
 from carapace.channels.matrix import (
@@ -22,7 +23,7 @@ from carapace.channels.matrix import (
 )
 from carapace.channels.matrix.subscriber import MatrixSubscriber
 from carapace.config import load_config
-from carapace.models.config import MatrixChannelConfig, MatrixTokenFile, Secret
+from carapace.models.config import MatrixChannelConfig, MatrixTokenFile, MatrixTokensFile, Secret
 from carapace.models.session import SessionBudget
 from carapace.notifications.presence import NotificationPresenceRegistry
 from carapace.sandbox.manager import SandboxManager
@@ -121,6 +122,43 @@ def test_find_session_returns_matching_session(tmp_path: Path):
     mgr = SessionManager(tmp_path)
     s = mgr.create_session("matrix", "!room:example.com")
     assert mgr.find_session("matrix", "!room:example.com") == s.session_id
+
+
+def test_matrix_session_created_with_token_owner(tmp_path: Path):
+    ch = _make_channel(tmp_path)
+    token_file = tmp_path / "matrix_token.yaml"
+    token_file.write_text(
+        yaml.safe_dump(
+            MatrixTokensFile(
+                tokens=[
+                    MatrixTokenFile(
+                        access_token="tok_good",
+                        device_id="DEV1",
+                        user_id="@carapace:example.com",
+                        user="Thies",
+                    )
+                ]
+            ).model_dump(mode="json", exclude_none=True)
+        )
+    )
+
+    token, device_id = ch._load_token(token_file)
+    session_id = ch._get_or_create_session("!room:example.com")
+
+    assert token == "tok_good"
+    assert device_id == "DEV1"
+    assert ch._session_mgr.load_meta(session_id).user == "thies"
+
+
+def test_matrix_existing_session_gets_missing_token_owner(tmp_path: Path):
+    ch = _make_channel(tmp_path)
+    existing = ch._session_mgr.create_session("matrix", "!room:example.com")
+    ch._owner_user = "thies"
+
+    session_id = ch._get_or_create_session("!room:example.com")
+
+    assert session_id == existing.session_id
+    assert ch._session_mgr.load_meta(session_id).user == "thies"
 
 
 def test_find_session_ignores_different_channel(tmp_path: Path):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -42,19 +42,22 @@ def test_config_defaults():
     assert ids == {"anthropic:claude-sonnet-4-6", "anthropic:claude-haiku-4-5"}
 
 
-def test_notification_subscription_rejects_empty_owner_key() -> None:
-    with pytest.raises(ValidationError, match="owner_key must not be empty"):
-        NotificationSubscription.model_validate(
-            {
-                "id": "sub-1",
-                "owner_key": " ",
-                "endpoint": "https://push.example.test/sub-1",
-                "p256dh": "key",
-                "auth": "auth",
-                "subscribed_at": "2026-05-12T00:00:00Z",
-                "expires_at": "2026-06-12T00:00:00Z",
-            }
-        )
+def test_notification_subscription_allows_empty_legacy_owner_key() -> None:
+    subscription = NotificationSubscription.model_validate(
+        {
+            "id": "sub-1",
+            "owner_key": " ",
+            "user": " Thies ",
+            "endpoint": "https://push.example.test/sub-1",
+            "p256dh": "key",
+            "auth": "auth",
+            "subscribed_at": "2026-05-12T00:00:00Z",
+            "expires_at": "2026-06-12T00:00:00Z",
+        }
+    )
+
+    assert subscription.owner_key == ""
+    assert subscription.user == "thies"
 
 
 def test_notifications_config_allows_missing_vapid_fields() -> None:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -217,6 +217,53 @@ async def test_notification_router_dispatch_turn_outcome_filters_by_preference_a
     sender.send_batch.assert_not_awaited()
 
 
+async def test_notification_router_skips_ownerless_session_when_owner_resolver_is_configured(tmp_path) -> None:
+    store = NotificationStore(tmp_path)
+    now = datetime.now(tz=UTC)
+    store.upsert_subscription(
+        owner_key="",
+        user="alice",
+        endpoint="https://push.example.test/alice",
+        p256dh="key-1",
+        auth="auth-1",
+        device_name="Alice Phone",
+        notification_prefs=NotificationPreferences(attended_turn_completed=True),
+        ttl=timedelta(days=30),
+        now=now,
+    )
+    store.upsert_subscription(
+        owner_key="",
+        user="bob",
+        endpoint="https://push.example.test/bob",
+        p256dh="key-2",
+        auth="auth-2",
+        device_name="Bob Laptop",
+        notification_prefs=NotificationPreferences(attended_turn_completed=True),
+        ttl=timedelta(days=30),
+        now=now,
+    )
+    sender = AsyncMock()
+    sender.send_batch = AsyncMock(return_value={})
+    router = NotificationRouter(
+        store=store,
+        presence=NotificationPresenceRegistry(ttl=timedelta(seconds=60)),
+        sender=sender,
+        owner_key="",
+        owner_for_session=lambda _session_id: None,
+    )
+
+    delivery = await router.dispatch_turn_outcome(
+        session_id="ownerless-session",
+        assistant_event_index=3,
+        kind="attended_turn_completed",
+        title="Session Update",
+        body="Assistant turn completed",
+    )
+
+    assert delivery == NotificationDeliveryResult(attempted_subscription_ids=set(), delivered_subscription_ids=set())
+    sender.send_batch.assert_not_awaited()
+
+
 async def test_notification_router_dispatch_test_targets_single_subscription(tmp_path) -> None:
     store = NotificationStore(tmp_path)
     sender = AsyncMock()

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -79,6 +79,36 @@ def test_notification_store_upsert_and_list_by_owner(tmp_path) -> None:
     assert [subscription.id for subscription in store.list_subscriptions(owner_key=owner_key)] == [created.id]
 
 
+def test_notification_store_find_by_endpoint_requires_owner_scope(tmp_path) -> None:
+    store = NotificationStore(tmp_path)
+    now = datetime(2026, 5, 12, tzinfo=UTC)
+    endpoint = "https://push.example.test/shared"
+    created = store.upsert_subscription(
+        owner_key=derive_owner_key("token-1"),
+        endpoint=endpoint,
+        p256dh="key-1",
+        auth="auth-1",
+        device_name="Desktop",
+        notification_prefs=NotificationPreferences(),
+        ttl=timedelta(days=30),
+        now=now,
+    )
+
+    assert store.find_by_endpoint(endpoint=endpoint) is None
+
+    ownerless = store.upsert_subscription(
+        endpoint=endpoint,
+        p256dh="key-2",
+        auth="auth-2",
+        device_name="Desktop 2",
+        notification_prefs=NotificationPreferences(),
+        ttl=timedelta(days=30),
+        now=now + timedelta(hours=1),
+    )
+
+    assert ownerless.id != created.id
+
+
 def test_notification_store_cleanup_expired(tmp_path) -> None:
     store = NotificationStore(tmp_path)
     now = datetime(2026, 5, 12, tzinfo=UTC)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1824,6 +1824,17 @@ def test_ws_session_not_found(client, auth_headers):
         pass
 
 
+def test_ws_ticket_allows_cookie_free_websocket(client, auth_headers):
+    ticket_resp = client.post("/api/auth/ws-ticket", headers=auth_headers)
+    assert ticket_resp.status_code == 200
+    ticket = ticket_resp.json()["ticket"]
+    create_resp = client.post("/api/sessions", headers=auth_headers, json={"channel_type": "web"})
+    sid = create_resp.json()["session_id"]
+
+    with client.websocket_connect(f"/api/chat/{sid}?ticket={ticket}") as ws:
+        _consume_status(ws)
+
+
 def _consume_status(ws):
     """Consume the initial status message sent on connect."""
     msg = ws.receive_json()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,6 +16,7 @@ from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserProm
 import carapace.sandbox.state as sandbox_state
 import carapace.server as srv
 import carapace.server.jobs as server_jobs
+from carapace.auth import AuthStore
 from carapace.bootstrap import ensure_data_dir
 from carapace.config import load_config
 from carapace.credentials import CredentialRegistry
@@ -25,7 +26,7 @@ from carapace.models.credentials import CredentialMetadata
 from carapace.models.jobs import JobDefinition
 from carapace.models.session import SessionBudget
 from carapace.notifications.presence import NotificationPresenceRegistry
-from carapace.notifications.store import NotificationStore, derive_owner_key
+from carapace.notifications.store import NotificationStore
 from carapace.notifications.vapid import derive_vapid_public_key, ensure_vapid_config
 from carapace.sandbox.manager import SandboxManager
 from carapace.sandbox.state import SessionSandboxSnapshot
@@ -41,16 +42,17 @@ _TEST_TOKEN = "test-bearer-token-for-server-tests"
 
 class _FakeSessionListCache:
     def __init__(self) -> None:
-        self._entries: dict[tuple[bool, bool], list[dict[str, object]]] = {}
+        self._entries: dict[tuple[str | None, bool, bool], list[dict[str, object]]] = {}
 
     async def get_session_infos(
         self,
         *,
+        user: str | None = None,
         include_archived: bool,
         include_message_count: bool,
         loader: Callable[[], list[dict[str, object]]],
     ) -> list[dict[str, object]]:
-        key = (include_archived, include_message_count)
+        key = (user, include_archived, include_message_count)
         cached = self._entries.get(key)
         if cached is not None:
             return cached
@@ -105,6 +107,8 @@ def _setup_server(tmp_path, monkeypatch):
     )
     srv._jobs_store = JobsStore(tmp_path)
     srv._jobs_scheduler = JobsScheduler(srv._jobs_store)
+    srv._auth_store = AuthStore(tmp_path, config.auth)
+    srv._auth_store.create_user(username="thies", password="secret", display_name="Thies")
     srv._notification_store = NotificationStore(tmp_path)
     srv._notification_presence = NotificationPresenceRegistry(
         ttl=timedelta(seconds=config.notifications.presence_ttl_seconds)
@@ -122,8 +126,10 @@ def client() -> TestClient:
 
 
 @pytest.fixture()
-def auth_headers(bearer) -> dict[str, str]:
-    return {"Authorization": f"Bearer {bearer}"}
+def auth_headers() -> dict[str, str]:
+    auth_session = srv._auth_store.create_session(username="thies")
+    token = srv._auth_store.issue_session_token(auth_session)
+    return {"Cookie": f"{srv._config.auth.cookie.name}={token}"}
 
 
 # --- Auth ---
@@ -137,6 +143,52 @@ def test_no_auth_returns_401(client):
 def test_bad_token_returns_401(client):
     resp = client.get("/api/sessions", headers={"Authorization": "Bearer wrong"})
     assert resp.status_code == 401
+
+
+def test_login_sets_session_cookie(client):
+    resp = client.post("/api/auth/login", json={"username": "thies", "password": "secret"})
+
+    assert resp.status_code == 200
+    assert resp.json()["user"]["username"] == "thies"
+    assert srv._config.auth.cookie.name in resp.cookies
+
+    meta_resp = client.get("/api/meta")
+
+    assert meta_resp.status_code == 200
+
+
+def test_logout_revokes_session_cookie(client):
+    login_resp = client.post("/api/auth/login", json={"username": "thies", "password": "secret"})
+    assert login_resp.status_code == 200
+
+    logout_resp = client.post("/api/auth/logout")
+
+    assert logout_resp.status_code == 204
+    assert srv._config.auth.cookie.name not in client.cookies
+
+    meta_resp = client.get("/api/meta")
+
+    assert meta_resp.status_code == 401
+
+
+def test_admin_user_management_uses_admin_token_only(client):
+    unauthenticated_resp = client.get("/api/admin/users")
+
+    assert unauthenticated_resp.status_code == 401
+
+    admin_headers = {"Authorization": f"Bearer {_TEST_TOKEN}"}
+    create_resp = client.post(
+        "/api/admin/users",
+        headers=admin_headers,
+        json={"username": "Ada", "password": "correct-horse-battery", "display_name": "Ada"},
+    )
+
+    assert create_resp.status_code == 201
+    assert create_resp.json()["username"] == "ada"
+
+    login_resp = client.post("/api/auth/login", json={"username": "ada", "password": "correct-horse-battery"})
+
+    assert login_resp.status_code == 200
 
 
 def test_meta_requires_auth(client):
@@ -225,8 +277,7 @@ def test_notification_preferences_patch_persists(client, auth_headers):
     assert patch_resp.status_code == 200
     assert patch_resp.json()["preferences"]["attended_turn_completed"] is False
 
-    owner_key = derive_owner_key(_TEST_TOKEN)
-    stored = srv._notification_store.list_subscriptions(owner_key=owner_key)
+    stored = srv._notification_store.list_subscriptions(user="thies")
     assert stored[0].notification_prefs.attended_turn_completed is False
 
 
@@ -281,6 +332,8 @@ def test_notification_test_endpoint_returns_502_when_delivery_fails(client, auth
 
 
 def test_notification_presence_updates_registry(client, auth_headers):
+    session_resp = client.post("/api/sessions", headers=auth_headers, json={"channel_type": "web"})
+    session_id = session_resp.json()["session_id"]
     create_resp = client.post(
         "/api/notifications/subscriptions",
         headers=auth_headers,
@@ -297,7 +350,7 @@ def test_notification_presence_updates_registry(client, auth_headers):
         f"/api/notifications/subscriptions/{subscription_id}/presence",
         headers=auth_headers,
         json={
-            "session_id": "session-1",
+            "session_id": session_id,
             "client_type": "web",
             "focus_state": "visible",
         },
@@ -305,15 +358,17 @@ def test_notification_presence_updates_registry(client, auth_headers):
 
     assert presence_resp.status_code == 200
     assert presence_resp.json() == {"heartbeat_received": True}
-    assert srv._notification_presence.is_session_actively_handled("session-1") is True
+    assert srv._notification_presence.is_session_actively_handled(session_id) is True
 
 
 def test_interactive_presence_endpoint_updates_registry(client, auth_headers):
+    session_resp = client.post("/api/sessions", headers=auth_headers, json={"channel_type": "web"})
+    session_id = session_resp.json()["session_id"]
     resp = client.post(
         "/api/notifications/presence",
         headers=auth_headers,
         json={
-            "session_id": "session-1",
+            "session_id": session_id,
             "source_id": "web-tab-1",
             "client_type": "web",
             "focus_state": "visible",
@@ -322,15 +377,17 @@ def test_interactive_presence_endpoint_updates_registry(client, auth_headers):
 
     assert resp.status_code == 200
     assert resp.json() == {"heartbeat_received": True}
-    assert srv._notification_presence.is_session_actively_handled("session-1") is True
+    assert srv._notification_presence.is_session_actively_handled(session_id) is True
 
 
 def test_interactive_presence_inactive_removes_registry_entry(client, auth_headers):
+    session_resp = client.post("/api/sessions", headers=auth_headers, json={"channel_type": "web"})
+    session_id = session_resp.json()["session_id"]
     client.post(
         "/api/notifications/presence",
         headers=auth_headers,
         json={
-            "session_id": "session-1",
+            "session_id": session_id,
             "source_id": "web-tab-1",
             "client_type": "web",
             "focus_state": "visible",
@@ -341,7 +398,7 @@ def test_interactive_presence_inactive_removes_registry_entry(client, auth_heade
         "/api/notifications/presence",
         headers=auth_headers,
         json={
-            "session_id": "session-1",
+            "session_id": session_id,
             "source_id": "web-tab-1",
             "client_type": "web",
             "focus_state": "inactive",
@@ -349,7 +406,7 @@ def test_interactive_presence_inactive_removes_registry_entry(client, auth_heade
     )
 
     assert resp.status_code == 200
-    assert srv._notification_presence.is_session_actively_handled("session-1") is False
+    assert srv._notification_presence.is_session_actively_handled(session_id) is False
 
 
 def test_interactive_presence_clears_pending_notifications(client, auth_headers):
@@ -612,7 +669,7 @@ def test_run_job_uses_existing_persistent_session(client, auth_headers, monkeypa
     submit_message = AsyncMock()
     monkeypatch.setattr(srv._engine, "submit_message", submit_message)
 
-    state = srv._engine.session_mgr.create_session(unattended=False)
+    state = srv._engine.session_mgr.create_session(user="thies", unattended=False)
     create_resp = client.post(
         "/api/jobs",
         headers=auth_headers,
@@ -671,6 +728,7 @@ async def test_run_due_jobs_once_dispatches_cron_jobs(monkeypatch) -> None:
         JobDefinition.model_validate(
             {
                 "id": "daily-briefing",
+                "user": "thies",
                 "name": "Daily Briefing",
                 "prompt": "Summarize the day.",
                 "triggers": [{"expression": "* * * * *"}],
@@ -700,6 +758,7 @@ async def test_run_due_jobs_once_uses_fired_trigger_timezone(monkeypatch) -> Non
         JobDefinition.model_validate(
             {
                 "id": "timezone-ambiguous",
+                "user": "thies",
                 "name": "Timezone Ambiguous",
                 "prompt": "Summarize the day.",
                 "triggers": [
@@ -1661,8 +1720,8 @@ def test_ws_auth_required(client):
         pass
 
 
-def test_ws_session_not_found(client, bearer):
-    with pytest.raises(Exception), client.websocket_connect(f"/api/chat/doesnotexist?token={bearer}"):  # noqa: B017
+def test_ws_session_not_found(client, auth_headers):
+    with pytest.raises(Exception), client.websocket_connect("/api/chat/doesnotexist", headers=auth_headers):  # noqa: B017
         pass
 
 
@@ -1673,11 +1732,11 @@ def _consume_status(ws):
     return msg
 
 
-def test_ws_help_command(client, auth_headers, bearer):
+def test_ws_help_command(client, auth_headers):
     create_resp = client.post("/api/sessions", headers=auth_headers, json={"channel_type": "web"})
     sid = create_resp.json()["session_id"]
 
-    with client.websocket_connect(f"/api/chat/{sid}?token={bearer}") as ws:
+    with client.websocket_connect(f"/api/chat/{sid}", headers=auth_headers) as ws:
         _consume_status(ws)
         ws.send_json({"type": "message", "content": "/help"})
         echo = ws.receive_json()
@@ -1695,22 +1754,22 @@ def test_ws_help_command(client, auth_headers, bearer):
         assert "/memory" not in commands
 
 
-def test_ws_connection_updates_presence_registry(client, auth_headers, bearer):
+def test_ws_connection_updates_presence_registry(client, auth_headers):
     create_resp = client.post("/api/sessions", headers=auth_headers, json={"channel_type": "web"})
     sid = create_resp.json()["session_id"]
 
-    with client.websocket_connect(f"/api/chat/{sid}?token={bearer}&client_id=web-tab-1") as ws:
+    with client.websocket_connect(f"/api/chat/{sid}?client_id=web-tab-1", headers=auth_headers) as ws:
         _consume_status(ws)
         assert srv._notification_presence.is_session_actively_handled(sid) is True
 
     assert srv._notification_presence.is_session_actively_handled(sid) is False
 
 
-def test_ws_blank_client_id_falls_back_to_generated_source_id(client, auth_headers, bearer):
+def test_ws_blank_client_id_falls_back_to_generated_source_id(client, auth_headers):
     create_resp = client.post("/api/sessions", headers=auth_headers, json={"channel_type": "web"})
     sid = create_resp.json()["session_id"]
 
-    with client.websocket_connect(f"/api/chat/{sid}?token={bearer}&client_id=%20%20%20") as ws:
+    with client.websocket_connect(f"/api/chat/{sid}?client_id=%20%20%20", headers=auth_headers) as ws:
         _consume_status(ws)
         entries = srv._notification_presence.list_presence(session_id=sid)
         assert len(entries) == 1
@@ -1732,11 +1791,11 @@ def test_list_commands_excludes_removed_commands(client, auth_headers):
     assert "/memory" not in commands
 
 
-def test_ws_session_command_for_web(client, auth_headers, bearer):
+def test_ws_session_command_for_web(client, auth_headers):
     create_resp = client.post("/api/sessions", headers=auth_headers, json={"channel_type": "web"})
     sid = create_resp.json()["session_id"]
 
-    with client.websocket_connect(f"/api/chat/{sid}?token={bearer}") as ws:
+    with client.websocket_connect(f"/api/chat/{sid}", headers=auth_headers) as ws:
         _consume_status(ws)
         ws.send_json({"type": "message", "content": "/session"})
         echo = ws.receive_json()
@@ -1748,7 +1807,7 @@ def test_ws_session_command_for_web(client, auth_headers, bearer):
         assert msg["data"]["channel_type"] == "web"
 
 
-def test_ws_reset_to_turn_emits_ack(client, auth_headers, bearer):
+def test_ws_reset_to_turn_emits_ack(client, auth_headers):
     create_resp = client.post("/api/sessions", headers=auth_headers)
     sid = create_resp.json()["session_id"]
     srv._engine.session_mgr.save_events(
@@ -1770,7 +1829,7 @@ def test_ws_reset_to_turn_emits_ack(client, auth_headers, bearer):
         ],
     )
 
-    with client.websocket_connect(f"/api/chat/{sid}?token={bearer}") as ws:
+    with client.websocket_connect(f"/api/chat/{sid}", headers=auth_headers) as ws:
         _consume_status(ws)
         ws.send_json({"type": "reset_to_turn", "event_index": 1})
         msg = ws.receive_json()
@@ -1784,18 +1843,18 @@ def test_ws_reset_to_turn_emits_ack(client, auth_headers, bearer):
     ]
 
 
-def test_ws_status_includes_budget_gauges_for_configured_defaults(client, auth_headers, bearer):
+def test_ws_status_includes_budget_gauges_for_configured_defaults(client, auth_headers):
     srv._engine.config.agent.default_session_budget = SessionBudget(input_tokens=1_000)
     create_resp = client.post("/api/sessions", headers=auth_headers)
     sid = create_resp.json()["session_id"]
 
-    with client.websocket_connect(f"/api/chat/{sid}?token={bearer}") as ws:
+    with client.websocket_connect(f"/api/chat/{sid}", headers=auth_headers) as ws:
         status = _consume_status(ws)
         assert status["usage"]["budget_gauges"][0]["key"] == "input"
         assert status["usage"]["budget_gauges"][0]["current_value"] == "0 tokens"
 
 
-def test_ws_status_includes_live_llm_activity_when_running(client, auth_headers, bearer):
+def test_ws_status_includes_live_llm_activity_when_running(client, auth_headers):
     create_resp = client.post("/api/sessions", headers=auth_headers)
     sid = create_resp.json()["session_id"]
     active = srv._engine.get_or_activate(sid)
@@ -1809,7 +1868,7 @@ def test_ws_status_includes_live_llm_activity_when_running(client, auth_headers,
     active.agent_task = MagicMock()
     active.agent_task.done.return_value = False
 
-    with client.websocket_connect(f"/api/chat/{sid}?token={bearer}") as ws:
+    with client.websocket_connect(f"/api/chat/{sid}", headers=auth_headers) as ws:
         status = _consume_status(ws)
         assert status["llm_activity"]["request_id"] == "req-1"
         assert status["llm_activity"]["phase"] == "thinking"
@@ -1860,11 +1919,11 @@ def test_history_includes_assistant_final_status(client, auth_headers):
     assert history[1]["final_status"] == "success"
 
 
-def test_ws_budget_command_emits_status_refresh(client, auth_headers, bearer):
+def test_ws_budget_command_emits_status_refresh(client, auth_headers):
     create_resp = client.post("/api/sessions", headers=auth_headers)
     sid = create_resp.json()["session_id"]
 
-    with client.websocket_connect(f"/api/chat/{sid}?token={bearer}") as ws:
+    with client.websocket_connect(f"/api/chat/{sid}", headers=auth_headers) as ws:
         _consume_status(ws)
         ws.send_json({"type": "message", "content": "/budget input 1000"})
         echo = ws.receive_json()
@@ -1877,11 +1936,11 @@ def test_ws_budget_command_emits_status_refresh(client, auth_headers, bearer):
         assert status["usage"]["budget_gauges"][0]["key"] == "input"
 
 
-def test_ws_skills_command(client, auth_headers, bearer):
+def test_ws_skills_command(client, auth_headers):
     create_resp = client.post("/api/sessions", headers=auth_headers)
     sid = create_resp.json()["session_id"]
 
-    with client.websocket_connect(f"/api/chat/{sid}?token={bearer}") as ws:
+    with client.websocket_connect(f"/api/chat/{sid}", headers=auth_headers) as ws:
         _consume_status(ws)
         ws.send_json({"type": "message", "content": "/skills"})
         echo = ws.receive_json()
@@ -1891,7 +1950,7 @@ def test_ws_skills_command(client, auth_headers, bearer):
         assert msg["command"] == "skills"
 
 
-def test_ws_unknown_command_is_agent_message(client, auth_headers, bearer, monkeypatch):
+def test_ws_unknown_command_is_agent_message(client, auth_headers, monkeypatch):
     create_resp = client.post("/api/sessions", headers=auth_headers)
     sid = create_resp.json()["session_id"]
 
@@ -1917,7 +1976,7 @@ def test_ws_unknown_command_is_agent_message(client, auth_headers, bearer, monke
     monkeypatch.setattr(srv._engine, "_generate_title", AsyncMock(return_value="title"))
     monkeypatch.setattr("carapace.session.engine.run_agent_turn", _fake_run_turn)
 
-    with client.websocket_connect(f"/api/chat/{sid}?token={bearer}") as ws:
+    with client.websocket_connect(f"/api/chat/{sid}", headers=auth_headers) as ws:
         _consume_status(ws)
         ws.send_json({"type": "message", "content": "/tmp"})
         msg = ws.receive_json()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -191,6 +191,26 @@ def test_admin_user_management_uses_admin_token_only(client):
     assert login_resp.status_code == 200
 
 
+def test_admin_user_update_can_clear_email(client):
+    admin_headers = {"Authorization": f"Bearer {_TEST_TOKEN}"}
+    create_resp = client.post(
+        "/api/admin/users",
+        headers=admin_headers,
+        json={
+            "username": "Ada",
+            "password": "correct-horse-battery",
+            "display_name": "Ada",
+            "email": "ada@example.test",
+        },
+    )
+    assert create_resp.status_code == 201
+
+    update_resp = client.patch("/api/admin/users/ada", headers=admin_headers, json={"email": None})
+
+    assert update_resp.status_code == 200
+    assert update_resp.json()["email"] is None
+
+
 def test_admin_user_management_returns_503_when_admin_token_is_unset(client, monkeypatch):
     monkeypatch.delenv("CARAPACE_TOKEN", raising=False)
 
@@ -773,6 +793,30 @@ async def test_run_due_jobs_once_dispatches_cron_jobs(monkeypatch) -> None:
     assert session_id
     assert "triggered automatically" in message
     assert "* * * * *" in message
+
+
+@pytest.mark.asyncio
+async def test_run_due_jobs_once_skips_ownerless_cron_jobs(monkeypatch) -> None:
+    submit_message = AsyncMock()
+    monkeypatch.setattr(srv._engine, "submit_message", submit_message)
+
+    srv._jobs_store.create_job(
+        JobDefinition.model_validate(
+            {
+                "id": "legacy-ownerless",
+                "name": "Legacy Ownerless",
+                "prompt": "Summarize the day.",
+                "triggers": [{"expression": "* * * * *"}],
+            }
+        )
+    )
+    start = datetime(2026, 5, 9, 10, 0, tzinfo=UTC)
+    assert srv._jobs_scheduler.collect_due_runs(now=start) == []
+
+    dispatched = await server_jobs._run_due_jobs_once(now=start + timedelta(minutes=1, seconds=5))
+
+    assert dispatched == 1
+    submit_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -191,6 +191,15 @@ def test_admin_user_management_uses_admin_token_only(client):
     assert login_resp.status_code == 200
 
 
+def test_admin_user_management_returns_503_when_admin_token_is_unset(client, monkeypatch):
+    monkeypatch.delenv("CARAPACE_TOKEN", raising=False)
+
+    resp = client.get("/api/admin/users", headers={"Authorization": "Bearer anything"})
+
+    assert resp.status_code == 503
+    assert resp.json() == {"detail": "Admin token is not configured"}
+
+
 def test_meta_requires_auth(client):
     resp = client.get("/api/meta")
     assert resp.status_code in (401, 403)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -228,6 +228,28 @@ def test_admin_user_update_cannot_remove_last_enabled_admin(client, admin_auth_h
     assert demote_resp.json() == {"detail": "Cannot remove the last enabled admin"}
 
 
+def test_admin_user_delete_removes_other_user_and_revokes_sessions(client, admin_auth_headers):
+    user_session = srv._auth_store.create_session(username="thies")
+    user_token = srv._auth_store.issue_session_token(user_session)
+
+    delete_resp = client.delete("/api/admin/users/thies", headers=admin_auth_headers)
+
+    assert delete_resp.status_code == 204
+    assert srv._auth_store.get_user("thies") is None
+    assert srv._auth_store.validate_session_token(user_token) is None
+
+    login_resp = client.post("/api/auth/login", json={"username": "thies", "password": "secret"})
+    assert login_resp.status_code == 401
+
+
+def test_admin_user_delete_cannot_delete_current_user(client, admin_auth_headers):
+    delete_resp = client.delete("/api/admin/users/admin", headers=admin_auth_headers)
+
+    assert delete_resp.status_code == 400
+    assert delete_resp.json() == {"detail": "Cannot delete your own user"}
+    assert srv._auth_store.get_user("admin") is not None
+
+
 def test_admin_user_upgrade_data_uses_selected_user(client, admin_auth_headers):
     state = srv._engine.session_mgr.create_session()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -200,6 +200,23 @@ def test_admin_user_management_returns_503_when_admin_token_is_unset(client, mon
     assert resp.json() == {"detail": "Admin token is not configured"}
 
 
+def test_admin_user_upgrade_data_uses_selected_user(client, bearer):
+    state = srv._engine.session_mgr.create_session()
+    headers = {"Authorization": f"Bearer {bearer}"}
+
+    resp = client.post("/api/admin/users/thies/upgrade-data", headers=headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["username"] == "thies"
+    assert srv._engine.session_mgr.load_meta(state.session_id).user == "thies"
+
+
+def test_admin_user_upgrade_data_requires_existing_user(client, bearer):
+    resp = client.post("/api/admin/users/missing/upgrade-data", headers={"Authorization": f"Bearer {bearer}"})
+
+    assert resp.status_code == 404
+
+
 def test_meta_requires_auth(client):
     resp = client.get("/api/meta")
     assert resp.status_code in (401, 403)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -108,16 +108,12 @@ def _setup_server(tmp_path, monkeypatch):
     srv._jobs_store = JobsStore(tmp_path)
     srv._jobs_scheduler = JobsScheduler(srv._jobs_store)
     srv._auth_store = AuthStore(tmp_path, config.auth)
+    srv._auth_store.create_user(username="admin", password="admin-secret", display_name="Admin", roles=["admin"])
     srv._auth_store.create_user(username="thies", password="secret", display_name="Thies")
     srv._notification_store = NotificationStore(tmp_path)
     srv._notification_presence = NotificationPresenceRegistry(
         ttl=timedelta(seconds=config.notifications.presence_ttl_seconds)
     )
-
-
-@pytest.fixture()
-def bearer() -> str:
-    return _TEST_TOKEN
 
 
 @pytest.fixture()
@@ -128,6 +124,13 @@ def client() -> TestClient:
 @pytest.fixture()
 def auth_headers() -> dict[str, str]:
     auth_session = srv._auth_store.create_session(username="thies")
+    token = srv._auth_store.issue_session_token(auth_session)
+    return {"Cookie": f"{srv._config.auth.cookie.name}={token}"}
+
+
+@pytest.fixture()
+def admin_auth_headers() -> dict[str, str]:
+    auth_session = srv._auth_store.create_session(username="admin")
     token = srv._auth_store.issue_session_token(auth_session)
     return {"Cookie": f"{srv._config.auth.cookie.name}={token}"}
 
@@ -150,6 +153,7 @@ def test_login_sets_session_cookie(client):
 
     assert resp.status_code == 200
     assert resp.json()["user"]["username"] == "thies"
+    assert resp.json()["user"]["roles"] == []
     assert srv._config.auth.cookie.name in resp.cookies
 
     meta_resp = client.get("/api/meta")
@@ -171,15 +175,19 @@ def test_logout_revokes_session_cookie(client):
     assert meta_resp.status_code == 401
 
 
-def test_admin_user_management_uses_admin_token_only(client):
+def test_admin_user_management_requires_admin_role(client, auth_headers, admin_auth_headers):
     unauthenticated_resp = client.get("/api/admin/users")
-
     assert unauthenticated_resp.status_code == 401
 
-    admin_headers = {"Authorization": f"Bearer {_TEST_TOKEN}"}
+    non_admin_resp = client.get("/api/admin/users", headers=auth_headers)
+    assert non_admin_resp.status_code == 403
+
+    token_resp = client.get("/api/admin/users", headers={"Authorization": f"Bearer {_TEST_TOKEN}"})
+    assert token_resp.status_code == 401
+
     create_resp = client.post(
         "/api/admin/users",
-        headers=admin_headers,
+        headers=admin_auth_headers,
         json={"username": "Ada", "password": "correct-horse-battery", "display_name": "Ada"},
     )
 
@@ -191,11 +199,10 @@ def test_admin_user_management_uses_admin_token_only(client):
     assert login_resp.status_code == 200
 
 
-def test_admin_user_update_can_clear_email(client):
-    admin_headers = {"Authorization": f"Bearer {_TEST_TOKEN}"}
+def test_admin_user_update_can_clear_email(client, admin_auth_headers):
     create_resp = client.post(
         "/api/admin/users",
-        headers=admin_headers,
+        headers=admin_auth_headers,
         json={
             "username": "Ada",
             "password": "correct-horse-battery",
@@ -205,34 +212,34 @@ def test_admin_user_update_can_clear_email(client):
     )
     assert create_resp.status_code == 201
 
-    update_resp = client.patch("/api/admin/users/ada", headers=admin_headers, json={"email": None})
+    update_resp = client.patch("/api/admin/users/ada", headers=admin_auth_headers, json={"email": None})
 
     assert update_resp.status_code == 200
     assert update_resp.json()["email"] is None
 
 
-def test_admin_user_management_returns_503_when_admin_token_is_unset(client, monkeypatch):
-    monkeypatch.delenv("CARAPACE_TOKEN", raising=False)
+def test_admin_user_update_cannot_remove_last_enabled_admin(client, admin_auth_headers):
+    disable_resp = client.patch("/api/admin/users/admin", headers=admin_auth_headers, json={"enabled": False})
+    demote_resp = client.patch("/api/admin/users/admin", headers=admin_auth_headers, json={"roles": []})
 
-    resp = client.get("/api/admin/users", headers={"Authorization": "Bearer anything"})
+    assert disable_resp.status_code == 400
+    assert disable_resp.json() == {"detail": "Cannot remove the last enabled admin"}
+    assert demote_resp.status_code == 400
+    assert demote_resp.json() == {"detail": "Cannot remove the last enabled admin"}
 
-    assert resp.status_code == 503
-    assert resp.json() == {"detail": "Admin token is not configured"}
 
-
-def test_admin_user_upgrade_data_uses_selected_user(client, bearer):
+def test_admin_user_upgrade_data_uses_selected_user(client, admin_auth_headers):
     state = srv._engine.session_mgr.create_session()
-    headers = {"Authorization": f"Bearer {bearer}"}
 
-    resp = client.post("/api/admin/users/thies/upgrade-data", headers=headers)
+    resp = client.post("/api/admin/users/thies/upgrade-data", headers=admin_auth_headers)
 
     assert resp.status_code == 200
     assert resp.json()["username"] == "thies"
     assert srv._engine.session_mgr.load_meta(state.session_id).user == "thies"
 
 
-def test_admin_user_upgrade_data_requires_existing_user(client, bearer):
-    resp = client.post("/api/admin/users/missing/upgrade-data", headers={"Authorization": f"Bearer {bearer}"})
+def test_admin_user_upgrade_data_requires_existing_user(client, admin_auth_headers):
+    resp = client.post("/api/admin/users/missing/upgrade-data", headers=admin_auth_headers)
 
     assert resp.status_code == 404
 

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -107,6 +107,16 @@ def test_list_sessions(tmp_path: Path):
     assert s2.session_id in sessions
 
 
+def test_list_sessions_filters_by_owner(tmp_path: Path) -> None:
+    mgr = SessionManager(tmp_path)
+    alice = mgr.create_session(user="alice")
+    bob = mgr.create_session(user="bob")
+    mgr.create_session()
+
+    assert mgr.list_sessions(user="alice") == [alice.session_id]
+    assert mgr.list_sessions(user="bob") == [bob.session_id]
+
+
 def test_save_and_resume_state(tmp_path: Path):
     mgr = SessionManager(tmp_path)
     state = mgr.create_session()

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,0 +1,70 @@
+"""Data upgrade tests (no LLM tokens needed)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from carapace.upgrade import upgrade_data_dir
+
+
+def _read_yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def test_upgrade_data_dir_adds_user_ownership_and_moves_knowledge(tmp_path: Path) -> None:
+    session_dir = tmp_path / "sessions" / "session-1"
+    session_dir.mkdir(parents=True)
+    (tmp_path / "knowledge").mkdir()
+    (tmp_path / "knowledge" / "SECURITY.md").write_text("Do no harm.\n", encoding="utf-8")
+    (tmp_path / "jobs.yaml").write_text(
+        yaml.safe_dump({"jobs": [{"id": "daily", "prompt": "Brief me"}]}),
+        encoding="utf-8",
+    )
+    subscriptions_dir = tmp_path / "notifications" / "subscriptions"
+    subscriptions_dir.mkdir(parents=True)
+    (subscriptions_dir / "sub-1.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "id": "sub-1",
+                "owner_key": "",
+                "endpoint": "https://push.example.test/sub-1",
+                "p256dh": "key",
+                "auth": "auth",
+                "subscribed_at": "2026-05-12T00:00:00Z",
+                "expires_at": "2026-06-12T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "matrix_token.json").write_text(
+        json.dumps({"access_token": "matrix-token", "device_id": "DEVICE"}),
+        encoding="utf-8",
+    )
+    (tmp_path / "sandbox_tokens.json").write_text(
+        json.dumps({"session-1": "sandbox-token"}),
+        encoding="utf-8",
+    )
+
+    summary = upgrade_data_dir(tmp_path, " Thies ")
+
+    assert "sessions" in summary
+    assert _read_yaml(session_dir / "meta.yaml") == {"user": "thies"}
+    assert _read_yaml(tmp_path / "jobs.yaml")["jobs"][0]["user"] == "thies"
+    assert _read_yaml(subscriptions_dir / "sub-1.yaml")["user"] == "thies"
+    assert (tmp_path / "knowledges" / "thies" / "SECURITY.md").read_text(encoding="utf-8") == "Do no harm.\n"
+    assert not (tmp_path / "knowledge").exists()
+
+    matrix_tokens = _read_yaml(tmp_path / "matrix_token.yaml")["tokens"]
+    assert matrix_tokens == [{"access_token": "matrix-token", "device_id": "DEVICE", "user": "thies"}]
+    assert (tmp_path / "matrix_token.json.bak").exists()
+
+    sandbox_tokens = _read_yaml(tmp_path / "sandbox_tokens.yaml")["tokens"]
+    assert sandbox_tokens["session-1"] == {"token": "sandbox-token", "user": "thies"}
+    assert (tmp_path / "sandbox_tokens.json.bak").exists()
+
+    users = _read_yaml(tmp_path / "auth" / "users.yaml")["users"]
+    assert users["thies"]["enabled"] is False
+    assert users["thies"]["config"]["default_models"]["agent"] == "anthropic:claude-sonnet-4-6"

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "ag-ui-protocol"
@@ -215,6 +219,49 @@ wheels = [
 ]
 
 [[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -312,11 +359,13 @@ dependencies = [
     { name = "docker" },
     { name = "fastapi" },
     { name = "genai-prices" },
+    { name = "joserfc" },
     { name = "kr8s" },
     { name = "logfire", extra = ["httpx"] },
     { name = "loguru" },
     { name = "markdown" },
     { name = "matrix-nio" },
+    { name = "pwdlib", extra = ["argon2"] },
     { name = "pydantic-ai" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -347,11 +396,13 @@ requires-dist = [
     { name = "docker", specifier = ">=7,<8" },
     { name = "fastapi", specifier = ">=0.115,<1" },
     { name = "genai-prices", specifier = ">=0.0.53" },
+    { name = "joserfc", specifier = ">=1.6.5" },
     { name = "kr8s", specifier = ">=0.20,<1" },
     { name = "logfire", extras = ["httpx"], specifier = ">=4,<5" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "markdown", specifier = ">=3,<4" },
     { name = "matrix-nio", specifier = ">=0.25,<1" },
+    { name = "pwdlib", extras = ["argon2"], specifier = ">=0.3.0" },
     { name = "pydantic-ai", specifier = ">=1.59,<2" },
     { name = "pydantic-settings", specifier = ">=2,<3" },
     { name = "python-dotenv", specifier = ">=1.2,<2" },
@@ -2081,6 +2132,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
     { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
     { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
+name = "pwdlib"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/41/a7c0d8a003c36ce3828ae3ed0391fe6a15aad65f082dbd6bec817ea95c0b/pwdlib-0.3.0.tar.gz", hash = "sha256:6ca30f9642a1467d4f5d0a4d18619de1c77f17dfccb42dd200b144127d3c83fc", size = 215810, upload-time = "2025-10-25T12:44:24.395Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/0c/9086a357d02a050fbb3270bf5043ac284dbfb845670e16c9389a41defc9e/pwdlib-0.3.0-py3-none-any.whl", hash = "sha256:f86c15c138858c09f3bba0a10984d4f9178158c55deaa72eac0210849b1a140d", size = 8633, upload-time = "2025-10-25T12:44:23.406Z" },
+]
+
+[package.optional-dependencies]
+argon2 = [
+    { name = "argon2-cffi" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds file-backed multi-user authentication and replaces normal API bearer auth with HttpOnly session cookies.

Summary:
- add users.yaml-backed users, password hashing, JWT cookie sessions, logout/revocation, and admin-only user management via CARAPACE_TOKEN
- scope sessions, jobs, notifications, history, sandbox controls, and WebSocket access by authenticated user
- update CLI and frontend login/transport to use username/password login with cookies
- add upgrade-data support for session metadata, per-user knowledge directories, jobs, notifications, Matrix tokens, sandbox tokens, and users.yaml
- update docs for the new auth model and admin-token semantics

Verification:
- uvx ruff check src/ tests/
- uv run pyrefly check
- uv run pytest -q -> 701 passed, 3 warnings
- cd frontend && pnpm test -> 39 passed
- cd frontend && pnpm lint
- cd frontend && pnpm build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Overhauls authentication, session invalidation, and per-user authorization across REST, WebSocket, jobs, and notifications—security-critical with migration steps for existing data.
> 
> **Overview**
> Replaces shared **bearer token** API auth with **file-backed users**, **Argon2** password hashes, and **HttpOnly `carapace_session` cookies** (signed JWTs backed by server-side session records). **`CARAPACE_TOKEN`** is now only the bootstrap password for the initial **`admin`** user when no enabled admin exists.
> 
> **Server & data:** Login/logout, `/api/auth/me`, short-lived **WebSocket tickets**, and **admin user CRUD** plus per-user **`upgrade-data`**. Sessions, jobs, notifications, session-list cache keys, and Matrix token persistence are scoped by **username**; legacy unowned records are hidden until upgraded.
> 
> **Clients:** CLI and frontend use **username/password** with **`credentials: include`**; the UI adds an **Admin → Users** panel and account menu logout. WebSockets authenticate via cookie-derived tickets instead of `?token=`.
> 
> **Docs/ops:** Quickstart, auth guide, and Helm/K8s examples describe the new model; **`uv run carapace upgrade-data`** migrates single-user installs (ownership metadata, `knowledges/<user>`, YAML token files).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9841ca77fcf14461500fb599bea8c73eb2c5e13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->