### PR TITLE
✨ feat: use standalone Bitwarden instances with HTTP Basic Auth

### DIFF
--- a/charts/carapace/README.md
+++ b/charts/carapace/README.md
@@ -194,9 +194,9 @@ config:
 
 The `url` defaults to `http://127.0.0.1:8087`, which works out of the box with the sidecar. Override it if `bw serve` runs elsewhere (e.g. a separate Service).
 
-Multiple instances are supported — just add more entries with different names and ports (e.g. `personal` on 8087, `work` on 8088). Each instance gets its own sidecar container, its own Kubernetes Secret, and (when persistence is enabled) its own PVC mounted at `/var/lib/bitwarden-cli` so Bitwarden CLI device/session data survives Pod reschedules — reducing repeated logins and “new device” emails from the vault provider. Set `bitwarden.persistence.enabled` to `false` if you prefer an ephemeral sidecar.
+Multiple instances are supported — just add more entries with different names and ports (e.g. `personal` on 8087, `work` on 8089). Each instance gets its own sidecar container, its own Kubernetes Secret, and (when persistence is enabled) its own PVC mounted at `/var/lib/bitwarden-cli` so Bitwarden CLI device/session data survives Pod reschedules — reducing repeated logins and “new device” emails from the vault provider. Set `bitwarden.persistence.enabled` to `false` if you prefer an ephemeral sidecar.
 
-For a standalone Bitwarden proxy, set `mode: standalone`. The Bitwarden CLI still binds to localhost inside its Pod, while nginx exposes a protected service port for carapace. Create the Basic Auth Secret separately; it must contain an htpasswd file named `htpasswd` unless you override `basicAuth.secretKey`.
+For a standalone Bitwarden proxy, set `mode: standalone`. The Bitwarden CLI binds to a fixed localhost-only internal port (`8088`) inside its Pod, while nginx exposes the configured service port for carapace. The service port must not be `8088`. Create the Basic Auth Secret separately; it must contain an htpasswd file named `htpasswd` unless you override `basicAuth.secretKey`.
 
 ```yaml
 bitwarden:
@@ -208,7 +208,6 @@ bitwarden:
       mode: standalone
       fullnameOverride: carapace-bitwarden
       port: 8087
-      servePort: 8088
       serverUrl: https://vault.example.com
       existingSecret: carapace-bw-personal
       basicAuth:

--- a/charts/carapace/README.md
+++ b/charts/carapace/README.md
@@ -79,12 +79,12 @@ All images default to the chart's `appVersion` tag, which is kept in sync with t
 
 ### Required configuration
 
-| What                   | How                                                                                                                         |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| What                   | How                                                                                                                                                                    |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Bootstrap password** | Set `CARAPACE_TOKEN` in the Secret referenced via `envFrom`. It is only used as the initial password for the bootstrap `admin` user when no enabled admin user exists. |
-| **Anthropic API key**  | Set `ANTHROPIC_API_KEY` in the same Secret.                                                                                 |
-| **Ingress hostname**   | `--set ingress.hostname=carapace.example.com`                                                                               |
-| **Gateway parent ref** | `--set ingress.parentRefs[0].name=my-gateway` (defaults to `default-gateway`)                                               |
+| **Anthropic API key**  | Set `ANTHROPIC_API_KEY` in the same Secret.                                                                                                                            |
+| **Ingress hostname**   | `--set ingress.hostname=carapace.example.com`                                                                                                                          |
+| **Gateway parent ref** | `--set ingress.parentRefs[0].name=my-gateway` (defaults to `default-gateway`)                                                                                          |
 
 ### Injecting secrets and environment variables
 
@@ -137,7 +137,7 @@ Replace `carapace-redis` with `<release>-redis` when your Helm release name is n
 
 ### Bitwarden / Vaultwarden credential backend
 
-To use a Bitwarden-compatible vault (including Vaultwarden) as a credential backend, the chart can inject one or more `bw serve` sidecar containers into the server Pod. Each sidecar shares the Pod's network namespace, so carapace reaches it at `127.0.0.1:<port>`. Because `bw serve` only listens on localhost, no NetworkPolicy is needed to protect it — unlike a standalone deployment where the unauthenticated API would be reachable cluster-wide.
+To use a Bitwarden-compatible vault (including Vaultwarden) as a credential backend, the chart can inject one or more `bw serve` sidecar containers into the server Pod, or deploy them as standalone companion Pods behind an nginx Basic Auth proxy. Sidecars share the Pod's network namespace, so carapace reaches them at `127.0.0.1:<port>`. Standalone instances are useful for per-user credential backend URLs and are protected by Basic Auth plus a NetworkPolicy that only allows ingress from the carapace server Pod.
 
 The sidecar image (`carapace-bitwarden-cli`) is built as part of the carapace release and bundles the Bitwarden CLI. On startup it logs in, unlocks the vault, and starts `bw serve`. The liveness probe periodically calls `/sync` to keep the vault data fresh.
 
@@ -196,6 +196,41 @@ The `url` defaults to `http://127.0.0.1:8087`, which works out of the box with t
 
 Multiple instances are supported — just add more entries with different names and ports (e.g. `personal` on 8087, `work` on 8088). Each instance gets its own sidecar container, its own Kubernetes Secret, and (when persistence is enabled) its own PVC mounted at `/var/lib/bitwarden-cli` so Bitwarden CLI device/session data survives Pod reschedules — reducing repeated logins and “new device” emails from the vault provider. Set `bitwarden.persistence.enabled` to `false` if you prefer an ephemeral sidecar.
 
+For a standalone Bitwarden proxy, set `mode: standalone`. The Bitwarden CLI still binds to localhost inside its Pod, while nginx exposes a protected service port for carapace. Create the Basic Auth Secret separately; it must contain an htpasswd file named `htpasswd` unless you override `basicAuth.secretKey`.
+
+```yaml
+bitwarden:
+  persistence:
+    finalizers:
+      - kubernetes.io/pvc-protection
+  instances:
+    - name: vaultwarden
+      mode: standalone
+      fullnameOverride: carapace-bitwarden
+      port: 8087
+      servePort: 8088
+      serverUrl: https://vault.example.com
+      existingSecret: carapace-bw-personal
+      basicAuth:
+        existingSecret: carapace-bitwarden-basic-auth
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 256Mi
+
+config:
+  credentials:
+    backends:
+      personal:
+        type: bitwarden
+        url: http://carapace-bitwarden:8087
+        basic_auth:
+          username: carapace
+          password: change-me
+```
+
 ### Key values
 
 | Value                                    | Default                          | Description                                                        |
@@ -224,10 +259,12 @@ Multiple instances are supported — just add more entries with different names 
 | `resources`                              | requests: 200m/256Mi, limit: 1Gi | Server resource requests/limits                                    |
 | `frontend.resources`                     | requests: 50m/64Mi, limit: 128Mi | Frontend resource requests/limits                                  |
 | `bitwarden.image.tag`                    | `""` (appVersion)                | bitwarden-cli sidecar image tag                                    |
+| `bitwarden.nginx.image.tag`              | pinned nginx digest              | nginx image tag/digest for standalone Basic Auth proxy             |
 | `bitwarden.persistence.enabled`          | `true`                           | Create a PVC per sidecar for CLI data (`BITWARDENCLI_APPDATA_DIR`) |
 | `bitwarden.persistence.size`             | `256Mi`                          | Size of each Bitwarden sidecar PVC                                 |
 | `bitwarden.persistence.storageClassName` | `""` (cluster default)           | StorageClass for Bitwarden PVCs                                    |
-| `bitwarden.instances`                    | `[]`                             | List of `bw serve` sidecars (see above)                            |
+| `bitwarden.persistence.finalizers`       | `[]`                             | Finalizers for Bitwarden PVCs                                      |
+| `bitwarden.instances`                    | `[]`                             | List of `bw serve` sidecar or standalone instances (see above)     |
 
 See [values.yaml](values.yaml) for the complete reference.
 

--- a/charts/carapace/README.md
+++ b/charts/carapace/README.md
@@ -137,11 +137,11 @@ Replace `carapace-redis` with `<release>-redis` when your Helm release name is n
 
 ### Bitwarden / Vaultwarden credential backend
 
-To use a Bitwarden-compatible vault (including Vaultwarden) as a credential backend, the chart can inject one or more `bw serve` sidecar containers into the server Pod, or deploy them as standalone companion Pods behind an nginx Basic Auth proxy. Sidecars share the Pod's network namespace, so carapace reaches them at `127.0.0.1:<port>`. Standalone instances are useful for per-user credential backend URLs and are protected by Basic Auth plus a NetworkPolicy that only allows ingress from the carapace server Pod.
+To use a Bitwarden-compatible vault (including Vaultwarden) as a credential backend, the chart can deploy one or more standalone Bitwarden CLI companion Pods behind nginx Basic Auth proxies. Each instance gets its own Service, Secret, and optional PVC, which makes it a good fit for per-user credential backend URLs. The chart also creates a NetworkPolicy that only allows ingress from the carapace server Pod.
 
