### PR TITLE
🐛 fix: add reverse proxy to compose deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,7 @@ docker compose build
 docker compose up -d
 ```
 
-This starts:
-
-- Server at `http://localhost:8321`
-- Frontend at `http://localhost:3001`
+This starts the proxy at `http://localhost:3001`, serving the frontend and routing `/api` to the backend internally.
 
 Optional CLI connection:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     depends_on:
       redis:
         condition: service_healthy
-    ports:
-      - "8321:8321"
     group_add:
       - ${DOCKER_GID:-0}
     volumes:
@@ -49,8 +47,19 @@ services:
 
   frontend:
     build: ./frontend
+
+  proxy:
+    image: traefik:v3.6@sha256:802adc80a7bb20a6766c9385c2ad547f0de98564cd20d31d0b6d8f726f906f66
+    command:
+      - "--providers.file.filename=/etc/traefik/dynamic.yml"
+      - "--entrypoints.web.address=:80"
+    depends_on:
+      - carapace
+      - frontend
     ports:
       - "3001:80"
+    volumes:
+      - ./docker/traefik-dynamic.yml:/etc/traefik/dynamic.yml:ro
 
   redis:
     image: redis:8-alpine@sha256:d146f83b1e0f02fc27c26a50cee39338c736674c5959db84363e6ae3cd9e02d2

--- a/docker/traefik-dynamic.yml
+++ b/docker/traefik-dynamic.yml
@@ -1,0 +1,23 @@
+http:
+  routers:
+    carapace-api:
+      rule: PathPrefix(`/api`)
+      entryPoints:
+        - web
+      priority: 100
+      service: carapace-api
+    carapace-frontend:
+      rule: PathPrefix(`/`)
+      entryPoints:
+        - web
+      priority: 1
+      service: carapace-frontend
+  services:
+    carapace-api:
+      loadBalancer:
+        servers:
+          - url: http://carapace:8321
+    carapace-frontend:
+      loadBalancer:
+        servers:
+          - url: http://frontend:80

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -381,13 +381,13 @@ services:
     environment:
       - CARAPACE_DATA_DIR=/data
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-    ports:
-      - "8321:8321"
-
   frontend:
     build: ./frontend
+
+  proxy:
+    image: traefik:v3.6
     ports:
-      - "3001:3000"
+      - "3001:80"
 ```
 
 For Kubernetes deployments, the Docker socket is replaced by in-cluster Kubernetes API access — see [kubernetes.md](kubernetes.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,25 +37,24 @@ docker compose up -d
 
 This starts:
 
-- **Server** at `http://localhost:8321`
-- **Frontend** at `http://localhost:3001`
+- **Proxy** at `http://localhost:3001`, serving the frontend and routing `/api` to the backend container internally
 - **Redis** for mandatory session-list caching
 - **Sandbox image** is built automatically
 
 Log in to the web UI as `admin` with the `CARAPACE_TOKEN` value, then open **Settings** → **Admin** → **Users** to create your normal user. You can also use the admin API after logging in and storing the session cookie:
 
 ```bash
-curl -c carapace.cookies -X POST http://localhost:8321/api/auth/login \
+curl -c carapace.cookies -X POST http://localhost:3001/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username":"admin","password":"'"$CARAPACE_TOKEN"'"}'
 
-curl -X POST http://localhost:8321/api/admin/users \
+curl -X POST http://localhost:3001/api/admin/users \
   -b carapace.cookies \
   -H "Content-Type: application/json" \
   -d '{"username":"thies","password":"change-me","display_name":"Thies"}'
 ```
 
-The web UI prompts for the server URL, username, and password on first connect.
+The web UI uses the same origin for frontend and API requests, so it only prompts for username and password on first connect.
 
 See [auth.md](auth.md) for the full user-file format, admin API, and session-cookie behavior.
 

--- a/src/carapace/sandbox/docker.py
+++ b/src/carapace/sandbox/docker.py
@@ -6,11 +6,12 @@ import shutil
 from pathlib import Path
 from typing import cast
 
-import docker
 import docker.models.containers
 from docker.errors import APIError, DockerException, ImageNotFound, NotFound
 from docker.types import Mount as DockerMount
 from loguru import logger
+
+import docker
 
 from .runtime import (
     ContainerConfig,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Compose networking and documentation only; no changes to auth, sentinel, or sandbox security logic.
> 
> **Overview**
> Docker Compose now exposes a single **Traefik** entry on port **3001** instead of publishing the API on **8321** separately. **`/api`** is routed to the **`carapace`** service; everything else goes to **`frontend`**, so the UI and REST/WebSocket share one origin in production-like compose runs.
> 
> Docs (**README**, **quickstart**, **architecture**) and example **`curl`** commands were updated to **`http://localhost:3001`** and to note that the web UI no longer needs a separate server URL. **`src/carapace/sandbox/docker.py`** only reorders an **`import docker`** line (no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8421487689957810f07c893996d60123f086557. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->