### PR TITLE
♻️ refactor: migrate Git configuration to user records and remove global Git settings

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -442,10 +442,6 @@ auth:
     secure: false
     same_site: lax
 
-git:
-  remote: https://gitea.example.com/user/knowledge.git
-  token: ghp_xxxxxxxxxxxx
-
 knowledge_dir: ./knowledge
 
 sandbox:

--- a/docs/git.md
+++ b/docs/git.md
@@ -6,14 +6,19 @@ Optionally, you can connect an **upstream remote** so the knowledge repo is sync
 
 ## Configuration
 
-Add a `git` section to your `config.yaml`:
+Add a `git` section to the owning user record in `$CARAPACE_DATA_DIR/auth/users.yaml`:
 
 ```yaml
-git:
-  remote: https://gitea.example.com/team/knowledge.git
-  branch: main
-  token: ghp_xxxxxxxxxxxx
+users:
+  thies:
+    config:
+      git:
+        remote: https://gitea.example.com/team/knowledge.git
+        branch: main
+        token: ghp_xxxxxxxxxxxx
 ```
+
+The knowledge repo is still a single shared server repo. Because of that, at most one enabled user may configure a non-empty `config.git.remote`; startup fails if multiple enabled users define one.
 
 | Field    | Default                    | Description                                                                                                                            |
 | -------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
@@ -36,14 +41,14 @@ The token is embedded as `x-access-token:<token>` in the remote URL for HTTPS au
 
 ## Remote branch
 
-The `branch` setting in the git config refers exclusively to the **remote** branch. The `branch` setting controls which **remote** branch carapace fetches from and pushes to. It does **not** affect the local knowledge repo, which always uses a `main` branch internally. This means you can point carapace at any branch on the remote (e.g. `dev`, `production`) without changing how sandboxes or the agent interact with the repo locally.
+The `branch` setting in the owning user's git config refers exclusively to the **remote** branch. The `branch` setting controls which **remote** branch carapace fetches from and pushes to. It does **not** affect the local knowledge repo, which always uses a `main` branch internally. This means you can point carapace at any branch on the remote (e.g. `dev`, `production`) without changing how sandboxes or the agent interact with the repo locally.
 
 The configured branch **must already exist** on the upstream remote before carapace connects to it. carapace does not create remote branches — it performs `git fetch origin <branch>` and `git merge --ff-only origin/<branch>`, both of which fail if the branch doesn't exist.
 
 If you're starting from scratch:
 
 1. Create the remote repository and its default branch (most hosting providers do this automatically).
-2. Set `branch` in `config.yaml` to match the remote branch you want to use (e.g. `main`, `dev`).
+2. Set `config.git.branch` in the owning user record to match the remote branch you want to use (e.g. `main`, `dev`).
 3. Start carapace — it will push the initial bootstrap commit to that branch.
 
 ## What happens on first start