-The sidecar image (`carapace-bitwarden-cli`) is built as part of the carapace release and bundles the Bitwarden CLI. On startup it logs in, unlocks the vault, and starts `bw serve`. The liveness probe periodically calls `/sync` to keep the vault data fresh.
+The Bitwarden CLI image (`carapace-bitwarden-cli`) is built as part of the carapace release and bundles the Bitwarden CLI. On startup it logs in, unlocks the vault, and starts `bw serve`. The liveness probe periodically calls `/sync` to keep the vault data fresh.
 
-1. **Create a Secret** with Bitwarden CLI credentials. The chart mounts it read-only at `/run/secrets/bitwarden`; the sidecar entrypoint reads keys from files when the matching env vars are unset (see [`bitwarden-cli/README.md`](../../bitwarden-cli/README.md)).
+1. **Create a Secret** with Bitwarden CLI credentials. The chart mounts it read-only at `/run/secrets/bitwarden`; the Bitwarden CLI entrypoint reads keys from files when the matching env vars are unset (see [`bitwarden-cli/README.md`](../../bitwarden-cli/README.md)).
 
 ```bash
 kubectl create secret generic carapace-bw-personal -n carapace \
@@ -162,50 +162,22 @@ Supported **Secret** keys (each becomes a file name under the mount):
 | `BW_CLIENTID`        | no       | API key client ID (generate in Bitwarden web UI → Account Settings → Keys) |
 | `BW_CLIENTSECRET`    | no       | API key client secret                                                      |
 
-When both `BW_CLIENTID` and `BW_CLIENTSECRET` are present, the sidecar uses API key login (required if 2FA is enabled). Otherwise it uses password login and needs `BW_EMAIL` in the Secret. The master password is needed in both cases. As the project readme mentions, it is recommended to use a dedicated user for carapace and share entries to it instead of using your account directly.
+When both `BW_CLIENTID` and `BW_CLIENTSECRET` are present, the Bitwarden CLI uses API key login (required if 2FA is enabled). Otherwise it uses password login and needs `BW_EMAIL` in the Secret. The master password is needed in both cases. As the project readme mentions, it is recommended to use a dedicated user for carapace and share entries to it instead of using your account directly.
 
-2. **Enable the sidecar** in your values:
+2. **Create a Basic Auth Secret** for nginx. It must contain an htpasswd file named `htpasswd` unless you override `basicAuth.secretKey`.
+
+```bash
+htpasswd -nB carapace > /tmp/carapace-bitwarden-htpasswd
+kubectl create secret generic carapace-bitwarden-basic-auth -n carapace \
+  --from-file=htpasswd=/tmp/carapace-bitwarden-htpasswd
+```
+
+3. **Enable a Bitwarden instance** in your values:
 
 ```yaml
 bitwarden:
   instances:
-    - name: bw-personal
-      port: 8087
-      serverUrl: https://vault.example.com
-      existingSecret: carapace-bw-personal
-      resources:
-        requests:
-          cpu: 50m
-          memory: 128Mi
-        limits:
-          memory: 256Mi
-```
-
-3. **Configure the matching credential backend** in your application config:
-
-```yaml
-config:
-  credentials:
-    backends:
-      personal:
-        type: bitwarden
-        url: http://127.0.0.1:8087
-```
-
-The `url` defaults to `http://127.0.0.1:8087`, which works out of the box with the sidecar. Override it if `bw serve` runs elsewhere (e.g. a separate Service).
-
-Multiple instances are supported — just add more entries with different names and ports (e.g. `personal` on 8087, `work` on 8089). Each instance gets its own sidecar container, its own Kubernetes Secret, and (when persistence is enabled) its own PVC mounted at `/var/lib/bitwarden-cli` so Bitwarden CLI device/session data survives Pod reschedules — reducing repeated logins and “new device” emails from the vault provider. Set `bitwarden.persistence.enabled` to `false` if you prefer an ephemeral sidecar.
-
-For a standalone Bitwarden proxy, set `mode: standalone`. The Bitwarden CLI binds to a fixed localhost-only internal port (`8088`) inside its Pod, while nginx exposes the configured service port for carapace. The service port must not be `8088`. Create the Basic Auth Secret separately; it must contain an htpasswd file named `htpasswd` unless you override `basicAuth.secretKey`.
-
-```yaml
-bitwarden:
-  persistence:
-    finalizers:
-      - kubernetes.io/pvc-protection
-  instances:
-    - name: vaultwarden
-      mode: standalone
+    - name: personal
       fullnameOverride: carapace-bitwarden
       port: 8087
       serverUrl: https://vault.example.com
@@ -218,7 +190,11 @@ bitwarden:
           memory: 128Mi
         limits:
           memory: 256Mi
+```
 
+4. **Configure the matching credential backend** in your application config or user config:
+
+```yaml
 config:
   credentials:
     backends:
@@ -229,6 +205,10 @@ config:
           username: carapace
           password: change-me
 ```
+
+Multiple instances are supported — just add more entries with different names and ports (e.g. `personal` on 8087, `work` on 8089). Each instance gets its own companion Pod, Kubernetes Secret, Service, Basic Auth proxy, and (when persistence is enabled) PVC mounted at `/var/lib/bitwarden-cli` so Bitwarden CLI device/session data survives Pod reschedules — reducing repeated logins and “new device” emails from the vault provider. Set `bitwarden.persistence.enabled` to `false` if you prefer ephemeral Bitwarden CLI data.
+
+The Bitwarden CLI binds to a fixed localhost-only internal port (`8088`) inside its Pod, while nginx exposes the configured service port for carapace. The service port must not be `8088`.
 
 ### Key values
 
@@ -257,13 +237,13 @@ config:
 | `redis.resources`                        | requests: 25m/64Mi, limit: 128Mi | Redis resource requests/limits                                     |
 | `resources`                              | requests: 200m/256Mi, limit: 1Gi | Server resource requests/limits                                    |
 | `frontend.resources`                     | requests: 50m/64Mi, limit: 128Mi | Frontend resource requests/limits                                  |
-| `bitwarden.image.tag`                    | `""` (appVersion)                | bitwarden-cli sidecar image tag                                    |
+| `bitwarden.image.tag`                    | `""` (appVersion)                | bitwarden-cli image tag                                            |
 | `bitwarden.nginx.image.tag`              | pinned nginx digest              | nginx image tag/digest for standalone Basic Auth proxy             |
-| `bitwarden.persistence.enabled`          | `true`                           | Create a PVC per sidecar for CLI data (`BITWARDENCLI_APPDATA_DIR`) |
-| `bitwarden.persistence.size`             | `256Mi`                          | Size of each Bitwarden sidecar PVC                                 |
+| `bitwarden.persistence.enabled`          | `true`                           | Create a PVC per instance for CLI data (`BITWARDENCLI_APPDATA_DIR`) |
+| `bitwarden.persistence.size`             | `256Mi`                          | Size of each Bitwarden instance PVC                                |
 | `bitwarden.persistence.storageClassName` | `""` (cluster default)           | StorageClass for Bitwarden PVCs                                    |
 | `bitwarden.persistence.finalizers`       | `[]`                             | Finalizers for Bitwarden PVCs                                      |
-| `bitwarden.instances`                    | `[]`                             | List of `bw serve` sidecar or standalone instances (see above)     |
+| `bitwarden.instances`                    | `[]`                             | List of standalone `bw serve` proxy instances (see above)          |
 
 See [values.yaml](values.yaml) for the complete reference.
 

--- a/charts/carapace/templates/_helpers.tpl
+++ b/charts/carapace/templates/_helpers.tpl
@@ -46,3 +46,25 @@ Bitwarden CLI sidecar image with tag defaulting to appVersion
 {{- define "carapace.bitwardenImage" -}}
 {{ .Values.bitwarden.image.registry }}/{{ .Values.bitwarden.image.repository }}:{{ .Values.bitwarden.image.tag | default .Chart.AppVersion }}
 {{- end }}
