### PR TITLE
✨ feat: no global credential config + disable file cred backend by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Optional CLI connection:
 ```bash
 # First login to the web UI as admin with CARAPACE_TOKEN, then create your normal user.
 
-uv run carapace --user thies --password change-me
+uv run carapace --user alice --password change-me
 ```
 
 The web UI uses the same username/password login and stores the session in an HttpOnly cookie.

--- a/charts/carapace/README.md
+++ b/charts/carapace/README.md
@@ -211,38 +211,38 @@ The Bitwarden CLI binds to a fixed localhost-only internal port (`8088`) inside 
 
 ### Key values
 
-| Value                                    | Default                          | Description                                                        |
-| ---------------------------------------- | -------------------------------- | ------------------------------------------------------------------ |
-| `image.registry`                         | `ghcr.io`                        | Server image registry                                              |
-| `image.repository`                       | `thiesgerken/carapace`           | Server image repository                                            |
-| `image.tag`                              | `""` (appVersion)                | Server image tag                                                   |
-| `frontend.enabled`                       | `true`                           | Deploy the Next.js frontend                                        |
-| `frontend.image.tag`                     | `""` (appVersion)                | Frontend image tag                                                 |
-| `sandbox.image.tag`                      | `""` (appVersion)                | Sandbox base image tag                                             |
-| `sandbox.sandboxesName`                  | `null` (`<release>-sandboxes`)   | `Sandboxes` CR name; set `""` to use the Deployment as owner       |
-| `ingress.enabled`                        | `true`                           | Create a Gateway API HTTPRoute                                     |
-| `ingress.hostname`                       | `carapace.example.com`           | Ingress hostname                                                   |
-| `ingress.parentRefs`                     | `[{name: default-gateway}]`      | Gateway parent references                                          |
-| `ingress.annotations`                    | `{}`                             | Extra annotations on the HTTPRoute                                 |
-| `persistence.storageClassName`           | `""` (cluster default)           | StorageClass for the RWX PVC                                       |
-| `persistence.size`                       | `10Gi`                           | PVC size                                                           |
-| `persistence.finalizers`                 | `[]`                             | PVC finalizers (e.g. `kubernetes.io/pvc-protection`)               |
-| `config`                                 | `{}`                             | Application config (mounted as `/data/config.yaml` via ConfigMap)  |
-| `priorityClassName`                      | `""`                             | PriorityClass for all pods (server, frontend, sandbox)             |
-| `envFrom`                                | `[]`                             | Secret/ConfigMap refs injected into the server                     |
-| `extraEnv`                               | `[]`                             | Extra env vars for the server container                            |
-| `redis.enabled`                          | `true`                           | Deploy the bundled Redis required for session-list cache           |
-| `redis.image.tag`                        | `7-alpine`                       | Redis image tag                                                    |
-| `redis.resources`                        | requests: 25m/64Mi, limit: 128Mi | Redis resource requests/limits                                     |
-| `resources`                              | requests: 200m/256Mi, limit: 1Gi | Server resource requests/limits                                    |
-| `frontend.resources`                     | requests: 50m/64Mi, limit: 128Mi | Frontend resource requests/limits                                  |
-| `bitwarden.image.tag`                    | `""` (appVersion)                | bitwarden-cli image tag                                            |
-| `bitwarden.nginx.image.tag`              | pinned nginx digest              | nginx image tag/digest for standalone Basic Auth proxy             |
+| Value                                    | Default                          | Description                                                         |
+| ---------------------------------------- | -------------------------------- | ------------------------------------------------------------------- |
+| `image.registry`                         | `ghcr.io`                        | Server image registry                                               |
+| `image.repository`                       | `thiesgerken/carapace`           | Server image repository                                             |
+| `image.tag`                              | `""` (appVersion)                | Server image tag                                                    |
+| `frontend.enabled`                       | `true`                           | Deploy the Next.js frontend                                         |
+| `frontend.image.tag`                     | `""` (appVersion)                | Frontend image tag                                                  |
+| `sandbox.image.tag`                      | `""` (appVersion)                | Sandbox base image tag                                              |
+| `sandbox.sandboxesName`                  | `null` (`<release>-sandboxes`)   | `Sandboxes` CR name; set `""` to use the Deployment as owner        |
+| `ingress.enabled`                        | `true`                           | Create a Gateway API HTTPRoute                                      |
+| `ingress.hostname`                       | `carapace.example.com`           | Ingress hostname                                                    |
+| `ingress.parentRefs`                     | `[{name: default-gateway}]`      | Gateway parent references                                           |
+| `ingress.annotations`                    | `{}`                             | Extra annotations on the HTTPRoute                                  |
+| `persistence.storageClassName`           | `""` (cluster default)           | StorageClass for the RWX PVC                                        |
+| `persistence.size`                       | `10Gi`                           | PVC size                                                            |
+| `persistence.finalizers`                 | `[]`                             | PVC finalizers (e.g. `kubernetes.io/pvc-protection`)                |
+| `config`                                 | `{}`                             | Application config (mounted as `/data/config.yaml` via ConfigMap)   |
+| `priorityClassName`                      | `""`                             | PriorityClass for all pods (server, frontend, sandbox)              |
+| `envFrom`                                | `[]`                             | Secret/ConfigMap refs injected into the server                      |
+| `extraEnv`                               | `[]`                             | Extra env vars for the server container                             |
+| `redis.enabled`                          | `true`                           | Deploy the bundled Redis required for session-list cache            |
+| `redis.image.tag`                        | `7-alpine`                       | Redis image tag                                                     |
+| `redis.resources`                        | requests: 25m/64Mi, limit: 128Mi | Redis resource requests/limits                                      |
+| `resources`                              | requests: 200m/256Mi, limit: 1Gi | Server resource requests/limits                                     |
+| `frontend.resources`                     | requests: 50m/64Mi, limit: 128Mi | Frontend resource requests/limits                                   |
+| `bitwarden.image.tag`                    | `""` (appVersion)                | bitwarden-cli image tag                                             |
+| `bitwarden.nginx.image.tag`              | pinned nginx digest              | nginx image tag/digest for standalone Basic Auth proxy              |
 | `bitwarden.persistence.enabled`          | `true`                           | Create a PVC per instance for CLI data (`BITWARDENCLI_APPDATA_DIR`) |
