### PR TITLE
✨ feat: support openrouter + fix small issues with model editing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ CARAPACE_TOKEN=pick-a-bootstrap-admin-password
 
 # Optional — LLM providers
 # GOOGLE_API_KEY=
+# OPENROUTER_API_KEY=
 
 # Optional — Matrix channel
 # CARAPACE_MATRIX_PASSWORD=

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,6 +13,7 @@
 
 - [ ] an actual database backend instead of files
 - [ ] api keys, mainly for subagents
+- [ ] keep a warm sandbox to be used as any time, the cold start in k8s is too much
 
 ## Workspace
 

--- a/charts/carapace/README.md
+++ b/charts/carapace/README.md
@@ -82,7 +82,7 @@ All images default to the chart's `appVersion` tag, which is kept in sync with t
 | What                   | How                                                                                                                                                                    |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Bootstrap password** | Set `CARAPACE_TOKEN` in the Secret referenced via `envFrom`. It is only used as the initial password for the bootstrap `admin` user when no enabled admin user exists. |
-| **Anthropic API key**  | Set `ANTHROPIC_API_KEY` in the same Secret.                                                                                                                            |
+| **LLM API key**        | Set `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, or another configured provider key in the same Secret.                                                                  |
 | **Ingress hostname**   | `--set ingress.hostname=carapace.example.com`                                                                                                                          |
 | **Gateway parent ref** | `--set ingress.parentRefs[0].name=my-gateway` (defaults to `default-gateway`)                                                                                          |
 
@@ -107,7 +107,7 @@ extraEnv:
 
 The chart no longer accepts application `config.yaml` through Helm values and does not render a ConfigMap for it. Platform and user settings are managed from the web UI after install:
 
-- **Settings** -> **Admin** -> **Platform** for model catalog, default models, OpenAI-compatible base URLs and API keys, reasoning options, and default budgets.
+- **Settings** -> **Admin** -> **Platform** for model catalog, default models, OpenAI-compatible base URLs, OpenRouter API keys, reasoning options, and default budgets.
 - **Settings** -> **Admin** -> **Users** for local users, roles, passwords, and assignment of existing data.
 - **Settings** -> **Account** for per-user model defaults, Matrix, Git, and credential backends.
 - **Settings** -> **Jobs** for saved jobs and schedules.
@@ -199,39 +199,39 @@ The Bitwarden CLI binds to a fixed localhost-only internal port (`8088`) inside 
 
 ### Key values
 
-| Value                                    | Default                          | Description                                                         |
-| ---------------------------------------- | -------------------------------- | ------------------------------------------------------------------- |
-| `image.registry`                         | `ghcr.io`                        | Server image registry                                               |
-| `image.repository`                       | `thiesgerken/carapace`           | Server image repository                                             |
-| `image.tag`                              | `""` (appVersion)                | Server image tag                                                    |
-| `frontend.enabled`                       | `true`                           | Deploy the Next.js frontend                                         |
-| `frontend.image.tag`                     | `""` (appVersion)                | Frontend image tag                                                  |
-| `server.probes.startup.initialDelaySeconds` | `15`                            | Delay before the server startup probe runs                          |
-| `server.probes`                          | see `values.yaml`                 | Server startup, liveness, and readiness probe timing                |
-| `sandbox.image.tag`                      | `""` (appVersion)                | Sandbox base image tag                                              |
-| `sandbox.sandboxesName`                  | `null` (`<release>-sandboxes`)   | `Sandboxes` CR name; set `""` to use the Deployment as owner        |
-| `ingress.enabled`                        | `true`                           | Create a Gateway API HTTPRoute                                      |
-| `ingress.hostname`                       | `carapace.example.com`           | Ingress hostname                                                    |
-| `ingress.parentRefs`                     | `[{name: default-gateway}]`      | Gateway parent references                                           |
-| `ingress.annotations`                    | `{}`                             | Extra annotations on the HTTPRoute                                  |
-| `persistence.data.storageClassName`      | `""` (cluster default)           | StorageClass for the data PVC                                       |
-| `persistence.data.size`                  | `10Gi`                           | Data PVC size                                                       |
-| `persistence.data.finalizers`            | `[]`                             | Data PVC finalizers (e.g. `kubernetes.io/pvc-protection`)           |
-| `priorityClassName`                      | `""`                             | PriorityClass for all pods (server, frontend, sandbox)              |
-| `envFrom`                                | `[]`                             | Secret/ConfigMap refs injected into the server                      |
-| `extraEnv`                               | `[]`                             | Extra env vars for the server container                             |
-| `redis.enabled`                          | `true`                           | Deploy the bundled Redis required for session-list cache            |
-| `redis.image.tag`                        | `8-alpine`                       | Redis image tag                                                     |
-| `redis.resources`                        | requests: 25m/64Mi, limit: 128Mi | Redis resource requests/limits                                      |
-| `resources`                              | requests: 200m/256Mi, limit: 1Gi | Server resource requests/limits                                     |
-| `frontend.resources`                     | requests: 50m/64Mi, limit: 128Mi | Frontend resource requests/limits                                   |
-| `bitwarden.image.tag`                    | `""` (appVersion)                | bitwarden-cli image tag                                             |
-| `bitwarden.nginx.image.tag`              | pinned nginx digest              | nginx image tag/digest for standalone Basic Auth proxy              |
-| `bitwarden.persistence.enabled`          | `true`                           | Create a PVC per instance for CLI data (`BITWARDENCLI_APPDATA_DIR`) |
-| `bitwarden.persistence.size`             | `256Mi`                          | Size of each Bitwarden instance PVC                                 |
-| `bitwarden.persistence.storageClassName` | `""` (cluster default)           | StorageClass for Bitwarden PVCs                                     |
-| `bitwarden.persistence.finalizers`       | `[]`                             | Finalizers for Bitwarden PVCs                                       |
-| `bitwarden.instances`                    | `[]`                             | List of standalone `bw serve` proxy instances (see above)           |
+| Value                                       | Default                          | Description                                                         |
+| ------------------------------------------- | -------------------------------- | ------------------------------------------------------------------- |
+| `image.registry`                            | `ghcr.io`                        | Server image registry                                               |
+| `image.repository`                          | `thiesgerken/carapace`           | Server image repository                                             |
+| `image.tag`                                 | `""` (appVersion)                | Server image tag                                                    |
+| `frontend.enabled`                          | `true`                           | Deploy the Next.js frontend                                         |
+| `frontend.image.tag`                        | `""` (appVersion)                | Frontend image tag                                                  |
+| `server.probes.startup.initialDelaySeconds` | `15`                             | Delay before the server startup probe runs                          |
+| `server.probes`                             | see `values.yaml`                | Server startup, liveness, and readiness probe timing                |
+| `sandbox.image.tag`                         | `""` (appVersion)                | Sandbox base image tag                                              |
+| `sandbox.sandboxesName`                     | `null` (`<release>-sandboxes`)   | `Sandboxes` CR name; set `""` to use the Deployment as owner        |
+| `ingress.enabled`                           | `true`                           | Create a Gateway API HTTPRoute                                      |
+| `ingress.hostname`                          | `carapace.example.com`           | Ingress hostname                                                    |
+| `ingress.parentRefs`                        | `[{name: default-gateway}]`      | Gateway parent references                                           |
+| `ingress.annotations`                       | `{}`                             | Extra annotations on the HTTPRoute                                  |
+| `persistence.data.storageClassName`         | `""` (cluster default)           | StorageClass for the data PVC                                       |
+| `persistence.data.size`                     | `10Gi`                           | Data PVC size                                                       |
+| `persistence.data.finalizers`               | `[]`                             | Data PVC finalizers (e.g. `kubernetes.io/pvc-protection`)           |
+| `priorityClassName`                         | `""`                             | PriorityClass for all pods (server, frontend, sandbox)              |
+| `envFrom`                                   | `[]`                             | Secret/ConfigMap refs injected into the server                      |
+| `extraEnv`                                  | `[]`                             | Extra env vars for the server container                             |
+| `redis.enabled`                             | `true`                           | Deploy the bundled Redis required for session-list cache            |
+| `redis.image.tag`                           | `8-alpine`                       | Redis image tag                                                     |
+| `redis.resources`                           | requests: 25m/64Mi, limit: 128Mi | Redis resource requests/limits                                      |
+| `resources`                                 | requests: 200m/256Mi, limit: 1Gi | Server resource requests/limits                                     |
+| `frontend.resources`                        | requests: 50m/64Mi, limit: 128Mi | Frontend resource requests/limits                                   |
+| `bitwarden.image.tag`                       | `""` (appVersion)                | bitwarden-cli image tag                                             |
+| `bitwarden.nginx.image.tag`                 | pinned nginx digest              | nginx image tag/digest for standalone Basic Auth proxy              |
+| `bitwarden.persistence.enabled`             | `true`                           | Create a PVC per instance for CLI data (`BITWARDENCLI_APPDATA_DIR`) |
+| `bitwarden.persistence.size`                | `256Mi`                          | Size of each Bitwarden instance PVC                                 |
+| `bitwarden.persistence.storageClassName`    | `""` (cluster default)           | StorageClass for Bitwarden PVCs                                     |
+| `bitwarden.persistence.finalizers`          | `[]`                             | Finalizers for Bitwarden PVCs                                       |
+| `bitwarden.instances`                       | `[]`                             | List of standalone `bw serve` proxy instances (see above)           |
 
 See [values.yaml](values.yaml) for the complete reference.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,9 @@ services:
       # Only keep this enabled when users who can change backend config are trustworthy;
       # the server process reads the configured path.
       - CARAPACE_ALLOW_FILE_CREDENTIAL_BACKEND=true
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-      - GOOGLE_API_KEY=${GOOGLE_API_KEY}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
     networks:
       - default
       - carapace-sandbox

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -412,6 +412,17 @@ agent:
 
 Admins can update the model catalog, platform defaults, provider keys, and default session budget from the web UI. Users can override the default agent, sentinel, and title models plus their own default session budget from **Settings** -> **Account**. Those defaults apply to newly created web, Matrix, and non-persistent job sessions; existing sessions keep their current model overrides and budget.
 
+OpenRouter is exposed as its own model provider. It uses Pydantic AI's `OpenRouterProvider`, including `OPENROUTER_API_KEY`, `OPENROUTER_APP_URL`, and `OPENROUTER_APP_TITLE` environment variable fallback. Example row:
+
+```yaml
+agent:
+  available_models:
+    - provider: openrouter
+      name: anthropic/claude-sonnet-4.5
+      api_key:
+        env: OPENROUTER_API_KEY
+```
+
 Additional configuration sections:
 
 ```yaml
