### PR TITLE
✨ Use same-origin backend for frontend

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -21,6 +21,8 @@ pnpm dev
 
 Open [http://localhost:3000](http://localhost:3000).
 
+The frontend calls the backend on the same origin. During `pnpm dev`, Next.js proxies `/api/*` to `CARAPACE_BACKEND_URL`, defaulting to `http://127.0.0.1:8321`, so start the carapace backend separately before signing in.
+
 ### Emoji Rendering
 
 The frontend bundles Twemoji SVG assets locally at build time and replaces emoji in rendered assistant markdown and session titles.

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -25,7 +25,7 @@
         }
     },
     "connect": {
-        "description": "Mit deinem Server verbinden",
+        "description": "Bei carapace anmelden",
         "serverLabel": "Server-URL",
         "usernameLabel": "Benutzername",
         "usernamePlaceholder": "thies",
@@ -89,7 +89,7 @@
             "upgraded": "Daten für {username} aktualisiert: {count} Änderungen."
         },
         "errors": {
-            "missingCredentials": "Server-URL ist erforderlich.",
+            "missingCredentials": "Aktueller Ursprung ist nicht verfügbar.",
             "load": "Benutzer konnten nicht geladen werden.",
             "create": "Benutzer konnte nicht angelegt werden.",
             "save": "Benutzer konnte nicht gespeichert werden.",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -25,7 +25,7 @@
         }
     },
     "connect": {
-        "description": "Connect to your server",
+        "description": "Sign in to carapace",
         "serverLabel": "Server URL",
         "usernameLabel": "Username",
         "usernamePlaceholder": "thies",
@@ -89,7 +89,7 @@
             "upgraded": "Upgraded data for {username}: {count} changes."
         },
         "errors": {
-            "missingCredentials": "Server URL is required.",
+            "missingCredentials": "Current origin is unavailable.",
             "load": "Failed to load users.",
             "create": "Failed to create user.",
             "save": "Failed to save user.",

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -25,4 +25,14 @@ const nextConfig: NextConfig = {
   images: { unoptimized: true },
 };
 
+if (process.env.NODE_ENV === "development") {
+  const backendUrl = (process.env.CARAPACE_BACKEND_URL?.trim() || "http://127.0.0.1:8321").replace(/\/$/, "");
+  nextConfig.rewrites = async () => [
+    {
+      source: "/api/:path*",
+      destination: `${backendUrl}/api/:path*`,
+    },
+  ];
+}
+
 export default nextConfig;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -416,7 +416,8 @@ function HomeContent() {
     };
   }, [activeSessionId, connected, hasActiveSessionLoaded, server, sessionListInitialized, token]);
 