@@ -62,7 +67,7 @@ If the pull encounters a merge conflict (i.e. local and remote have diverged and
 
 ## Adding a remote to an existing instance
 
-If you've been running carapace without a remote and later add `git.remote` to the config:
+If you've been running carapace without a remote and later add `config.git.remote` to the owning user record:
 
 1. **Restart the server.** On startup it registers the remote, pulls (fast-forward only), and pushes any local-only commits upstream.
 2. **Running sessions are unaffected.** Their sandboxes already have a `/workspace` clone from before the remote was added. They continue working normally — agent pushes go to the server's local knowledge repo.
@@ -105,7 +110,7 @@ This makes it easy to trace which session produced which commit in the upstream 
 
 ## Local-only mode
 
-If `git.remote` is not set (or is an empty string), carapace runs in local-only mode:
+If no enabled user has `config.git.remote` set (or it is an empty string), carapace runs in local-only mode:
 
 - The knowledge repo is still Git-backed (for the sandbox clone workflow and security-gated pushes).
 - `/pull` and `/push` return "No external remote configured."

--- a/docs/security.md
+++ b/docs/security.md
@@ -163,7 +163,7 @@ Like tool calls and proxy domains, the sentinel can escalate a git push to the u
 
 If a push is denied, `git push` fails in the sandbox with a descriptive error message from the sentinel.
 
-If an external remote is configured (`git.remote` in config), a successful push from the sandbox is automatically forwarded to the remote. Users can also trigger this manually with the `/push` slash command.
+If an external remote is configured (`config.git.remote` in the owning user record), a successful push from the sandbox is automatically forwarded to the remote. Users can also trigger this manually with the `/push` slash command.
 
 If the sentinel escalates a domain request, it is forwarded to the user through their channel (WebSocket, Matrix).
 

--- a/src/carapace/git/store.py
+++ b/src/carapace/git/store.py
@@ -106,6 +106,11 @@ class GitStore:
         self.remote_branch = remote_branch
         self.author_template = author
         self._index_lock = asyncio.Lock()
+        self._remote_configured = False
+
+    @property
+    def remote_configured(self) -> bool:
+        return self._remote_configured
 
     async def _run(self, *args: str, cwd: Path | None = None) -> tuple[int, str]:
         """Run a git command and return ``(exit_code, combined_output)``."""
@@ -237,7 +242,16 @@ class GitStore:
             await self._run("remote", "set-url", "origin", authed_url)
         else:
             await self._run("remote", "add", "origin", authed_url)
+        self._remote_configured = True
         logger.info(f"Git remote origin set to {url}")
+
+    async def remove_remote(self) -> None:
+        """Remove the ``origin`` remote when upstream sync is disabled."""
+        code, _ = await self._run("remote", "get-url", "origin")
+        if code == 0:
+            await self._run("remote", "remove", "origin")
+            logger.info("Git remote origin removed")
+        self._remote_configured = False
 
     async def push_to_remote(self) -> None:
         """Push the local branch to the configured remote branch."""

--- a/src/carapace/models/config.py
+++ b/src/carapace/models/config.py
@@ -231,15 +231,6 @@ class SandboxConfig(BaseSettings):
     cleanup_orphans_on_startup: bool = True
 
 
-class GitConfig(ConfigModel):
-    """Git-backed knowledge store configuration."""
-
-    remote: str = ""  # optional external remote URL
-    branch: str = "main"  # remote branch to fetch/push (local is always "main")
-    author: str = "carapace <carapace@%h>"  # %s → session ID, %h → hostname
-    token: str | None = None
-
-
 class SessionCommitConfig(ConfigModel):
     enabled: bool = True
     path_prefix: str = "sessions"
@@ -309,7 +300,6 @@ class Config(ConfigModel):
     agent: AgentConfig = AgentConfig()
     sessions: SessionsConfig = SessionsConfig()
     sandbox: SandboxConfig = SandboxConfig()
-    git: GitConfig = GitConfig()
     credentials: CredentialsConfig = CredentialsConfig()
     data_dir: str = "."  # resolved relative to config file location
     knowledge_dir: str = "./knowledge"  # resolved relative to config file location

--- a/src/carapace/models/user.py
+++ b/src/carapace/models/user.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from .matrix import MatrixChannelConfig
+
+DEFAULT_GIT_BRANCH = "main"
+DEFAULT_GIT_AUTHOR = "carapace <carapace@%h>"
 
 
 class UserConfigModel(BaseModel):
@@ -17,9 +20,18 @@ class UserChannelsConfig(UserConfigModel):
 
 class UserGitConfig(UserConfigModel):
     remote: str = ""
-    branch: str = "main"
-    author: str = "carapace <carapace@%h>"
+    branch: str = DEFAULT_GIT_BRANCH
+    author: str = DEFAULT_GIT_AUTHOR
     token: str | None = None
+
+    @model_validator(mode="after")
+    def _normalize(self) -> UserGitConfig:
+        self.remote = self.remote.strip()
+        self.branch = self.branch.strip() or DEFAULT_GIT_BRANCH
+        self.author = self.author.strip() or DEFAULT_GIT_AUTHOR
+        if self.token is not None:
+            self.token = self.token.strip() or None
+        return self
 
 
 class UserConfig(UserConfigModel):

--- a/src/carapace/server/__init__.py
+++ b/src/carapace/server/__init__.py
@@ -7,6 +7,7 @@ import os
 import sys
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -38,6 +39,7 @@ from ..git.store import GitStore
 from ..jobs import JobsScheduler, JobsStore
 from ..llm import make_model_factory
 from ..models.config import Config
+from ..models.user import DEFAULT_GIT_AUTHOR, DEFAULT_GIT_BRANCH, UserGitConfig
 from ..notifications.presence import NotificationPresenceRegistry
 from ..notifications.router import NotificationRouter
 from ..notifications.sender import WebPushSender
@@ -83,6 +85,38 @@ _notification_store: NotificationStore
 _notification_presence: NotificationPresenceRegistry
 _notification_router: NotificationRouter
 _auth_store: AuthStore
+
+
+@dataclass(frozen=True)
+class KnowledgeGitConfig:
+    owner: str | None = None
+    remote: str = ""
+    branch: str = DEFAULT_GIT_BRANCH
+    author: str = DEFAULT_GIT_AUTHOR
+    token: str | None = None
+
+
+def _select_knowledge_git_config(auth_store: AuthStore) -> KnowledgeGitConfig:
+    configured: list[tuple[str, UserGitConfig]] = []
+    for username, user in sorted(auth_store.load_users().users.items()):
+        if user.enabled and user.config.git.remote:
+            configured.append((username, user.config.git))
+
+    if not configured:
+        return KnowledgeGitConfig()
+    if len(configured) > 1:
+        owners = ", ".join(username for username, _ in configured)
+        raise RuntimeError(f"knowledge Git remote is configured for multiple enabled users: {owners}")
+
+    owner, git = configured[0]
+    return KnowledgeGitConfig(
+        owner=owner,
+        remote=git.remote,
+        branch=git.branch,
+        author=git.author,
+        token=git.token,
+    )
+
 
 _SESSION_COMMIT_SWEEP_SECONDS = 15 * 60
 _APP_VERSION = get_version()
@@ -200,24 +234,28 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     _auth_store = AuthStore(_data_dir, _config.auth)
     if _auth_store.ensure_bootstrap_admin() is not None:
         logger.warning("Created bootstrap admin user 'admin' with password from CARAPACE_TOKEN")
+    knowledge_git = _select_knowledge_git_config(_auth_store)
 
     # 3. Git-backed knowledge store
     git_store = GitStore(
         knowledge_dir,
-        remote_branch=_config.git.branch,
-        author=_config.git.author,
+        remote_branch=knowledge_git.branch,
+        author=knowledge_git.author,
     )
     await git_store.ensure_repo()
 
     # Pull from external remote if configured
-    if _config.git.remote:
-        await git_store.add_remote(_config.git.remote, _config.git.token)
+    if knowledge_git.remote:
+        logger.info(f"Using knowledge Git remote from user {knowledge_git.owner}")
+        await git_store.add_remote(knowledge_git.remote, knowledge_git.token)
         try:
             summary = await git_store.pull_from_remote()
             logger.info(f"Pulled from remote: {summary}")
         except RuntimeError as exc:
             logger.error(str(exc))
             raise SystemExit(1) from exc
+    else:
+        await git_store.remove_remote()
 
     # Bootstrap knowledge files (after pull so we don't override remote content)
     seeded = ensure_knowledge_dir(knowledge_dir)
@@ -227,7 +265,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
         except RuntimeError as exc:
             logger.warning(f"Bootstrap knowledge seed commit failed: {exc}")
         else:
-            if committed and _config.git.remote:
+            if committed and git_store.remote_configured:
                 await git_store.push_to_remote()
 
     if _config.carapace.logfire_token:
@@ -284,7 +322,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
         idle_timeout_minutes=_config.sandbox.idle_timeout_minutes,
         proxy_port=proxy_port,
         sandbox_port=_config.server.sandbox_port,
-        git_author=_config.git.author,
+        git_author=knowledge_git.author,
     )
     logger.info(f"Sandbox enabled (image={base_image}, network={sandbox_network})")
 