@@ -465,7 +476,7 @@ Session commit settings control how conversation histories are copied into the k
 - `sessions.commit.autosave_inactivity_hours`: inactivity threshold before a public session is auto-committed
 - `sessions.commit.delete_from_knowledge_on_session_delete`: whether deleting a session also removes its current committed snapshot directory from the knowledge repo
 
-LLM API keys are provided as standard environment variables (`ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, etc.) — not through the config file.
+LLM API keys are provided as standard environment variables (`ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `OPENROUTER_API_KEY`, etc.) or configured on model rows that support per-row keys.
 
 Credential backends are configured per user under `config.credentials`. Sandbox credential requests resolve the session
 owner before listing or fetching credentials:
@@ -490,7 +501,7 @@ File credential backends are ignored unless `CARAPACE_ALLOW_FILE_CREDENTIAL_BACK
 
 ### Secrets
 
-Global config `Secret` fields, such as OpenAI-compatible model API keys, support three sources:
+Global config `Secret` fields, such as OpenAI-compatible and OpenRouter model API keys, support three sources:
 
 ```yaml
 # Inline value (also accepts a plain string as shorthand)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -68,7 +68,7 @@ You can also set `CARAPACE_USER` and `CARAPACE_PASSWORD` for the CLI.
 
 Most first-run configuration now lives in the web UI:
 
-- **Settings** -> **Admin** -> **Platform** manages the model catalog, platform default agent/sentinel/title models, OpenAI-compatible base URLs and API keys, reasoning options, and default session budget.
+- **Settings** -> **Admin** -> **Platform** manages the model catalog, platform default agent/sentinel/title models, OpenAI-compatible base URLs, OpenRouter API keys, reasoning options, and default session budget.
 - **Settings** -> **Admin** -> **Users** manages local users, roles, passwords, profile fields, enabled/disabled state, and assignment of existing single-user data.
 - **Settings** -> **Account** manages each user's default models and budget, Matrix channel, Git remote, and credential backends.
 - **Settings** -> **Jobs** manages saved jobs and schedules.

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -197,7 +197,7 @@
             "xhigh": "Extra hoch"
         },
         "units": {
-            "tokens": "Token"
+            "tokens": "Tokens"
         },
         "modelRow": "Modell {index}"
     },
@@ -790,7 +790,7 @@
         "thinkingMeta": {
             "durationStreaming": "seit {duration}",
             "durationComplete": "{duration} lang",
-            "reasoning": "{count} Reasoning"
+            "reasoning": "{count} Tokens"
         },
         "actions": {
             "fork": "Sitzung von hier forken",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -790,7 +790,7 @@
         "thinkingMeta": {
             "durationStreaming": "for {duration}",
             "durationComplete": "for {duration}",
-            "reasoning": "{count} reasoning"
+            "reasoning": "{count} tokens"
         },
         "actions": {
             "fork": "Fork session from here",

--- a/frontend/src/components/platform-settings-view.test.tsx
+++ b/frontend/src/components/platform-settings-view.test.tsx
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildPlatformSettingsPatch } from "./platform-settings-view";
+import { buildPlatformSettingsPatch, sortModelDrafts } from "./platform-settings-view";
 
 type PlatformDraft = Parameters<typeof buildPlatformSettingsPatch>[0];
 
@@ -100,4 +100,70 @@ test("buildPlatformSettingsPatch includes OpenRouter API key fields without base
   assert.deepEqual(model.api_key, { source: "env", value: "OPENROUTER_API_KEY" });
   assert.equal(Object.hasOwn(model, "base_url"), false);
   assert.equal(Object.hasOwn(model, "thinking_budget_tokens"), false);
+});
+
+test("sortModelDrafts orders complete rows by provider then model name while keeping incomplete rows first", () => {
+  const sorted = sortModelDrafts([
+    {
+      rowId: "model-1",
+      provider: "openai",
+      name: "gpt-4o-mini",
+      id: "",
+      maxInputTokens: "",
+      thinking: "",
+      thinkingBudgetTokens: "",
+      baseUrl: "",
+      apiKeySource: "none",
+      apiKeyValue: "",
+      apiKeyConfigured: false,
+      apiKeyConfiguredSource: "none",
+    },
+    {
+      rowId: "model-2",
+      provider: "anthropic",
+      name: "claude-sonnet-4-6",
+      id: "",
+      maxInputTokens: "",
+      thinking: "",
+      thinkingBudgetTokens: "",
+      baseUrl: "",
+      apiKeySource: "none",
+      apiKeyValue: "",
+      apiKeyConfigured: false,
+      apiKeyConfiguredSource: "none",
+    },
+    {
+      rowId: "model-3",
+      provider: "openai",
+      name: "",
+      id: "",
+      maxInputTokens: "",
+      thinking: "",
+      thinkingBudgetTokens: "",
+      baseUrl: "",
+      apiKeySource: "none",
+      apiKeyValue: "",
+      apiKeyConfigured: false,
+      apiKeyConfiguredSource: "none",
+    },
+    {
+      rowId: "model-4",
+      provider: "anthropic",
+      name: "claude-haiku-4-5",
+      id: "",
+      maxInputTokens: "",
+      thinking: "",
+      thinkingBudgetTokens: "",
+      baseUrl: "",
+      apiKeySource: "none",
+      apiKeyValue: "",
+      apiKeyConfigured: false,
+      apiKeyConfiguredSource: "none",
+    },
+  ]);
+
+  assert.deepEqual(
+    sorted.map((model) => model.rowId),
+    ["model-3", "model-4", "model-2", "model-1"],
+  );
 });

--- a/frontend/src/components/platform-settings-view.test.tsx
+++ b/frontend/src/components/platform-settings-view.test.tsx
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildPlatformSettingsPatch, sortModelDrafts } from "./platform-settings-view";
+import { flushReact, installDom, renderReact, runInAct } from "../../test/react-test-utils";
+
+import { buildPlatformSettingsPatch, ModelRow, sortModelDrafts } from "./platform-settings-view";
 
 type PlatformDraft = Parameters<typeof buildPlatformSettingsPatch>[0];
 
@@ -166,4 +168,51 @@ test("sortModelDrafts orders complete rows by provider then model name while kee
     sorted.map((model) => model.rowId),
     ["model-3", "model-4", "model-2", "model-1"],
   );
+});
+
+test("ModelRow reopens incomplete rows after a manual collapse", async () => {
+  const cleanup = installDom();
+
+  try {
+    const view = await renderReact(
+      <ModelRow
+        model={{
+          rowId: "model-1",
+          provider: "openai",
+          name: "",
+          id: "",
+          maxInputTokens: "",
+          thinking: "",
+          thinkingBudgetTokens: "",
+          baseUrl: "",
+          apiKeySource: "none",
+          apiKeyValue: "",
+          apiKeyConfigured: false,
+          apiKeyConfiguredSource: "none",
+        }}
+        disabled={false}
+        onChange={() => undefined}
+        onRemove={() => undefined}
+        t={translate}
+      />,
+    );
+
+    try {
+      const details = view.container.querySelector("details");
+      assert.ok(details instanceof HTMLElement);
+      assert.equal((details as HTMLDetailsElement).open, true);
+
+      await runInAct(() => {
+        (details as HTMLDetailsElement).open = false;
+        details.dispatchEvent(new window.Event("toggle", { bubbles: true }));
+      });
+      await flushReact();
+
+      assert.equal((details as HTMLDetailsElement).open, true);
+    } finally {
+      await view.unmount();
+    }
+  } finally {
+    cleanup();
+  }
 });

--- a/frontend/src/components/platform-settings-view.test.tsx
+++ b/frontend/src/components/platform-settings-view.test.tsx
@@ -75,3 +75,29 @@ test("buildPlatformSettingsPatch reuses configured raw OpenAI secrets", () => {
 
   assert.deepEqual(patch.available_models[0]?.api_key, { source: "raw" });
 });
