### PR TITLE
🐛 fix: revoked session pruning audit trail

### DIFF
--- a/src/carapace/auth.py
+++ b/src/carapace/auth.py
@@ -456,7 +456,7 @@ class AuthStore:
     def _prune_sessions_file(self, sessions_file: SessionsFile, *, now: datetime) -> int:
         before = len(sessions_file.sessions)
         sessions_file.sessions = {
-            session_id: session for session_id, session in sessions_file.sessions.items() if session.is_active(now=now)
+            session_id: session for session_id, session in sessions_file.sessions.items() if session.expires_at > now
         }
         return before - len(sessions_file.sessions)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -206,7 +206,7 @@ def test_revoke_token_invalidates_session(tmp_path) -> None:
     assert store.revoke_token("not-a-token") is False
 
 
-def test_create_session_prunes_expired_and_revoked_sessions(tmp_path) -> None:
+def test_create_session_prunes_expired_sessions_and_keeps_revoked_audit_trail(tmp_path) -> None:
     store = AuthStore(tmp_path, AuthConfig(cookie=JwtCookieConfig(ttl_seconds=3600)))
     store.create_user(username="thies", password="secret")
     now = datetime.now(tz=UTC)
@@ -235,7 +235,8 @@ def test_create_session_prunes_expired_and_revoked_sessions(tmp_path) -> None:
     fresh_session = store.create_session(username="thies")
 
     persisted_sessions = store.load_sessions().sessions
-    assert list(persisted_sessions) == [fresh_session.id]
+    assert list(persisted_sessions) == [revoked_session.id, fresh_session.id]
+    assert persisted_sessions[revoked_session.id].revoked_at == revoked_session.revoked_at
 
 
 def test_websocket_token_is_scoped_to_session_and_revocation(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- Keep revoked session records in `auth/sessions.yaml` until their normal expiry time.
- Continue pruning expired sessions during login/session creation.
- Update auth regression coverage so revoked sessions remain available as audit records while still being invalid for token validation.

## Context
Follow-up for post-merge Bugbot feedback on PR #173: revoked sessions were pruned immediately because pruning reused `AuthSession.is_active()`.

## Verification
- `uv run pytest tests/test_auth.py -k 'prunes or revoke or websocket'`
- `uv run pyrefly check`
- `uv run pytest`
- `uv run prek run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow persistence change; session validity still enforced via is_active() and token checks.
> 
> **Overview**
> Session cleanup in `auth/sessions.yaml` no longer drops **revoked** sessions early. `_prune_sessions_file` used `AuthSession.is_active()`, which treated revoked sessions like garbage; it now only removes entries whose **`expires_at`** is in the past.
> 
> Revoked sessions still cannot authenticate—`is_active()` and token validation are unchanged. The fix keeps revoked rows on disk until natural expiry so **`revoked_at`** remains available for audit. Regression coverage was updated so pruning on `create_session` removes expired sessions but retains a still-valid revoked record.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12d5be27f55ce72bfa1b4f0cc067197c2c609a4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->