-| `bitwarden.persistence.size`             | `256Mi`                          | Size of each Bitwarden instance PVC                                |
-| `bitwarden.persistence.storageClassName` | `""` (cluster default)           | StorageClass for Bitwarden PVCs                                    |
-| `bitwarden.persistence.finalizers`       | `[]`                             | Finalizers for Bitwarden PVCs                                      |
-| `bitwarden.instances`                    | `[]`                             | List of standalone `bw serve` proxy instances (see above)          |
+| `bitwarden.persistence.size`             | `256Mi`                          | Size of each Bitwarden instance PVC                                 |
+| `bitwarden.persistence.storageClassName` | `""` (cluster default)           | StorageClass for Bitwarden PVCs                                     |
+| `bitwarden.persistence.finalizers`       | `[]`                             | Finalizers for Bitwarden PVCs                                       |
+| `bitwarden.instances`                    | `[]`                             | List of standalone `bw serve` proxy instances (see above)           |
 
 See [values.yaml](values.yaml) for the complete reference.
 

--- a/charts/carapace/README.md
+++ b/charts/carapace/README.md
@@ -179,7 +179,6 @@ bitwarden:
   instances:
     - name: personal
       fullnameOverride: carapace-bitwarden
-      port: 8087
       serverUrl: https://vault.example.com
       existingSecret: carapace-bw-personal
       basicAuth:
@@ -200,15 +199,15 @@ config:
     backends:
       personal:
         type: bitwarden
-        url: http://carapace-bitwarden:8087
+        url: http://carapace-bitwarden
         basic_auth:
           username: carapace
           password: change-me
 ```
 
-Multiple instances are supported — just add more entries with different names and ports (e.g. `personal` on 8087, `work` on 8089). Each instance gets its own companion Pod, Kubernetes Secret, Service, Basic Auth proxy, and (when persistence is enabled) PVC mounted at `/var/lib/bitwarden-cli` so Bitwarden CLI device/session data survives Pod reschedules — reducing repeated logins and “new device” emails from the vault provider. Set `bitwarden.persistence.enabled` to `false` if you prefer ephemeral Bitwarden CLI data.
+Multiple instances are supported — just add more entries with different names and ports. Each instance gets its own companion Pod, Kubernetes Secret, Service, Basic Auth proxy, and (when persistence is enabled) PVC mounted at `/var/lib/bitwarden-cli` so Bitwarden CLI device/session data survives Pod reschedules — reducing repeated logins and “new device” emails from the vault provider. Set `bitwarden.persistence.enabled` to `false` if you prefer ephemeral Bitwarden CLI data.
 
-The Bitwarden CLI binds to a fixed localhost-only internal port (`8088`) inside its Pod, while nginx exposes the configured service port for carapace. The service port must not be `8088`.
+The Bitwarden CLI binds to a fixed localhost-only internal port (`8088`) inside its Pod, while nginx exposes the configured service port for carapace. The service port defaults to `80` and must not be `8088`.
 
 ### Key values
 

--- a/charts/carapace/templates/deployment-bitwarden.yaml
+++ b/charts/carapace/templates/deployment-bitwarden.yaml
@@ -1,7 +1,7 @@
 {{- range .Values.bitwarden.instances }}
 {{- $name := include "carapace.bitwardenStandaloneName" (dict "root" $ "instance" .) }}
 {{- $servePort := 8088 }}
-{{- $servicePort := .port | default 8087 }}
+{{- $servicePort := .port | default 80 }}
 {{- if eq (int $servicePort) $servePort }}
 {{- fail (printf "bitwarden standalone instance %q cannot use port %d because it is reserved for internal bw serve traffic" .name $servePort) }}
 {{- end }}

--- a/charts/carapace/values.yaml
+++ b/charts/carapace/values.yaml
@@ -113,7 +113,6 @@ config: {}
 #     instances:
 #       - name: personal
 #         fullnameOverride: carapace-bitwarden-personal
-#         port: 8087
 #         serverUrl: https://vault.example.com
 #         existingSecret: carapace-bw-personal
 #         basicAuth:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,10 @@ services:
       - CARAPACE_MATRIX_PASSWORD=${CARAPACE_MATRIX_PASSWORD:-}
       - CARAPACE_GIT_TOKEN=${CARAPACE_GIT_TOKEN:-}
       - CARAPACE_CACHE_REDIS_URL=redis://redis:6379/0
+      # Enables credentials.backends.<name>.type=file for this local Compose example.
+      # Only keep this enabled when users who can change backend config are trustworthy;
+      # the server process reads the configured path.
+      - CARAPACE_ALLOW_FILE_CREDENTIAL_BACKEND=true
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - GOOGLE_API_KEY=${GOOGLE_API_KEY}
     networks:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -465,20 +465,26 @@ Session commit settings control how conversation histories are copied into the k
 
 LLM API keys are provided as standard environment variables (`ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, etc.) — not through the config file.
 