+
+test("buildPlatformSettingsPatch includes OpenRouter API key fields without base URL", () => {
+  const patch = buildPlatformSettingsPatch(
+    draftWithModel({
+      rowId: "model-1",
+      provider: "openrouter",
+      name: "anthropic/claude-sonnet-4.5",
+      id: "openrouter:sonnet",
+      maxInputTokens: "",
+      thinking: "",
+      thinkingBudgetTokens: "128",
+      baseUrl: "https://openrouter.ai/api/v1",
+      apiKeySource: "env",
+      apiKeyValue: "OPENROUTER_API_KEY",
+      apiKeyConfigured: false,
+      apiKeyConfiguredSource: "none",
+    }),
+    translate,
+  );
+
+  const model = patch.available_models[0]!;
+  assert.equal(model.provider, "openrouter");
+  assert.deepEqual(model.api_key, { source: "env", value: "OPENROUTER_API_KEY" });
+  assert.equal(Object.hasOwn(model, "base_url"), false);
+  assert.equal(Object.hasOwn(model, "thinking_budget_tokens"), false);
+});

--- a/frontend/src/components/platform-settings-view.tsx
+++ b/frontend/src/components/platform-settings-view.tsx
@@ -514,7 +514,7 @@ export function PlatformSettingsView({ server, token }: { server: string; token:
         <Section
           title={t("sections.catalog")}
           action={(
-            <SecondaryButton disabled={fieldsDisabled} onClick={() => updateDraft({ models: [...draft.models, newModelDraft()] })}>
+            <SecondaryButton disabled={fieldsDisabled} onClick={() => updateDraft({ models: [newModelDraft(), ...draft.models] })}>
               <Plus className="h-4 w-4" />
               {t("actions.addModel")}
             </SecondaryButton>

--- a/frontend/src/components/platform-settings-view.tsx
+++ b/frontend/src/components/platform-settings-view.tsx
@@ -681,8 +681,10 @@ function ProviderInput({ value, disabled, onChange }: { value: string; disabled:
   );
 }
 
-function ModelRow({ model, disabled, onChange, onRemove, t }: { model: ModelDraft; disabled: boolean; onChange: (patch: Partial<ModelDraft>) => void; onRemove: () => void; t: Translate }) {
-  const [expanded, setExpanded] = useState(!model.name.trim());
+export function ModelRow({ model, disabled, onChange, onRemove, t }: { model: ModelDraft; disabled: boolean; onChange: (patch: Partial<ModelDraft>) => void; onRemove: () => void; t: Translate }) {
+  const incomplete = isIncompleteModelDraft(model);
+  const [expanded, setExpanded] = useState(incomplete);
+  const open = expanded || incomplete;
   const effectiveId = modelId(model);
   const summaryId = model.name.trim() ? effectiveId : t("placeholders.generatedId");
   const provider = model.provider.trim();
@@ -698,7 +700,19 @@ function ModelRow({ model, disabled, onChange, onRemove, t }: { model: ModelDraf
   if (model.thinking || (openAICompatible && model.thinkingBudgetTokens.trim())) summaryBadges.push({ label: thinkingBadgeLabel(model.thinking, openAICompatible ? model.thinkingBudgetTokens : "", t), className: neutralBadgeClassName, icon: Brain });
   const rawSecretConfigured = model.apiKeySource === "raw" && hasReusableRawSecret(model);
   return (
-    <details className="group rounded-lg border border-border bg-background/70" open={expanded} onToggle={(event) => setExpanded(event.currentTarget.open)}>
+    <details
+      className="group rounded-lg border border-border bg-background/70"
+      open={open}
+      onToggle={(event) => {
+        const nextOpen = event.currentTarget.open;
+        if (!nextOpen && incomplete) {
+          event.currentTarget.open = true;
+          setExpanded(true);
+          return;
+        }
+        setExpanded(nextOpen);
+      }}
+    >
       <summary className="flex cursor-pointer list-none items-center justify-between gap-3 p-4 outline-none transition-colors hover:bg-muted/40 focus-visible:ring-2 focus-visible:ring-ring/30 [&::-webkit-details-marker]:hidden">
         <div className="min-w-0 space-y-2">
           <div className="break-all font-mono text-sm font-medium">{summaryId}</div>

--- a/frontend/src/components/platform-settings-view.tsx
+++ b/frontend/src/components/platform-settings-view.tsx
@@ -162,6 +162,35 @@ function modelId(model: Pick<ModelDraft, "provider" | "name" | "id">): string {
   return model.id.trim() || `${model.provider.trim()}:${model.name.trim()}`;
 }
 
+function compareModelText(left: string, right: string): number {
+  return left.localeCompare(right, undefined, { sensitivity: "base" });
+}
+
+function isIncompleteModelDraft(model: Pick<ModelDraft, "provider" | "name">): boolean {
+  return !model.provider.trim() || !model.name.trim();
+}
+
+export function sortModelDrafts(models: ModelDraft[]): ModelDraft[] {
+  return [...models].sort((left, right) => {
+    const leftIncomplete = isIncompleteModelDraft(left);
+    const rightIncomplete = isIncompleteModelDraft(right);
+    if (leftIncomplete !== rightIncomplete) {
+      return leftIncomplete ? -1 : 1;
+    }
+    if (leftIncomplete && rightIncomplete) {
+      return 0;
+    }
+
+    const providerOrder = compareModelText(left.provider.trim(), right.provider.trim());
+    if (providerOrder !== 0) return providerOrder;
+
+    const nameOrder = compareModelText(left.name.trim(), right.name.trim());
+    if (nameOrder !== 0) return nameOrder;
+
+    return compareModelText(modelId(left), modelId(right));
+  });
+}
+
 function isOpenAICompatibleProvider(provider: string): boolean {
   const normalized = provider.trim().toLowerCase();
   return normalized === "openai" || normalized === "openai-chat";
@@ -216,7 +245,7 @@ function draftFromSettings(response: PlatformSettingsResponseInfo): PlatformDraf
   return {
     defaultModels: { ...response.settings.default_models },
     budget: budgetDraftFromSettings(response.settings.default_budget),
-    models: response.settings.available_models.map(modelDraftFromSettings),
+    models: sortModelDrafts(response.settings.available_models.map(modelDraftFromSettings)),
   };
 }
 
@@ -353,7 +382,7 @@ function comparableDraft(draft: PlatformDraft | null): unknown {
 }
 
 function draftModelOptions(models: ModelDraft[]): AvailableModelInfo[] {
-  return models
+  return sortModelDrafts(models)
     .filter((model) => model.provider.trim() && model.name.trim())
     .map((model) => ({
       id: modelId(model),

--- a/frontend/src/components/platform-settings-view.tsx
+++ b/frontend/src/components/platform-settings-view.tsx
@@ -2,7 +2,7 @@
 
 import { Brain, BrainCircuit, Check, ChevronDown, Cloud, KeyRound, Loader2, Plus, Save, StretchHorizontal, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { type ComponentType, useCallback, useEffect, useMemo, useState } from "react";
+import { type ComponentType, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 
 import {
   getPlatformSettings,
@@ -54,7 +54,7 @@ interface SummaryBadge {
   icon?: BadgeIcon;
 }
 
-const providerPresets = ["anthropic", "google-gla", "google-vertex", "openai", "openai-chat"];
+const providerPresets = ["anthropic", "google-gla", "google-vertex", "openai", "openai-chat", "openrouter"];
 const thinkingOptions: ThinkingDraft[] = ["", "true", "false", "minimal", "low", "medium", "high", "xhigh"];
 
 const inputClassName = cn(
@@ -178,6 +178,11 @@ function isOpenAICompatibleProvider(provider: string): boolean {
   return normalized === "openai" || normalized === "openai-chat";
 }
 
+function supportsModelApiKey(provider: string): boolean {
+  const normalized = provider.trim().toLowerCase();
+  return isOpenAICompatibleProvider(normalized) || normalized === "openrouter";
+}
+
 function hasReusableRawSecret(model: Pick<ModelDraft, "apiKeyConfigured" | "apiKeyConfiguredSource">): boolean {
   return model.apiKeyConfigured && model.apiKeyConfiguredSource === "raw";
 }
@@ -287,10 +292,11 @@ function modelsFromDraft(models: ModelDraft[], t: Translate): PlatformModelEntry
     if (ids.has(effectiveId)) throw new Error(t("errors.duplicateModel", { id: effectiveId }));
     ids.add(effectiveId);
     const openAICompatible = isOpenAICompatibleProvider(provider);
-    if (openAICompatible && model.apiKeySource === "raw" && !model.apiKeyValue.trim() && !hasReusableRawSecret(model)) {
+    const modelApiKeySupported = supportsModelApiKey(provider);
+    if (modelApiKeySupported && model.apiKeySource === "raw" && !model.apiKeyValue.trim() && !hasReusableRawSecret(model)) {
       throw new Error(t("errors.rawSecretRequired", { id: effectiveId }));
     }
-    if (openAICompatible && (model.apiKeySource === "env" || model.apiKeySource === "file") && !model.apiKeyValue.trim()) {
+    if (modelApiKeySupported && (model.apiKeySource === "env" || model.apiKeySource === "file") && !model.apiKeyValue.trim()) {
       throw new Error(t("errors.secretValueRequired", { id: effectiveId }));
     }
 
@@ -301,16 +307,18 @@ function modelsFromDraft(models: ModelDraft[], t: Translate): PlatformModelEntry
       max_input_tokens: numericLimit(model.maxInputTokens, t("fields.maxInputTokens"), t),
       thinking: thinkingFromDraft(model.thinking),
     };
-    if (!openAICompatible) return entry;
-
-    entry.thinking_budget_tokens = nonNegativeLimit(model.thinkingBudgetTokens, t("fields.thinkingBudgetTokens"), t);
-    entry.base_url = model.baseUrl.trim() || null;
-    entry.api_key = model.apiKeySource === "none"
-      ? { source: null }
-      : {
-          source: model.apiKeySource,
-          ...(model.apiKeyValue.trim() ? { value: model.apiKeyValue.trim() } : {}),
-        };
+    if (openAICompatible) {
+      entry.thinking_budget_tokens = nonNegativeLimit(model.thinkingBudgetTokens, t("fields.thinkingBudgetTokens"), t);
+      entry.base_url = model.baseUrl.trim() || null;
+    }
+    if (modelApiKeySupported) {
+      entry.api_key = model.apiKeySource === "none"
+        ? { source: null }
+        : {
+            source: model.apiKeySource,
+            ...(model.apiKeyValue.trim() ? { value: model.apiKeyValue.trim() } : {}),
+          };
+    }
     return entry;
   });
 }
@@ -526,9 +534,6 @@ export function PlatformSettingsView({ server, token }: { server: string; token:
           )}
         >
           <div className="space-y-3">
-            <datalist id="platform-model-provider-presets">
-              {providerPresets.map((provider) => <option key={provider} value={provider} />)}
-            </datalist>
             {draft.models.map((model) => (
               <ModelRow
                 key={model.rowId}
@@ -585,16 +590,95 @@ function SecondaryButton({ children, disabled, onClick }: { children: React.Reac
   );
 }
 
+function ProviderInput({ value, disabled, onChange }: { value: string; disabled: boolean; onChange: (value: string) => void }) {
+  const [open, setOpen] = useState(false);
+  const listId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  function closeWhenFocusLeaves(event: React.FocusEvent<HTMLDivElement>): void {
+    const nextTarget = event.relatedTarget;
+    if (nextTarget instanceof Node && wrapperRef.current?.contains(nextTarget)) return;
+    setOpen(false);
+  }
+
+  function toggleDropdown(): void {
+    if (disabled) return;
+    setOpen((current) => !current);
+    window.setTimeout(() => inputRef.current?.focus(), 0);
+  }
+
+  return (
+    <div ref={wrapperRef} className="relative" onBlur={closeWhenFocusLeaves}>
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        disabled={disabled}
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listId}
+        aria-haspopup="listbox"
+        aria-autocomplete="list"
+        onFocus={() => setOpen(true)}
+        onKeyDown={(event) => {
+          if (event.key === "ArrowDown") setOpen(true);
+          if (event.key === "Escape") setOpen(false);
+        }}
+        onChange={(event) => onChange(event.target.value)}
+        className={cn(inputClassName, "pr-10")}
+      />
+      <button
+        type="button"
+        disabled={disabled}
+        aria-label="Provider presets"
+        aria-expanded={open}
+        onMouseDown={(event) => event.preventDefault()}
+        onClick={toggleDropdown}
+        className="absolute right-1 top-1/2 inline-flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <ChevronDown className={cn("h-4 w-4 transition-transform", open ? "rotate-180" : null)} />
+      </button>
+      {open ? (
+        <div id={listId} role="listbox" className="absolute z-30 mt-2 max-h-56 w-full overflow-y-auto rounded-xl border border-border bg-background p-1 shadow-xl">
+          {providerPresets.map((provider) => (
+            <button
+              key={provider}
+              type="button"
+              role="option"
+              aria-selected={provider === value}
+              className={cn(
+                "block w-full rounded-lg px-2.5 py-2 text-left font-mono text-sm transition-colors focus:outline-none",
+                provider === value ? "bg-accent text-accent-foreground" : "hover:bg-accent/50 focus:bg-accent/50",
+              )}
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => {
+                onChange(provider);
+                setOpen(false);
+                inputRef.current?.focus();
+              }}
+            >
+              {provider}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function ModelRow({ model, disabled, providerColors, modelNameColors, onChange, onRemove, t }: { model: ModelDraft; disabled: boolean; providerColors: ReadonlyMap<string, string>; modelNameColors: ReadonlyMap<string, string>; onChange: (patch: Partial<ModelDraft>) => void; onRemove: () => void; t: Translate }) {
   const effectiveId = modelId(model);
   const summaryId = model.name.trim() ? effectiveId : t("placeholders.generatedId");
   const provider = model.provider.trim();
   const openAICompatible = isOpenAICompatibleProvider(provider);
+  const modelApiKeySupported = supportsModelApiKey(provider);
   const openAIFieldsDisabled = disabled || !openAICompatible;
+  const apiKeyFieldsDisabled = disabled || !modelApiKeySupported;
   const providerLabel = providerBadgeLabel(provider, openAICompatible ? model.baseUrl : "");
   const summaryBadges: SummaryBadge[] = [];
   if (provider) summaryBadges.push({ label: providerLabel, className: providerBadgeClassName(provider, openAICompatible ? model.baseUrl : "", providerColors), icon: Cloud });
-  if (model.id.trim() && model.name.trim()) summaryBadges.push({ label: model.name.trim(), className: modelNameBadgeClassName(model.name, modelNameColors), icon: BrainCircuit });
+  if (model.name.trim()) summaryBadges.push({ label: model.name.trim(), className: modelNameBadgeClassName(model.name, modelNameColors), icon: BrainCircuit });
   if (model.maxInputTokens.trim()) summaryBadges.push({ label: tokenLabel(compactTokenCount(model.maxInputTokens), t), className: neutralBadgeClassName, icon: StretchHorizontal });
   if (model.thinking || (openAICompatible && model.thinkingBudgetTokens.trim())) summaryBadges.push({ label: thinkingBadgeLabel(model.thinking, openAICompatible ? model.thinkingBudgetTokens : "", t), className: neutralBadgeClassName, icon: Brain });
   const rawSecretConfigured = model.apiKeySource === "raw" && hasReusableRawSecret(model);
@@ -626,7 +710,7 @@ function ModelRow({ model, disabled, providerColors, modelNameColors, onChange, 
       </summary>
       <div className="grid gap-4 border-t border-border p-4 md:grid-cols-2 lg:grid-cols-3">
         <Field label={t("fields.provider")}>
-          <input list="platform-model-provider-presets" value={model.provider} disabled={disabled} onChange={(event) => onChange({ provider: event.target.value })} className={inputClassName} />
+          <ProviderInput value={model.provider} disabled={disabled} onChange={(provider) => onChange({ provider })} />
         </Field>
         <TextInput label={t("fields.name")} value={model.name} disabled={disabled} onChange={(name) => onChange({ name })} />
         <TextInput label={t("fields.id")} value={model.id} disabled={disabled} placeholder={t("placeholders.generatedId")} onChange={(id) => onChange({ id })} />
@@ -639,14 +723,14 @@ function ModelRow({ model, disabled, providerColors, modelNameColors, onChange, 
         <TextInput label={t("fields.thinkingBudgetTokens")} value={model.thinkingBudgetTokens} disabled={openAIFieldsDisabled} onChange={(thinkingBudgetTokens) => onChange({ thinkingBudgetTokens })} />
         <TextInput label={t("fields.baseUrl")} value={model.baseUrl} disabled={openAIFieldsDisabled} onChange={(baseUrl) => onChange({ baseUrl })} />
         <Field label={t("fields.apiKeySource")}>
-          <select value={model.apiKeySource} disabled={openAIFieldsDisabled} onChange={(event) => onChange(apiKeySourceChangePatch(model, event.target.value as SecretSource))} className={inputClassName}>
+          <select value={model.apiKeySource} disabled={apiKeyFieldsDisabled} onChange={(event) => onChange(apiKeySourceChangePatch(model, event.target.value as SecretSource))} className={inputClassName}>
             <option value="none">{t("secretSources.none")}</option>
             <option value="raw">{t("secretSources.raw")}</option>
             <option value="env">{t("secretSources.env")}</option>
             <option value="file">{t("secretSources.file")}</option>
           </select>
         </Field>
-        {openAICompatible && model.apiKeySource !== "none" ? (
+        {modelApiKeySupported && model.apiKeySource !== "none" ? (
           <Field label={model.apiKeySource === "raw" ? t("fields.apiKey") : t("fields.secretReference")}>
             <div className="relative">
               <KeyRound className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />

--- a/frontend/src/components/platform-settings-view.tsx
+++ b/frontend/src/components/platform-settings-view.tsx
@@ -117,35 +117,24 @@ function modelNameKey(name: string): string {
   return name.trim().toLowerCase();
 }
 
-function badgeColorClassMap(keys: string[], classNames: readonly string[]): ReadonlyMap<string, string> {
-  const uniqueKeys = Array.from(new Set(keys.filter(Boolean))).sort();
-  return new Map(uniqueKeys.map((key, index) => [key, classNames[index % classNames.length]]));
+function badgeClassNameFromHash(key: string, classNames: readonly string[]): string {
+  let hash = 0;
+  for (let index = 0; index < key.length; index += 1) {
+    hash = (hash * 31 + key.charCodeAt(index)) >>> 0;
+  }
+  return classNames[hash % classNames.length];
 }
 
-function providerColorClassMap(models: ModelDraft[]): ReadonlyMap<string, string> {
-  return badgeColorClassMap(models.map((model) => providerKey(model.provider, model.baseUrl)), providerBadgeClassNames);
-}
-
-function modelNameColorClassMap(models: ModelDraft[]): ReadonlyMap<string, string> {
-  return badgeColorClassMap(models.map((model) => modelNameKey(model.name)), modelBadgeClassNames);
-}
-
-function providerBadgeClassName(provider: string, baseUrl: string, providerColors: ReadonlyMap<string, string>): string {
+function providerBadgeClassName(provider: string, baseUrl: string): string {
   const normalized = providerKey(provider, baseUrl);
   if (!normalized) return neutralBadgeClassName;
-  const className = providerColors.get(normalized);
-  if (className) return className;
-  let hash = 0;
-  for (let index = 0; index < normalized.length; index += 1) {
-    hash = (hash * 31 + normalized.charCodeAt(index)) >>> 0;
-  }
-  return providerBadgeClassNames[hash % providerBadgeClassNames.length];
+  return badgeClassNameFromHash(normalized, providerBadgeClassNames);
 }
 
-function modelNameBadgeClassName(name: string, modelNameColors: ReadonlyMap<string, string>): string {
+function modelNameBadgeClassName(name: string): string {
   const normalized = modelNameKey(name);
   if (!normalized) return neutralBadgeClassName;
-  return modelNameColors.get(normalized) ?? modelBadgeClassNames[0];
+  return badgeClassNameFromHash(normalized, modelBadgeClassNames);
 }
 
 function compactTokenCount(value: string): string {
@@ -426,8 +415,6 @@ export function PlatformSettingsView({ server, token }: { server: string; token:
   }, [notice]);
 
   const modelOptions = useMemo(() => draftModelOptions(draft?.models ?? []), [draft?.models]);
-  const providerColors = useMemo(() => providerColorClassMap(draft?.models ?? []), [draft?.models]);
-  const modelNameColors = useMemo(() => modelNameColorClassMap(draft?.models ?? []), [draft?.models]);
   const changed = useMemo(() => comparableDraft(draft) !== null && JSON.stringify(comparableDraft(draft)) !== JSON.stringify(comparableDraft(settings ? draftFromSettings(settings) : null)), [draft, settings]);
   const configWritable = settings?.config_writable ?? false;
   const fieldsDisabled = saving || !configWritable;
@@ -539,8 +526,6 @@ export function PlatformSettingsView({ server, token }: { server: string; token:
                 key={model.rowId}
                 model={model}
                 disabled={fieldsDisabled}
-                providerColors={providerColors}
-                modelNameColors={modelNameColors}
                 onChange={(patch) => updateModel(model.rowId, patch)}
                 onRemove={() => updateDraft({ models: draft.models.filter((item) => item.rowId !== model.rowId) })}
                 t={t}
@@ -667,7 +652,8 @@ function ProviderInput({ value, disabled, onChange }: { value: string; disabled:
   );
 }
 
-function ModelRow({ model, disabled, providerColors, modelNameColors, onChange, onRemove, t }: { model: ModelDraft; disabled: boolean; providerColors: ReadonlyMap<string, string>; modelNameColors: ReadonlyMap<string, string>; onChange: (patch: Partial<ModelDraft>) => void; onRemove: () => void; t: Translate }) {
+function ModelRow({ model, disabled, onChange, onRemove, t }: { model: ModelDraft; disabled: boolean; onChange: (patch: Partial<ModelDraft>) => void; onRemove: () => void; t: Translate }) {
+  const [expanded, setExpanded] = useState(!model.name.trim());
   const effectiveId = modelId(model);
   const summaryId = model.name.trim() ? effectiveId : t("placeholders.generatedId");
   const provider = model.provider.trim();
@@ -677,13 +663,13 @@ function ModelRow({ model, disabled, providerColors, modelNameColors, onChange, 
   const apiKeyFieldsDisabled = disabled || !modelApiKeySupported;
   const providerLabel = providerBadgeLabel(provider, openAICompatible ? model.baseUrl : "");
   const summaryBadges: SummaryBadge[] = [];
-  if (provider) summaryBadges.push({ label: providerLabel, className: providerBadgeClassName(provider, openAICompatible ? model.baseUrl : "", providerColors), icon: Cloud });
-  if (model.name.trim()) summaryBadges.push({ label: model.name.trim(), className: modelNameBadgeClassName(model.name, modelNameColors), icon: BrainCircuit });
+  if (provider) summaryBadges.push({ label: providerLabel, className: providerBadgeClassName(provider, openAICompatible ? model.baseUrl : ""), icon: Cloud });
+  if (model.name.trim()) summaryBadges.push({ label: model.name.trim(), className: modelNameBadgeClassName(model.name), icon: BrainCircuit });
   if (model.maxInputTokens.trim()) summaryBadges.push({ label: tokenLabel(compactTokenCount(model.maxInputTokens), t), className: neutralBadgeClassName, icon: StretchHorizontal });
   if (model.thinking || (openAICompatible && model.thinkingBudgetTokens.trim())) summaryBadges.push({ label: thinkingBadgeLabel(model.thinking, openAICompatible ? model.thinkingBudgetTokens : "", t), className: neutralBadgeClassName, icon: Brain });
   const rawSecretConfigured = model.apiKeySource === "raw" && hasReusableRawSecret(model);
   return (
-    <details className="group rounded-lg border border-border bg-background/70" open={!model.name.trim() || undefined}>
+    <details className="group rounded-lg border border-border bg-background/70" open={expanded} onToggle={(event) => setExpanded(event.currentTarget.open)}>
       <summary className="flex cursor-pointer list-none items-center justify-between gap-3 p-4 outline-none transition-colors hover:bg-muted/40 focus-visible:ring-2 focus-visible:ring-ring/30 [&::-webkit-details-marker]:hidden">
         <div className="min-w-0 space-y-2">
           <div className="break-all font-mono text-sm font-medium">{summaryId}</div>

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -94,7 +94,6 @@ export function Sidebar({
   sessions,
   showArchivedSessions = true,
   activeSessionId,
-  activeView = "chat",
   frontendVersion = null,
   backendVersion = null,
   currentUser = null,
@@ -125,6 +124,11 @@ export function Sidebar({
     : [];
   const accountName = currentUser?.display_name?.trim() || currentUser?.username || t("account.unknown");
   const accountUsername = currentUser?.username ?? t("account.unknown");
+
+  function handleOpenSettings(): void {
+    setAccountMenuOpen(false);
+    onOpenSettings();
+  }
 
   useEffect(() => {
     const updateReferenceTime = (): void => {
@@ -595,6 +599,15 @@ export function Sidebar({
           <VersionBadge frontendVersion={frontendVersion} backendVersion={backendVersion} />
         </div>
         <div className="flex items-center gap-0.5">
+          <button
+            type="button"
+            onClick={handleOpenSettings}
+            title={t("navigation.settings")}
+            aria-label={t("navigation.settings")}
+            className="inline-flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            <Settings2 className="h-4 w-4" />
+          </button>
           <div ref={accountMenuRef} className="relative">
             <button
               type="button"
@@ -608,7 +621,7 @@ export function Sidebar({
               <span
                 className={cn(
                   "flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-border text-[11px] font-semibold transition-colors",
-                  activeView === "settings" || accountMenuOpen
+                  accountMenuOpen
                     ? "bg-accent text-accent-foreground"
                     : "bg-background text-muted-foreground",
                 )}
@@ -654,10 +667,7 @@ export function Sidebar({
                   <button
                     type="button"
                     role="menuitem"
-                    onClick={() => {
-                      setAccountMenuOpen(false);
-                      onOpenSettings();
-                    }}
+                    onClick={handleOpenSettings}
                     className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm text-foreground transition-colors hover:bg-muted"
                   >
                     <Settings2 className="h-4 w-4 text-muted-foreground" />

--- a/src/carapace/agent/loop.py
+++ b/src/carapace/agent/loop.py
@@ -34,6 +34,7 @@ from ..security.context import (
     SentinelVerdict,
     UserMessageEntry,
 )
+from ..usage import provider_cost_usd_from_messages
 from ..ws_models import ApprovalRequest, FinalStatus
 from .deps import Deps, TaskDone, TaskFailed
 from .tools import create_agent
@@ -97,7 +98,12 @@ async def run_agent_turn(
         usage_limits=usage_limits,
     )
     last_thinking = "".join(current_thinking_parts)
-    deps.usage_tracker.record(usage_model_key, "agent", result.usage)
+    deps.usage_tracker.record(
+        usage_model_key,
+        "agent",
+        result.usage,
+        cost_usd=provider_cost_usd_from_messages(result.new_messages()),
+    )
     messages = result.all_messages()
     if on_messages_snapshot is not None:
         on_messages_snapshot(list(messages))
@@ -161,7 +167,12 @@ async def run_agent_turn(
             usage_limits=usage_limits,
         )
         last_thinking = "".join(current_thinking_parts)
-        deps.usage_tracker.record(usage_model_key, "agent", result.usage)
+        deps.usage_tracker.record(
+            usage_model_key,
+            "agent",
+            result.usage,
+            cost_usd=provider_cost_usd_from_messages(result.new_messages()),
+        )
         messages = result.all_messages()
         if on_messages_snapshot is not None:
             on_messages_snapshot(list(messages))

--- a/src/carapace/llm.py
+++ b/src/carapace/llm.py
@@ -9,9 +9,11 @@ from typing import Literal, cast
 from httpx import AsyncClient, HTTPStatusError, Timeout
 from pydantic_ai.models import Model, infer_model
 from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.models.openrouter import OpenRouterModel
 from pydantic_ai.providers import Provider, infer_provider, infer_provider_class
 from pydantic_ai.providers.google import GoogleProvider
 from pydantic_ai.providers.openai import OpenAIProvider
+from pydantic_ai.providers.openrouter import OpenRouterProvider
 from pydantic_ai.retries import AsyncTenacityTransport, RetryConfig, wait_retry_after
 from pydantic_ai.settings import ModelSettings
 from tenacity import retry_if_exception_type, stop_after_attempt, wait_exponential
@@ -89,6 +91,12 @@ def make_model_factory(config: Config) -> Callable[[str], Model]:
     def factory(model_name: str) -> Model:
         entry = resolve_available_model_entry(config, model_name)
         resolved_model_name = f"{entry.provider}:{entry.name}"
+        if entry.provider == "openrouter":
+            api_key: str | None = None
+            if entry.api_key is not None:
+                api_key = entry.api_key.resolve().get_secret_value()
+            provider = OpenRouterProvider(api_key=api_key, http_client=retry_http_client())
+            return OpenRouterModel(entry.name, provider=provider)
         if entry.provider in ("openai", "openai-chat"):
             api_key: str | None = None
             if entry.api_key is not None:

--- a/src/carapace/llm.py
+++ b/src/carapace/llm.py
@@ -67,6 +67,8 @@ def model_settings_for_entry(
     default_thinking: ThinkingSetting | None = None,
 ) -> ModelSettings | None:
     settings: dict[str, object] = {}
+    if entry.provider == "openrouter":
+        settings["openrouter_usage"] = {"include": True}
     thinking = entry.thinking if entry.thinking is not None else default_thinking
     if thinking is not None:
         settings["thinking"] = thinking

--- a/src/carapace/models/config.py
+++ b/src/carapace/models/config.py
@@ -11,6 +11,9 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from ..notifications.models import NotificationsConfig
 from .session import SessionBudget
 
+OPENAI_COMPATIBLE_PROVIDERS = {"openai", "openai-chat"}
+PROVIDERS_WITH_MODEL_API_KEYS = OPENAI_COMPATIBLE_PROVIDERS | {"openrouter"}
+
 
 class ConfigModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -72,7 +75,7 @@ class AvailableModelEntry(ConfigModel):
     """One row in ``agent.available_models``: shorthand ``provider:name`` string or a mapping."""
 
     provider: str = Field(
-        description="API kind used to access the model, such as anthropic, openai, or openai-chat.",
+        description="API kind used to access the model, such as anthropic, openai, openai-chat, or openrouter.",
     )
     name: str = Field(
         description="Provider-specific model name sent to that API.",
@@ -110,12 +113,12 @@ class AvailableModelEntry(ConfigModel):
 
     @model_validator(mode="after")
     def _validate_openai_compatible_fields(self) -> AvailableModelEntry:
-        if self.base_url is None and self.api_key is None and self.thinking_budget_tokens is None:
-            return self
-        if self.provider not in ("openai", "openai-chat"):
-            raise ValueError(
-                "base_url/api_key/thinking_budget_tokens are only supported for provider 'openai' or 'openai-chat'"
-            )
+        if self.base_url is not None and self.provider not in OPENAI_COMPATIBLE_PROVIDERS:
+            raise ValueError("base_url is only supported for provider 'openai' or 'openai-chat'")
+        if self.thinking_budget_tokens is not None and self.provider not in OPENAI_COMPATIBLE_PROVIDERS:
+            raise ValueError("thinking_budget_tokens is only supported for provider 'openai' or 'openai-chat'")
+        if self.api_key is not None and self.provider not in PROVIDERS_WITH_MODEL_API_KEYS:
+            raise ValueError("api_key is only supported for provider 'openai', 'openai-chat', or 'openrouter'")
         return self
 
     @property

--- a/src/carapace/security/sentinel.py
+++ b/src/carapace/security/sentinel.py
@@ -13,7 +13,7 @@ from pydantic_ai.models import Model, infer_model
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.usage import UsageLimits
 
-from ..usage import LlmRequestLogCapability, UsageTracker
+from ..usage import LlmRequestLogCapability, UsageTracker, provider_cost_usd_from_messages
 from .context import (
     ActionLogEntry,
     AgentResponseEntry,
@@ -403,7 +403,12 @@ class Sentinel:
         session.sentinel_eval_count += 1
 
         if usage_tracker:
-            usage_tracker.record(self._model, "sentinel", result.usage)
+            usage_tracker.record(
+                self._model,
+                "sentinel",
+                result.usage,
+                cost_usd=provider_cost_usd_from_messages(result.new_messages()),
+            )
 
         usage = result.usage
         output = self._normalize_verdict(result.output)

--- a/src/carapace/security/sentinel.py
+++ b/src/carapace/security/sentinel.py
@@ -188,6 +188,19 @@ class Sentinel:
         self._model = model
         self._agent = self._create_agent()
 
+    def set_model_runtime(
+        self,
+        *,
+        model: str | None = None,
+        model_factory: Callable[[str], Model] | None,
+        model_settings_resolver: Callable[[str], ModelSettings | None] | None,
+    ) -> None:
+        if model is not None:
+            self._model = model
+        self._model_factory = model_factory
+        self._model_settings_resolver = model_settings_resolver
+        self._agent = self._create_agent()
+
     def set_policy(self, *, ask_mode: bool | None = None, unattended: bool | None = None) -> None:
         """Update live mutable policy flags without discarding sentinel conversation state."""
         changed = False

--- a/src/carapace/server/platform_settings.py
+++ b/src/carapace/server/platform_settings.py
@@ -13,7 +13,15 @@ from pydantic_ai.models import Model
 
 from ..config import get_config_path
 from ..llm import make_model_factory
-from ..models.config import AgentConfig, AvailableModelEntry, Config, Secret, agent_available_model_entries
+from ..models.config import (
+    OPENAI_COMPATIBLE_PROVIDERS,
+    PROVIDERS_WITH_MODEL_API_KEYS,
+    AgentConfig,
+    AvailableModelEntry,
+    Config,
+    Secret,
+    agent_available_model_entries,
+)
 from ..models.session import SessionBudget
 from .auth import verify_admin_user
 from .state import server_module
@@ -216,7 +224,11 @@ def _secret_from_patch(patch: PlatformSecretPatch | None, existing: Secret | Non
 
 
 def _openai_compatible_provider(provider: str) -> bool:
-    return provider in {"openai", "openai-chat"}
+    return provider in OPENAI_COMPATIBLE_PROVIDERS
+
+
+def _provider_supports_api_key(provider: str) -> bool:
+    return provider in PROVIDERS_WITH_MODEL_API_KEYS
 
 
 def _agent_config_from_patch(body: PlatformSettingsPatch, existing_agent: AgentConfig) -> AgentConfig:
@@ -225,6 +237,7 @@ def _agent_config_from_patch(body: PlatformSettingsPatch, existing_agent: AgentC
     for patch in body.available_models:
         existing = existing_by_id.get(patch.model_id)
         openai_compatible = _openai_compatible_provider(patch.provider)
+        supports_api_key = _provider_supports_api_key(patch.provider)
         entries.append(
             AvailableModelEntry(
                 provider=patch.provider,
@@ -236,7 +249,7 @@ def _agent_config_from_patch(body: PlatformSettingsPatch, existing_agent: AgentC
                 base_url=patch.base_url if openai_compatible else None,
                 api_key=(
                     _secret_from_patch(patch.api_key, existing.api_key if existing is not None else None)
-                    if openai_compatible
+                    if supports_api_key
                     else None
                 ),
             )

--- a/src/carapace/session/model_selection.py
+++ b/src/carapace/session/model_selection.py
@@ -80,8 +80,12 @@ class SessionModelMixin(SessionModelHost):
         self._agent_model = agent_model
         for active in self._active.values():
             active.agent_model = None
-            if active.sentinel_model_name is None and active.sentinel is not None:
-                active.sentinel.set_model(config.agent.sentinel_model)
+            if active.sentinel is not None:
+                active.sentinel.set_model_runtime(
+                    model=active.sentinel_model_name or config.agent.sentinel_model,
+                    model_factory=model_factory,
+                    model_settings_resolver=self._resolve_model_settings,
+                )
 
     def _restore_persisted_model_overrides(self, active: ActiveSession) -> None:
         """Validate restored overrides, falling back to defaults when they are no longer usable."""

--- a/src/carapace/session/model_selection.py
+++ b/src/carapace/session/model_selection.py
@@ -81,11 +81,29 @@ class SessionModelMixin(SessionModelHost):
         for active in self._active.values():
             active.agent_model = None
             if active.sentinel is not None:
-                active.sentinel.set_model_runtime(
-                    model=active.sentinel_model_name or config.agent.sentinel_model,
-                    model_factory=model_factory,
-                    model_settings_resolver=self._resolve_model_settings,
-                )
+                model_name = active.sentinel_model_name or config.agent.sentinel_model
+                try:
+                    active.sentinel.set_model_runtime(
+                        model=model_name,
+                        model_factory=model_factory,
+                        model_settings_resolver=self._resolve_model_settings,
+                    )
+                except Exception as exc:
+                    if active.sentinel_model_name is None:
+                        raise
+                    _logger().warning(
+                        f"Active sentinel model override {active.sentinel_model_name!r} for session "
+                        + f"{active.state.session_id} is no longer valid after platform config update: {exc}. "
+                        + f"Falling back to {config.agent.sentinel_model!r}."
+                    )
+                    active.sentinel.set_model_runtime(
+                        model=config.agent.sentinel_model,
+                        model_factory=model_factory,
+                        model_settings_resolver=self._resolve_model_settings,
+                    )
+                    active.sentinel_model_name = None
+                    active.state.sentinel_model_name = None
+                    self._session_mgr.save_state(active.state)
 
     def _restore_persisted_model_overrides(self, active: ActiveSession) -> None:
         """Validate restored overrides, falling back to defaults when they are no longer usable."""

--- a/src/carapace/session/titler.py
+++ b/src/carapace/session/titler.py
@@ -11,7 +11,7 @@ from pydantic_ai.models import Model, infer_model
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.usage import UsageLimits
 
-from ..usage import LlmRequestLogCapability, UsageTracker
+from ..usage import LlmRequestLogCapability, UsageTracker, provider_cost_usd_from_messages
 
 _SYSTEM_PROMPT = """\
 Generate a very short title (3-8 words) for a chat conversation.
@@ -74,7 +74,12 @@ async def generate_title(
             before_llm_call()
         result = await agent.run(prompt, usage_limits=usage_limits)
         if usage_tracker:
-            usage_tracker.record(model, "title", result.usage)
+            usage_tracker.record(
+                model,
+                "title",
+                result.usage,
+                cost_usd=provider_cost_usd_from_messages(result.new_messages()),
+            )
         return result.output.strip()
     except Exception:
         logger.opt(exception=True).warning("Title generation failed")

--- a/src/carapace/usage.py
+++ b/src/carapace/usage.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Any, Literal, Protocol, TypedDict, assert_never
 
 import tiktoken
@@ -47,9 +47,12 @@ class ModelUsage(BaseModel):
     output_audio_tokens: int = 0
     cache_audio_read_tokens: int = 0
     requests: int = 0
+    cost_usd: Decimal = Decimal(0)
 
 
 def _price_for_usage(model_key: str, u: ModelUsage) -> Decimal | None:
+    if u.cost_usd:
+        return u.cost_usd
     provider_id, _, model_ref = model_key.partition(":")
     if not model_ref:
         model_ref, provider_id = provider_id, None
@@ -83,21 +86,55 @@ def _merge_run_usage_into_bucket(bucket: ModelUsage, usage: RunUsage) -> None:
     bucket.requests += usage.requests
 
 
+def _merge_cost_into_bucket(bucket: ModelUsage, cost_usd: Decimal | None) -> None:
+    if cost_usd is not None:
+        bucket.cost_usd += cost_usd
+
+
+def _coerce_cost_usd(value: Any) -> Decimal | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, int | float | str):
+        try:
+            return Decimal(str(value))
+        except (InvalidOperation, ValueError):
+            return None
+    return None
+
+
+def provider_cost_usd_from_messages(messages: list[ModelMessage]) -> Decimal | None:
+    total = Decimal(0)
+    found = False
+    for message in messages:
+        if not isinstance(message, ModelResponse) or message.provider_details is None:
+            continue
+        cost = _coerce_cost_usd(message.provider_details.get("cost"))
+        if cost is None:
+            continue
+        total += cost
+        found = True
+    return total if found else None
+
+
 class UsageTracker(BaseModel):
     models: dict[str, ModelUsage] = {}
     categories: dict[str, ModelUsage] = {}
     category_by_model: dict[str, dict[str, ModelUsage]] = {}
     tool_calls: int = 0
 
-    def record(self, model: str, category: str, usage: RunUsage) -> None:
+    def record(self, model: str, category: str, usage: RunUsage, *, cost_usd: Decimal | None = None) -> None:
         for bucket in (
             self.models.setdefault(model, ModelUsage()),
             self.categories.setdefault(category, ModelUsage()),
         ):
             _merge_run_usage_into_bucket(bucket, usage)
+            _merge_cost_into_bucket(bucket, cost_usd)
         cm = self.category_by_model.setdefault(category, {})
         m_bucket = cm.setdefault(model, ModelUsage())
         _merge_run_usage_into_bucket(m_bucket, usage)
+        _merge_cost_into_bucket(m_bucket, cost_usd)
 
     def record_tool_call(self) -> None:
         self.tool_calls += 1

--- a/src/carapace/usage.py
+++ b/src/carapace/usage.py
@@ -51,13 +51,12 @@ class ModelUsage(BaseModel):
 
 
 def _price_for_usage(model_key: str, u: ModelUsage) -> Decimal | None:
-    if u.cost_usd:
-        return u.cost_usd
+    provider_cost = u.cost_usd if u.cost_usd else None
     provider_id, _, model_ref = model_key.partition(":")
     if not model_ref:
         model_ref, provider_id = provider_id, None
     try:
-        return calc_price(
+        token_cost = calc_price(
             PriceUsage(
                 input_tokens=u.input_tokens,
                 output_tokens=u.output_tokens,
@@ -72,7 +71,8 @@ def _price_for_usage(model_key: str, u: ModelUsage) -> Decimal | None:
         ).total_price
     except LookupError:
         logger.debug(f"No pricing data for model {model_key}")
-        return None
+        return provider_cost
+    return max(provider_cost, token_cost) if provider_cost is not None else token_cost
 
 
 def _merge_run_usage_into_bucket(bucket: ModelUsage, usage: RunUsage) -> None:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -31,6 +31,9 @@ class _FakeResult:
     def all_messages(self) -> list[Any]:
         return []
 
+    def new_messages(self) -> list[Any]:
+        return []
+
 
 def _make_deps(tmp_path: Path, *, unattended: bool) -> Deps:
     session_id = "session-1"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock
 import pytest
 from pydantic import ValidationError
 from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.models.openrouter import OpenRouterModel
+from pydantic_ai.providers.openrouter import OpenRouterProvider
 
 from carapace.llm import make_model_factory, model_settings_for_config
 from carapace.models.config import (
@@ -279,6 +281,26 @@ def test_available_model_entry_rejects_api_key_for_non_openai_provider():
         )
 
 
+def test_available_model_entry_allows_api_key_for_openrouter_provider():
+    e = AvailableModelEntry.model_validate(
+        {"provider": "openrouter", "name": "anthropic/claude-sonnet-4.5", "api_key": {"raw": "secret"}}
+    )
+
+    assert e.model_id == "openrouter:anthropic/claude-sonnet-4.5"
+    assert e.api_key is not None
+
+
+def test_available_model_entry_rejects_base_url_for_openrouter_provider():
+    with pytest.raises(ValidationError):
+        AvailableModelEntry.model_validate(
+            {
+                "provider": "openrouter",
+                "name": "anthropic/claude-sonnet-4.5",
+                "base_url": "https://openrouter.ai/api/v1",
+            }
+        )
+
+
 def test_available_model_entry_rejects_thinking_budget_tokens_for_non_openai_provider():
     with pytest.raises(ValidationError):
         AvailableModelEntry.model_validate(
@@ -354,6 +376,29 @@ def test_make_model_factory_openai_compatible_row():
     factory = make_model_factory(cfg)
     m = factory("on-prem:custom")
     assert isinstance(m, OpenAIChatModel)
+
+
+def test_make_model_factory_openrouter_row():
+    cfg = Config.model_validate(
+        {
+            "agent": {
+                "model": "openrouter:anthropic/claude-sonnet-4.5",
+                "sentinel_model": "openrouter:anthropic/claude-sonnet-4.5",
+                "title_model": "openrouter:anthropic/claude-sonnet-4.5",
+                "available_models": [
+                    {
+                        "provider": "openrouter",
+                        "name": "anthropic/claude-sonnet-4.5",
+                        "api_key": {"raw": "x"},
+                    },
+                ],
+            }
+        }
+    )
+    factory = make_model_factory(cfg)
+    m = factory("openrouter:anthropic/claude-sonnet-4.5")
+    assert isinstance(m, OpenRouterModel)
+    assert isinstance(m.provider, OpenRouterProvider)
 
 
 def test_make_model_factory_rejects_unregistered_model():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -408,6 +408,28 @@ def test_make_model_factory_rejects_unregistered_model():
         factory("openai:gpt-4o")
 
 
+def test_model_settings_for_config_enables_openrouter_usage_accounting():
+    cfg = Config.model_validate(
+        {
+            "agent": {
+                "model": "openrouter:openai/gpt-5.2",
+                "sentinel_model": "openrouter:openai/gpt-5.2",
+                "title_model": "openrouter:openai/gpt-5.2",
+                "available_models": [
+                    {
+                        "provider": "openrouter",
+                        "name": "openai/gpt-5.2",
+                    },
+                ],
+            }
+        }
+    )
+
+    settings = model_settings_for_config(cfg, "openrouter:openai/gpt-5.2")
+
+    assert settings == {"openrouter_usage": {"include": True}}
+
+
 def test_make_model_factory_resolves_registered_alias(monkeypatch: pytest.MonkeyPatch):
     cfg = Config.model_validate(
         {

--- a/tests/test_session_engine_models.py
+++ b/tests/test_session_engine_models.py
@@ -18,6 +18,7 @@ from pydantic_ai.usage import RunUsage
 
 import carapace.security as security_mod
 import carapace.usage as usage_mod
+from carapace.models.config import AgentConfig
 from carapace.models.session import SessionBudget
 from carapace.security.context import SentinelVerdict, SessionSecurity, ToolCallEntry
 from carapace.security.sentinel import Sentinel
@@ -415,6 +416,45 @@ def test_apply_platform_model_config_invalidates_cached_override_agent_model(tmp
 
     assert active.agent_model_name == "openai:gpt-4o"
     assert active.agent_model is None
+
+
+def test_apply_platform_model_config_refreshes_active_sentinel_factory(tmp_path: Path) -> None:
+    engine = _make_engine(tmp_path)
+
+    def old_factory(name: str) -> TestModel:
+        if name == "local:new-model":
+            raise ValueError("old catalog")
+        return TestModel()
+
+    engine._model_factory = old_factory
+    state = engine.session_mgr.create_session(user="thies")
+    active = engine.get_or_activate(state.session_id)
+    assert active.sentinel is not None
+
+    def new_factory(_name: str) -> TestModel:
+        return TestModel()
+
+    config = engine.config.model_copy(deep=True)
+    config.agent = AgentConfig(
+        model=engine.config.agent.model,
+        sentinel_model=engine.config.agent.sentinel_model,
+        title_model=engine.config.agent.title_model,
+        available_models=[
+            *engine.config.agent.available_models,
+            {"provider": "openai", "name": "new-model", "id": "local:new-model"},
+        ],
+    )
+    engine.apply_platform_model_config(config, model_factory=new_factory, agent_model=TestModel())
+    updated = engine.update_session_model_overrides(
+        state.session_id,
+        agent_model_name="local:new-model",
+        sentinel_model_name="local:new-model",
+    )
+
+    assert updated.agent_model_name == "local:new-model"
+    assert updated.sentinel_model_name == "local:new-model"
+    assert active.agent_model_name == "local:new-model"
+    assert active.sentinel_model_name == "local:new-model"
 
 
 def test_invalid_model_overrides_fall_back_on_restart(tmp_path: Path) -> None:

--- a/tests/test_session_engine_models.py
+++ b/tests/test_session_engine_models.py
@@ -457,6 +457,44 @@ def test_apply_platform_model_config_refreshes_active_sentinel_factory(tmp_path:
     assert active.sentinel_model_name == "local:new-model"
 
 
+def test_apply_platform_model_config_clears_stale_active_sentinel_override(tmp_path: Path) -> None:
+    with _patch_sentinel() as sentinel_cls, patch("carapace.session.engine.logger.warning") as warning_mock:
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session(user="thies")
+        active = engine.get_or_activate(state.session_id)
+        assert active.sentinel is not None
+
+        active.sentinel_model_name = "openai:missing-sentinel"
+        active.state.sentinel_model_name = "openai:missing-sentinel"
+        engine.session_mgr.save_state(active.state)
+
+        sentinel = sentinel_cls.return_value
+
+        def _set_model_runtime(*, model: str | None = None, **_kwargs: Any) -> None:
+            if model == "openai:missing-sentinel":
+                raise ValueError("missing sentinel model")
+
+        sentinel.set_model_runtime.side_effect = _set_model_runtime
+
+        engine.apply_platform_model_config(
+            engine.config,
+            model_factory=lambda _name: TestModel(),
+            agent_model=TestModel(),
+        )
+
+    assert active.sentinel_model_name is None
+    assert active.state.sentinel_model_name is None
+
+    persisted = engine.session_mgr.load_state(state.session_id)
+    assert persisted is not None
+    assert persisted.sentinel_model_name is None
+
+    assert sentinel.set_model_runtime.call_count == 2
+    assert sentinel.set_model_runtime.call_args_list[0].kwargs["model"] == "openai:missing-sentinel"
+    assert sentinel.set_model_runtime.call_args_list[1].kwargs["model"] == engine.config.agent.sentinel_model
+    warning_mock.assert_called_once()
+
+
 def test_invalid_model_overrides_fall_back_on_restart(tmp_path: Path) -> None:
     with _patch_sentinel():
         engine = _make_engine(tmp_path)

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from typing import Any
 
+import pytest
 from pydantic_ai.messages import ModelRequest, ModelResponse
 from pydantic_ai.usage import RunUsage
 
@@ -77,6 +79,48 @@ def test_estimated_cost_uses_provider_cost_when_available() -> None:
 
     assert t.estimated_cost()["openrouter:openai/gpt-5.2"] == Decimal("0.0123")
     assert t.estimated_cost()["total"] == Decimal("0.0123")
+    assert t.estimated_category_cost()["agent"] == Decimal("0.0123")
+
+
+def test_estimated_cost_uses_token_price_when_provider_cost_is_partial(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Price:
+        total_price = Decimal("0.05")
+
+    def fake_calc_price(*_args: Any, **_kwargs: Any) -> Price:
+        return Price()
+
+    monkeypatch.setattr("carapace.usage.calc_price", fake_calc_price)
+    t = UsageTracker()
+    t.record(
+        "openrouter:openai/gpt-5.2",
+        "agent",
+        RunUsage(input_tokens=100, output_tokens=50, requests=1),
+        cost_usd=Decimal("0.0123"),
+    )
+    t.record(
+        "openrouter:openai/gpt-5.2",
+        "agent",
+        RunUsage(input_tokens=1000, output_tokens=500, requests=1),
+    )
+
+    assert t.estimated_cost()["openrouter:openai/gpt-5.2"] == Decimal("0.05")
+    assert t.estimated_category_cost()["agent"] == Decimal("0.05")
+
+
+def test_estimated_cost_falls_back_to_provider_cost_when_pricing_is_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_calc_price(*_args: Any, **_kwargs: Any) -> None:
+        raise LookupError
+
+    monkeypatch.setattr("carapace.usage.calc_price", fake_calc_price)
+    t = UsageTracker()
+    t.record(
+        "openrouter:unknown-model",
+        "agent",
+        RunUsage(input_tokens=100, output_tokens=50, requests=1),
+        cost_usd=Decimal("0.0123"),
+    )
+
+    assert t.estimated_cost()["openrouter:unknown-model"] == Decimal("0.0123")
     assert t.estimated_category_cost()["agent"] == Decimal("0.0123")
 
 

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from decimal import Decimal
 
+from pydantic_ai.messages import ModelRequest, ModelResponse
 from pydantic_ai.usage import RunUsage
 
 from carapace.usage import (
     UsageTracker,
+    provider_cost_usd_from_messages,
     usage_budget_exceeded_error,
     usage_budget_gauges,
     usage_limits_for_remaining_budget,
@@ -50,6 +52,32 @@ def test_category_by_model_splits_per_category() -> None:
     assert t.models["anthropic:claude-haiku-4-5"].input_tokens == 110
     assert t.category_by_model["agent"]["anthropic:claude-haiku-4-5"].input_tokens == 100
     assert t.category_by_model["title"]["anthropic:claude-haiku-4-5"].input_tokens == 10
+
+
+def test_provider_cost_usd_from_messages_sums_response_costs() -> None:
+    messages = [
+        ModelRequest(parts=[]),
+        ModelResponse(parts=[], provider_details={"cost": 0.0012}),
+        ModelResponse(parts=[], provider_details={"cost": "0.0034"}),
+        ModelResponse(parts=[], provider_details={"cost": True}),
+        ModelResponse(parts=[]),
+    ]
+
+    assert provider_cost_usd_from_messages(messages) == Decimal("0.0046")
+
+
+def test_estimated_cost_uses_provider_cost_when_available() -> None:
+    t = UsageTracker()
+    t.record(
+        "openrouter:openai/gpt-5.2",
+        "agent",
+        RunUsage(input_tokens=100, output_tokens=50, requests=1),
+        cost_usd=Decimal("0.0123"),
+    )
+
+    assert t.estimated_cost()["openrouter:openai/gpt-5.2"] == Decimal("0.0123")
+    assert t.estimated_cost()["total"] == Decimal("0.0123")
+    assert t.estimated_category_cost()["agent"] == Decimal("0.0123")
 
 
 def test_estimated_category_cost_sums_to_model_costs_when_disjoint() -> None:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches LLM routing, API keys, usage/cost accounting, and live sentinel model refresh on config changes—important for billing and security-sensitive model selection, but covered by new tests.
> 
> **Overview**
> Adds **OpenRouter** as a first-class model provider end-to-end: catalog/config validation, `OpenRouterModel`/`OpenRouterProvider` wiring with optional per-row API keys and `openrouter_usage` for billing metadata, plus docs/Compose/Helm env hints (`OPENROUTER_API_KEY`).
> 
> **Platform model editor** gains `openrouter` in presets, API-key fields without OpenAI-only `base_url`/thinking-budget, sorted catalog rows (incomplete rows stay on top and cannot stay collapsed), a custom provider preset dropdown, and new models prepended when added.
> 
> **Usage and budgets** now accumulate provider-reported `cost` from LLM responses (agent, sentinel, titler) and combine it with token-based pricing via `max(provider, catalog)` so OpenRouter spend shows up in session cost estimates.
> 
> **Runtime fixes**: active sessions refresh sentinel model factory on platform config changes and clear invalid sentinel overrides; sidebar adds a dedicated settings control and drops `activeView`-based account highlighting.
> 
> Minor copy/i18n tweaks (reasoning line labeled as tokens) and a roadmap item for warm sandboxes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c970b73da257a01abec1f79eb6595be51019973. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->