@@ -348,7 +386,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
         default_branch="main",
         api_port=_config.server.internal_port,
         verify_session_token=_sandbox_mgr.verify_session_token,
-        on_push_success=git_store.push_to_remote if _config.git.remote else None,
+        on_push_success=git_store.push_to_remote if git_store.remote_configured else None,
     )
 
     proxy = ProxyServer(

--- a/src/carapace/session/commands.py
+++ b/src/carapace/session/commands.py
@@ -210,7 +210,7 @@ class SessionCommandMixin:
 
     async def _handle_push_command(self) -> dict[str, Any]:
         """Handle the ``/push`` slash command — push to external remote."""
-        if not self._config.git.remote:
+        if not self._git_store.remote_configured:
             return {"command": "push", "data": {"message": "No external remote configured."}}
         try:
             await self._git_store.push_to_remote()
@@ -220,7 +220,7 @@ class SessionCommandMixin:
 
     async def _handle_pull_command(self) -> dict[str, Any]:
         """Handle the ``/pull`` slash command — pull from external remote."""
-        if not self._config.git.remote:
+        if not self._git_store.remote_configured:
             return {"command": "pull", "data": {"message": "No external remote configured."}}
         try:
             summary = await self._git_store.pull_from_remote()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -62,7 +62,7 @@ def test_load_config_rejects_unknown_nested_config_key(tmp_path: Path):
         load_config(tmp_path)
 
 
-def test_load_config_rejects_git_secret_source_object(tmp_path: Path):
+def test_load_config_rejects_global_git_config(tmp_path: Path):
     (tmp_path / "config.yaml").write_text(
         "git:\n  remote: https://gitea.example.com/team/knowledge.git\n  token:\n    env: CARAPACE_GIT_TOKEN\n"
     )

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -232,6 +232,15 @@ class TestGitStoreRemote:
         _, url = await store._run("remote", "get-url", "origin")
         assert "new.com" in url
 
+    async def test_remove_remote(self, store: GitStore):
+        await store.add_remote("https://example.com/repo.git", token="tok123")
+        assert store.remote_configured is True
+
+        await store.remove_remote()
+
+        assert store.remote_configured is False
+        assert not await store.has_remote()
+
     async def test_pull_no_remote_fails(self, store: GitStore):
         with pytest.raises(RuntimeError, match="fetch failed"):
             await store.pull_from_remote()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -25,6 +25,7 @@ from carapace.jobs import JobsScheduler, JobsStore
 from carapace.models.credentials import CredentialMetadata
 from carapace.models.jobs import JobDefinition
 from carapace.models.session import SessionBudget
+from carapace.models.user import UserConfig
 from carapace.notifications.presence import NotificationPresenceRegistry
 from carapace.notifications.store import NotificationStore
 from carapace.notifications.vapid import derive_vapid_public_key, ensure_vapid_config
@@ -119,6 +120,45 @@ def _setup_server(tmp_path, monkeypatch):
 @pytest.fixture()
 def client() -> TestClient:
     return TestClient(app)
+
+
+def test_select_knowledge_git_config_uses_single_enabled_user(tmp_path) -> None:
+    store = AuthStore(tmp_path / "git-owner", srv._config.auth)
+    store.create_user(
+        username="Thies",
+        password="secret",
+        config=UserConfig.model_validate(
+            {
+                "git": {
+                    "remote": " https://gitea.example.com/team/knowledge.git ",
+                    "branch": " dev ",
+                    "author": " Thies <thies@example.com> ",
+                    "token": " token-value ",
+                }
+            }
+        ),
+    )
+
+    selected = srv._select_knowledge_git_config(store)
+
+    assert selected.owner == "thies"
+    assert selected.remote == "https://gitea.example.com/team/knowledge.git"
+    assert selected.branch == "dev"
+    assert selected.author == "Thies <thies@example.com>"
+    assert selected.token == "token-value"
+
+
+def test_select_knowledge_git_config_rejects_multiple_enabled_user_remotes(tmp_path) -> None:
+    store = AuthStore(tmp_path / "git-owners", srv._config.auth)
+    for username in ("alice", "bob"):
+        store.create_user(
+            username=username,
+            password="secret",
+            config=UserConfig.model_validate({"git": {"remote": f"https://gitea.example.com/{username}.git"}}),
+        )
+
+    with pytest.raises(RuntimeError, match="multiple enabled users"):
+        srv._select_knowledge_git_config(store)
 
 
 @pytest.fixture()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how upstream sync credentials are stored and which user owns them; misconfiguration or multiple remotes now fail at startup, and deployments must migrate off removed global `git:` config.
> 
> **Overview**
> **Upstream Git configuration is no longer in global `config.yaml`.** Remote URL, branch, author, and token now live under each enabled user’s `config.git` in `auth/users.yaml`. Docs (`architecture`, `git`, `security`) describe that model and the rule that **at most one enabled user** may set a non-empty remote; otherwise startup fails.
> 
> **Server startup** resolves knowledge Git settings via `_select_knowledge_git_config`, wires `GitStore` and sandbox author / push forwarding from that owner, **removes `origin`** when no remote is configured, and uses `GitStore.remote_configured` instead of global flags. **`GitConfig` is removed** from the root config model; user git fields are normalized (strip whitespace, defaults). **`/pull` and `/push`** gate on `remote_configured`. Tests cover rejecting legacy global `git:` in YAML, owner selection, and `remove_remote`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dfc589229b5b83b0019fe27e0fed92237ce616f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->