-Credential backends are configured under `credentials.backends`:
+Credential backends are configured per user under `config.credentials`. Sandbox credential requests resolve the session
+owner before listing or fetching credentials:
 
 ```yaml
-credentials:
-  backends:
-    dev:
-      type: file
-      path: ./data/secrets.env
-    personal:
-      type: bitwarden
-      url: http://127.0.0.1:8087
-      expose:
-        - "9742101e-68b8-4a07-b5b1-9578b5f88e6f"
+users:
+  thies:
+    config:
+      credentials:
+        backends:
+          personal:
+            type: bitwarden
+            url: http://127.0.0.1:8087
+            basic_auth:
+              username: thies
+              password: user-specific-random-proxy-password
+            expose:
+              - "9742101e-68b8-4a07-b5b1-9578b5f88e6f"
 ```
+
+File credential backends are ignored unless `CARAPACE_ALLOW_FILE_CREDENTIAL_BACKEND=true` is set on the server process.
 
 ### Secrets
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -470,7 +470,7 @@ owner before listing or fetching credentials:
 
 ```yaml
 users:
-  thies:
+  alice:
     config:
       credentials:
         backends:
@@ -478,7 +478,7 @@ users:
             type: bitwarden
             url: http://127.0.0.1:8087
             basic_auth:
-              username: thies
+              username: alice
               password: user-specific-random-proxy-password
             expose:
               - "9742101e-68b8-4a07-b5b1-9578b5f88e6f"

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -17,12 +17,12 @@ One `users.yaml` entry looks like this:
 ```yaml
 version: 1
 users:
-  thies:
+  alice:
     password_hash: "$argon2id$v=19$..."
     enabled: true
     token_version: 1
-    display_name: Thies
-    email: thies@example.com
+    display_name: Alice
+    email: alice@example.com
     roles: []
     created_at: "2026-05-24T12:00:00Z"
     updated_at: "2026-05-24T12:00:00Z"
@@ -35,7 +35,7 @@ users:
             type: bitwarden
             url: http://carapace-bitwarden:8087
             basic_auth:
-              username: thies
+              username: alice
               password: user-specific-random-proxy-password
       channels:
         matrix:
@@ -68,13 +68,13 @@ curl -c carapace.cookies -X POST http://localhost:8321/api/auth/login \
 curl -X POST http://localhost:8321/api/admin/users \
   -b carapace.cookies \
   -H "Content-Type: application/json" \
-  -d '{"username":"thies","password":"change-me","display_name":"Thies"}'
+  -d '{"username":"alice","password":"change-me","display_name":"Alice"}'
 ```
 
 The web UI logs in with username and password. The CLI does the same:
 
 ```bash
-uv run carapace --user thies --password change-me
+uv run carapace --user alice --password change-me
 ```
 
 You can also set `CARAPACE_USER` and `CARAPACE_PASSWORD` for the CLI.

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -26,7 +26,7 @@ users:
             path: ./data/secrets.env
           personal:
             type: bitwarden
-            url: http://127.0.0.1:8087
+            url: http://carapace-bitwarden-thies
             basic_auth:
               username: thies
               password: user-specific-random-proxy-password

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -12,21 +12,8 @@ In short: credentials are consumed inside the sandbox, not returned to the user-
 
 ## Backends
 
-Backends are configured in `config.yaml` under `credentials.backends`:
-
-```yaml
-credentials:
-  backends:
-    dev:
-      type: file
-      path: ./data/secrets.env
-    personal:
-      type: bitwarden
-      url: http://127.0.0.1:8087
-```
-
-In multi-user deployments, prefer configuring credential backends on the user record instead of the global
-`config.yaml`, so each user can point at their own vault proxy and authentication boundary:
+Backends are configured on each user record under `config.credentials`. Sessions use the credential backends owned by
+their session user.
 
 ```yaml
 users:
@@ -34,17 +21,28 @@ users:
     config:
       credentials:
         backends:
-          vault:
+          dev:
+            type: file
+            path: ./data/secrets.env
+          personal:
             type: bitwarden
-            url: http://carapace-bitwarden:8087
+            url: http://127.0.0.1:8087
             basic_auth:
               username: thies
               password: user-specific-random-proxy-password
 ```
 
+The file backend is disabled by default. Enable it with `CARAPACE_ALLOW_FILE_CREDENTIAL_BACKEND=true` only when the
+users who can influence credential backend configuration are trustworthy: a file backend path is read by the server
+process and can point at arbitrary files the backend can access.
+
+Each user can point at their own vault proxy and authentication boundary. Admin API responses redact backend proxy
+passwords, and updates that omit an existing proxy password keep the stored value.
+
 Supported backend types:
 
-- `file`: reads `key=value` pairs from a secrets file (`path` defaults to `<data_dir>/secrets.env`).
+- `file`: reads `key=value` pairs from a secrets file (`path` defaults to `<data_dir>/secrets.env`). This backend is
+  ignored unless `CARAPACE_ALLOW_FILE_CREDENTIAL_BACKEND=true` is set on the server process.
 - `bitwarden`: talks to an externally managed `bw serve` endpoint (typically a companion container or a separate Pod behind a proxy). The Docker Compose `bw` service uses env vars such as `BW_SERVER_URL` (vault base URL for the CLI login). Empty `BW_SERVER_URL` is applied as US cloud via `bw config server bitwarden.com` when it first differs from the value stored under the Bitwarden CLI data directory (`$BW_DATA_DIR/carapace-state/`, e.g. on a Docker volume or Kubernetes PVC); the Bitwarden CLI process only logs out and re-runs `bw config server` when that env changes. See `docs/quickstart.md` for the full Docker Compose variable list.
 
 For a standalone Kubernetes `bw serve` Pod, keep `bw serve` bound to localhost inside that Pod and expose an nginx
@@ -61,15 +59,21 @@ Each credential is addressed by `vault_path` as `<backend>/<id>`, for example:
 Each backend can restrict visible credentials:
 
 ```yaml