-  function handleConnect(srv: string, user: AuthUserInfo) {
+  function handleConnect(user: AuthUserInfo) {
+    const srv = getServer();
     refreshRequestIdRef.current += 1;
     loadingMoreSessionsRef.current = false;
     failedLoadMoreCursorRef.current = null;
@@ -427,7 +428,7 @@ function HomeContent() {
     setSessions([]);
     setSessionListCursor(null);
     setSessionListHasMore(false);
-    saveConnection(srv, user.username);
+    saveConnection(user.username);
     setCurrentUser(user);
     setConnection({ connected: true, server: srv, token: user.username });
   }

--- a/frontend/src/components/admin-users-page.tsx
+++ b/frontend/src/components/admin-users-page.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 
 import { createAdminUser, deleteAdminUser, getCurrentUser, listAdminUsers, updateAdminUser, upgradeAdminUserData, type AdminUserInfo } from "@/lib/api";
-import { defaultServer, normalizeServer } from "@/lib/server-url";
+import { normalizeServer } from "@/lib/server-url";
 import { getServer } from "@/lib/storage";
 import { cn } from "@/lib/utils";
 
@@ -81,12 +81,7 @@ interface AdminUsersPageProps {
 
 export function AdminUsersPage({ embedded = false, server: serverProp, currentUsername = null }: AdminUsersPageProps = {}) {
   const t = useTranslations("admin");
-  const [server, setServer] = useState(() => {
-    if (serverProp !== undefined) return normalizeServer(serverProp);
-    if (typeof window === "undefined") return defaultServer();
-    const params = new URLSearchParams(window.location.search);
-    return normalizeServer(params.get("server") ?? getServer() ?? defaultServer());
-  });
+  const [server, setServer] = useState(() => normalizeServer(serverProp ?? ""));
   const [users, setUsers] = useState<AdminUserInfo[]>([]);
   const [selectedUsername, setSelectedUsername] = useState<string | "new">("new");
   const [editDraft, setEditDraft] = useState<UserDraft | null>(null);
@@ -106,6 +101,17 @@ export function AdminUsersPage({ embedded = false, server: serverProp, currentUs
     [selectedUsername, users],
   );
 
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      const nextServer = normalizeServer(serverProp ?? getServer());
+      setServer((current) => current === nextServer ? current : nextServer);
+    }, 0);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [serverProp]);
+
   const refreshUsers = useCallback(async (preferredUsername: string | "new" = selectedUsername, message?: string): Promise<void> => {
     const normalizedServer = normalizeServer(server);
     if (!normalizedServer) {
@@ -121,7 +127,6 @@ export function AdminUsersPage({ embedded = false, server: serverProp, currentUs
         listAdminUsers(normalizedServer),
         currentUsername === null ? getCurrentUser(normalizedServer).catch(() => null) : Promise.resolve(null),
       ]);
-      setServer(normalizedServer);
       setUsers(loadedUsers);
       setResolvedCurrentUsername(currentUsername ?? loadedCurrentUser?.username ?? null);
       if (preferredUsername === "new") {
@@ -281,32 +286,15 @@ export function AdminUsersPage({ embedded = false, server: serverProp, currentUs
                 <h1 className="mt-1 text-2xl font-semibold tracking-tight md:mt-0">{t("users.title")}</h1>
                 <p className="mt-1 max-w-2xl text-sm text-muted-foreground">{t("users.description")}</p>
               </div>
-              <form
-                onSubmit={(event) => {
-                  event.preventDefault();
-                  void refreshUsers();
-                }}
-                className="grid gap-2 sm:grid-cols-[minmax(13rem,1fr)_auto] lg:w-[28rem]"
+              <button
+                type="button"
+                onClick={() => void refreshUsers()}
+                disabled={loading || !server.trim()}
+                className="inline-flex min-h-10 items-center justify-center gap-2 self-end rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-50"
               >
-                <label className="space-y-1">
-                  <span className="text-xs font-medium text-muted-foreground">{t("serverLabel")}</span>
-                  <input
-                    type="url"
-                    value={server}
-                    onChange={(event) => setServer(event.target.value)}
-                    placeholder="http://127.0.0.1:8321"
-                    className={inputClassName}
-                  />
-                </label>
-                <button
-                  type="submit"
-                  disabled={loading || !server.trim()}
-                  className="inline-flex min-h-10 items-center justify-center gap-2 self-end rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
-                  {loading ? t("actions.loading") : t("actions.load")}
-                </button>
-              </form>
+                {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                {loading ? t("actions.loading") : t("actions.load")}
+              </button>
             </div>
             {(error || notice) && (
               <div className={cn("mt-3 text-sm", error ? "text-destructive" : "text-muted-foreground")}>
@@ -614,7 +602,6 @@ export function AdminUsersPage({ embedded = false, server: serverProp, currentUs
             <ShieldCheck className="h-4 w-4 text-muted-foreground" />
             {t("title")}
           </div>
-          <div className="mt-1 truncate text-xs text-muted-foreground">{server || t("serverPlaceholder")}</div>
         </div>
         <nav className="flex-1 p-3">
           <button

--- a/frontend/src/components/connect-form.tsx
+++ b/frontend/src/components/connect-form.tsx
@@ -3,17 +3,15 @@
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { login, type AuthUserInfo } from "@/lib/api";
-import { defaultServer, normalizeServer } from "@/lib/server-url";
 import { getServer, getToken } from "@/lib/storage";
 import { cn } from "@/lib/utils";
 
 interface ConnectFormProps {
-  onConnect: (server: string, user: AuthUserInfo) => void;
+  onConnect: (user: AuthUserInfo) => void;
 }
 
 export function ConnectForm({ onConnect }: ConnectFormProps) {
   const t = useTranslations("connect");
-  const [server, setServer] = useState(() => getServer() || defaultServer());
   const [username, setUsername] = useState(getToken);
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -25,9 +23,8 @@ export function ConnectForm({ onConnect }: ConnectFormProps) {
     setLoading(true);
 
     try {
-      const normalizedServer = normalizeServer(server);
-      const user = await login(normalizedServer, username, password);
-      onConnect(normalizedServer, user);
+      const user = await login(getServer(), username, password);
+      onConnect(user);
     } catch (err) {
       setError(err instanceof Error ? err.message : t("errors.connectionFailed"));
     } finally {
@@ -46,29 +43,6 @@ export function ConnectForm({ onConnect }: ConnectFormProps) {
         </div>
 
         <div className="space-y-3">
-          <div className="space-y-1.5">
-            <label
-              htmlFor="server"
-              className="text-xs font-medium text-muted-foreground"
-            >
-              {t("serverLabel")}
-            </label>
-            <input
-              id="server"
-              type="url"
-              value={server}
-              onChange={(e) => setServer(e.target.value)}
-              placeholder="http://127.0.0.1:8321"
-              required
-              className={cn(
-                "w-full rounded-lg border border-border bg-background px-3 py-2.5 text-base sm:text-sm",
-                "outline-none transition-colors",
-                "focus:ring-2 focus:ring-ring/30 focus:border-ring",
-                "placeholder:text-muted-foreground/50",
-              )}
-            />
-          </div>
-
           <div className="space-y-1.5">
             <label
               htmlFor="username"

--- a/frontend/src/lib/server-url.ts
+++ b/frontend/src/lib/server-url.ts
@@ -1,10 +1,6 @@
 export function defaultServer(): string {
-  if (typeof window === "undefined") return "http://127.0.0.1:8321";
-  const url = new URL(window.location.origin);
-  if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
-    return `${url.protocol}//${url.hostname}:8321`;
-  }
-  return window.location.origin;
+  if (typeof window === "undefined") return "";
+  return normalizeServer(window.location.origin);
 }
 
 export function normalizeServer(server: string): string {

--- a/frontend/src/lib/storage.test.ts
+++ b/frontend/src/lib/storage.test.ts
@@ -64,6 +64,7 @@ test.beforeEach(() => {
   setWindow({
     localStorage,
     sessionStorage,
+    location: { origin: "https://carapace.example.test" },
   });
   Object.defineProperty(globalThis, "localStorage", {
     configurable: true,
@@ -114,18 +115,25 @@ test.afterEach(() => {
   }
 });
 
-test("connection helpers persist and clear server credentials", () => {
-  assert.equal(hasConnection(), false);
-
-  saveConnection("https://carapace.example.test", "token-1");
+test("connection helpers use same-origin server and clear legacy state", () => {
+  localStorage.setItem("carapace_server", "https://old.example.test");
+  localStorage.setItem("carapace_token", "legacy-token");
 
   assert.equal(getServer(), "https://carapace.example.test");
-  assert.equal(getToken(), "token-1");
+  assert.equal(localStorage.getItem("carapace_server"), null);
+  assert.equal(hasConnection(), false);
+
+  saveConnection("thies");
+
+  assert.equal(getServer(), "https://carapace.example.test");
+  assert.equal(getToken(), "thies");
   assert.equal(hasConnection(), true);
+  assert.equal(localStorage.getItem("carapace_server"), null);
+  assert.equal(localStorage.getItem("carapace_token"), null);
 
   clearConnection();
 
-  assert.equal(getServer(), "");
+  assert.equal(getServer(), "https://carapace.example.test");
   assert.equal(getToken(), "");
   assert.equal(hasConnection(), false);
 });

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -1,3 +1,5 @@
+import { normalizeServer } from "./server-url";
+
 const SERVER_KEY = "carapace_server";
 const USERNAME_KEY = "carapace_username";
 const LEGACY_TOKEN_KEY = "carapace_token";
@@ -12,7 +14,8 @@ export type LocaleOverride = "system" | "en" | "de";
 
 export function getServer(): string {
   if (typeof window === "undefined") return "";
-  return localStorage.getItem(SERVER_KEY) ?? "";
+  localStorage.removeItem(SERVER_KEY);
+  return normalizeServer(window.location.origin);
 }
 
 export function getToken(): string {
@@ -20,8 +23,8 @@ export function getToken(): string {
   return localStorage.getItem(USERNAME_KEY) ?? "";
 }
 
-export function saveConnection(server: string, username: string) {
-  localStorage.setItem(SERVER_KEY, server);
+export function saveConnection(username: string) {
+  localStorage.removeItem(SERVER_KEY);
   localStorage.setItem(USERNAME_KEY, username);
   localStorage.removeItem(LEGACY_TOKEN_KEY);
 }
@@ -33,7 +36,7 @@ export function clearConnection() {
 }
 
 export function hasConnection(): boolean {
-  return !!getServer() && !!getToken();
+  return !!getToken();
 }
 
 export function getLocaleOverride(): LocaleOverride {


### PR DESCRIPTION
## Summary

- remove the editable backend server URL from the connect and admin user flows
- resolve frontend API calls against the current origin and clear legacy persisted server URLs
- add a dev-only Next.js `/api/*` rewrite to `CARAPACE_BACKEND_URL`, defaulting to `http://127.0.0.1:8321`

## Verification

- `pnpm test`
- `pnpm lint`
- `pnpm build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> All API routing now assumes the backend is served on the same origin as the UI; misconfigured reverse proxies or dev without the rewrite could break login and admin until deployment matches the new model.
> 
> **Overview**
> The frontend no longer lets users pick a backend URL: **sign-in** and **admin users** only collect credentials, and API calls always use **`window.location.origin`**. Persisted **`carapace_server`** / legacy token keys are cleared on read; **`hasConnection`** depends on username only.
> 
> **Local dev** adds a Next.js rewrite so **`/api/*`** proxies to **`CARAPACE_BACKEND_URL`** (default `http://127.0.0.1:8321`). Copy in **README** and **en/de** strings reflects same-origin sign-in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c0c799f609b67929d7c6f71baaebffaeefd2ecb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->