+
+{{/*
+Bitwarden nginx proxy image
+*/}}
+{{- define "carapace.bitwardenNginxImage" -}}
+{{ .Values.bitwarden.nginx.image.registry }}/{{ .Values.bitwarden.nginx.image.repository }}:{{ .Values.bitwarden.nginx.image.tag }}
+{{- end }}
+
+{{/*
+Standalone Bitwarden resource name for one instance.
+*/}}
+{{- define "carapace.bitwardenStandaloneName" -}}
+{{- $root := .root -}}
+{{- $instance := .instance -}}
+{{- if $instance.fullnameOverride -}}
+{{ $instance.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else if and $instance.standalone $instance.standalone.fullnameOverride -}}
+{{ $instance.standalone.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+{{ printf "%s-bitwarden-%s" $root.Release.Name $instance.name | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+{{- end }}

--- a/charts/carapace/templates/_helpers.tpl
+++ b/charts/carapace/templates/_helpers.tpl
@@ -41,7 +41,7 @@ Sandbox owner name. Nil means use the release default, empty string means Deploy
 {{- end }}
 
 {{/*
-Bitwarden CLI sidecar image with tag defaulting to appVersion
+Bitwarden CLI image with tag defaulting to appVersion
 */}}
 {{- define "carapace.bitwardenImage" -}}
 {{ .Values.bitwarden.image.registry }}/{{ .Values.bitwarden.image.repository }}:{{ .Values.bitwarden.image.tag | default .Chart.AppVersion }}
@@ -62,8 +62,6 @@ Standalone Bitwarden resource name for one instance.
 {{- $instance := .instance -}}
 {{- if $instance.fullnameOverride -}}
 {{ $instance.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else if and $instance.standalone $instance.standalone.fullnameOverride -}}
-{{ $instance.standalone.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else -}}
 {{ printf "%s-bitwarden-%s" $root.Release.Name $instance.name | trunc 63 | trimSuffix "-" }}
 {{- end -}}

--- a/charts/carapace/templates/deployment-bitwarden.yaml
+++ b/charts/carapace/templates/deployment-bitwarden.yaml
@@ -1,8 +1,11 @@
 {{- range .Values.bitwarden.instances }}
 {{- if eq (.mode | default "sidecar") "standalone" }}
 {{- $name := include "carapace.bitwardenStandaloneName" (dict "root" $ "instance" .) }}
-{{- $servePort := .servePort | default 8088 }}
+{{- $servePort := 8088 }}
 {{- $servicePort := .port | default 8087 }}
+{{- if eq (int $servicePort) $servePort }}
+{{- fail (printf "bitwarden standalone instance %q cannot use port %d because it is reserved for internal bw serve traffic" .name $servePort) }}
+{{- end }}
 {{- $basicAuth := .basicAuth | default dict }}
 {{- $basicAuthEnabled := true }}
 {{- if hasKey $basicAuth "enabled" }}

--- a/charts/carapace/templates/deployment-bitwarden.yaml
+++ b/charts/carapace/templates/deployment-bitwarden.yaml
@@ -1,5 +1,4 @@
 {{- range .Values.bitwarden.instances }}
-{{- if eq (.mode | default "sidecar") "standalone" }}
 {{- $name := include "carapace.bitwardenStandaloneName" (dict "root" $ "instance" .) }}
 {{- $servePort := 8088 }}
 {{- $servicePort := .port | default 8087 }}
@@ -226,6 +225,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ $servicePort }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/carapace/templates/deployment-bitwarden.yaml
+++ b/charts/carapace/templates/deployment-bitwarden.yaml
@@ -1,0 +1,228 @@
+{{- range .Values.bitwarden.instances }}
+{{- if eq (.mode | default "sidecar") "standalone" }}
+{{- $name := include "carapace.bitwardenStandaloneName" (dict "root" $ "instance" .) }}
+{{- $servePort := .servePort | default 8088 }}
+{{- $servicePort := .port | default 8087 }}
+{{- $basicAuth := .basicAuth | default dict }}
+{{- $basicAuthEnabled := true }}
+{{- if hasKey $basicAuth "enabled" }}
+{{- $basicAuthEnabled = $basicAuth.enabled }}
+{{- end }}
+{{- $networkPolicy := .networkPolicy | default dict }}
+{{- $networkPolicyEnabled := true }}
+{{- if hasKey $networkPolicy "enabled" }}
+{{- $networkPolicyEnabled = $networkPolicy.enabled }}
+{{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}-nginx
+  labels:
+    {{- include "carapace.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: bitwarden
+data:
+  default.conf: |
+    server {
+      listen {{ $servicePort }};
+      server_name _;
+
+      location = /healthz {
+        auth_basic off;
+        access_log off;
+        return 204;
+      }
+
+      location / {
+{{- if $basicAuthEnabled }}
+        auth_basic {{ $basicAuth.realm | default "carapace-bitwarden" | quote }};
+        auth_basic_user_file /etc/nginx/auth/{{ $basicAuth.secretKey | default "htpasswd" }};
+{{- else }}
+        auth_basic off;
+{{- end }}
+
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass http://127.0.0.1:{{ $servePort }};
+      }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "carapace.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: bitwarden
+spec:
+  selector:
+    app.kubernetes.io/name: carapace
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/component: bitwarden
+    app.kubernetes.io/bitwarden-instance: {{ .name }}
+  ports:
+    - name: http
+      port: {{ $servicePort }}
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "carapace.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: bitwarden
+    app.kubernetes.io/bitwarden-instance: {{ .name }}
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: carapace
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+      app.kubernetes.io/component: bitwarden
+      app.kubernetes.io/bitwarden-instance: {{ .name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: carapace
+        app.kubernetes.io/instance: {{ $.Release.Name }}
+        app.kubernetes.io/component: bitwarden
+        app.kubernetes.io/bitwarden-instance: {{ .name }}
+    spec:
+      {{- if or .priorityClassName $.Values.priorityClassName }}
+      priorityClassName: {{ .priorityClassName | default $.Values.priorityClassName }}
+      {{- end }}
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 999
+      containers:
+        - name: bitwarden
+          image: {{ include "carapace.bitwardenImage" $ }}
+          imagePullPolicy: {{ $.Values.bitwarden.image.pullPolicy }}
+          env:
+            - name: BW_SERVER_URL
+              value: {{ .serverUrl | quote }}
+            - name: BW_SERVE_PORT
+              value: {{ $servePort | quote }}
+          volumeMounts:
+            {{- if $.Values.bitwarden.persistence.enabled }}
+            - name: bitwarden-data
+              mountPath: /var/lib/bitwarden-cli
+            {{- end }}
+            - name: bitwarden-creds
+              mountPath: /run/secrets/bitwarden
+              readOnly: true
+          {{- with .resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          startupProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - curl -sS -o /dev/null --connect-timeout 2 --max-time 5 http://127.0.0.1:{{ $servePort }}/
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 36
+            timeoutSeconds: 6
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - curl -sS -o /dev/null --connect-timeout 2 --max-time 5 http://127.0.0.1:{{ $servePort }}/
+            periodSeconds: 10
+            timeoutSeconds: 6
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - curl -sS -f -o /dev/null -X POST --connect-timeout 10 --max-time 60 http://127.0.0.1:{{ $servePort }}/sync
+            periodSeconds: 120
+            timeoutSeconds: 65
+        - name: nginx
+          image: {{ include "carapace.bitwardenNginxImage" $ }}
+          imagePullPolicy: {{ $.Values.bitwarden.nginx.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ $servicePort }}
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+              readOnly: true
+            {{- if $basicAuthEnabled }}
+            - name: nginx-auth
+              mountPath: /etc/nginx/auth
+              readOnly: true
+            {{- end }}
+          {{- with $.Values.bitwarden.nginx.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 30
+      volumes:
+        {{- if $.Values.bitwarden.persistence.enabled }}
+        - name: bitwarden-data
+          persistentVolumeClaim:
+            claimName: {{ $.Release.Name }}-bitwarden-{{ .name }}
+        {{- end }}
+        - name: bitwarden-creds
+          secret:
+            secretName: {{ .existingSecret }}
+            defaultMode: 0400
+        - name: nginx-config
+          configMap:
+            name: {{ $name }}-nginx
+        {{- if $basicAuthEnabled }}
+        - name: nginx-auth
+          secret:
+            secretName: {{ required "bitwarden standalone basicAuth.existingSecret is required when basic auth is enabled" $basicAuth.existingSecret }}
+            defaultMode: 0400
+        {{- end }}
+{{- if $networkPolicyEnabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "carapace.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: bitwarden
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: carapace
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+      app.kubernetes.io/component: bitwarden
+      app.kubernetes.io/bitwarden-instance: {{ .name }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: carapace
+              app.kubernetes.io/instance: {{ $.Release.Name }}
+              app.kubernetes.io/component: server
+      ports:
+        - protocol: TCP
+          port: {{ $servicePort }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/carapace/templates/deployment-server.yaml
+++ b/charts/carapace/templates/deployment-server.yaml
@@ -142,58 +142,6 @@ spec:
               port: api
             initialDelaySeconds: 5
             periodSeconds: 10
-      {{- range .Values.bitwarden.instances }}
-      {{- if ne (.mode | default "sidecar") "standalone" }}
-        - name: {{ .name }}
-          image: {{ include "carapace.bitwardenImage" $ }}
-          imagePullPolicy: {{ $.Values.bitwarden.image.pullPolicy }}
-          env:
-            - name: BW_SERVER_URL
-              value: {{ .serverUrl | quote }}
-            - name: BW_SERVE_PORT
-              value: {{ .port | default 8087 | quote }}
-          volumeMounts:
-            {{- if $.Values.bitwarden.persistence.enabled }}
-            - name: bitwarden-data-{{ .name }}
-              mountPath: /var/lib/bitwarden-cli
-            {{- end }}
-            - name: bitwarden-creds-{{ .name }}
-              mountPath: /run/secrets/bitwarden
-              readOnly: true
-          {{- with .resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          startupProbe:
-            exec:
-              # bw serve binds 127.0.0.1 only — kubelet tcp probes use the pod IP and would fail.
-              command:
-                - sh
-                - -c
-                - curl -sS -o /dev/null --connect-timeout 2 --max-time 5 http://127.0.0.1:{{ .port | default 8087 }}/
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            failureThreshold: 36
-            timeoutSeconds: 6
-          readinessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - curl -sS -o /dev/null --connect-timeout 2 --max-time 5 http://127.0.0.1:{{ .port | default 8087 }}/
-            periodSeconds: 10
-            timeoutSeconds: 6
-          livenessProbe:
-            exec:
-              # doubles as a periodic vault sync; must hit localhost (bw not bound on pod IP)
-              command:
-                - sh
-                - -c
-                - curl -sS -f -o /dev/null -X POST --connect-timeout 10 --max-time 60 http://127.0.0.1:{{ .port | default 8087 }}/sync
-            periodSeconds: 120
-            timeoutSeconds: 65
-          {{- end }}
-      {{- end }}
       volumes:
         - name: data
           persistentVolumeClaim:
@@ -202,21 +150,4 @@ spec:
         - name: config
           configMap:
             name: {{ .Release.Name }}-config
-      {{- end }}
-      {{- if $.Values.bitwarden.persistence.enabled }}
-      {{- range .Values.bitwarden.instances }}
-      {{- if ne (.mode | default "sidecar") "standalone" }}
-        - name: bitwarden-data-{{ .name }}
-          persistentVolumeClaim:
-            claimName: {{ $.Release.Name }}-bitwarden-{{ .name }}
-      {{- end }}
-      {{- end }}
-      {{- end }}
-      {{- range .Values.bitwarden.instances }}
-      {{- if ne (.mode | default "sidecar") "standalone" }}
-        - name: bitwarden-creds-{{ .name }}
-          secret:
-            secretName: {{ .existingSecret }}
-            defaultMode: 0400
-      {{- end }}
       {{- end }}

--- a/charts/carapace/templates/deployment-server.yaml
+++ b/charts/carapace/templates/deployment-server.yaml
@@ -143,6 +143,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
       {{- range .Values.bitwarden.instances }}
+      {{- if ne (.mode | default "sidecar") "standalone" }}
         - name: {{ .name }}
           image: {{ include "carapace.bitwardenImage" $ }}
           imagePullPolicy: {{ $.Values.bitwarden.image.pullPolicy }}
@@ -191,6 +192,7 @@ spec:
                 - curl -sS -f -o /dev/null -X POST --connect-timeout 10 --max-time 60 http://127.0.0.1:{{ .port | default 8087 }}/sync
             periodSeconds: 120
             timeoutSeconds: 65
+          {{- end }}
       {{- end }}
       volumes:
         - name: data
@@ -203,14 +205,18 @@ spec:
       {{- end }}
       {{- if $.Values.bitwarden.persistence.enabled }}
       {{- range .Values.bitwarden.instances }}
+      {{- if ne (.mode | default "sidecar") "standalone" }}
         - name: bitwarden-data-{{ .name }}
           persistentVolumeClaim:
             claimName: {{ $.Release.Name }}-bitwarden-{{ .name }}
       {{- end }}
       {{- end }}
+      {{- end }}
       {{- range .Values.bitwarden.instances }}
+      {{- if ne (.mode | default "sidecar") "standalone" }}
         - name: bitwarden-creds-{{ .name }}
           secret:
             secretName: {{ .existingSecret }}
             defaultMode: 0400
+      {{- end }}
       {{- end }}

--- a/charts/carapace/templates/pvc-bitwarden.yaml
+++ b/charts/carapace/templates/pvc-bitwarden.yaml
@@ -5,6 +5,10 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ $.Release.Name }}-bitwarden-{{ .name }}
+  {{- with $.Values.bitwarden.persistence.finalizers }}
+  finalizers:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "carapace.labels" $ | nindent 4 }}
     app.kubernetes.io/component: bitwarden

--- a/charts/carapace/values.yaml
+++ b/charts/carapace/values.yaml
@@ -130,12 +130,27 @@ bitwarden:
     repository: thiesgerken/carapace-bitwarden-cli
     tag: "" # defaults to appVersion
     pullPolicy: IfNotPresent
+  nginx:
+    image:
+      registry: docker.io
+      repository: library/nginx
+      tag: 1.31.1@sha256:0a0818182f39b9853d2b259d5a18a2e02808f05e2221bea43725aaea6ee94a86
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 5m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
   # -- One PVC per bitwarden instance; stores CLI device/session data so redeploys do not
   # trigger a fresh login (and provider "new device" emails). Disable for ephemeral sidecars.
   persistence:
     enabled: true
     size: 256Mi
     storageClassName: ""
+    # -- Finalizers to protect Bitwarden CLI data PVCs from accidental deletion.
+    finalizers: []
   instances: []
 
 # -- Extra environment variables injected into the server container

--- a/charts/carapace/values.yaml
+++ b/charts/carapace/values.yaml
@@ -99,23 +99,25 @@ resetAssets: false
 #         enabled: true
 config: {}
 
-# -- Bitwarden CLI sidecar(s) for Bitwarden-compatible credential backends.
-# Each entry spawns a sidecar container running `bw serve` in the server Pod,
-# sharing the network namespace so carapace reaches it at 127.0.0.1:<port>.
+# -- Standalone Bitwarden CLI proxy instance(s) for Bitwarden-compatible credential backends.
+# Each entry spawns a companion Pod running `bw serve` behind an nginx Basic Auth proxy.
 # The matching credential backend in config.yaml should use type: bitwarden
-# with url set to http://127.0.0.1:<port>.
+# with url set to http://<release>-bitwarden-<name>:<port> or fullnameOverride:<port>.
 #
 # Example:
 #   bitwarden:
 #     persistence:
-#       enabled: true   # set false for ephemeral sidecar (no PVC)
+#       enabled: true   # set false for ephemeral Bitwarden CLI data (no PVC)
 #       size: 256Mi
 #       storageClassName: ""
 #     instances:
-#       - name: bw-personal
+#       - name: personal
+#         fullnameOverride: carapace-bitwarden-personal
 #         port: 8087
 #         serverUrl: https://vault.example.com
 #         existingSecret: carapace-bw-personal
+#         basicAuth:
+#           existingSecret: carapace-bitwarden-personal-basic-auth
 #         # The Secret is mounted as files under /run/secrets/bitwarden (e.g. BW_MASTER_PASSWORD;
 #         # BW_CLIENTID + BW_CLIENTSECRET for API key login, or BW_EMAIL for password-only login).
 #         resources:
@@ -144,7 +146,7 @@ bitwarden:
         cpu: 100m
         memory: 64Mi
   # -- One PVC per bitwarden instance; stores CLI device/session data so redeploys do not
-  # trigger a fresh login (and provider "new device" emails). Disable for ephemeral sidecars.
+  # trigger a fresh login (and provider "new device" emails). Disable for ephemeral instances.
   persistence:
     enabled: true
     size: 256Mi

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -29,7 +29,14 @@ users:
     password_changed_at: "2026-05-24T12:00:00Z"
     last_login_at: null
     config:
-      credentials: {}
+      credentials:
+        backends:
+          vault:
+            type: bitwarden
+            url: http://carapace-bitwarden:8087
+            basic_auth:
+              username: thies
+              password: user-specific-random-proxy-password
       channels:
         matrix:
           enabled: false
@@ -42,6 +49,8 @@ users:
 ```
 
 Usernames are normalized to lowercase and should be stable, hand-picked names for the self-hosted users of an instance.
+Per-user credential backend secrets are stored in `users.yaml`; API responses redact backend proxy passwords, and updates
+that omit an existing proxy password keep the stored value.
 
 ## Creating Users
 

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -45,7 +45,7 @@ users:
 Supported backend types:
 
 - `file`: reads `key=value` pairs from a secrets file (`path` defaults to `<data_dir>/secrets.env`).
-- `bitwarden`: talks to an externally managed `bw serve` endpoint (typically sidecar/companion container or a separate Pod behind a proxy). The Docker Compose `bw` service uses env vars such as `BW_SERVER_URL` (vault base URL for the CLI login). Empty `BW_SERVER_URL` is applied as US cloud via `bw config server bitwarden.com` when it first differs from the value stored under the sidecar data directory (`$BW_DATA_DIR/carapace-state/`, e.g. on a Docker volume or Kubernetes PVC); the sidecar only logs out and re-runs `bw config server` when that env changes. See `docs/quickstart.md` for the full sidecar variable list.
+- `bitwarden`: talks to an externally managed `bw serve` endpoint (typically a companion container or a separate Pod behind a proxy). The Docker Compose `bw` service uses env vars such as `BW_SERVER_URL` (vault base URL for the CLI login). Empty `BW_SERVER_URL` is applied as US cloud via `bw config server bitwarden.com` when it first differs from the value stored under the Bitwarden CLI data directory (`$BW_DATA_DIR/carapace-state/`, e.g. on a Docker volume or Kubernetes PVC); the Bitwarden CLI process only logs out and re-runs `bw config server` when that env changes. See `docs/quickstart.md` for the full Docker Compose variable list.
 
 For a standalone Kubernetes `bw serve` Pod, keep `bw serve` bound to localhost inside that Pod and expose an nginx
 proxy with HTTP Basic Auth. Configure the matching `basic_auth` block on the user's Bitwarden backend. carapace redacts

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -25,10 +25,31 @@ credentials:
       url: http://127.0.0.1:8087
 ```
 
+In multi-user deployments, prefer configuring credential backends on the user record instead of the global
+`config.yaml`, so each user can point at their own vault proxy and authentication boundary:
+
+```yaml
+users:
+  thies:
+    config:
+      credentials:
+        backends:
+          vault:
+            type: bitwarden
+            url: http://carapace-bitwarden:8087
+            basic_auth:
+              username: thies
+              password: user-specific-random-proxy-password
+```
+
 Supported backend types:
 
 - `file`: reads `key=value` pairs from a secrets file (`path` defaults to `<data_dir>/secrets.env`).
-- `bitwarden`: talks to an externally managed `bw serve` endpoint (typically sidecar/companion container). The Docker Compose `bw` service uses env vars such as `BW_SERVER_URL` (vault base URL for the CLI login). Empty `BW_SERVER_URL` is applied as US cloud via `bw config server bitwarden.com` when it first differs from the value stored under the sidecar data directory (`$BW_DATA_DIR/carapace-state/`, e.g. on a Docker volume or Kubernetes PVC); the sidecar only logs out and re-runs `bw config server` when that env changes. See `docs/quickstart.md` for the full sidecar variable list.
+- `bitwarden`: talks to an externally managed `bw serve` endpoint (typically sidecar/companion container or a separate Pod behind a proxy). The Docker Compose `bw` service uses env vars such as `BW_SERVER_URL` (vault base URL for the CLI login). Empty `BW_SERVER_URL` is applied as US cloud via `bw config server bitwarden.com` when it first differs from the value stored under the sidecar data directory (`$BW_DATA_DIR/carapace-state/`, e.g. on a Docker volume or Kubernetes PVC); the sidecar only logs out and re-runs `bw config server` when that env changes. See `docs/quickstart.md` for the full sidecar variable list.
+
+For a standalone Kubernetes `bw serve` Pod, keep `bw serve` bound to localhost inside that Pod and expose an nginx
+proxy with HTTP Basic Auth. Configure the matching `basic_auth` block on the user's Bitwarden backend. carapace redacts
+the proxy password from auth/admin API responses, but stores it in the user's local `auth/users.yaml` config.
 
 Each credential is addressed by `vault_path` as `<backend>/<id>`, for example:
 

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -32,7 +32,7 @@ Inject additional config via `extraEnv` (inline values) or `envFrom` (external S
 
 Session-list caching requires Redis. The Helm chart deploys an in-cluster Redis by default; if you disable it, point carapace at an external Redis instance instead.
 
-Kubernetes credential backends can be deployed through the Helm chart too. For Bitwarden/Vaultwarden, use the default sidecar mode when a backend only needs localhost access from the server pod. Use `mode: standalone` when you want a separately addressable, per-user vault proxy protected by HTTP Basic Auth and NetworkPolicy.
+Kubernetes credential backends can be deployed through the Helm chart too. For Bitwarden/Vaultwarden, the chart runs separately addressable vault proxies protected by HTTP Basic Auth and NetworkPolicy.
 
 See the [chart README](../charts/carapace/README.md) for installation details and the full values reference.
 
@@ -129,25 +129,7 @@ kubectl create secret generic carapace-bw-personal -n carapace \
   --from-literal=BW_EMAIL=you@example.com
 ```
 
-Use a sidecar when carapace can reach the backend on localhost:
-
-```yaml
-bitwarden:
-  instances:
-    - name: bw-personal
-      port: 8087
-      serverUrl: https://vault.example.com
-      existingSecret: carapace-bw-personal
-
-config:
-  credentials:
-    backends:
-      personal:
-        type: bitwarden
-        url: http://127.0.0.1:8087
-```
-
-For multi-user deployments, prefer standalone instances. Each user can get a separate Service, Basic Auth boundary, Secret, and PVC. The Bitwarden CLI still binds to a fixed localhost-only internal port (`8088`) inside its own Pod; nginx exposes the configured service port and the chart creates a NetworkPolicy that only allows ingress from the carapace server Pod. The service port must not be `8088`.
+Each user can get a separate Service, Basic Auth boundary, Secret, and PVC. The Bitwarden CLI binds to a fixed localhost-only internal port (`8088`) inside its own Pod; nginx exposes the configured service port and the chart creates a NetworkPolicy that only allows ingress from the carapace server Pod. The service port must not be `8088`.
 
 Create the proxy auth Secret separately. It must contain an htpasswd file named `htpasswd` unless you override `basicAuth.secretKey`:
 
@@ -157,7 +139,7 @@ kubectl create secret generic carapace-bitwarden-alice-basic-auth -n carapace \
   --from-file=htpasswd=/tmp/carapace-bitwarden-alice-htpasswd
 ```
 
-Then enable a standalone instance with user-specific names in the Helm values:
+Then enable an instance with user-specific names in the Helm values:
 
 ```yaml
 bitwarden:
@@ -168,7 +150,6 @@ bitwarden:
       - kubernetes.io/pvc-protection
   instances:
     - name: vaultwarden-alice
-      mode: standalone
       fullnameOverride: carapace-bitwarden-alice
       port: 8087
       serverUrl: https://vault.example.com

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -32,6 +32,8 @@ Inject additional config via `extraEnv` (inline values) or `envFrom` (external S
 
 Session-list caching requires Redis. The Helm chart deploys an in-cluster Redis by default; if you disable it, point carapace at an external Redis instance instead.
 
+Kubernetes credential backends can be deployed through the Helm chart too. For Bitwarden/Vaultwarden, use the default sidecar mode when a backend only needs localhost access from the server pod. Use `mode: standalone` when you want a separately addressable, per-user vault proxy protected by HTTP Basic Auth and NetworkPolicy.
+
 See the [chart README](../charts/carapace/README.md) for installation details and the full values reference.
 
 ## Architecture
@@ -114,6 +116,87 @@ config:
 The Helm chart deploys an in-cluster Redis by default. Its Service name is `<release>-redis`, so a typical URL is `redis://<release>-redis:6379/0`. If you set `redis.enabled=false`, you must provide an external Redis URL via `config.cache.redis_url` or `CARAPACE_CACHE_REDIS_URL`.
 
 > **Important:** Always pin the sandbox image to a specific version tag (e.g. `:0.25.1`). Using `:latest` in production can lead to version mismatches between the server and sandbox image.
+
+### Bitwarden / Vaultwarden credential backends
+
+The chart can run Bitwarden CLI (`bw serve`) instances for the `bitwarden` credential backend. Each instance uses a Kubernetes Secret containing Bitwarden login material, mounted as files under `/run/secrets/bitwarden`:
+
+```bash
+kubectl create secret generic carapace-bw-personal -n carapace \
+  --from-literal=BW_CLIENTID=user.xxxxxxxx-... \
+  --from-literal=BW_CLIENTSECRET=xxxxxxxxxxxx \
+  --from-literal=BW_MASTER_PASSWORD=your-master-password \
+  --from-literal=BW_EMAIL=you@example.com
+```
+
+Use a sidecar when carapace can reach the backend on localhost:
+
+```yaml
+bitwarden:
+  instances:
+    - name: bw-personal
+      port: 8087
+      serverUrl: https://vault.example.com
+      existingSecret: carapace-bw-personal
+
+config:
+  credentials:
+    backends:
+      personal:
+        type: bitwarden
+        url: http://127.0.0.1:8087
+```
+
+For multi-user deployments, prefer standalone instances. Each user can get a separate Service, Basic Auth boundary, Secret, and PVC. The Bitwarden CLI still binds to localhost inside its own Pod; nginx exposes the service port and the chart creates a NetworkPolicy that only allows ingress from the carapace server Pod.
+
+Create the proxy auth Secret separately. It must contain an htpasswd file named `htpasswd` unless you override `basicAuth.secretKey`:
+
+```bash
+htpasswd -nB alice > /tmp/carapace-bitwarden-alice-htpasswd
+kubectl create secret generic carapace-bitwarden-alice-basic-auth -n carapace \
+  --from-file=htpasswd=/tmp/carapace-bitwarden-alice-htpasswd
+```
+
+Then enable a standalone instance with user-specific names in the Helm values:
+
+```yaml
+bitwarden:
+  persistence:
+    enabled: true
+    size: 256Mi
+    finalizers:
+      - kubernetes.io/pvc-protection
+  instances:
+    - name: vaultwarden-alice
+      mode: standalone
+      fullnameOverride: carapace-bitwarden-alice
+      port: 8087
+      servePort: 8088
+      serverUrl: https://vault.example.com
+      existingSecret: carapace-bw-alice
+      basicAuth:
+        existingSecret: carapace-bitwarden-alice-basic-auth
+```
+
+Configure the matching Bitwarden backend on the user record, for example in `auth/users.yaml` or through the admin API:
+
+```yaml
+users:
+  alice:
+    config:
+      credentials:
+        backends:
+          vault:
+            type: bitwarden
+            url: http://carapace-bitwarden-alice:8087
+            basic_auth:
+              username: alice
+              password: user-specific-random-proxy-password
+```
+
+Keep the username/password in the carapace user config aligned with the htpasswd entry in the proxy Secret. carapace redacts the proxy password from admin API responses, but the local `auth/users.yaml` still stores it so the server can authenticate to nginx.
+
+See [credentials.md](credentials.md) for backend behavior, exposure controls, and credential access auditing.
 
 ### Auto-detection
 

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -147,7 +147,7 @@ config:
         url: http://127.0.0.1:8087
 ```
 
-For multi-user deployments, prefer standalone instances. Each user can get a separate Service, Basic Auth boundary, Secret, and PVC. The Bitwarden CLI still binds to localhost inside its own Pod; nginx exposes the service port and the chart creates a NetworkPolicy that only allows ingress from the carapace server Pod.
+For multi-user deployments, prefer standalone instances. Each user can get a separate Service, Basic Auth boundary, Secret, and PVC. The Bitwarden CLI still binds to a fixed localhost-only internal port (`8088`) inside its own Pod; nginx exposes the configured service port and the chart creates a NetworkPolicy that only allows ingress from the carapace server Pod. The service port must not be `8088`.
 
 Create the proxy auth Secret separately. It must contain an htpasswd file named `htpasswd` unless you override `basicAuth.secretKey`:
 
@@ -171,7 +171,6 @@ bitwarden:
       mode: standalone
       fullnameOverride: carapace-bitwarden-alice
       port: 8087
-      servePort: 8088
       serverUrl: https://vault.example.com
       existingSecret: carapace-bw-alice
       basicAuth:

--- a/src/carapace/credentials/__init__.py
+++ b/src/carapace/credentials/__init__.py
@@ -5,6 +5,7 @@ from .file import FileVaultBackend
 from .protocol import VaultBackend, is_exposed
 from .registry import (
     CredentialRegistry,
+    SessionCredentialRegistry,
     build_credential_registry,
 )
 
@@ -12,6 +13,7 @@ __all__ = [
     "BitwardenBackend",
     "CredentialRegistry",
     "FileVaultBackend",
+    "SessionCredentialRegistry",
     "VaultBackend",
     "build_credential_registry",
     "is_exposed",

--- a/src/carapace/credentials/bitwarden.py
+++ b/src/carapace/credentials/bitwarden.py
@@ -8,12 +8,12 @@ from .protocol import is_exposed, require_exposed
 
 
 class BitwardenBackend:
-    """Talks to an external ``bw serve`` instance (sidecar / companion container).
+    """Talks to an external ``bw serve`` instance (companion container / Pod).
 
     Expects ``bw serve`` to already be running at *base_url* — carapace does not
     manage the process lifecycle.  In Docker Compose the ``bw serve`` container
     shares the network namespace via ``network_mode: service:carapace``; in
-    Kubernetes it runs as a sidecar in the same Pod.
+    Kubernetes the Helm chart runs it as a companion Pod behind an nginx proxy.
     """
 
     def __init__(

--- a/src/carapace/credentials/bitwarden.py
+++ b/src/carapace/credentials/bitwarden.py
@@ -26,7 +26,12 @@ class BitwardenBackend:
         self._name = name
         self._cfg = cfg
         self._base_url = base_url.rstrip("/")
-        self._client = httpx.AsyncClient(base_url=base_url, timeout=30.0)
+        auth = None
+        if cfg.basic_auth is not None:
+            if cfg.basic_auth.password is None:
+                raise ValueError(f"Bitwarden backend {name!r} basic_auth.password is required")
+            auth = httpx.BasicAuth(cfg.basic_auth.username, cfg.basic_auth.password)
+        self._client = httpx.AsyncClient(base_url=base_url, timeout=30.0, auth=auth)
 
     async def _get(
         self,

--- a/src/carapace/credentials/registry.py
+++ b/src/carapace/credentials/registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import assert_never
 
@@ -8,6 +9,7 @@ from loguru import logger
 from ..models.credentials import (
     BitwardenCredentialBackendConfig,
     CredentialMetadata,
+    CredentialRegistryProtocol,
     CredentialsConfig,
     FileCredentialBackendConfig,
 )
@@ -60,6 +62,31 @@ class CredentialRegistry:
         """Close all managed credential backends."""
         for backend in self._backends.values():
             await backend.close()
+
+
+class SessionCredentialRegistry:
+    """Credential registry view bound to one session owner."""
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        resolve_registry: Callable[[str], Awaitable[CredentialRegistryProtocol]],
+    ) -> None:
+        self._session_id = session_id
+        self._resolve_registry = resolve_registry
+
+    async def _registry(self) -> CredentialRegistryProtocol:
+        return await self._resolve_registry(self._session_id)
+
+    async def fetch(self, vault_path: str) -> str:
+        return await (await self._registry()).fetch(vault_path)
+
+    async def fetch_metadata(self, vault_path: str) -> CredentialMetadata:
+        return await (await self._registry()).fetch_metadata(vault_path)
+
+    async def list(self, query: str = "") -> list[CredentialMetadata]:
+        return await (await self._registry()).list(query)
 
 
 async def build_credential_registry(config: CredentialsConfig, data_dir: Path) -> CredentialRegistry:

--- a/src/carapace/models/credentials.py
+++ b/src/carapace/models/credentials.py
@@ -35,11 +35,26 @@ class FileCredentialBackendConfig(ConfigModel):
     hide: list[str] = []
 
 
+class BasicAuthConfig(ConfigModel):
+    """HTTP Basic Auth credentials for a credential backend proxy."""
+
+    username: str
+    password: str | None = None
+
+    @model_validator(mode="after")
+    def _normalize(self) -> BasicAuthConfig:
+        self.username = self.username.strip()
+        if not self.username:
+            raise ValueError("basic_auth.username must not be empty")
+        return self
+
+
 class BitwardenCredentialBackendConfig(ConfigModel):
     """Configuration for a Bitwarden/Vaultwarden credential backend."""
 
     type: Literal["bitwarden"] = "bitwarden"
     url: str = "http://127.0.0.1:8087"
+    basic_auth: BasicAuthConfig | None = None
     expose: list[str] = []
     hide: list[str] = []
 

--- a/src/carapace/models/user.py
+++ b/src/carapace/models/user.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from typing import Any
-
 from pydantic import BaseModel, ConfigDict, model_validator
 
+from .credentials import CredentialsConfig
 from .matrix import MatrixChannelConfig
 
 DEFAULT_GIT_BRANCH = "main"
@@ -35,8 +34,8 @@ class UserGitConfig(UserConfigModel):
 
 
 class UserConfig(UserConfigModel):
-    credentials: dict[str, Any] = {}
+    credentials: CredentialsConfig = CredentialsConfig()
     channels: UserChannelsConfig = UserChannelsConfig()
     git: UserGitConfig = UserGitConfig()
     default_models: dict[str, str] = {}
-    budgets: dict[str, Any] = {}
+    budgets: dict[str, object] = {}

--- a/src/carapace/server/__init__.py
+++ b/src/carapace/server/__init__.py
@@ -77,6 +77,7 @@ _config: Config
 _engine: SessionEngine
 _git_handler: GitHttpHandler
 _credential_registry: CredentialRegistry
+_user_credential_registries: dict[str, tuple[str, CredentialRegistry]]
 _session_archive: SessionArchiveService
 _session_list_cache: SessionListCache
 _jobs_store: JobsStore
@@ -156,6 +157,43 @@ def _create_sandbox_runtime(config: Config, data_dir: Path) -> ContainerRuntime:
     )
 
 
+def _credential_config_fingerprint(username: str) -> tuple[str, bool]:
+    user = _auth_store.get_user(username)
+    if user is None:
+        raise KeyError(username)
+    user_credentials = user.config.credentials
+    if user_credentials.backends:
+        return user_credentials.model_dump_json(exclude_none=True), True
+    return _config.credentials.model_dump_json(exclude_none=True), False
+
+
+async def _credential_registry_for_user(username: str) -> CredentialRegistry:
+    fingerprint, is_user_specific = _credential_config_fingerprint(username)
+    if not is_user_specific:
+        return _credential_registry
+
+    cached = _user_credential_registries.get(username)
+    if cached is not None:
+        cached_fingerprint, cached_registry = cached
+        if cached_fingerprint == fingerprint:
+            return cached_registry
+        await cached_registry.close()
+
+    user = _auth_store.get_user(username)
+    if user is None:
+        raise KeyError(username)
+    registry = await build_credential_registry(user.config.credentials, _data_dir)
+    _user_credential_registries[username] = (fingerprint, registry)
+    if registry.backend_names:
+        logger.info(f"Credential backends for user {username!r}: {', '.join(registry.backend_names)}")
+    return registry
+
+
+async def _credential_registry_for_session(session_id: str) -> CredentialRegistry:
+    meta = _engine.session_mgr.load_meta(session_id)
+    return await _credential_registry_for_user(meta.user)
+
+
 async def _idle_cleanup_loop(sandbox_mgr: SandboxManager) -> None:
     """Periodically clean up idle sandbox containers."""
     while True:
@@ -214,6 +252,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
         _engine, \
         _git_handler, \
         _credential_registry, \
+        _user_credential_registries, \
         _session_archive, \
         _session_list_cache, \
         _jobs_store, \
@@ -333,6 +372,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
             logger.info(f"Cleaned up {removed} orphaned sandbox(es)")
 
     _credential_registry = await build_credential_registry(_config.credentials, _data_dir)
+    _user_credential_registries = {}
     if _credential_registry.backend_names:
         logger.info(f"Credential backends: {', '.join(_credential_registry.backend_names)}")
 
@@ -368,6 +408,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
         agent_model=agent_model,
         sandbox_mgr=_sandbox_mgr,
         credential_registry=_credential_registry,
+        credential_registry_for_session=_credential_registry_for_session,
         model_factory=model_factory,
         notification_router=_notification_router,
     )
@@ -480,6 +521,8 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
         await internal_task
     await proxy.stop()
     await _credential_registry.close()
+    for _, registry in _user_credential_registries.values():
+        await registry.close()
     await _sandbox_mgr.cleanup_all()
     await _session_list_cache.close()
     price_updater.stop()
@@ -700,7 +743,12 @@ async def list_credentials(request: Request, q: str = "") -> list[dict[str, str]
     if active.security is None:
         raise HTTPException(status_code=403, detail="Session not initialized")
 
-    items = await _credential_registry.list(q)
+    try:
+        credential_registry = await _credential_registry_for_session(session_id)
+    except KeyError:
+        raise HTTPException(status_code=403, detail="Session owner is not configured") from None
+
+    items = await credential_registry.list(q)
     paths = [i.vault_path for i in items]
     names = [i.name for i in items]
     explanation = f"Sandbox listed credential metadata (query={q!r}, {len(paths)} item(s))"
@@ -732,7 +780,8 @@ async def fetch_credential(request: Request, vault_path: str) -> Response:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
     try:
-        meta = await _credential_registry.fetch_metadata(vault_path)
+        credential_registry = await _credential_registry_for_session(session_id)
+        meta = await credential_registry.fetch_metadata(vault_path)
     except KeyError:
         return Response(status_code=404, content="Credential not found")
 
@@ -793,7 +842,7 @@ async def fetch_credential(request: Request, vault_path: str) -> Response:
             return Response(status_code=403, content="Credential access denied")
 
     try:
-        value = await _credential_registry.fetch(vault_path)
+        value = await credential_registry.fetch(vault_path)
     except KeyError:
         return Response(status_code=404, content="Credential not found")
 

--- a/src/carapace/server/__init__.py
+++ b/src/carapace/server/__init__.py
@@ -781,6 +781,10 @@ async def fetch_credential(request: Request, vault_path: str) -> Response:
 
     try:
         credential_registry = await _credential_registry_for_session(session_id)
+    except KeyError:
+        raise HTTPException(status_code=403, detail="Session owner is not configured") from None
+
+    try:
         meta = await credential_registry.fetch_metadata(vault_path)
     except KeyError:
         return Response(status_code=404, content="Credential not found")

--- a/src/carapace/server/auth.py
+++ b/src/carapace/server/auth.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, WebSocket, WebSocketException, status
 from pydantic import BaseModel
 
 from ..auth import AuthStore, UserIdentity, has_admin_role, normalize_username
+from ..models.credentials import BitwardenCredentialBackendConfig
 from ..models.user import UserConfig
 from .state import server_module
 
@@ -19,8 +20,16 @@ class LoginRequest(BaseModel):
     password: str
 
 
+class PublicUserIdentity(BaseModel):
+    username: str
+    display_name: str = ""
+    email: str | None = None
+    roles: list[str] = []
+    config: dict[str, Any] = {}
+
+
 class LoginResponse(BaseModel):
-    user: UserIdentity
+    user: PublicUserIdentity
 
 
 class WebSocketTicketResponse(BaseModel):
@@ -56,7 +65,50 @@ class AdminUserResponse(BaseModel):
     updated_at: str
     password_changed_at: str
     last_login_at: str | None = None
-    config: UserConfig
+    config: dict[str, Any]
+
+
+def _redact_user_config(config: UserConfig) -> dict[str, Any]:
+    payload = config.model_dump(mode="json", exclude_none=True)
+    backends = payload.get("credentials", {}).get("backends", {})
+    if isinstance(backends, dict):
+        for backend in backends.values():
+            if not isinstance(backend, dict):
+                continue
+            basic_auth = backend.get("basic_auth")
+            if isinstance(basic_auth, dict):
+                basic_auth.pop("password", None)
+    return payload
+
+
+def _public_identity(user: UserIdentity) -> PublicUserIdentity:
+    return PublicUserIdentity(
+        username=user.username,
+        display_name=user.display_name,
+        email=user.email,
+        roles=user.roles,
+        config=_redact_user_config(user.config),
+    )
+
+
+def _config_with_preserved_backend_passwords(username: str | None, config: UserConfig) -> UserConfig:
+    merged = config.model_copy(deep=True)
+    existing_user = _auth_store().get_user(username) if username is not None else None
+    existing_config = existing_user.config if existing_user is not None else None
+
+    for backend_name, backend in merged.credentials.backends.items():
+        if not isinstance(backend, BitwardenCredentialBackendConfig) or backend.basic_auth is None:
+            continue
+        if backend.basic_auth.password is not None:
+            continue
+        existing_backend = None
+        if existing_config is not None:
+            existing_backend = existing_config.credentials.backends.get(backend_name)
+        if isinstance(existing_backend, BitwardenCredentialBackendConfig) and existing_backend.basic_auth is not None:
+            backend.basic_auth.password = existing_backend.basic_auth.password
+        if backend.basic_auth.password is None:
+            raise ValueError(f"basic_auth.password is required for credential backend {backend_name!r}")
+    return merged
 
 
 def _auth_store() -> AuthStore:
@@ -87,7 +139,7 @@ def _user_response(username: str) -> AdminUserResponse:
         updated_at=user.updated_at.isoformat(),
         password_changed_at=user.password_changed_at.isoformat(),
         last_login_at=user.last_login_at.isoformat() if user.last_login_at is not None else None,
-        config=user.config,
+        config=_redact_user_config(user.config),
     )
 
 
@@ -187,7 +239,7 @@ async def login(request: Request, response: Response, body: LoginRequest) -> Log
         samesite=cookie.same_site,
         path="/",
     )
-    return LoginResponse(user=user.identity(username))
+    return LoginResponse(user=_public_identity(user.identity(username)))
 
 
 @router.post("/auth/logout", status_code=204)
@@ -204,9 +256,9 @@ async def logout(
     return response
 
 
-@router.get("/auth/me", response_model=UserIdentity)
-async def me(user: Annotated[UserIdentity, Depends(current_user)]) -> UserIdentity:
-    return user
+@router.get("/auth/me", response_model=PublicUserIdentity)
+async def me(user: Annotated[UserIdentity, Depends(current_user)]) -> PublicUserIdentity:
+    return _public_identity(user)
 
 
 @router.post("/auth/ws-ticket", response_model=WebSocketTicketResponse)
@@ -241,7 +293,7 @@ async def create_admin_user(
             display_name=body.display_name,
             email=body.email,
             roles=body.roles,
-            config=body.config,
+            config=_config_with_preserved_backend_passwords(None, body.config),
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -254,8 +306,10 @@ async def update_admin_user(
     body: AdminUserUpdateRequest,
     _admin_user: Annotated[UserIdentity, Depends(verify_admin_user)],
 ) -> AdminUserResponse:
-    updates = body.model_dump(exclude_unset=True)
-    password = updates.pop("password", None)
+    updates = body.model_dump(exclude_unset=True, exclude={"config", "password"})
+    password = body.password if "password" in body.model_fields_set else None
+    if "config" in body.model_fields_set and body.config is not None:
+        updates["config"] = _config_with_preserved_backend_passwords(username, body.config)
     try:
         if updates:
             _assert_not_removing_last_admin(username, updates)

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -13,7 +13,7 @@ import asyncio
 import base64
 import contextlib
 import secrets
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -27,6 +27,7 @@ from pydantic_ai.models import Model
 
 from ..agent.deps import Deps
 from ..agent.loop import run_agent_turn as _run_agent_turn
+from ..credentials import SessionCredentialRegistry
 from ..git.store import GitStore
 from ..models.config import Config
 from ..models.credentials import CredentialRegistryProtocol
@@ -117,6 +118,7 @@ class SessionEngine(
         agent_model: Model | None,
         sandbox_mgr: SandboxManager,
         credential_registry: CredentialRegistryProtocol,
+        credential_registry_for_session: Callable[[str], Awaitable[CredentialRegistryProtocol]] | None = None,
         model_factory: Callable[[str], Model] | None = None,
         notification_router: NotificationRouter | None = None,
     ) -> None:
@@ -130,6 +132,7 @@ class SessionEngine(
         self._sandbox_mgr = sandbox_mgr
         self._model_factory = model_factory
         self._credential_registry = credential_registry
+        self._credential_registry_for_session = credential_registry_for_session
         self._notification_router = notification_router
         self._active: dict[str, ActiveSession] = {}
         self._llm_semaphore = asyncio.Semaphore(config.agent.max_parallel_llm)
@@ -138,6 +141,19 @@ class SessionEngine(
         sandbox_mgr.set_activated_skills_callback(self._get_activated_skills)
         sandbox_mgr.set_skill_activation_inputs_callback(self._skill_activation_inputs)
         sandbox_mgr.set_skill_command_aliases_callback(self._skill_command_aliases)
+
+    async def _resolve_credential_registry(self, session_id: str) -> CredentialRegistryProtocol:
+        if self._credential_registry_for_session is None:
+            return self._credential_registry
+        return await self._credential_registry_for_session(session_id)
+
+    def _session_credential_registry(self, session_id: str) -> CredentialRegistryProtocol:
+        if self._credential_registry_for_session is None:
+            return self._credential_registry
+        return SessionCredentialRegistry(
+            session_id=session_id,
+            resolve_registry=self._resolve_credential_registry,
+        )
 
     # -- public access to file I/O manager --
 
@@ -294,7 +310,7 @@ class SessionEngine(
                 value = None
             try:
                 if value is None:
-                    value = await self._credential_registry.fetch(decl.vault_path)
+                    value = await self._session_credential_registry(session_id).fetch(decl.vault_path)
                     self._sandbox_mgr.cache_credential(session_id, decl.vault_path, value)
             except KeyError:
                 logger.warning(f"Credential {decl.vault_path} not found in vault during re-injection")
@@ -450,7 +466,7 @@ class SessionEngine(
             llm_usage_limits=lambda: self._remaining_aux_usage_limits(active),
             sandbox=self._sandbox_mgr,
             activated_skills=[],
-            credential_registry=self._credential_registry,
+            credential_registry=self._session_credential_registry(session_id),
         )
 
     async def submit_message(

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -14,6 +14,7 @@ from carapace.credentials import (
     is_exposed,
 )
 from carapace.models.credentials import (
+    BasicAuthConfig,
     BitwardenCredentialBackendConfig,
     CredentialMetadata,
     CredentialsConfig,
@@ -31,6 +32,30 @@ def test_credential_metadata_defaults():
     assert meta.vault_path == "dev/gmail"
     assert meta.name == "Gmail"
     assert meta.description == ""
+
+
+def test_bitwarden_backend_basic_auth_requires_password() -> None:
+    cfg = BitwardenCredentialBackendConfig(basic_auth=BasicAuthConfig(username="carapace"))
+
+    with pytest.raises(ValueError, match=r"basic_auth\.password"):
+        BitwardenBackend(name="bw", base_url="http://bitwarden.local", cfg=cfg)
+
+
+def test_bitwarden_backend_configures_basic_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr("carapace.credentials.bitwarden.httpx.AsyncClient", FakeAsyncClient)
+    cfg = BitwardenCredentialBackendConfig(
+        basic_auth=BasicAuthConfig(username="carapace", password="proxy-password"),
+    )
+
+    BitwardenBackend(name="bw", base_url="http://bitwarden.local", cfg=cfg)
+
+    assert isinstance(captured["auth"], httpx.BasicAuth)
 
 
 def test_credential_metadata_with_description():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -22,7 +22,7 @@ from carapace.config import load_config
 from carapace.credentials import CredentialRegistry
 from carapace.git.store import GitStore
 from carapace.jobs import JobsScheduler, JobsStore
-from carapace.models.credentials import CredentialMetadata
+from carapace.models.credentials import BasicAuthConfig, BitwardenCredentialBackendConfig, CredentialMetadata
 from carapace.models.jobs import JobDefinition
 from carapace.models.session import SessionBudget
 from carapace.models.user import UserConfig
@@ -89,6 +89,7 @@ def _setup_server(tmp_path, monkeypatch):
     srv._data_dir = tmp_path
     srv._config = config
     srv._credential_registry = cred_reg
+    srv._user_credential_registries = {}
     srv._engine = SessionEngine(
         config=config,
         data_dir=tmp_path,
@@ -256,6 +257,58 @@ def test_admin_user_update_can_clear_email(client, admin_auth_headers):
 
     assert update_resp.status_code == 200
     assert update_resp.json()["email"] is None
+
+
+def test_admin_user_config_redacts_and_preserves_backend_password(client, admin_auth_headers):
+    create_resp = client.post(
+        "/api/admin/users",
+        headers=admin_auth_headers,
+        json={
+            "username": "Ada",
+            "password": "correct-horse-battery",
+            "display_name": "Ada",
+            "config": {
+                "credentials": {
+                    "backends": {
+                        "vault": {
+                            "type": "bitwarden",
+                            "url": "http://carapace-bitwarden:8087",
+                            "basic_auth": {"username": "ada", "password": "proxy-password"},
+                        }
+                    }
+                }
+            },
+        },
+    )
+
+    assert create_resp.status_code == 201
+    backend = create_resp.json()["config"]["credentials"]["backends"]["vault"]
+    assert backend["basic_auth"] == {"username": "ada"}
+
+    update_resp = client.patch(
+        "/api/admin/users/ada",
+        headers=admin_auth_headers,
+        json={
+            "config": {
+                "credentials": {
+                    "backends": {
+                        "vault": {
+                            "type": "bitwarden",
+                            "url": "http://carapace-bitwarden:8087",
+                            "basic_auth": {"username": "ada"},
+                        }
+                    }
+                }
+            }
+        },
+    )
+
+    assert update_resp.status_code == 200
+    user = srv._auth_store.get_user("ada")
+    assert user is not None
+    stored_backend = user.config.credentials.backends["vault"]
+    assert isinstance(stored_backend, BitwardenCredentialBackendConfig)
+    assert stored_backend.basic_auth == BasicAuthConfig(username="ada", password="proxy-password")
 
 
 def test_admin_user_update_cannot_remove_last_enabled_admin(client, admin_auth_headers):


### PR DESCRIPTION
- Introduced new Helm template for Bitwarden deployment in standalone mode, including Nginx proxy configuration.
- Updated values.yaml to include configuration for Nginx image and Bitwarden instances.
- Enhanced Bitwarden backend to support HTTP Basic Auth for user-specific configurations.
- Implemented credential registry handling for user-specific sessions.
- Added tests for Bitwarden backend authentication and user configuration redaction.
- Updated documentation to reflect changes in credential backend configuration and usage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes credential vault access paths, stores proxy passwords in user config, and alters Kubernetes deployment/security boundaries for secrets handling.
> 
> **Overview**
> This PR **replaces in-pod Bitwarden sidecars** with **standalone companion Deployments** (Bitwarden CLI + nginx Basic Auth), each with its own Service, optional PVC, and a **NetworkPolicy** that only allows the carapace **server** pod to reach the proxy port. Server deployment no longer mounts Bitwarden containers or secrets.
> 
> On the application side, **Bitwarden backends** can use **`basic_auth`** when talking to those proxies. **User `config.credentials`** is now a typed `CredentialsConfig`; sessions resolve credentials from **per-user backends** when configured (otherwise global config), including sandbox list/fetch and skill re-injection. **Auth/admin APIs** return redacted user config (no proxy passwords) but **preserve** omitted `basic_auth.password` on user updates.
> 
> Docs and chart **values/README** describe per-user vault URLs, htpasswd secrets, and the internal `8088` vs exposed service port rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5eb3e1bce5708abea70ba2a1e25144f7cbe2061. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->