-credentials:
-  backends:
-    personal:
-      type: bitwarden
-      expose:
-        - "9742101e-68b8-4a07-b5b1-9578b5f88e6f"
-      # or:
-      # hide:
-      #   - "deadbeef-..."
+users:
+  thies:
+    config:
+      credentials:
+        backends:
+          personal:
+            type: bitwarden
+            basic_auth:
+              username: thies
+              password: user-specific-random-proxy-password
+            expose:
+              - "9742101e-68b8-4a07-b5b1-9578b5f88e6f"
+            # or:
+            # hide:
+            #   - "deadbeef-..."
 ```
 
 - `expose`: allowlist mode (only listed IDs are accessible)

--- a/docs/git.md
+++ b/docs/git.md
@@ -10,7 +10,7 @@ Add a `git` section to the owning user record in `$CARAPACE_DATA_DIR/auth/users.
 
 ```yaml
 users:
-  thies:
+  alice:
     config:
       git:
         remote: https://gitea.example.com/team/knowledge.git

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -151,7 +151,7 @@ Example manual run:
 curl -c carapace-cookie.jar \
   -H "Content-Type: application/json" \
   http://localhost:8321/api/auth/login \
-  -d '{"username":"thies","password":"change-me"}'
+  -d '{"username":"alice","password":"change-me"}'
 
 curl -X POST \
   -b carapace-cookie.jar \

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -129,7 +129,7 @@ kubectl create secret generic carapace-bw-personal -n carapace \
   --from-literal=BW_EMAIL=you@example.com
 ```
 
-Each user can get a separate Service, Basic Auth boundary, Secret, and PVC. The Bitwarden CLI binds to a fixed localhost-only internal port (`8088`) inside its own Pod; nginx exposes the configured service port and the chart creates a NetworkPolicy that only allows ingress from the carapace server Pod. The service port must not be `8088`.
+Each user can get a separate Service, Basic Auth boundary, Secret, and PVC. The Bitwarden CLI binds to a fixed localhost-only internal port (`8088`) inside its own Pod; nginx exposes the configured service port and the chart creates a NetworkPolicy that only allows ingress from the carapace server Pod. The service port defaults to `80` and must not be `8088`.
 
 Create the proxy auth Secret separately. It must contain an htpasswd file named `htpasswd` unless you override `basicAuth.secretKey`:
 
@@ -151,7 +151,6 @@ bitwarden:
   instances:
     - name: vaultwarden-alice
       fullnameOverride: carapace-bitwarden-alice
-      port: 8087
       serverUrl: https://vault.example.com
       existingSecret: carapace-bw-alice
       basicAuth:
@@ -168,7 +167,7 @@ users:
         backends:
           vault:
             type: bitwarden
-            url: http://carapace-bitwarden-alice:8087
+            url: http://carapace-bitwarden-alice
             basic_auth:
               username: alice
               password: user-specific-random-proxy-password

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -49,7 +49,7 @@ curl -c carapace.cookies -X POST http://localhost:3001/api/auth/login \
 curl -X POST http://localhost:3001/api/admin/users \
   -b carapace.cookies \
   -H "Content-Type: application/json" \
-  -d '{"username":"thies","password":"change-me","display_name":"Thies"}'
+  -d '{"username":"alice","password":"change-me","display_name":"Alice"}'
 ```
 
 The web UI uses the same origin for frontend and API requests, so it only prompts for username and password on first connect.
@@ -59,7 +59,7 @@ See [auth.md](auth.md) for the full user-file format, admin API, and session-coo
 ## 3. Connect via CLI (optional)
 
 ```bash
-uv run carapace --user thies --password change-me
+uv run carapace --user alice --password change-me
 ```
 
 You can also set `CARAPACE_USER` and `CARAPACE_PASSWORD` for the CLI.
@@ -179,7 +179,7 @@ Add the backend to your user config in `data/auth/users.yaml`:
 
 ```yaml
 users:
-  thies:
+  alice:
     config:
       credentials:
         backends:
@@ -226,7 +226,7 @@ Startup messages from the entrypoint go to the **`bw` container** — use `docke
 
 ```yaml
 users:
-  thies:
+  alice:
     config:
       credentials:
         backends:
@@ -234,7 +234,7 @@ users:
             type: bitwarden
             # url defaults to http://127.0.0.1:8087
             basic_auth:
-              username: thies
+              username: alice
               password: user-specific-random-proxy-password
 ```
 
@@ -246,14 +246,14 @@ By default, all credentials in a backend are accessible (subject to sentinel + u
 
 ```yaml
 users:
-  thies:
+  alice:
     config:
       credentials:
         backends:
           personal:
             type: bitwarden
             basic_auth:
-              username: thies
+              username: alice
               password: user-specific-random-proxy-password
             expose: # allowlist — only these UUIDs are accessible
               - "9742101e-68b8-4a07-b5b1-9578b5f88e6f"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -162,7 +162,11 @@ Restart carapace after changing the user config. carapace starts one Matrix chan
 
 carapace can fetch credentials from a password manager on demand. The agent does not have blanket access — every credential request is evaluated by the sentinel agent and requires explicit user approval the first time it is used in a session. Credentials are intended to be consumed inside the sandbox (auto-injected via skill config or fetched with `ccred`) and must never be echoed or logged. Two backends are available.
 
-### File backend (simple)
+### File backend (local trusted users only)
+
+The file backend is disabled by default because its configured path is read by the server process. Only enable it with
+`CARAPACE_ALLOW_FILE_CREDENTIAL_BACKEND=true` when the users who can influence credential backend config are
+trustworthy.
 
 Create a `.env`-format secrets file:
 
@@ -171,14 +175,17 @@ echo "github-token=ghp_xxxxxxxxxxxx" > data/secrets.env
 echo "smtp-password=myapppassword" >> data/secrets.env
 ```
 
-Add to `data/config.yaml`:
+Add the backend to your user config in `data/auth/users.yaml`:
 
 ```yaml
-credentials:
-  backends:
-    dev:
-      type: file
-      # path defaults to <data_dir>/secrets.env
+users:
+  thies:
+    config:
+      credentials:
+        backends:
+          dev:
+            type: file
+            # path defaults to <data_dir>/secrets.env
 ```
 
 Credentials are accessible as `dev/github-token`, `dev/smtp-password`, etc.
@@ -215,14 +222,20 @@ docker compose up -d --scale bw=1
 
 Startup messages from the entrypoint go to the **`bw` container** — use `docker compose logs -f bw` (not only `carapace`). Without a TTY, stdout is often block-buffered and lines can appear late or only after exit; this stack allocates a TTY for `bw` and logs progress to stderr so `docker compose logs` shows them as they run. The `bitwarden-cli-data` volume keeps Bitwarden CLI login/device state and the cached server URL across container recreation; removing that volume applies `BW_SERVER_URL` from scratch on the next start.
 
-3. Add to `data/config.yaml`:
+3. Add the backend to your user config in `data/auth/users.yaml`:
 
 ```yaml
-credentials:
-  backends:
-    personal:
-      type: bitwarden
-      # url defaults to http://127.0.0.1:8087
+users:
+  thies:
+    config:
+      credentials:
+        backends:
+          personal:
+            type: bitwarden
+            # url defaults to http://127.0.0.1:8087
+            basic_auth:
+              username: thies
+              password: user-specific-random-proxy-password
 ```
 
 Credentials are accessible by their Bitwarden UUID: `personal/9742101e-68b8-4a07-b5b1-...`. Look up UUIDs in the Bitwarden web UI or via `bw list items`.
@@ -232,16 +245,22 @@ Credentials are accessible by their Bitwarden UUID: `personal/9742101e-68b8-4a07
 By default, all credentials in a backend are accessible (subject to sentinel + user approval). To restrict which credentials carapace can see:
 
 ```yaml
-credentials:
-  backends:
-    personal:
-      type: bitwarden
-      expose: # allowlist — only these UUIDs are accessible
-        - "9742101e-68b8-4a07-b5b1-9578b5f88e6f"
-        - "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-      # OR:
-      # hide:  # blocklist — these UUIDs are excluded
-      #   - "deadbeef-..."
+users:
+  thies:
+    config:
+      credentials:
+        backends:
+          personal:
+            type: bitwarden
+            basic_auth:
+              username: thies
+              password: user-specific-random-proxy-password
+            expose: # allowlist — only these UUIDs are accessible
+              - "9742101e-68b8-4a07-b5b1-9578b5f88e6f"
+              - "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            # OR:
+            # hide:  # blocklist — these UUIDs are excluded
+            #   - "deadbeef-..."
 ```
 
 ## 7. Personalise

--- a/src/carapace/credentials/registry.py
+++ b/src/carapace/credentials/registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import assert_never
@@ -16,6 +17,20 @@ from ..models.credentials import (
 from .bitwarden import BitwardenBackend
 from .file import FileVaultBackend
 from .protocol import VaultBackend
+
+FILE_CREDENTIAL_BACKEND_ENV = "CARAPACE_ALLOW_FILE_CREDENTIAL_BACKEND"
+_TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
+_FALSE_ENV_VALUES = {"", "0", "false", "no", "off"}
+
+
+def file_credential_backend_allowed_from_env() -> bool:
+    raw = os.environ.get(FILE_CREDENTIAL_BACKEND_ENV, "")
+    normalized = raw.strip().lower()
+    if normalized in _TRUE_ENV_VALUES:
+        return True
+    if normalized in _FALSE_ENV_VALUES:
+        return False
+    raise ValueError(f"{FILE_CREDENTIAL_BACKEND_ENV} must be a boolean value (true/false, yes/no, on/off, or 1/0)")
 
 
 class CredentialRegistry:
@@ -89,12 +104,26 @@ class SessionCredentialRegistry:
         return await (await self._registry()).list(query)
 
 
-async def build_credential_registry(config: CredentialsConfig, data_dir: Path) -> CredentialRegistry:
+async def build_credential_registry(
+    config: CredentialsConfig,
+    data_dir: Path,
+    *,
+    file_backend_allowed: bool | None = None,
+) -> CredentialRegistry:
     """Create a :class:`CredentialRegistry` from the ``credentials`` config block."""
+    is_file_backend_allowed = (
+        file_credential_backend_allowed_from_env() if file_backend_allowed is None else file_backend_allowed
+    )
     registry = CredentialRegistry()
     for name, cfg in config.backends.items():
         match cfg:
             case FileCredentialBackendConfig():
+                if not is_file_backend_allowed:
+                    logger.warning(
+                        f"File credential backend '{name}' is disabled; set {FILE_CREDENTIAL_BACKEND_ENV}=true "
+                        "only when credential backend configs are managed by trusted users"
+                    )
+                    continue
                 if cfg.path:
                     raw = Path(cfg.path)
                     path = raw if raw.is_absolute() else data_dir / raw

--- a/src/carapace/models/config.py
+++ b/src/carapace/models/config.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_serializer, 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from ..notifications.models import NotificationsConfig
-from .credentials import CredentialsConfig
 from .session import SessionBudget
 
 
@@ -300,6 +299,5 @@ class Config(ConfigModel):
     agent: AgentConfig = AgentConfig()
     sessions: SessionsConfig = SessionsConfig()
     sandbox: SandboxConfig = SandboxConfig()
-    credentials: CredentialsConfig = CredentialsConfig()
     data_dir: str = "."  # resolved relative to config file location
     knowledge_dir: str = "./knowledge"  # resolved relative to config file location

--- a/src/carapace/server/__init__.py
+++ b/src/carapace/server/__init__.py
@@ -76,7 +76,6 @@ _data_dir: Path
 _config: Config
 _engine: SessionEngine
 _git_handler: GitHttpHandler
-_credential_registry: CredentialRegistry
 _user_credential_registries: dict[str, tuple[str, CredentialRegistry]]
 _session_archive: SessionArchiveService
 _session_list_cache: SessionListCache
@@ -157,20 +156,15 @@ def _create_sandbox_runtime(config: Config, data_dir: Path) -> ContainerRuntime:
     )
 
 
-def _credential_config_fingerprint(username: str) -> tuple[str, bool]:
+def _credential_config_fingerprint(username: str) -> str:
     user = _auth_store.get_user(username)
     if user is None:
         raise KeyError(username)
-    user_credentials = user.config.credentials
-    if user_credentials.backends:
-        return user_credentials.model_dump_json(exclude_none=True), True
-    return _config.credentials.model_dump_json(exclude_none=True), False
+    return user.config.credentials.model_dump_json(exclude_none=True)
 
 
 async def _credential_registry_for_user(username: str) -> CredentialRegistry:
-    fingerprint, is_user_specific = _credential_config_fingerprint(username)
-    if not is_user_specific:
-        return _credential_registry
+    fingerprint = _credential_config_fingerprint(username)
 
     cached = _user_credential_registries.get(username)
     if cached is not None:
@@ -182,7 +176,10 @@ async def _credential_registry_for_user(username: str) -> CredentialRegistry:
     user = _auth_store.get_user(username)
     if user is None:
         raise KeyError(username)
-    registry = await build_credential_registry(user.config.credentials, _data_dir)
+    registry = await build_credential_registry(
+        user.config.credentials,
+        _data_dir,
+    )
     _user_credential_registries[username] = (fingerprint, registry)
     if registry.backend_names:
         logger.info(f"Credential backends for user {username!r}: {', '.join(registry.backend_names)}")
@@ -251,7 +248,6 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
         _config, \
         _engine, \
         _git_handler, \
-        _credential_registry, \
         _user_credential_registries, \
         _session_archive, \
         _session_list_cache, \
@@ -371,10 +367,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
         if removed:
             logger.info(f"Cleaned up {removed} orphaned sandbox(es)")
 
-    _credential_registry = await build_credential_registry(_config.credentials, _data_dir)
     _user_credential_registries = {}
-    if _credential_registry.backend_names:
-        logger.info(f"Credential backends: {', '.join(_credential_registry.backend_names)}")
 
     _config.notifications = ensure_vapid_config(_config.notifications, _data_dir)
 
@@ -407,7 +400,6 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
         skill_catalog=skill_catalog,
         agent_model=agent_model,
         sandbox_mgr=_sandbox_mgr,
-        credential_registry=_credential_registry,
         credential_registry_for_session=_credential_registry_for_session,
         model_factory=model_factory,
         notification_router=_notification_router,
@@ -520,7 +512,6 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     with contextlib.suppress(asyncio.CancelledError):
         await internal_task
     await proxy.stop()
-    await _credential_registry.close()
     for _, registry in _user_credential_registries.values():
         await registry.close()
     await _sandbox_mgr.cleanup_all()

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -117,8 +117,7 @@ class SessionEngine(
         skill_catalog: list[SkillInfo],
         agent_model: Model | None,
         sandbox_mgr: SandboxManager,
-        credential_registry: CredentialRegistryProtocol,
-        credential_registry_for_session: Callable[[str], Awaitable[CredentialRegistryProtocol]] | None = None,
+        credential_registry_for_session: Callable[[str], Awaitable[CredentialRegistryProtocol]],
         model_factory: Callable[[str], Model] | None = None,
         notification_router: NotificationRouter | None = None,
     ) -> None:
@@ -131,7 +130,6 @@ class SessionEngine(
         self._agent_model = agent_model
         self._sandbox_mgr = sandbox_mgr
         self._model_factory = model_factory
-        self._credential_registry = credential_registry
         self._credential_registry_for_session = credential_registry_for_session
         self._notification_router = notification_router
         self._active: dict[str, ActiveSession] = {}
@@ -143,13 +141,9 @@ class SessionEngine(
         sandbox_mgr.set_skill_command_aliases_callback(self._skill_command_aliases)
 
     async def _resolve_credential_registry(self, session_id: str) -> CredentialRegistryProtocol:
-        if self._credential_registry_for_session is None:
-            return self._credential_registry
         return await self._credential_registry_for_session(session_id)
 
     def _session_credential_registry(self, session_id: str) -> CredentialRegistryProtocol:
-        if self._credential_registry_for_session is None:
-            return self._credential_registry
         return SessionCredentialRegistry(
             session_id=session_id,
             resolve_registry=self._resolve_credential_registry,

--- a/tests/session_helpers.py
+++ b/tests/session_helpers.py
@@ -12,6 +12,7 @@ from carapace.bootstrap import ensure_data_dir
 from carapace.config import load_config
 from carapace.credentials import CredentialRegistry
 from carapace.git.store import GitStore
+from carapace.models.credentials import CredentialRegistryProtocol
 from carapace.models.tooling import ToolResult
 from carapace.sandbox.manager import SandboxManager
 from carapace.security.context import ApprovalSource, ApprovalVerdict
@@ -178,7 +179,7 @@ def _sentinel_set_model_mock(active: ActiveSession) -> MagicMock:
     return cast(MagicMock, cast(Any, active.sentinel.set_model))
 
 
-def _make_engine(tmp_path: Path) -> SessionEngine:
+def _make_engine(tmp_path: Path, credential_registry: CredentialRegistryProtocol | None = None) -> SessionEngine:
     ensure_data_dir(tmp_path)
     config = load_config(tmp_path)
     session_mgr = SessionManager(tmp_path)
@@ -188,6 +189,11 @@ def _make_engine(tmp_path: Path) -> SessionEngine:
     sandbox_mgr.refresh_sandbox_snapshot = AsyncMock()
     sandbox_mgr.reset_session = AsyncMock()
     sandbox_mgr.get_domain_info.return_value = []
+    registry_for_session = credential_registry or CredentialRegistry()
+
+    async def credential_registry_for_session(_session_id: str) -> CredentialRegistryProtocol:
+        return registry_for_session
+
     return SessionEngine(
         config=config,
         data_dir=tmp_path,
@@ -197,6 +203,6 @@ def _make_engine(tmp_path: Path) -> SessionEngine:
         skill_catalog=skill_catalog,
         agent_model=None,
         sandbox_mgr=sandbox_mgr,
-        credential_registry=CredentialRegistry(),
+        credential_registry_for_session=credential_registry_for_session,
         model_factory=lambda _name: TestModel(),
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -71,6 +71,15 @@ def test_load_config_rejects_global_git_config(tmp_path: Path):
         load_config(tmp_path)
 
 
+def test_load_config_rejects_global_credentials_config(tmp_path: Path):
+    (tmp_path / "config.yaml").write_text(
+        "credentials:\n  backends:\n    vault:\n      type: bitwarden\n      url: http://127.0.0.1:8087\n"
+    )
+
+    with pytest.raises(ValidationError):
+        load_config(tmp_path)
+
+
 def test_load_workspace_file_missing(tmp_path: Path):
     result = load_workspace_file(tmp_path, "SECURITY.md")
     assert result == ""

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -13,6 +13,7 @@ from carapace.credentials import (
     build_credential_registry,
     is_exposed,
 )
+from carapace.credentials.registry import FILE_CREDENTIAL_BACKEND_ENV, file_credential_backend_allowed_from_env
 from carapace.models.credentials import (
     BasicAuthConfig,
     BitwardenCredentialBackendConfig,
@@ -56,6 +57,29 @@ def test_bitwarden_backend_configures_basic_auth(monkeypatch: pytest.MonkeyPatch
     BitwardenBackend(name="bw", base_url="http://bitwarden.local", cfg=cfg)
 
     assert isinstance(captured["auth"], httpx.BasicAuth)
+
+
+def test_file_backend_env_switch_defaults_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(FILE_CREDENTIAL_BACKEND_ENV, raising=False)
+    assert file_credential_backend_allowed_from_env() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+def test_file_backend_env_switch_accepts_true_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv(FILE_CREDENTIAL_BACKEND_ENV, value)
+    assert file_credential_backend_allowed_from_env() is True
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "FALSE", "no", "off"])
+def test_file_backend_env_switch_accepts_false_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv(FILE_CREDENTIAL_BACKEND_ENV, value)
+    assert file_credential_backend_allowed_from_env() is False
+
+
+def test_file_backend_env_switch_rejects_invalid_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(FILE_CREDENTIAL_BACKEND_ENV, "sometimes")
+    with pytest.raises(ValueError, match=FILE_CREDENTIAL_BACKEND_ENV):
+        file_credential_backend_allowed_from_env()
 
 
 def test_credential_metadata_with_description():
@@ -375,35 +399,54 @@ def test_registry_backend_names(file_backend: FileVaultBackend) -> None:
 
 
 @pytest.mark.asyncio
-async def test_build_registry_file_backend(tmp_path: Path) -> None:
+async def test_build_registry_file_backend(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(FILE_CREDENTIAL_BACKEND_ENV, "true")
     env = _write_env(tmp_path, "token=abc\n")
-    config = CredentialsConfig(backends={"dev": FileCredentialBackendConfig(type="file", path=str(env))})
+    config = CredentialsConfig(
+        backends={"dev": FileCredentialBackendConfig(type="file", path=str(env))},
+    )
     reg = await build_credential_registry(config, tmp_path)
     assert "dev" in reg.backend_names
 
 
 @pytest.mark.asyncio
-async def test_build_registry_unknown_type(tmp_path: Path) -> None:
+async def test_build_registry_file_backend_disabled_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(FILE_CREDENTIAL_BACKEND_ENV, raising=False)
     config = CredentialsConfig(
         backends={"x": FileCredentialBackendConfig(type="file", path=str(tmp_path / "missing.env"))}
     )
     reg = await build_credential_registry(config, tmp_path)
-    assert "x" in reg.backend_names
+    assert "x" not in reg.backend_names
+
+
+@pytest.mark.asyncio
+async def test_build_registry_file_backend_respects_server_override(tmp_path: Path) -> None:
+    env = _write_env(tmp_path, "token=abc\n")
+    config = CredentialsConfig(
+        backends={"dev": FileCredentialBackendConfig(type="file", path=str(env))},
+    )
+    reg = await build_credential_registry(config, tmp_path, file_backend_allowed=False)
+    assert "dev" not in reg.backend_names
 
 
 @pytest.mark.asyncio
 async def test_build_registry_default_path(tmp_path: Path) -> None:
     (tmp_path / "secrets.env").write_text("k=v\n")
     config = CredentialsConfig(backends={"dev": FileCredentialBackendConfig(type="file")})
-    reg = await build_credential_registry(config, tmp_path)
+    reg = await build_credential_registry(config, tmp_path, file_backend_allowed=True)
     assert "dev" in reg.backend_names
 
 
 @pytest.mark.asyncio
 async def test_build_registry_relative_path_under_data_dir(tmp_path: Path) -> None:
     (tmp_path / "secrets.env").write_text("k=v\n")
-    config = CredentialsConfig(backends={"dev": FileCredentialBackendConfig(type="file", path="secrets.env")})
-    reg = await build_credential_registry(config, tmp_path)
+    config = CredentialsConfig(
+        backends={"dev": FileCredentialBackendConfig(type="file", path="secrets.env")},
+    )
+    reg = await build_credential_registry(config, tmp_path, file_backend_allowed=True)
     assert await reg.fetch("dev/k") == "v"
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -84,11 +84,14 @@ def _setup_server(tmp_path, monkeypatch):
     sandbox_mgr.destroy_session = AsyncMock()
 
     cred_reg = CredentialRegistry()
+
+    async def credential_registry_for_session(_session_id: str) -> CredentialRegistry:
+        return cred_reg
+
     git_store = MagicMock(spec=GitStore)
     git_store.commit = AsyncMock(return_value=True)
     srv._data_dir = tmp_path
     srv._config = config
-    srv._credential_registry = cred_reg
     srv._user_credential_registries = {}
     srv._engine = SessionEngine(
         config=config,
@@ -99,7 +102,7 @@ def _setup_server(tmp_path, monkeypatch):
         skill_catalog=skill_catalog,
         agent_model=None,
         sandbox_mgr=sandbox_mgr,
-        credential_registry=cred_reg,
+        credential_registry_for_session=credential_registry_for_session,
     )
     srv._session_archive = SessionArchiveService(
         knowledge_dir=tmp_path,
@@ -1836,7 +1839,7 @@ def test_sandbox_list_credentials_audit(client, auth_headers, monkeypatch):
 
     mock_reg = MagicMock()
     mock_reg.list = AsyncMock(return_value=[CredentialMetadata(vault_path="dev/key", name="key", description="test")])
-    monkeypatch.setattr(srv, "_credential_registry", mock_reg, raising=False)
+    monkeypatch.setattr(srv, "_credential_registry_for_session", AsyncMock(return_value=mock_reg), raising=False)
     srv._engine.sandbox_mgr.verify_session_token.side_effect = lambda s, t: s == sid and t == "secret"
     srv._engine.sandbox_mgr.mark_credential_notified.return_value = False
 

--- a/tests/test_session_engine_core.py
+++ b/tests/test_session_engine_core.py
@@ -46,8 +46,11 @@ async def test_skill_activation_inputs_use_context_grant(tmp_path: Path):
         "---\n"
     )
 
+    mock_reg = AsyncMock(spec=CredentialRegistryProtocol)
+    mock_reg.fetch = AsyncMock(return_value="secret-value")
+
     with _patch_sentinel():
-        engine = _make_engine(tmp_path)
+        engine = _make_engine(tmp_path, credential_registry=mock_reg)
 
     state = engine.session_mgr.create_session(user="thies")
     sid = state.session_id
@@ -63,10 +66,6 @@ async def test_skill_activation_inputs_use_context_grant(tmp_path: Path):
             ),
         ],
     )
-
-    mock_reg = AsyncMock(spec=CredentialRegistryProtocol)
-    mock_reg.fetch = AsyncMock(return_value="secret-value")
-    engine._credential_registry = mock_reg
 
     result = await engine._skill_activation_inputs(sid, skill_name)
     assert result.environment == {"API_KEY": "secret-value"}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Drops global credential config (breaking for existing deployments) and changes credential resolution to session owners; file-backend opt-in affects secret exposure if misconfigured.
> 
> **Overview**
> Credential backends are **user-scoped only**: `credentials` is removed from global `config.yaml`, startup no longer builds a shared registry, and sandbox/skill access resolves backends from the **session owner** via a required per-session resolver (no global fallback).
> 
> **File** backends are **off unless** `CARAPACE_ALLOW_FILE_CREDENTIAL_BACKEND=true`; disabled backends are skipped with a warning. Docker Compose sets that flag for local dev with an explicit trust comment.
> 
> Helm Bitwarden standalone proxies default the nginx **Service port to 80** (was 8087); docs and examples use host-only URLs like `http://carapace-bitwarden` and the sample user **alice** instead of thies.
> 
> Docs across quickstart, credentials, architecture, auth, git, jobs, k8s, and chart README describe per-user `config.credentials`, the file-backend gate, and updated Bitwarden wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95e439f7c8c61b28d3776bb39f36120c7e0477d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->