### PR TITLE
✨ feat: individual knowledge repos per user

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@
   <a href="charts/carapace/README.md">⚓ Helm Chart</a>
 </p>
 
-carapace is a self-hosted AI agent with a web UI, CLI, and Matrix channel for operators who want an assistant they can actually reason about. Every meaningful action is evaluated by a dedicated sentinel LLM against your natural-language security policy, executed inside a containerized sandbox, and recorded in an audit trail. Its durable context is not hidden inside an app-specific database: personality, policy, skills and archived sessions live in a Git-backed knowledge repo you can inspect, diff, and sync.
+carapace is a self-hosted AI agent with a web UI, CLI, and Matrix channel for operators who want an assistant they can actually reason about. Every meaningful action is evaluated by a dedicated sentinel LLM against your natural-language security policy, executed inside a containerized sandbox, and recorded in an audit trail. Its durable context is not hidden inside an app-specific database: personality, policy, skills, and archived sessions live in Git-backed knowledge repos you can inspect, diff, and sync.
 
 ## Highlights
 
 - 🛡️ Sentinel-gated execution. Every non-trivial action is reviewed by a dedicated security agent that keeps session context, not a static allowlist spreadsheet.
 - ☸️ Kubernetes-ready sandboxes. Docker and Kubernetes runtimes are both supported, with StatefulSet-backed sandbox sessions, per-session PVCs, and idle-to-zero scaling already in place.
-- 🗃️ Git-native knowledge repo. `SOUL.md`, `USER.md`, `SECURITY.md`, skills, and archived sessions live in files you can inspect, diff, sync, and push upstream.
+- 🗃️ Git-native per-user knowledge repos. `SOUL.md`, `USER.md`, `SECURITY.md`, skills, and archived sessions live in files you can inspect, diff, sync, and push upstream.
 - 🚫 No-direct-internet sandboxes. Sandbox workloads do not get ambient internet access; outbound traffic is forced through the proxy path.
 - 🔑 Context-scoped credentials. Secrets stay in your vault, with native Bitwarden support, and are only injected or fetched on demand for exec calls that have the matching approved skill context. Neither the agent nor the backend have a giant `.env` with all of your secrets.
 - 👥 Multi-user. Bootstrap an admin user, then manage users, roles, passwords, per-user models, Matrix, Git, and credential backends from Settings. Invite your family!
@@ -79,7 +79,7 @@ Who doesn't want a personal assistant? OpenClaw showed that this is achievable w
   <img src="docs/assets/screenshots/pancake_tree.png" width="1000">
 </p>
 
-<p align="center"><em>State of the knowledge repo after some sessions and a new skill were added.</em></p>
+<p align="center"><em>State of one user's knowledge repo after some sessions and a new skill were added.</em></p>
 
 <p align="center">
   <img src="docs/assets/screenshots/post_readonly.png" width="1000">
@@ -103,7 +103,7 @@ carapace treats long-term agent state as a repository, not as an opaque internal
 - Its personality and user model live in `SOUL.md` and `USER.md`.
 - Skills are plain files in AgentSkills format.
 - Durable context is markdown and other plain files on disk.
-- Session histories can be archived into the knowledge repo and pushed upstream.
+- Session histories can be archived into the owning user's knowledge repo and pushed upstream.
 
 That makes the system inspectable in a way most agent projects are not. You can review what changed, diff it, sync it, and audit how the agent's knowledge evolves over time.
 
@@ -148,7 +148,7 @@ For the full Docker Compose setup, multi-user auth model, UI-managed configurati
 
 ## Architecture
 
-The server runs the agent loop, session lifecycle, and security system. The CLI, web UI, and Matrix channel are thin clients. The knowledge repo is a first-class part of the design: session output can be promoted into Git-backed knowledge, and outbound Git operations are security-reviewed instead of treated as an afterthought.
+The server runs the agent loop, session lifecycle, and security system. The CLI, web UI, and Matrix channel are thin clients. Owner-scoped knowledge repos are a first-class part of the design: session output can be promoted into Git-backed knowledge, and outbound Git operations are security-reviewed instead of treated as an afterthought.
 
 See [docs/architecture.md](docs/architecture.md) for the diagrams and fuller architecture breakdown.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -392,7 +392,7 @@ services:
 
 For Kubernetes deployments, the Docker socket is replaced by in-cluster Kubernetes API access — see [kubernetes.md](kubernetes.md).
 
-The `$CARAPACE_DATA_DIR` environment variable (defaults to `./data`) points to the runtime data directory. Runtime state such as `config.yaml`, auth files, session files, notification state, and `jobs.yaml` lives there. The Git-backed knowledge repo lives in a separate `knowledge_dir` (default `./knowledge` relative to the config file, which resolves to `data/knowledge/` in the default setup).
+The `$CARAPACE_DATA_DIR` environment variable (defaults to `./data`) points to the runtime data directory. Runtime state such as `config.yaml`, auth files, session files, notification state, and `jobs.yaml` lives there. Git-backed knowledge state lives under a per-user root at `data/knowledges/<normalized-user>/` in the default setup. Session owner determines which repo, skills tree, archive path, and sandbox clone URL are used.
 
 ## Configuration
 

--- a/docs/git.md
+++ b/docs/git.md
@@ -1,8 +1,8 @@
 # Git Integration
 
-carapace manages a **knowledge repository** — a Git repo containing the security policy, workspace files, skills, archived session snapshots, and any other durable files the agent works with. The repo lives on the server at `$CARAPACE_DATA_DIR/knowledge/` and is cloned into every sandbox container at `/workspace`.
+carapace manages one Git-backed knowledge repo per user. Each repo contains that user's `SECURITY.md`, workspace files, skills, archived session snapshots, and other durable files the agent works with. With the default layout, the repo for user `alice` lives at `$CARAPACE_DATA_DIR/knowledges/alice/`. Sandboxes clone the repo that matches the session owner into `/workspace`.
 
-Optionally, you can connect an **upstream remote** so the knowledge repo is synchronised with an external Git server (GitHub, Gitea, GitLab, etc.).
+Each user can optionally connect an upstream remote so their knowledge repo is synchronized with an external Git server such as GitHub, Gitea, or GitLab. Remote settings are isolated per owner: one user's remote, branch, token, and author template do not affect any other user's repo.
 
 ## Configuration
 
@@ -13,22 +13,19 @@ users:
   alice:
     config:
       git:
-        remote: https://gitea.example.com/team/knowledge.git
+        remote: https://gitea.example.com/team/alice-knowledge.git
         branch: main
         token: ghp_xxxxxxxxxxxx
 ```
 
-The knowledge repo is still a single shared server repo. Because of that, at most one enabled user may configure a non-empty `config.git.remote`; startup fails if multiple enabled users define one.
+The owning user can also manage these fields from the web UI under Settings -> Account. The token field is write-only: responses report `token_set`, but never return the token value.
 
-The owning user can also manage these fields from the web UI under Settings -> Account. The token field is write-only:
-responses report `token_set`, but never return the token value.
-
-| Field    | Default                    | Description                                                                                                                            |
-| -------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `remote` | `""` (none)                | URL of the upstream Git remote. Leave empty for local-only mode.                                                                       |
-| `branch` | `"main"`                   | Remote branch to fetch from and push to. **Must already exist on the remote.** The local knowledge repo always uses `main` internally. |
-| `author` | `"carapace <carapace@%h>"` | Commit author template. `%s` is replaced with the session ID, `%h` with the hostname.                                                  |
-| `token`  | `null`                     | Authentication token for the remote (see below).                                                                                       |
+| Field    | Default                    | Description                                                                                                                 |
+| -------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `remote` | `""` (none)                | URL of the upstream remote for this user's repo. Leave empty for local-only mode.                                           |
+| `branch` | `"main"`                   | Remote branch to fetch from and push to. **Must already exist on the remote.** The local repo still uses `main` internally. |
+| `author` | `"carapace <carapace@%h>"` | Commit author template for this user's repo. `%s` is replaced with the session ID, `%h` with the hostname.                  |
+| `token`  | `null`                     | Authentication token for the remote (see below).                                                                            |
 
 ### Authentication
 
@@ -38,83 +35,75 @@ The `token` field accepts a literal token string:
 token: ghp_xxxxxxxxxxxx
 ```
 
-It does not support `env` or `file` indirection. Git remote credentials belong to the configured knowledge owner and must not let user-owned config read arbitrary server environment variables or files.
+It does not support `env` or `file` indirection. Git remote credentials belong to the configured user and must not let user-owned config read arbitrary server environment variables or files.
 
-The token is embedded as `x-access-token:<token>` in the remote URL for HTTPS authentication. If no token is configured, the remote is added without credentials (suitable for public repos or SSH URLs).
+The token is embedded as `x-access-token:<token>` in the remote URL for HTTPS authentication. If no token is configured, the remote is added without credentials, which is suitable for public repos or SSH URLs.
 
 ## Remote branch
 
-The `branch` setting in the owning user's git config refers exclusively to the **remote** branch. The `branch` setting controls which **remote** branch carapace fetches from and pushes to. It does **not** affect the local knowledge repo, which always uses a `main` branch internally. This means you can point carapace at any branch on the remote (e.g. `dev`, `production`) without changing how sandboxes or the agent interact with the repo locally.
+The `branch` setting refers exclusively to the remote branch for that user's repo. It controls which remote branch carapace fetches from and pushes to. It does not change the local branch name, which remains `main` internally. This means a user can point carapace at any existing remote branch such as `main`, `dev`, or `production` without changing how sandboxes or the agent interact with the repo locally.
 
-The configured branch **must already exist** on the upstream remote before carapace connects to it. carapace does not create remote branches — it performs `git fetch origin <branch>` and `git merge --ff-only origin/<branch>`, both of which fail if the branch doesn't exist.
+The configured branch must already exist on the upstream remote before carapace connects to it. carapace does not create remote branches. It performs `git fetch origin <branch>` and then fast-forwards local state to `origin/<branch>`.
 
-If you're starting from scratch:
+## What happens on startup
 
-1. Create the remote repository and its default branch (most hosting providers do this automatically).
-2. Set `config.git.branch` in the owning user record to match the remote branch you want to use (e.g. `main`, `dev`).
-3. Start carapace — it will push the initial bootstrap commit to that branch.
+For every enabled user, startup runs the same sequence against that user's repo:
 
-## What happens on first start
+1. Initialize or open the local repo at `$CARAPACE_DATA_DIR/knowledges/<normalized-user>/`.
+2. If `config.git.remote` is set, add or update the `origin` remote for that repo.
+3. Pull the configured remote branch before any bootstrap seeding.
+4. Seed default files such as `SECURITY.md`, `SOUL.md`, `USER.md`, and bundled example skills only if they are still missing.
+5. If bootstrap created new files, commit them and push them to that user's remote.
 
-When the server starts with a remote configured:
+Users without a remote still get a local Git-backed repo. They skip the remote add, pull, and upstream push steps.
 
-1. **Initialise local repo.** If `$CARAPACE_DATA_DIR/knowledge/` has no `.git` directory, `git init -b main` creates one. The local branch is always `main`, regardless of the `branch` setting.
-2. **Add remote.** The upstream URL is registered as `origin` (or updated if it already exists).
-3. **Pull.** carapace fetches from the remote and syncs the local branch. If the local repo is empty (fresh init) and the remote has content, it adopts the remote branch directly (`git reset --hard`). If the local repo already has commits, it does a fast-forward merge. If the remote branch is also empty, this step is a no-op.
-4. **Bootstrap.** Default knowledge files (`SECURITY.md`, `SOUL.md`, `USER.md`, example skills) are seeded **only if they don't already exist** — files pulled from the remote are not overwritten.
-5. **Commit & push.** If the bootstrap created any new files, they are committed and pushed to the remote.
+If a pull would require a non-fast-forward merge, startup fails loudly instead of guessing how to reconcile local and remote state.
 
-On subsequent server restarts the same sequence runs, but typically only step 3 (pull) has any effect, keeping the server in sync with upstream changes.
+## Adding or changing a remote on an existing instance
 
-If the pull encounters a merge conflict (i.e. local and remote have diverged and a fast-forward is not possible), the server **exits with an error**. You'll need to resolve the conflict manually inside the `knowledge/` directory and restart.
+If you add or change `config.git.remote` for a user after the server is already running:
 
-## Adding a remote to an existing instance
-
-If you've been running carapace without a remote and later add `config.git.remote` to the owning user record:
-
-1. **Restart the server.** On startup it registers the remote, pulls (fast-forward only), and pushes any local-only commits upstream.
-2. **Running sessions are unaffected.** Their sandboxes already have a `/workspace` clone from before the remote was added. They continue working normally — agent pushes go to the server's local knowledge repo.
-3. **New sessions** will clone a workspace that includes the remote content.
-4. To explicitly sync a running session, use the `/pull` slash command.
+1. Restart the server. Startup reinitializes only that user's repo runtime, registers the new remote, pulls, and pushes any new bootstrap files if needed.
+2. Running sandboxes are not hot-migrated. They keep the clone they already have.
+3. New sessions for that user clone the refreshed repo.
+4. To explicitly sync an existing sandbox, use the `/pull` slash command inside one of that user's sessions.
 
 ## Sandbox Git workflow
 
-Every session gets its own **sandbox container** with a clone of the knowledge repo at `/workspace`. The clone uses the server's built-in Git HTTP backend — sandboxes never talk to the upstream remote directly.
+Every session gets its own sandbox container with a clone of the owning user's repo at `/workspace`. The clone uses the server's built-in Git HTTP backend. Sandboxes never talk to the upstream remote directly.
 
-```
-┌───────────────────┐     git push/pull      ┌────────────────┐    git push     ┌──────────────┐
-│  Sandbox          │ ◄──────────────────────►│  carapace      │ ──────────────► │  Upstream     │
-│  /workspace       │    (HTTP Smart Proto)   │  knowledge/    │   (on success)  │  Remote       │
-└───────────────────┘                         └────────────────┘                 └──────────────┘
+```text
+Sandbox /workspace  <->  carapace /git/<owner>  <->  owner's upstream remote
 ```
 
-1. **Clone on creation.** When a sandbox starts, `git clone $GIT_REPO_URL /workspace` pulls the latest state from the server. If the workspace already exists (e.g. Kubernetes PVC from a previous run), the clone is skipped.
-2. **Agent commits & pushes.** The agent can run `git add`, `git commit`, and `git push` inside the sandbox. Pushes go to the server's Git HTTP backend.
-3. **Security gate.** Every push triggers a **pre-receive hook** that sends the full diff to the sentinel agent for evaluation. The sentinel can allow or deny the push based on the security policy.
-4. **Upstream propagation.** If the push is accepted _and_ an upstream remote is configured, the server automatically pushes to the external remote.
+1. Clone on creation. When a sandbox starts, `git clone $GIT_REPO_URL /workspace` pulls the latest state for the session owner from the server.
+2. Agent commits and pushes. The agent can run `git add`, `git commit`, and `git push` inside the sandbox. Pushes go to the server's Git HTTP backend.
+3. Owner validation. The Git HTTP backend validates that the session token may only access the repo for that session's owner and rejects cross-user paths.
+4. Security gate. Every push triggers a pre-receive hook that sends the full diff to the sentinel agent for evaluation.
+5. Upstream propagation. If the push is accepted and that user has an upstream remote configured, the server pushes only that user's repo upstream.
 
 ### Git identity
 
-Commits made inside a sandbox use a per-session identity derived from the `author` template:
+Commits made inside a sandbox use a per-session identity derived from the owning user's `author` template:
 
-```
+```text
 carapace Session <session-id> <session-id@carapace.local>
 ```
 
-This makes it easy to trace which session produced which commit in the upstream history.
+This makes it easy to trace which session produced which commit in the repo history.
 
 ## Slash commands
 
-| Command   | Description                                                                                                                                                                          |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `/pull`   | Fetch and fast-forward merge from the upstream remote into the server's knowledge repo. Re-scans skills afterwards. Fails if no remote is configured or if there's a merge conflict. |
-| `/push`   | Push the server's knowledge repo to the upstream remote. Fails if no remote is configured.                                                                                           |
-| `/reload` | Destroy the session's sandbox and re-create it on the next command. The new sandbox gets a fresh clone, picking up any changes that were pulled or pushed since the session started. |
+| Command   | Description                                                                                                                                                   |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/pull`   | Fetch and fast-forward merge from the session owner's upstream remote into that user's server repo. Re-scans that user's skills afterwards.                   |
+| `/push`   | Push the session owner's server repo to that user's upstream remote. Fails if no remote is configured.                                                        |
+| `/reload` | Destroy the session's sandbox and re-create it on the next command. The new sandbox reclones the same owner's repo and picks up any changes pulled or pushed. |
 
 ## Local-only mode
 
-If no enabled user has `config.git.remote` set (or it is an empty string), carapace runs in local-only mode:
+If a user has no `config.git.remote` set, that user still gets a local Git-backed repo for sandbox clones and security-gated pushes.
 
-- The knowledge repo is still Git-backed (for the sandbox clone workflow and security-gated pushes).
-- `/pull` and `/push` return "No external remote configured."
-- No upstream synchronisation occurs.
+- `/pull` and `/push` in that user's sessions report that no external remote is configured.
+- Another user's remote does not change this user's behavior.
+- Users with a remote and users without one can coexist on the same server without conflict.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -75,7 +75,7 @@ Most first-run configuration now lives in the web UI:
 
 The old mental model was “edit `data/config.yaml`, then restart”. That file still exists as the backing store for platform settings and as an escape hatch for automation, but day-to-day setup should happen through Settings. The UI writes the relevant backing files and keeps write-only secrets out of API responses.
 
-On first start, carapace seeds runtime files under `data/` and a separate Git-backed knowledge repo under `data/knowledge/` by default. The equivalent backing-file shape for platform defaults is:
+On first start, carapace seeds runtime files under `data/` and bootstraps one Git-backed knowledge repo per enabled user under `data/knowledges/<normalized-user>/`. The equivalent backing-file shape for platform defaults is:
 
 ```yaml
 agent:
@@ -91,7 +91,7 @@ agent:
 sessions:
   commit:
     enabled: true
-    # Histories are written to data/knowledge/sessions/YYYY/MM/<session_id>/conversation.json
+    # Histories are written to data/knowledges/<user>/sessions/YYYY/MM/<session_id>/conversation.json
     path_prefix: sessions
     autosave_enabled: true
     autosave_inactivity_hours: 4
@@ -103,9 +103,9 @@ cache:
   redis_url: redis://redis:6379/0
 ```
 
-Session histories always live primarily under `data/sessions/<session_id>/`. The `sessions.commit.*` settings control a secondary commit flow into the Git-backed knowledge repo so the agent can refer back to past conversations later.
+Session histories always live primarily under `data/sessions/<session_id>/`. The `sessions.commit.*` settings control a secondary commit flow into the owning user's knowledge repo so the agent can refer back to past conversations later.
 
-The knowledge repo location defaults to `data/knowledge/` because `knowledge_dir` defaults to `./knowledge` relative to the config file.
+By default the knowledge root is `data/knowledges/`. Each enabled user gets a repo at `data/knowledges/<normalized-user>/`, initialized independently on startup. If a user has a Git remote configured, carapace adds that remote and pulls its configured branch before seeding any missing bootstrap files into that user's repo.
 
 In the web UI, public sessions expose a "Commit to knowledge" action. Private sessions do not. Autosave uses the same privacy rule: only public, inactive sessions are eligible.
 
@@ -272,7 +272,7 @@ users:
 
 ## 7. Personalise
 
-Edit the workspace files in the knowledge repo to shape carapace's behaviour. With the default config, these live under `data/knowledge/`:
+Edit the workspace files in your own knowledge repo to shape carapace's behaviour. With the default config, user `alice` would edit files under `data/knowledges/alice/`:
 
 | File          | Purpose                                                   |
 | ------------- | --------------------------------------------------------- |
@@ -283,7 +283,7 @@ Edit the workspace files in the knowledge repo to shape carapace's behaviour. Wi
 
 ## Next steps
 
-- Install skills into `data/knowledge/skills/` by default, or into your configured `knowledge_dir` — see [docs/skills.md](skills.md)
+- Install skills into `data/knowledges/<your-user>/skills/` by default — see [docs/skills.md](skills.md)
 - Explore the [architecture](architecture.md) and [security model](security.md)
 - Explore [jobs.md](jobs.md) for scheduled and on-demand job runs
 - Deploy to Kubernetes with the [Helm chart](../charts/carapace/README.md)

--- a/docs/security.md
+++ b/docs/security.md
@@ -38,7 +38,7 @@ flowchart TD
 
 ## SECURITY.md -- the policy file
 
-The security policy lives in the Git-backed knowledge repo as `SECURITY.md`. With the default config path, that file is `data/knowledge/SECURITY.md`; if you override `knowledge_dir`, the sentinel reads `<knowledge_dir>/SECURITY.md`. It is written in plain English and becomes part of the sentinel agent's system prompt. There are no rigid YAML rules to parse -- the sentinel interprets the policy with full LLM understanding.
+The security policy lives in each user's Git-backed knowledge repo as `SECURITY.md`. With the default layout, the file for user `alice` is `data/knowledges/alice/SECURITY.md`. The sentinel resolves the policy from the session owner, so two users can run with different policies at the same time. The file is written in plain English and becomes part of the sentinel agent's system prompt. There are no rigid YAML rules to parse -- the sentinel interprets the policy with full LLM understanding.
 
 The shipped default policy (see `src/carapace/assets/SECURITY.md`) covers:
 

--- a/src/carapace/channels/matrix/channel.py
+++ b/src/carapace/channels/matrix/channel.py
@@ -16,7 +16,6 @@ from loguru import logger
 from ...auth import normalize_username
 from ...models.config import Config
 from ...models.matrix import MatrixChannelConfig, MatrixTokenFile, MatrixTokensFile
-from ...models.skills import SkillInfo
 from ...models.user import UserConfig
 from ...notifications.presence import NotificationPresenceRegistry
 from ...sandbox.manager import SandboxManager
@@ -97,7 +96,6 @@ class MatrixChannel:
         config: MatrixChannelConfig,
         full_config: Config,
         session_mgr: SessionManager,
-        skill_catalog: list[SkillInfo],
         agent_model: Any,
         sandbox_mgr: SandboxManager,
         engine: SessionEngine,
@@ -108,7 +106,6 @@ class MatrixChannel:
         self._config = config
         self._full_config = full_config
         self._session_mgr = session_mgr
-        self._skill_catalog = skill_catalog
         self._agent_model = agent_model
         self._sandbox_mgr = sandbox_mgr
         self._engine = engine

--- a/src/carapace/config.py
+++ b/src/carapace/config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import yaml
 
 from .models.config import Config
+from .usernames import normalize_username
 
 
 def get_config_path() -> Path:
@@ -31,6 +32,16 @@ def _resolve_data_dir(config_path: Path, config: Config | None = None) -> Path:
     if config and config.data_dir:
         return (config_dir / config.data_dir).resolve()
     return config_dir.resolve()
+
+
+def resolve_knowledge_repos_dir(data_dir: Path) -> Path:
+    """Return the parent directory containing all per-user knowledge repos."""
+    return (data_dir / "knowledges").resolve()
+
+
+def resolve_user_knowledge_dir(data_dir: Path, username: str) -> Path:
+    """Return the canonical knowledge repo path for a specific user."""
+    return (resolve_knowledge_repos_dir(data_dir) / normalize_username(username)).resolve()
 
 
 def _resolve_knowledge_dir(config_path: Path, config: Config) -> Path:

--- a/src/carapace/config.py
+++ b/src/carapace/config.py
@@ -34,14 +34,21 @@ def _resolve_data_dir(config_path: Path, config: Config | None = None) -> Path:
     return config_dir.resolve()
 
 
-def resolve_knowledge_repos_dir(data_dir: Path) -> Path:
+def resolve_knowledge_repos_dir(data_dir: Path, knowledge_repos_dir: Path | None = None) -> Path:
     """Return the parent directory containing all per-user knowledge repos."""
+    if knowledge_repos_dir is not None:
+        return knowledge_repos_dir.resolve()
     return (data_dir / "knowledges").resolve()
 
 
-def resolve_user_knowledge_dir(data_dir: Path, username: str) -> Path:
+def resolve_user_knowledge_dir(
+    data_dir: Path,
+    username: str,
+    *,
+    knowledge_repos_dir: Path | None = None,
+) -> Path:
     """Return the canonical knowledge repo path for a specific user."""
-    return (resolve_knowledge_repos_dir(data_dir) / normalize_username(username)).resolve()
+    return (resolve_knowledge_repos_dir(data_dir, knowledge_repos_dir) / normalize_username(username)).resolve()
 
 
 def _resolve_knowledge_dir(config_path: Path, config: Config) -> Path:

--- a/src/carapace/config.py
+++ b/src/carapace/config.py
@@ -56,7 +56,7 @@ def _resolve_knowledge_dir(config_path: Path, config: Config) -> Path:
     config_dir = config_path.parent
     if config.knowledge_dir:
         return (config_dir / config.knowledge_dir).resolve()
-    return (config_dir / "knowledge").resolve()
+    return (config_dir / "knowledges").resolve()
 
 
 def load_config(data_dir: Path | None = None) -> Config:

--- a/src/carapace/git/http.py
+++ b/src/carapace/git/http.py
@@ -22,16 +22,14 @@ class GitHttpHandler:
     def __init__(
         self,
         *,
-        knowledge_dir: Path,
+        knowledge_root: Path,
+        owner_for_session: Callable[[str], str],
         default_branch: str,
         api_port: int = 8320,
         verify_session_token: Callable[[str, str], bool] | None = None,
         on_push_success: Callable[[str], Awaitable[None]] | None = None,
-        owner_for_session: Callable[[str], str] | None = None,
-        knowledge_root: Path | None = None,
     ) -> None:
-        self._knowledge_dir = knowledge_dir
-        self._knowledge_root = knowledge_root or knowledge_dir.parent
+        self._knowledge_root = knowledge_root
         self._default_branch = default_branch
         self._api_port = api_port
         self._verify_session_token = verify_session_token
@@ -39,8 +37,6 @@ class GitHttpHandler:
         self._owner_for_session = owner_for_session
 
     def _repo_name_for_session(self, session_id: str) -> str:
-        if self._owner_for_session is None:
-            return self._knowledge_dir.name
         return self._owner_for_session(session_id)
 
     def authenticate(self, authorization: str | None) -> str | None:

--- a/src/carapace/git/http.py
+++ b/src/carapace/git/http.py
@@ -26,13 +26,22 @@ class GitHttpHandler:
         default_branch: str,
         api_port: int = 8320,
         verify_session_token: Callable[[str, str], bool] | None = None,
-        on_push_success: Callable[[], Awaitable[None]] | None = None,
+        on_push_success: Callable[[str], Awaitable[None]] | None = None,
+        owner_for_session: Callable[[str], str] | None = None,
+        knowledge_root: Path | None = None,
     ) -> None:
         self._knowledge_dir = knowledge_dir
+        self._knowledge_root = knowledge_root or knowledge_dir.parent
         self._default_branch = default_branch
         self._api_port = api_port
         self._verify_session_token = verify_session_token
         self._on_push_success = on_push_success
+        self._owner_for_session = owner_for_session
+
+    def _repo_name_for_session(self, session_id: str) -> str:
+        if self._owner_for_session is None:
+            return self._knowledge_dir.name
+        return self._owner_for_session(session_id)
 
     def authenticate(self, authorization: str | None) -> str | None:
         """Validate an ``Authorization: Basic ...`` header.
@@ -81,12 +90,12 @@ class GitHttpHandler:
         # Validate PATH_INFO using Path() to catch traversal segments and
         # normalise double slashes before checking the allowed repo prefix.
         path_obj = Path(path_info)
-        repo_name = self._knowledge_dir.name
+        repo_name = self._repo_name_for_session(session_id)
         allowed_prefixes = (f"/{repo_name}/", f"/{repo_name}.git/")
         if (
             ".." in path_obj.parts
             or "\\" in path_info
-            or not any(str(path_obj).startswith(p) for p in allowed_prefixes)
+            or not any(path_info.startswith(prefix) for prefix in allowed_prefixes)
         ):
             logger.warning(f"Rejected git request with unexpected PATH_INFO: {path_info}")
             return 403, {}, b""
@@ -95,7 +104,7 @@ class GitHttpHandler:
 
         # Build CGI environment
         cgi_env = {
-            "GIT_PROJECT_ROOT": str(self._knowledge_dir.parent),
+            "GIT_PROJECT_ROOT": str(self._knowledge_root),
             "GIT_HTTP_EXPORT_ALL": "1",
             "PATH_INFO": path_info,
             "REMOTE_USER": session_id,
@@ -144,7 +153,7 @@ class GitHttpHandler:
         # "ng refs/…" in the Git report-status inside the response body.
         if is_push and 200 <= status_code < 300 and b"ng refs/" not in response_body and self._on_push_success:
             try:
-                await self._on_push_success()
+                await self._on_push_success(repo_name)
             except Exception as exc:
                 logger.warning(f"Post-push callback failed: {exc}")
 

--- a/src/carapace/git/store.py
+++ b/src/carapace/git/store.py
@@ -245,6 +245,23 @@ class GitStore:
         self._remote_configured = True
         logger.info(f"Git remote origin set to {url}")
 
+    async def get_remote_url(self) -> str | None:
+        """Return the current ``origin`` URL if configured."""
+        code, out = await self._run("remote", "get-url", "origin")
+        if code != 0:
+            return None
+        return out or None
+
+    async def restore_remote(self, url: str) -> None:
+        """Restore the ``origin`` remote from a previously captured URL."""
+        code, _ = await self._run("remote", "get-url", "origin")
+        if code == 0:
+            await self._run("remote", "set-url", "origin", url)
+        else:
+            await self._run("remote", "add", "origin", url)
+        self._remote_configured = True
+        logger.info("Git remote origin restored")
+
     async def remove_remote(self) -> None:
         """Remove the ``origin`` remote when upstream sync is disabled."""
         code, _ = await self._run("remote", "get-url", "origin")

--- a/src/carapace/knowledge.py
+++ b/src/carapace/knowledge.py
@@ -30,17 +30,19 @@ class KnowledgeRepoRegistry:
         self,
         data_dir: Path,
         *,
+        knowledge_repos_dir: Path | None = None,
         git_store_factory: GitStoreFactory | None = None,
         skill_registry_factory: SkillRegistryFactory | None = None,
     ) -> None:
         self._data_dir = data_dir
+        self._knowledge_repos_dir = resolve_knowledge_repos_dir(data_dir, knowledge_repos_dir)
         self._git_store_factory = git_store_factory or GitStore
         self._skill_registry_factory = skill_registry_factory or SkillRegistry
         self._handles: dict[str, KnowledgeRepoHandle] = {}
 
     @property
     def knowledge_repos_dir(self) -> Path:
-        return resolve_knowledge_repos_dir(self._data_dir)
+        return self._knowledge_repos_dir
 
     def get_for_user(self, username: str) -> KnowledgeRepoHandle:
         owner = normalize_username(username)
@@ -48,7 +50,11 @@ class KnowledgeRepoRegistry:
         if cached is not None:
             return cached
 
-        knowledge_dir = resolve_user_knowledge_dir(self._data_dir, owner)
+        knowledge_dir = resolve_user_knowledge_dir(
+            self._data_dir,
+            owner,
+            knowledge_repos_dir=self._knowledge_repos_dir,
+        )
         handle = KnowledgeRepoHandle(
             owner=owner,
             knowledge_dir=knowledge_dir,

--- a/src/carapace/knowledge.py
+++ b/src/carapace/knowledge.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from .config import resolve_knowledge_repos_dir, resolve_user_knowledge_dir
+from .git.store import GitStore
+from .skills import SkillRegistry
+from .usernames import normalize_username
+
+type GitStoreFactory = Callable[[Path], GitStore]
+type SkillRegistryFactory = Callable[[Path], SkillRegistry]
+type SessionOwnerResolver = Callable[[str], str]
+
+
+@dataclass(frozen=True)
+class KnowledgeRepoHandle:
+    owner: str
+    knowledge_dir: Path
+    git_store: GitStore
+    skill_registry: SkillRegistry
+
+
+class KnowledgeRepoRegistry:
+    def __init__(
+        self,
+        data_dir: Path,
+        *,
+        git_store_factory: GitStoreFactory | None = None,
+        skill_registry_factory: SkillRegistryFactory | None = None,
+    ) -> None:
+        self._data_dir = data_dir
+        self._git_store_factory = git_store_factory or GitStore
+        self._skill_registry_factory = skill_registry_factory or SkillRegistry
+        self._handles: dict[str, KnowledgeRepoHandle] = {}
+
+    @property
+    def knowledge_repos_dir(self) -> Path:
+        return resolve_knowledge_repos_dir(self._data_dir)
+
+    def get_for_user(self, username: str) -> KnowledgeRepoHandle:
+        owner = normalize_username(username)
+        cached = self._handles.get(owner)
+        if cached is not None:
+            return cached
+
+        knowledge_dir = resolve_user_knowledge_dir(self._data_dir, owner)
+        handle = KnowledgeRepoHandle(
+            owner=owner,
+            knowledge_dir=knowledge_dir,
+            git_store=self._git_store_factory(knowledge_dir),
+            skill_registry=self._skill_registry_factory(knowledge_dir / "skills"),
+        )
+        self._handles[owner] = handle
+        return handle
+
+    def ensure_user_repo(self, username: str) -> KnowledgeRepoHandle:
+        handle = self.get_for_user(username)
+        handle.knowledge_dir.mkdir(parents=True, exist_ok=True)
+        return handle
+
+    def get_for_session(self, session_id: str, resolve_owner: SessionOwnerResolver) -> KnowledgeRepoHandle:
+        return self.get_for_user(resolve_owner(session_id))

--- a/src/carapace/knowledge.py
+++ b/src/carapace/knowledge.py
@@ -22,6 +22,9 @@ class KnowledgeRepoHandle:
     skill_registry: SkillRegistry
 
 
+type KnowledgeRepoResolver = Callable[[str], KnowledgeRepoHandle]
+
+
 class KnowledgeRepoRegistry:
     def __init__(
         self,

--- a/src/carapace/models/config.py
+++ b/src/carapace/models/config.py
@@ -303,4 +303,4 @@ class Config(ConfigModel):
     sessions: SessionsConfig = SessionsConfig()
     sandbox: SandboxConfig = SandboxConfig()
     data_dir: str = "."  # resolved relative to config file location
-    knowledge_dir: str = "./knowledge"  # resolved relative to config file location
+    knowledge_dir: str = "./knowledges"  # parent directory for per-user repos, resolved relative to config file

--- a/src/carapace/sandbox/manager.py
+++ b/src/carapace/sandbox/manager.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from loguru import logger
 
-from ..knowledge import KnowledgeRepoHandle
+from ..knowledge import KnowledgeRepoHandle, KnowledgeRepoResolver
 from ..security.context import ApprovalSource, ApprovalVerdict
 from . import file_ops
 from .exec_flow import SandboxExecCoordinator, SandboxExecState
@@ -193,19 +193,15 @@ class SandboxManager:
         self,
         runtime: ContainerRuntime,
         data_dir: Path,
-        knowledge_dir: Path,
+        knowledge_repo_for_session: KnowledgeRepoResolver,
         base_image: str = "carapace-sandbox:latest",
         network_name: str = "carapace-sandbox",
         idle_timeout_minutes: int = 15,
         proxy_port: int = 3128,
         sandbox_port: int = 8322,
-        git_author: str = "carapace <carapace@%h>",
-        knowledge_repo_for_session: Callable[[str], KnowledgeRepoHandle] | None = None,
     ) -> None:
         self._runtime = runtime
         self._data_dir = data_dir
-        self._knowledge_dir = knowledge_dir
-        self._git_author = git_author
         self._knowledge_repo_for_session = knowledge_repo_for_session
         self._base_image = base_image
         self._network_name = network_name
@@ -255,13 +251,11 @@ class SandboxManager:
                 exec_notified_credentials=self._exec_notified_credentials,
             ),
             data_dir=data_dir,
-            knowledge_dir=knowledge_dir,
             base_image=base_image,
             network_name=network_name,
             idle_timeout=self._idle_timeout,
             proxy_port=proxy_port,
             sandbox_port=sandbox_port,
-            git_author=git_author,
             knowledge_repo_name_for_session=self._knowledge_repo_name_for_session,
             git_author_for_session=self._git_author_for_session,
         )
@@ -315,27 +309,17 @@ class SandboxManager:
         """Register a callback to retrieve command aliases for a skill."""
         self._skill_command_aliases_cb = cb
 
-    def _repo_for_session(self, session_id: str) -> KnowledgeRepoHandle | None:
-        if self._knowledge_repo_for_session is None:
-            return None
+    def _repo_for_session(self, session_id: str) -> KnowledgeRepoHandle:
         return self._knowledge_repo_for_session(session_id)
 
     def _knowledge_dir_for_session(self, session_id: str) -> Path:
-        handle = self._repo_for_session(session_id)
-        return handle.knowledge_dir if handle is not None else self._knowledge_dir
+        return self._repo_for_session(session_id).knowledge_dir
 
     def _knowledge_repo_name_for_session(self, session_id: str) -> str:
         return self._knowledge_dir_for_session(session_id).name
 
     def _git_author_for_session(self, session_id: str) -> str:
-        handle = self._repo_for_session(session_id)
-        if handle is not None:
-            return handle.git_store.author_template
-        return self._git_author
-
-    def set_git_author(self, git_author: str) -> None:
-        self._git_author = git_author
-        self._session_lifecycle.set_git_author(git_author)
+        return self._repo_for_session(session_id).git_store.author_template
 
     async def refresh_git_identities(self) -> None:
         for session_id, session in self._sessions.items():

--- a/src/carapace/sandbox/manager.py
+++ b/src/carapace/sandbox/manager.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from loguru import logger
 
+from ..knowledge import KnowledgeRepoHandle
 from ..security.context import ApprovalSource, ApprovalVerdict
 from . import file_ops
 from .exec_flow import SandboxExecCoordinator, SandboxExecState
@@ -199,11 +200,13 @@ class SandboxManager:
         proxy_port: int = 3128,
         sandbox_port: int = 8322,
         git_author: str = "carapace <carapace@%h>",
+        knowledge_repo_for_session: Callable[[str], KnowledgeRepoHandle] | None = None,
     ) -> None:
         self._runtime = runtime
         self._data_dir = data_dir
         self._knowledge_dir = knowledge_dir
         self._git_author = git_author
+        self._knowledge_repo_for_session = knowledge_repo_for_session
         self._base_image = base_image
         self._network_name = network_name
         self._idle_timeout = idle_timeout_minutes * 60
@@ -230,7 +233,7 @@ class SandboxManager:
         self._exec_notified_credentials: dict[str, set[str]] = {}  # dedupe credential UI notifications
         self._get_activated_skills_cb: Callable[[str], list[str]] | None = None
         self._skill_activation_inputs_cb: Callable[[str, str], Awaitable[SkillActivationInputs]] | None = None
-        self._skill_command_aliases_cb: Callable[[str], list[tuple[str, str]]] | None = None
+        self._skill_command_aliases_cb: Callable[[str, str], list[tuple[str, str]]] | None = None
         self._session_lifecycle = SandboxSessionLifecycle(
             runtime=runtime,
             state=SandboxSessionLifecycleState(
@@ -259,6 +262,8 @@ class SandboxManager:
             proxy_port=proxy_port,
             sandbox_port=sandbox_port,
             git_author=git_author,
+            knowledge_repo_name_for_session=self._knowledge_repo_name_for_session,
+            git_author_for_session=self._git_author_for_session,
         )
         self._exec_coordinator = SandboxExecCoordinator(
             runtime=runtime,
@@ -306,9 +311,27 @@ class SandboxManager:
         """Register a callback to retrieve activation inputs for a skill."""
         self._skill_activation_inputs_cb = cb
 
-    def set_skill_command_aliases_callback(self, cb: Callable[[str], list[tuple[str, str]]]) -> None:
+    def set_skill_command_aliases_callback(self, cb: Callable[[str, str], list[tuple[str, str]]]) -> None:
         """Register a callback to retrieve command aliases for a skill."""
         self._skill_command_aliases_cb = cb
+
+    def _repo_for_session(self, session_id: str) -> KnowledgeRepoHandle | None:
+        if self._knowledge_repo_for_session is None:
+            return None
+        return self._knowledge_repo_for_session(session_id)
+
+    def _knowledge_dir_for_session(self, session_id: str) -> Path:
+        handle = self._repo_for_session(session_id)
+        return handle.knowledge_dir if handle is not None else self._knowledge_dir
+
+    def _knowledge_repo_name_for_session(self, session_id: str) -> str:
+        return self._knowledge_dir_for_session(session_id).name
+
+    def _git_author_for_session(self, session_id: str) -> str:
+        handle = self._repo_for_session(session_id)
+        if handle is not None:
+            return handle.git_store.author_template
+        return self._git_author
 
     def set_git_author(self, git_author: str) -> None:
         self._git_author = git_author
@@ -325,10 +348,10 @@ class SandboxManager:
             return SkillActivationInputs()
         return await self._skill_activation_inputs_cb(session_id, skill_name)
 
-    def _get_skill_command_aliases(self, skill_name: str) -> list[tuple[str, str]]:
+    def _get_skill_command_aliases(self, session_id: str, skill_name: str) -> list[tuple[str, str]]:
         if self._skill_command_aliases_cb is None:
             return []
-        return self._skill_command_aliases_cb(skill_name)
+        return self._skill_command_aliases_cb(session_id, skill_name)
 
     def _get_or_create_token(self, session_id: str) -> str:
         return self._session_lifecycle.get_or_create_token(session_id)
@@ -600,12 +623,12 @@ class SandboxManager:
 
         # Check that the skill exists in the server-side knowledge store.
         # The sandbox already has it at /workspace/skills/{name} via git clone.
-        master_skill_dir = self._knowledge_dir / "skills" / skill_name
+        master_skill_dir = self._knowledge_dir_for_session(session_id) / "skills" / skill_name
         if not master_skill_dir.exists():
             logger.warning(f"Skill '{skill_name}' not found for session {session_id}")
             return f"Skill '{skill_name}' not found."
 
-        command_aliases = self._get_skill_command_aliases(skill_name)
+        command_aliases = self._get_skill_command_aliases(session_id, skill_name)
 
         activation_msg = ""
         try:
@@ -677,8 +700,8 @@ class SandboxManager:
 
     async def _rerun_skill_setup(self, sc: SessionContainer, skill_name: str) -> str:
         """Restore trusted skill files from git and rerun automatic setup providers."""
-        master = self._knowledge_dir / "skills" / skill_name
-        command_aliases = self._get_skill_command_aliases(skill_name)
+        master = self._knowledge_dir_for_session(sc.session_id) / "skills" / skill_name
+        command_aliases = self._get_skill_command_aliases(sc.session_id, skill_name)
         lines = await self._skill_activation_runner.restore_and_run_detected_providers(
             sc,
             skill_name,

--- a/src/carapace/sandbox/session_lifecycle.py
+++ b/src/carapace/sandbox/session_lifecycle.py
@@ -57,40 +57,29 @@ class SandboxSessionLifecycle:
         runtime: ContainerRuntime,
         state: SandboxSessionLifecycleState,
         data_dir: Path,
-        knowledge_dir: Path,
         base_image: str,
         network_name: str,
         idle_timeout: int,
         proxy_port: int,
         sandbox_port: int,
-        git_author: str,
-        knowledge_repo_name_for_session: Callable[[str], str] | None = None,
-        git_author_for_session: Callable[[str], str] | None = None,
+        knowledge_repo_name_for_session: Callable[[str], str],
+        git_author_for_session: Callable[[str], str],
     ) -> None:
         self._runtime = runtime
         self._state = state
         self._data_dir = data_dir
-        self._knowledge_dir = knowledge_dir
         self._base_image = base_image
         self._network_name = network_name
         self._idle_timeout = idle_timeout
         self._proxy_port = proxy_port
         self._sandbox_port = sandbox_port
-        self._git_author = git_author
         self._knowledge_repo_name_for_session = knowledge_repo_name_for_session
         self._git_author_for_session = git_author_for_session
 
-    def set_git_author(self, git_author: str) -> None:
-        self._git_author = git_author
-
     def _repo_name_for_session(self, session_id: str) -> str:
-        if self._knowledge_repo_name_for_session is None:
-            return self._knowledge_dir.name
         return self._knowledge_repo_name_for_session(session_id)
 
     def _author_for_session(self, session_id: str) -> str:
-        if self._git_author_for_session is None:
-            return self._git_author
         return self._git_author_for_session(session_id)
 
     def _token_path(self, session_id: str) -> Path:

--- a/src/carapace/sandbox/session_lifecycle.py
+++ b/src/carapace/sandbox/session_lifecycle.py
@@ -64,6 +64,8 @@ class SandboxSessionLifecycle:
         proxy_port: int,
         sandbox_port: int,
         git_author: str,
+        knowledge_repo_name_for_session: Callable[[str], str] | None = None,
+        git_author_for_session: Callable[[str], str] | None = None,
     ) -> None:
         self._runtime = runtime
         self._state = state
@@ -75,9 +77,21 @@ class SandboxSessionLifecycle:
         self._proxy_port = proxy_port
         self._sandbox_port = sandbox_port
         self._git_author = git_author
+        self._knowledge_repo_name_for_session = knowledge_repo_name_for_session
+        self._git_author_for_session = git_author_for_session
 
     def set_git_author(self, git_author: str) -> None:
         self._git_author = git_author
+
+    def _repo_name_for_session(self, session_id: str) -> str:
+        if self._knowledge_repo_name_for_session is None:
+            return self._knowledge_dir.name
+        return self._knowledge_repo_name_for_session(session_id)
+
+    def _author_for_session(self, session_id: str) -> str:
+        if self._git_author_for_session is None:
+            return self._git_author
+        return self._git_author_for_session(session_id)
 
     def _token_path(self, session_id: str) -> Path:
         return self._data_dir / "sessions" / session_id / "token"
@@ -126,9 +140,8 @@ class SandboxSessionLifecycle:
         authed_url = f"{scheme}://{session_id}:{proxy_token}@{rest}"
         no_proxy_host = rest.rsplit(":", 1)[0]
         no_proxy = ",".join([no_proxy_host, "localhost", "127.0.0.1"])
-        git_url = (
-            f"{scheme}://{session_id}:{proxy_token}@{no_proxy_host}:{self._sandbox_port}/git/{self._knowledge_dir.name}"
-        )
+        repo_name = self._repo_name_for_session(session_id)
+        git_url = f"{scheme}://{session_id}:{proxy_token}@{no_proxy_host}:{self._sandbox_port}/git/{repo_name}"
         return {
             "HTTP_PROXY": authed_url,
             "HTTPS_PROXY": authed_url,
@@ -282,7 +295,7 @@ class SandboxSessionLifecycle:
 
     async def setup_git_identity(self, container_id: str, session_id: str) -> None:
         """Configure git user.name and user.email inside the sandbox."""
-        name_tpl = self._git_author.replace("%s", session_id)
+        name_tpl = self._author_for_session(session_id).replace("%s", session_id)
         if "<" in name_tpl and name_tpl.endswith(">"):
             name, _, email = name_tpl.rpartition("<")
             name, email = name.strip(), email.rstrip(">").strip()

--- a/src/carapace/server/__init__.py
+++ b/src/carapace/server/__init__.py
@@ -31,7 +31,7 @@ from .. import get_version
 from ..auth import AuthStore
 from ..bootstrap import ensure_data_dir, ensure_knowledge_dir
 from ..cache import SessionListCache
-from ..config import _resolve_data_dir, get_config_path, get_data_dir, load_config
+from ..config import _resolve_data_dir, _resolve_knowledge_dir, get_config_path, get_data_dir, load_config
 from ..credentials import CredentialBackendError, CredentialRegistry, build_credential_registry
 from ..git.http import GitHttpHandler
 from ..jobs import JobsScheduler, JobsStore
@@ -296,7 +296,10 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     _auth_store = AuthStore(_data_dir, _config.auth)
     if _auth_store.ensure_bootstrap_admin() is not None:
         logger.warning("Created bootstrap admin user 'admin' with password from CARAPACE_TOKEN")
-    _knowledge_repo_registry = KnowledgeRepoRegistry(_data_dir)
+    _knowledge_repo_registry = KnowledgeRepoRegistry(
+        _data_dir,
+        knowledge_repos_dir=_resolve_knowledge_dir(config_path, _config),
+    )
     user_git_configs = _enabled_user_git_configs(_auth_store)
     for username, git_config in user_git_configs.items():
         await _bootstrap_user_knowledge_repo(_knowledge_repo_registry, username, git_config)

--- a/src/carapace/server/__init__.py
+++ b/src/carapace/server/__init__.py
@@ -31,15 +31,14 @@ from .. import get_version
 from ..auth import AuthStore
 from ..bootstrap import ensure_data_dir, ensure_knowledge_dir
 from ..cache import SessionListCache
-from ..config import _resolve_data_dir, _resolve_knowledge_dir, get_config_path, get_data_dir, load_config
+from ..config import _resolve_data_dir, get_config_path, get_data_dir, load_config
 from ..credentials import CredentialBackendError, CredentialRegistry, build_credential_registry
 from ..git.http import GitHttpHandler
-from ..git.store import GitStore
 from ..jobs import JobsScheduler, JobsStore
 from ..knowledge import KnowledgeRepoRegistry
 from ..llm import make_model_factory
 from ..models.config import Config
-from ..models.user import UserConfig, UserGitConfig
+from ..models.user import UserConfig
 from ..notifications.presence import NotificationPresenceRegistry
 from ..notifications.router import NotificationRouter
 from ..notifications.sender import WebPushSender
@@ -50,7 +49,6 @@ from ..sandbox.proxy import ProxyServer
 from ..sandbox.runtime import ContainerRuntime
 from ..session import SessionEngine, SessionManager
 from ..session.archive import SessionArchiveService
-from ..skills import SkillRegistry
 from ..usage import SessionBudgetExceededError
 from .auth import router as auth_router
 from .auth import verify_ws_token
@@ -292,7 +290,6 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     _config_path = config_path
     _config = load_config()
     _data_dir = _resolve_data_dir(config_path, _config)
-    knowledge_dir = _resolve_knowledge_dir(config_path, _config)
 
     # 2. Bootstrap directories
     ensure_data_dir(_data_dir)
@@ -304,17 +301,12 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     for username, git_config in user_git_configs.items():
         await _bootstrap_user_knowledge_repo(_knowledge_repo_registry, username, git_config)
 
-    # Legacy fallback store for any remaining non-session-routed call sites.
-    git_store = GitStore(knowledge_dir)
-
     if _config.carapace.logfire_token:
         logfire.configure(token=_config.carapace.logfire_token, console=False)
         logfire.instrument_pydantic_ai()
 
     _session_list_cache = SessionListCache(_config.cache)
     session_mgr = SessionManager(_data_dir, on_change=_session_list_cache.invalidate_sync)
-    registry = SkillRegistry(knowledge_dir / "skills")
-    skill_catalog = registry.scan()
     model_factory = make_model_factory(_config)
     agent_model = model_factory(_config.agent.model)
 
@@ -352,19 +344,21 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     proxy_port = _config.sandbox.proxy_port
 
+    def resolve_session_owner(session_id: str) -> str:
+        return session_mgr.load_meta(session_id).user
+
+    def knowledge_repo_for_session(session_id: str):
+        return _knowledge_repo_registry.get_for_session(session_id, resolve_session_owner)
+
     _sandbox_mgr = SandboxManager(
         runtime=runtime,
         data_dir=_data_dir,
-        knowledge_dir=knowledge_dir,
         base_image=base_image,
         network_name=sandbox_network,
         idle_timeout_minutes=_config.sandbox.idle_timeout_minutes,
         proxy_port=proxy_port,
         sandbox_port=_config.server.sandbox_port,
-        git_author=UserGitConfig().author,
-        knowledge_repo_for_session=lambda session_id: _knowledge_repo_registry.get_for_user(
-            session_mgr.load_meta(session_id).user
-        ),
+        knowledge_repo_for_session=knowledge_repo_for_session,
     )
     logger.info(f"Sandbox enabled (image={base_image}, network={sandbox_network})")
 
@@ -401,45 +395,35 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
             max_payload_bytes=_config.notifications.max_payload_bytes,
             delivery_ttl_seconds=_config.notifications.delivery_ttl_seconds,
         ),
-        owner_for_session=lambda session_id: session_mgr.load_meta(session_id).user,
+        owner_for_session=resolve_session_owner,
     )
 
     _engine = SessionEngine(
         config=_config,
         data_dir=_data_dir,
-        knowledge_dir=knowledge_dir,
-        git_store=git_store,
         session_mgr=session_mgr,
-        skill_catalog=skill_catalog,
         agent_model=agent_model,
         sandbox_mgr=_sandbox_mgr,
         credential_registry_for_session=_credential_registry_for_session,
-        knowledge_repo_for_session=lambda session_id: _knowledge_repo_registry.get_for_user(
-            session_mgr.load_meta(session_id).user
-        ),
+        knowledge_repo_for_session=knowledge_repo_for_session,
         model_factory=model_factory,
         notification_router=_notification_router,
     )
     _session_archive = SessionArchiveService(
-        knowledge_dir=knowledge_dir,
-        git_store=git_store,
         session_mgr=session_mgr,
         config=_config.sessions.commit,
-        knowledge_repo_for_session=lambda session_id: _knowledge_repo_registry.get_for_user(
-            session_mgr.load_meta(session_id).user
-        ),
+        knowledge_repo_for_session=knowledge_repo_for_session,
     )
     _jobs_store = JobsStore(_data_dir)
     _jobs_scheduler = JobsScheduler(_jobs_store)
 
     # Git HTTP handler — serves the knowledge repo on the sandbox API
     _git_handler = GitHttpHandler(
-        knowledge_dir=knowledge_dir,
         knowledge_root=_knowledge_repo_registry.knowledge_repos_dir,
+        owner_for_session=resolve_session_owner,
         default_branch="main",
         api_port=_config.server.internal_port,
         verify_session_token=_sandbox_mgr.verify_session_token,
-        owner_for_session=lambda session_id: session_mgr.load_meta(session_id).user,
         on_push_success=_knowledge_git_runtime.push_if_configured,
     )
 
@@ -495,7 +479,6 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
             config=user_config.channels.matrix,
             full_config=_config,
             session_mgr=session_mgr,
-            skill_catalog=skill_catalog,
             agent_model=agent_model,
             sandbox_mgr=_sandbox_mgr,
             engine=_engine,
@@ -511,7 +494,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     logger.info(
         f"carapace server ready — model={_config.agent.model}, "
-        f"user_repos={len(user_git_configs)}, skills={len(skill_catalog)}, proxy_port={proxy_port}"
+        f"user_repos={len(user_git_configs)}, proxy_port={proxy_port}"
         + (
             f", matrix=on ({_matrix_channel_manager.channel_count} user channel(s))"
             if _matrix_channel_manager.channel_count

--- a/src/carapace/server/__init__.py
+++ b/src/carapace/server/__init__.py
@@ -36,6 +36,7 @@ from ..credentials import CredentialBackendError, CredentialRegistry, build_cred
 from ..git.http import GitHttpHandler
 from ..git.store import GitStore
 from ..jobs import JobsScheduler, JobsStore
+from ..knowledge import KnowledgeRepoRegistry
 from ..llm import make_model_factory
 from ..models.config import Config
 from ..models.user import UserConfig, UserGitConfig
@@ -79,6 +80,7 @@ _config_path: Path
 _config: Config
 _engine: SessionEngine
 _git_handler: GitHttpHandler
+_knowledge_repo_registry: KnowledgeRepoRegistry
 _knowledge_git_runtime: KnowledgeGitRuntime
 _matrix_channel_manager: MatrixChannelManager
 _user_credential_registries: dict[str, tuple[str, CredentialRegistry]]
@@ -92,26 +94,54 @@ _notification_router: NotificationRouter
 _auth_store: AuthStore
 
 
-def _select_knowledge_git_config(auth_store: AuthStore) -> KnowledgeGitConfig:
-    configured: list[tuple[str, UserGitConfig]] = []
+def _enabled_user_git_configs(auth_store: AuthStore) -> dict[str, KnowledgeGitConfig]:
+    configs: dict[str, KnowledgeGitConfig] = {}
     for username, user in sorted(auth_store.load_users().users.items()):
-        if user.enabled and user.config.git.remote:
-            configured.append((username, user.config.git))
+        if not user.enabled:
+            continue
+        configs[username] = KnowledgeGitConfig(
+            owner=username,
+            remote=user.config.git.remote,
+            branch=user.config.git.branch,
+            author=user.config.git.author,
+            token=user.config.git.token,
+        )
+    return configs
 
-    if not configured:
-        return KnowledgeGitConfig()
-    if len(configured) > 1:
-        owners = ", ".join(username for username, _ in configured)
-        raise RuntimeError(f"knowledge Git remote is configured for multiple enabled users: {owners}")
 
-    owner, git = configured[0]
-    return KnowledgeGitConfig(
-        owner=owner,
-        remote=git.remote,
-        branch=git.branch,
-        author=git.author,
-        token=git.token,
-    )
+async def _bootstrap_user_knowledge_repo(
+    repo_registry: KnowledgeRepoRegistry,
+    username: str,
+    config: KnowledgeGitConfig,
+) -> None:
+    handle = repo_registry.ensure_user_repo(username)
+    git_store = handle.git_store
+    git_store.remote_branch = config.branch
+    git_store.author_template = config.author
+    await git_store.ensure_repo()
+
+    if config.remote:
+        logger.info(f"Using knowledge Git remote from user {username}")
+        await git_store.add_remote(config.remote, config.token)
+        try:
+            summary = await git_store.pull_from_remote()
+            logger.info(f"Pulled from remote for user {username}: {summary}")
+        except RuntimeError as exc:
+            logger.error(str(exc))
+            raise SystemExit(1) from exc
+    else:
+        await git_store.remove_remote()
+
+    seeded = ensure_knowledge_dir(handle.knowledge_dir)
+    if not seeded:
+        return
+    try:
+        committed = await git_store.commit(seeded, "🔧 bootstrap: seed default files")
+    except RuntimeError as exc:
+        logger.warning(f"Bootstrap knowledge seed commit failed for user {username}: {exc}")
+        return
+    if committed and git_store.remote_configured:
+        await git_store.push_to_remote()
 
 
 _SESSION_COMMIT_SWEEP_SECONDS = 15 * 60
@@ -269,39 +299,13 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     _auth_store = AuthStore(_data_dir, _config.auth)
     if _auth_store.ensure_bootstrap_admin() is not None:
         logger.warning("Created bootstrap admin user 'admin' with password from CARAPACE_TOKEN")
-    knowledge_git = _select_knowledge_git_config(_auth_store)
+    _knowledge_repo_registry = KnowledgeRepoRegistry(_data_dir)
+    user_git_configs = _enabled_user_git_configs(_auth_store)
+    for username, git_config in user_git_configs.items():
+        await _bootstrap_user_knowledge_repo(_knowledge_repo_registry, username, git_config)
 
-    # 3. Git-backed knowledge store
-    git_store = GitStore(
-        knowledge_dir,
-        remote_branch=knowledge_git.branch,
-        author=knowledge_git.author,
-    )
-    await git_store.ensure_repo()
-
-    # Pull from external remote if configured
-    if knowledge_git.remote:
-        logger.info(f"Using knowledge Git remote from user {knowledge_git.owner}")
-        await git_store.add_remote(knowledge_git.remote, knowledge_git.token)
-        try:
-            summary = await git_store.pull_from_remote()
-            logger.info(f"Pulled from remote: {summary}")
-        except RuntimeError as exc:
-            logger.error(str(exc))
-            raise SystemExit(1) from exc
-    else:
-        await git_store.remove_remote()
-
-    # Bootstrap knowledge files (after pull so we don't override remote content)
-    seeded = ensure_knowledge_dir(knowledge_dir)
-    if seeded:
-        try:
-            committed = await git_store.commit(seeded, "🔧 bootstrap: seed default files")
-        except RuntimeError as exc:
-            logger.warning(f"Bootstrap knowledge seed commit failed: {exc}")
-        else:
-            if committed and git_store.remote_configured:
-                await git_store.push_to_remote()
+    # Legacy fallback store for any remaining non-session-routed call sites.
+    git_store = GitStore(knowledge_dir)
 
     if _config.carapace.logfire_token:
         logfire.configure(token=_config.carapace.logfire_token, console=False)
@@ -357,14 +361,17 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
         idle_timeout_minutes=_config.sandbox.idle_timeout_minutes,
         proxy_port=proxy_port,
         sandbox_port=_config.server.sandbox_port,
-        git_author=knowledge_git.author,
+        git_author=UserGitConfig().author,
+        knowledge_repo_for_session=lambda session_id: _knowledge_repo_registry.get_for_user(
+            session_mgr.load_meta(session_id).user
+        ),
     )
     logger.info(f"Sandbox enabled (image={base_image}, network={sandbox_network})")
 
     _knowledge_git_runtime = KnowledgeGitRuntime(
-        git_store=git_store,
+        repo_registry=_knowledge_repo_registry,
         sandbox_mgr=_sandbox_mgr,
-        current_config=knowledge_git,
+        current_configs=user_git_configs,
     )
 
     if _config.sandbox.cleanup_orphans_on_startup:
@@ -407,6 +414,9 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
         agent_model=agent_model,
         sandbox_mgr=_sandbox_mgr,
         credential_registry_for_session=_credential_registry_for_session,
+        knowledge_repo_for_session=lambda session_id: _knowledge_repo_registry.get_for_user(
+            session_mgr.load_meta(session_id).user
+        ),
         model_factory=model_factory,
         notification_router=_notification_router,
     )
@@ -415,6 +425,9 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
         git_store=git_store,
         session_mgr=session_mgr,
         config=_config.sessions.commit,
+        knowledge_repo_for_session=lambda session_id: _knowledge_repo_registry.get_for_user(
+            session_mgr.load_meta(session_id).user
+        ),
     )
     _jobs_store = JobsStore(_data_dir)
     _jobs_scheduler = JobsScheduler(_jobs_store)
@@ -422,9 +435,11 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     # Git HTTP handler — serves the knowledge repo on the sandbox API
     _git_handler = GitHttpHandler(
         knowledge_dir=knowledge_dir,
+        knowledge_root=_knowledge_repo_registry.knowledge_repos_dir,
         default_branch="main",
         api_port=_config.server.internal_port,
         verify_session_token=_sandbox_mgr.verify_session_token,
+        owner_for_session=lambda session_id: session_mgr.load_meta(session_id).user,
         on_push_success=_knowledge_git_runtime.push_if_configured,
     )
 
@@ -496,7 +511,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     logger.info(
         f"carapace server ready — model={_config.agent.model}, "
-        f"skills={len(skill_catalog)}, proxy_port={proxy_port}"
+        f"user_repos={len(user_git_configs)}, skills={len(skill_catalog)}, proxy_port={proxy_port}"
         + (
             f", matrix=on ({_matrix_channel_manager.channel_count} user channel(s))"
             if _matrix_channel_manager.channel_count

--- a/src/carapace/server/auth.py
+++ b/src/carapace/server/auth.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, WebSocket, WebSocketException, status
+from loguru import logger
 from pydantic import BaseModel
 
 from ..auth import AuthStore, UserIdentity, has_admin_role, normalize_username
+from ..bootstrap import ensure_knowledge_dir
 from ..models.credentials import BitwardenCredentialBackendConfig
 from ..models.user import UserConfig
-from .runtime import KnowledgeGitConfig
 from .state import server_module
 
 server = server_module()
@@ -238,21 +239,31 @@ async def _bootstrap_user_knowledge_repo_if_enabled(username: str) -> None:
         return
 
     repo_registry = getattr(server, "_knowledge_repo_registry", None)
-    bootstrap_user_knowledge_repo = getattr(server, "_bootstrap_user_knowledge_repo", None)
-    if repo_registry is None or not callable(bootstrap_user_knowledge_repo):
-        return
+    runtime = getattr(server, "_knowledge_git_runtime", None)
+    if repo_registry is None:
+        raise HTTPException(status_code=503, detail="Knowledge repo registry is not initialized")
+    if runtime is None:
+        raise HTTPException(status_code=503, detail="Git runtime is not initialized")
 
-    await bootstrap_user_knowledge_repo(
-        repo_registry,
-        normalized_username,
-        KnowledgeGitConfig(
-            owner=normalized_username,
-            remote=user.config.git.remote,
-            branch=user.config.git.branch,
-            author=user.config.git.author,
-            token=user.config.git.token,
-        ),
-    )
+    try:
+        await runtime.apply_user_config(normalized_username, user.config.git)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Knowledge Git settings reload failed")
+        raise HTTPException(status_code=500, detail=f"Git settings reload failed: {exc}") from exc
+
+    handle = repo_registry.ensure_user_repo(normalized_username)
+    seeded = ensure_knowledge_dir(handle.knowledge_dir)
+    if not seeded:
+        return
+    try:
+        committed = await handle.git_store.commit(seeded, "🔧 bootstrap: seed default files")
+    except RuntimeError as exc:
+        logger.warning(f"Bootstrap knowledge seed commit failed for user {normalized_username}: {exc}")
+        return
+    if committed and handle.git_store.remote_configured:
+        await handle.git_store.push_to_remote()
 
 
 @router.post("/auth/login", response_model=LoginResponse)
@@ -348,16 +359,26 @@ async def update_admin_user(
 ) -> AdminUserResponse:
     updates = body.model_dump(exclude_unset=True, exclude={"config", "password"})
     password = body.password if "password" in body.model_fields_set else None
+    git_config_changed = False
     if "config" in body.model_fields_set and body.config is not None:
-        updates["config"] = _config_with_preserved_backend_passwords(username, body.config)
+        existing = _auth_store().get_user(username)
+        if existing is None:
+            raise HTTPException(status_code=404, detail="User not found")
+        merged_config = _config_with_preserved_backend_passwords(username, body.config)
+        updates["config"] = merged_config
+        git_config_changed = merged_config.git != existing.config.git
     try:
+        existing_user = _auth_store().get_user(username)
+        if existing_user is None:
+            raise KeyError(username)
+        was_enabled = existing_user.enabled
         if updates:
             _assert_not_removing_last_admin(username, updates)
         if updates:
             _auth_store().update_user(username, updates)
         if password is not None:
             _auth_store().set_password(username, password)
-        if ("enabled" in body.model_fields_set and body.enabled is True) or "config" in body.model_fields_set:
+        if ("enabled" in body.model_fields_set and body.enabled is True and not was_enabled) or git_config_changed:
             await _bootstrap_user_knowledge_repo_if_enabled(username)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail="User not found") from exc

--- a/src/carapace/server/auth.py
+++ b/src/carapace/server/auth.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from ..auth import AuthStore, UserIdentity, has_admin_role, normalize_username
 from ..models.credentials import BitwardenCredentialBackendConfig
 from ..models.user import UserConfig
+from .runtime import KnowledgeGitConfig
 from .state import server_module
 
 server = server_module()
@@ -230,6 +231,30 @@ def _assert_user_can_be_deleted(username: str, admin_user: UserIdentity) -> None
         raise HTTPException(status_code=400, detail="Cannot remove the last enabled admin")
 
 
+async def _bootstrap_user_knowledge_repo_if_enabled(username: str) -> None:
+    normalized_username = normalize_username(username)
+    user = _auth_store().get_user(normalized_username)
+    if user is None or not user.enabled:
+        return
+
+    repo_registry = getattr(server, "_knowledge_repo_registry", None)
+    bootstrap_user_knowledge_repo = getattr(server, "_bootstrap_user_knowledge_repo", None)
+    if repo_registry is None or not callable(bootstrap_user_knowledge_repo):
+        return
+
+    await bootstrap_user_knowledge_repo(
+        repo_registry,
+        normalized_username,
+        KnowledgeGitConfig(
+            owner=normalized_username,
+            remote=user.config.git.remote,
+            branch=user.config.git.branch,
+            author=user.config.git.author,
+            token=user.config.git.token,
+        ),
+    )
+
+
 @router.post("/auth/login", response_model=LoginResponse)
 async def login(request: Request, response: Response, body: LoginRequest) -> LoginResponse:
     store = _auth_store()
@@ -309,6 +334,7 @@ async def create_admin_user(
             roles=body.roles,
             config=_config_with_preserved_backend_passwords(None, body.config),
         )
+        await _bootstrap_user_knowledge_repo_if_enabled(body.username)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return _user_response(body.username)
@@ -331,6 +357,8 @@ async def update_admin_user(
             _auth_store().update_user(username, updates)
         if password is not None:
             _auth_store().set_password(username, password)
+        if ("enabled" in body.model_fields_set and body.enabled is True) or "config" in body.model_fields_set:
+            await _bootstrap_user_knowledge_repo_if_enabled(username)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail="User not found") from exc
     except ValueError as exc:

--- a/src/carapace/server/auth.py
+++ b/src/carapace/server/auth.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response, WebSoc
 from loguru import logger
 from pydantic import BaseModel
 
-from ..auth import AuthStore, UserIdentity, has_admin_role, normalize_username
+from ..auth import AuthStore, AuthUser, UserIdentity, has_admin_role, normalize_username
 from ..bootstrap import ensure_knowledge_dir
 from ..models.credentials import BitwardenCredentialBackendConfig
 from ..models.user import UserConfig
@@ -118,6 +118,38 @@ def _config_with_preserved_backend_passwords(username: str | None, config: UserC
         if backend.basic_auth.password is None:
             raise ValueError(f"basic_auth.password is required for credential backend {backend_name!r}")
     return merged
+
+
+def _deep_merge_dict(base: dict[str, Any], patch: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    for key, value in patch.items():
+        current = merged.get(key)
+        if isinstance(current, dict) and isinstance(value, dict):
+            merged[key] = _deep_merge_dict(current, value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _merge_user_config_patch(username: str, config: UserConfig) -> UserConfig:
+    existing_user = _auth_store().get_user(username)
+    existing_config = existing_user.config if existing_user is not None else UserConfig()
+    merged_payload = _deep_merge_dict(
+        existing_config.model_dump(mode="python"),
+        config.model_dump(mode="python", exclude_unset=True),
+    )
+    return _config_with_preserved_backend_passwords(username, UserConfig.model_validate(merged_payload))
+
+
+def _restore_user_from_snapshot(username: str, snapshot: AuthUser | None) -> None:
+    key = normalize_username(username)
+    store = _auth_store()
+    users_file = store.load_users()
+    if snapshot is None:
+        users_file.users.pop(key, None)
+    else:
+        users_file.users[key] = snapshot.model_copy(deep=True)
+    store.save_users(users_file)
 
 
 def _auth_store() -> AuthStore:
@@ -336,8 +368,10 @@ async def create_admin_user(
     body: AdminUserCreateRequest,
     _admin_user: Annotated[UserIdentity, Depends(verify_admin_user)],
 ) -> AdminUserResponse:
+    store = _auth_store()
+    previous_user = store.get_user(body.username)
     try:
-        _auth_store().create_user(
+        store.create_user(
             username=body.username,
             password=body.password,
             display_name=body.display_name,
@@ -347,7 +381,11 @@ async def create_admin_user(
         )
         await _bootstrap_user_knowledge_repo_if_enabled(body.username)
     except ValueError as exc:
+        _restore_user_from_snapshot(body.username, previous_user)
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception:
+        _restore_user_from_snapshot(body.username, previous_user)
+        raise
     return _user_response(body.username)
 
 
@@ -357,33 +395,37 @@ async def update_admin_user(
     body: AdminUserUpdateRequest,
     _admin_user: Annotated[UserIdentity, Depends(verify_admin_user)],
 ) -> AdminUserResponse:
+    store = _auth_store()
+    existing_user = store.get_user(username)
+    if existing_user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    previous_user = existing_user.model_copy(deep=True)
     updates = body.model_dump(exclude_unset=True, exclude={"config", "password"})
     password = body.password if "password" in body.model_fields_set else None
     git_config_changed = False
     if "config" in body.model_fields_set and body.config is not None:
-        existing = _auth_store().get_user(username)
-        if existing is None:
-            raise HTTPException(status_code=404, detail="User not found")
-        merged_config = _config_with_preserved_backend_passwords(username, body.config)
+        merged_config = _merge_user_config_patch(username, body.config)
         updates["config"] = merged_config
-        git_config_changed = merged_config.git != existing.config.git
+        git_config_changed = merged_config.git != previous_user.config.git
     try:
-        existing_user = _auth_store().get_user(username)
-        if existing_user is None:
-            raise KeyError(username)
         was_enabled = existing_user.enabled
         if updates:
             _assert_not_removing_last_admin(username, updates)
         if updates:
-            _auth_store().update_user(username, updates)
+            store.update_user(username, updates)
         if password is not None:
-            _auth_store().set_password(username, password)
+            store.set_password(username, password)
         if ("enabled" in body.model_fields_set and body.enabled is True and not was_enabled) or git_config_changed:
             await _bootstrap_user_knowledge_repo_if_enabled(username)
     except KeyError as exc:
+        _restore_user_from_snapshot(username, previous_user)
         raise HTTPException(status_code=404, detail="User not found") from exc
     except ValueError as exc:
+        _restore_user_from_snapshot(username, previous_user)
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception:
+        _restore_user_from_snapshot(username, previous_user)
+        raise
     return _user_response(username)
 
 

--- a/src/carapace/server/runtime.py
+++ b/src/carapace/server/runtime.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Protocol
 
 from loguru import logger
 
 from ..auth import normalize_username
-from ..git.store import GitStore
-from ..models.user import DEFAULT_GIT_AUTHOR, DEFAULT_GIT_BRANCH, UserConfig
+from ..knowledge import KnowledgeRepoRegistry
+from ..models.user import DEFAULT_GIT_AUTHOR, DEFAULT_GIT_BRANCH, UserConfig, UserGitConfig
 from ..sandbox.manager import SandboxManager
 
 
@@ -92,56 +92,89 @@ class KnowledgeGitRuntime:
     def __init__(
         self,
         *,
-        git_store: GitStore,
+        repo_registry: KnowledgeRepoRegistry,
         sandbox_mgr: SandboxManager,
-        current_config: KnowledgeGitConfig | None = None,
+        current_configs: Mapping[str, KnowledgeGitConfig] | None = None,
     ) -> None:
-        self._git_store = git_store
+        self._repo_registry = repo_registry
         self._sandbox_mgr = sandbox_mgr
-        self._config = current_config or KnowledgeGitConfig()
+        self._configs = {
+            normalize_username(username): self._normalize_config(username, config)
+            for username, config in (current_configs or {}).items()
+        }
         self._lock = asyncio.Lock()
 
-    @property
-    def config(self) -> KnowledgeGitConfig:
-        return self._config
+    def _normalize_config(self, username: str, config: KnowledgeGitConfig | UserGitConfig) -> KnowledgeGitConfig:
+        owner = normalize_username(username)
+        if isinstance(config, UserGitConfig):
+            return KnowledgeGitConfig(
+                owner=owner,
+                remote=config.remote,
+                branch=config.branch,
+                author=config.author,
+                token=config.token,
+            )
 
-    async def apply_config(self, config: KnowledgeGitConfig) -> None:
+        config_owner = normalize_username(config.owner) if config.owner is not None else owner
+        if config_owner != owner:
+            raise ValueError(f"knowledge Git config owner mismatch: expected {owner!r}, got {config_owner!r}")
+        return KnowledgeGitConfig(
+            owner=owner,
+            remote=config.remote,
+            branch=config.branch,
+            author=config.author,
+            token=config.token,
+        )
+
+    def config_for_user(self, username: str) -> KnowledgeGitConfig:
+        owner = normalize_username(username)
+        return self._configs.get(owner, KnowledgeGitConfig(owner=owner))
+
+    async def apply_user_config(self, username: str, config: KnowledgeGitConfig | UserGitConfig) -> None:
+        owner = normalize_username(username)
+        next_config = self._normalize_config(owner, config)
         async with self._lock:
-            previous_config = self._config
-            previous_branch = self._git_store.remote_branch
-            previous_author = self._git_store.author_template
+            handle = self._repo_registry.ensure_user_repo(owner)
+            git_store = handle.git_store
+            previous_config = self.config_for_user(owner)
+            previous_branch = git_store.remote_branch
+            previous_author = git_store.author_template
             try:
-                self._git_store.remote_branch = config.branch
-                self._git_store.author_template = config.author
+                git_store.remote_branch = next_config.branch
+                git_store.author_template = next_config.author
+                await git_store.ensure_repo()
 
-                if config.remote:
-                    logger.info(f"Using knowledge Git remote from user {config.owner}")
-                    await self._git_store.add_remote(config.remote, config.token)
-                    summary = await self._git_store.pull_from_remote()
-                    logger.info(f"Pulled from remote: {summary}")
+                if next_config.remote:
+                    logger.info(f"Using knowledge Git remote from user {owner}")
+                    await git_store.add_remote(next_config.remote, next_config.token)
+                    summary = await git_store.pull_from_remote()
+                    logger.info(f"Pulled from remote for user {owner}: {summary}")
                 else:
-                    await self._git_store.remove_remote()
+                    await git_store.remove_remote()
 
-                self._sandbox_mgr.set_git_author(config.author)
                 await self._sandbox_mgr.refresh_git_identities()
             except Exception:
-                self._config = previous_config
-                self._git_store.remote_branch = previous_branch
-                self._git_store.author_template = previous_author
-                self._sandbox_mgr.set_git_author(previous_author)
+                git_store.remote_branch = previous_branch
+                git_store.author_template = previous_author
                 try:
                     if previous_config.remote:
-                        await self._git_store.add_remote(previous_config.remote, previous_config.token)
+                        await git_store.add_remote(previous_config.remote, previous_config.token)
                     else:
-                        await self._git_store.remove_remote()
+                        await git_store.remove_remote()
                     await self._sandbox_mgr.refresh_git_identities()
                 except Exception as rollback_exc:
-                    logger.warning(f"Knowledge Git runtime rollback failed: {rollback_exc}")
+                    logger.warning(f"Knowledge Git runtime rollback failed for user {owner}: {rollback_exc}")
                 raise
 
-            self._config = config
+            self._configs[owner] = next_config
 
-    async def push_if_configured(self) -> None:
+    async def push_if_configured(self, owner: str) -> None:
+        normalized_owner = normalize_username(owner)
         async with self._lock:
-            if self._git_store.remote_configured:
-                await self._git_store.push_to_remote()
+            handle = self._repo_registry.ensure_user_repo(normalized_owner)
+            config = self._configs.get(normalized_owner)
+            if config is not None:
+                handle.git_store.remote_branch = config.branch
+                handle.git_store.author_template = config.author
+            if handle.git_store.remote_configured:
+                await handle.git_store.push_to_remote()

--- a/src/carapace/server/runtime.py
+++ b/src/carapace/server/runtime.py
@@ -136,9 +136,11 @@ class KnowledgeGitRuntime:
         async with self._lock:
             handle = self._repo_registry.ensure_user_repo(owner)
             git_store = handle.git_store
-            previous_config = self.config_for_user(owner)
+            previous_config = self._configs.get(owner)
             previous_branch = git_store.remote_branch
             previous_author = git_store.author_template
+            previous_remote_url = await git_store.get_remote_url()
+            previous_remote_configured = git_store.remote_configured
             try:
                 git_store.remote_branch = next_config.branch
                 git_store.author_template = next_config.author
@@ -157,9 +159,11 @@ class KnowledgeGitRuntime:
                 git_store.remote_branch = previous_branch
                 git_store.author_template = previous_author
                 try:
-                    if previous_config.remote:
+                    if previous_config is not None and previous_config.remote:
                         await git_store.add_remote(previous_config.remote, previous_config.token)
-                    else:
+                    elif previous_remote_url is not None:
+                        await git_store.restore_remote(previous_remote_url)
+                    elif not previous_remote_configured:
                         await git_store.remove_remote()
                     await self._sandbox_mgr.refresh_git_identities()
                 except Exception as rollback_exc:

--- a/src/carapace/server/sessions.py
+++ b/src/carapace/server/sessions.py
@@ -12,7 +12,6 @@ from pydantic_ai.messages import ModelMessage
 from ..auth import UserIdentity
 from ..models.session import SessionAttributes, SessionJobRunContext, SessionState
 from ..sandbox.state import SessionSandboxSnapshot
-from ..session.manager import SessionMeta
 from ..user_defaults import apply_user_model_defaults, effective_user_budget
 from .auth import verify_token
 from .history import _history_from_messages
@@ -434,7 +433,6 @@ async def fork_session(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    server._engine.session_mgr.save_meta(forked.session_id, SessionMeta(user=user.username))
     return SessionInfo.from_state(
         forked,
         message_count=_session_message_count(forked.session_id),

--- a/src/carapace/server/user_settings.py
+++ b/src/carapace/server/user_settings.py
@@ -20,16 +20,10 @@ from ..models.matrix import MatrixChannelConfig, MatrixTokensFile
 from ..models.session import SessionBudget
 from ..models.user import UserConfig, UserDefaultModelsConfig, UserGitConfig
 from .auth import verify_token
-from .runtime import KnowledgeGitConfig
 from .state import server_module
 
 server = server_module()
 router = APIRouter()
-
-_KNOWLEDGE_GIT_REMOTE_CONFLICT_DETAIL = (
-    "Knowledge Git remote is already configured for another enabled user. "
-    "The shared knowledge repo supports only one enabled remote owner."
-)
 
 
 @dataclass(frozen=True)
@@ -348,20 +342,6 @@ def _credentials_with_preserved_backend_passwords(username: str, credentials: Cr
     return merged
 
 
-def _assert_git_remote_owner(username: str, next_config: UserConfig) -> None:
-    if not next_config.git.remote:
-        return
-    normalized_username = normalize_username(username)
-    for other_username, other_user in _auth_store().load_users().users.items():
-        if normalize_username(other_username) == normalized_username:
-            continue
-        if other_user.enabled and other_user.config.git.remote:
-            raise HTTPException(
-                status_code=400,
-                detail=_KNOWLEDGE_GIT_REMOTE_CONFLICT_DETAIL,
-            )
-
-
 async def _invalidate_user_credential_registry(username: str) -> None:
     registries = getattr(server, "_user_credential_registries", None)
     if not isinstance(registries, dict):
@@ -386,38 +366,12 @@ async def _reload_matrix_settings(username: str, config: UserConfig) -> None:
         raise HTTPException(status_code=500, detail=f"Matrix settings reload failed: {exc}") from exc
 
 
-def _knowledge_git_config_with_candidate(username: str, config: UserConfig) -> KnowledgeGitConfig:
-    configured: list[tuple[str, UserGitConfig]] = []
-    normalized_username = normalize_username(username)
-    for stored_username, stored_user in sorted(_auth_store().load_users().users.items()):
-        user_config = config if normalize_username(stored_username) == normalized_username else stored_user.config
-        if stored_user.enabled and user_config.git.remote:
-            configured.append((stored_username, user_config.git))
-
-    if not configured:
-        return KnowledgeGitConfig()
-    if len(configured) > 1:
-        raise HTTPException(
-            status_code=400,
-            detail=_KNOWLEDGE_GIT_REMOTE_CONFLICT_DETAIL,
-        )
-
-    owner, git = configured[0]
-    return KnowledgeGitConfig(
-        owner=owner,
-        remote=git.remote,
-        branch=git.branch,
-        author=git.author,
-        token=git.token,
-    )
-
-
-async def _reload_git_settings(config: KnowledgeGitConfig) -> None:
+async def _reload_git_settings(username: str, config: UserGitConfig) -> None:
     runtime = getattr(server, "_knowledge_git_runtime", None)
     if runtime is None:
         raise HTTPException(status_code=503, detail="Git runtime is not initialized")
     try:
-        await runtime.apply_config(config)
+        await runtime.apply_user_config(username, config)
     except HTTPException:
         raise
     except Exception as exc:
@@ -439,7 +393,7 @@ async def _rollback_settings_runtime(
             logger.warning(f"Matrix settings runtime rollback failed for user {username!r}: {exc.detail}")
     if git_changed:
         try:
-            await _reload_git_settings(_knowledge_git_config_with_candidate(username, config))
+            await _reload_git_settings(username, config.git)
         except HTTPException as exc:
             logger.warning(f"Git settings runtime rollback failed: {exc.detail}")
 
@@ -548,7 +502,6 @@ async def update_user_settings(
 
     if body.git is not None:
         _apply_git_patch(next_config, body.git)
-        _assert_git_remote_owner(user.username, next_config)
 
     credentials_changed = original_config.credentials != next_config.credentials
     matrix_defaults_changed = (
@@ -572,7 +525,7 @@ async def update_user_settings(
             runtime_errors.append(exc)
     if git_changed:
         try:
-            await _reload_git_settings(_knowledge_git_config_with_candidate(user.username, next_config))
+            await _reload_git_settings(user.username, next_config.git)
         except HTTPException as exc:
             runtime_errors.append(exc)
 

--- a/src/carapace/session/archive.py
+++ b/src/carapace/session/archive.py
@@ -14,13 +14,12 @@ from loguru import logger
 from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, ThinkingPart, ToolCallPart, UserPromptPart
 
 from ..git.store import GitStore
-from ..knowledge import KnowledgeRepoHandle
+from ..knowledge import KnowledgeRepoResolver
 from ..models.config import SessionCommitConfig
 from ..models.session import SessionState
 from .manager import SessionManager
 
 ArchiveTrigger = Literal["manual", "autosave", "archive"]
-type KnowledgeRepoResolver = Callable[[str], KnowledgeRepoHandle]
 
 _SCHEMA_VERSION = 1
 
@@ -38,14 +37,10 @@ class SessionArchiveService:
     def __init__(
         self,
         *,
-        knowledge_dir: Path,
-        git_store: GitStore,
         session_mgr: SessionManager,
         config: SessionCommitConfig,
-        knowledge_repo_for_session: KnowledgeRepoResolver | None = None,
+        knowledge_repo_for_session: KnowledgeRepoResolver,
     ) -> None:
-        self._knowledge_dir = knowledge_dir
-        self._git_store = git_store
         self._session_mgr = session_mgr
         self._config = config
         self._knowledge_repo_for_session = knowledge_repo_for_session
@@ -66,14 +61,10 @@ class SessionArchiveService:
         return knowledge_dir / self.archive_relative_path_for_state(state)
 
     def _repo_for_session(self, session_id: str) -> tuple[Path, GitStore]:
-        if self._knowledge_repo_for_session is None:
-            return self._knowledge_dir, self._git_store
         handle = self._knowledge_repo_for_session(session_id)
         return handle.knowledge_dir, handle.git_store
 
-    async def _ensure_repo_ready(self, session_id: str, *, knowledge_dir: Path, git_store: GitStore) -> None:
-        if self._knowledge_repo_for_session is None:
-            return
+    async def _ensure_repo_ready(self, *, knowledge_dir: Path, git_store: GitStore) -> None:
         if (knowledge_dir / ".git").exists():
             return
         await git_store.ensure_repo()
@@ -170,7 +161,7 @@ class SessionArchiveService:
                 )
 
             knowledge_dir, git_store = self._repo_for_session(session_id)
-            await self._ensure_repo_ready(session_id, knowledge_dir=knowledge_dir, git_store=git_store)
+            await self._ensure_repo_ready(knowledge_dir=knowledge_dir, git_store=git_store)
             archive_path = self.archive_relative_path_for_state(current_state)
             archive_file = knowledge_dir / archive_path
             committed_at = datetime.now(tz=UTC)

--- a/src/carapace/session/archive.py
+++ b/src/carapace/session/archive.py
@@ -14,11 +14,13 @@ from loguru import logger
 from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, ThinkingPart, ToolCallPart, UserPromptPart
 
 from ..git.store import GitStore
+from ..knowledge import KnowledgeRepoHandle
 from ..models.config import SessionCommitConfig
 from ..models.session import SessionState
 from .manager import SessionManager
 
 ArchiveTrigger = Literal["manual", "autosave", "archive"]
+type KnowledgeRepoResolver = Callable[[str], KnowledgeRepoHandle]
 
 _SCHEMA_VERSION = 1
 
@@ -40,11 +42,13 @@ class SessionArchiveService:
         git_store: GitStore,
         session_mgr: SessionManager,
         config: SessionCommitConfig,
+        knowledge_repo_for_session: KnowledgeRepoResolver | None = None,
     ) -> None:
         self._knowledge_dir = knowledge_dir
         self._git_store = git_store
         self._session_mgr = session_mgr
         self._config = config
+        self._knowledge_repo_for_session = knowledge_repo_for_session
         self._session_locks: dict[str, asyncio.Lock] = {}
         self._session_lock_refs: dict[str, int] = {}
 
@@ -58,7 +62,21 @@ class SessionArchiveService:
         return relative.as_posix()
 
     def archive_absolute_path_for_state(self, state: SessionState) -> Path:
-        return self._knowledge_dir / self.archive_relative_path_for_state(state)
+        knowledge_dir, _ = self._repo_for_session(state.session_id)
+        return knowledge_dir / self.archive_relative_path_for_state(state)
+
+    def _repo_for_session(self, session_id: str) -> tuple[Path, GitStore]:
+        if self._knowledge_repo_for_session is None:
+            return self._knowledge_dir, self._git_store
+        handle = self._knowledge_repo_for_session(session_id)
+        return handle.knowledge_dir, handle.git_store
+
+    async def _ensure_repo_ready(self, session_id: str, *, knowledge_dir: Path, git_store: GitStore) -> None:
+        if self._knowledge_repo_for_session is None:
+            return
+        if (knowledge_dir / ".git").exists():
+            return
+        await git_store.ensure_repo()
 
     def _get_session_lock(self, session_id: str) -> asyncio.Lock:
         lock = self._session_locks.get(session_id)
@@ -151,8 +169,10 @@ class SessionArchiveService:
                     reason="Session has no history to archive yet",
                 )
 
+            knowledge_dir, git_store = self._repo_for_session(session_id)
+            await self._ensure_repo_ready(session_id, knowledge_dir=knowledge_dir, git_store=git_store)
             archive_path = self.archive_relative_path_for_state(current_state)
-            archive_file = self._knowledge_dir / archive_path
+            archive_file = knowledge_dir / archive_path
             committed_at = datetime.now(tz=UTC)
             session_payload = {
                 "session_id": current_state.session_id,
@@ -198,14 +218,14 @@ class SessionArchiveService:
             commit_action = "add" if current_state.knowledge_last_committed_at is None else "update"
 
             try:
-                commit_made = await self._git_store.commit(
+                commit_made = await git_store.commit(
                     [archive_path],
                     f"💾 session: {commit_action} {session_id}",
                     session_id=session_id,
                 )
             except RuntimeError:
                 archive_file.unlink(missing_ok=True)
-                self._prune_empty_archive_dirs(archive_file.parent)
+                self._prune_empty_archive_dirs(archive_file.parent, knowledge_dir=knowledge_dir)
                 raise
 
             latest_state = self._session_mgr.load_state(session_id)
@@ -238,13 +258,14 @@ class SessionArchiveService:
                 return False
 
             archive_path = state.knowledge_last_archive_path or self.archive_relative_path_for_state(state)
-            archive_file = self._knowledge_dir / archive_path
+            knowledge_dir, git_store = self._repo_for_session(state.session_id)
+            archive_file = knowledge_dir / archive_path
             if not archive_file.exists():
                 return False
 
             archive_file.unlink()
-            self._prune_empty_archive_dirs(archive_file.parent)
-            commit_made = await self._git_store.commit_removals(
+            self._prune_empty_archive_dirs(archive_file.parent, knowledge_dir=knowledge_dir)
+            commit_made = await git_store.commit_removals(
                 [archive_path],
                 f"🗑️ session: remove archive {state.session_id}",
                 session_id=state.session_id,
@@ -269,8 +290,8 @@ class SessionArchiveService:
             json.dumps(stable_payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
         ).hexdigest()
 
-    def _prune_empty_archive_dirs(self, start_dir: Path) -> None:
-        stop_dir = (self._knowledge_dir / self._config.path_prefix).resolve()
+    def _prune_empty_archive_dirs(self, start_dir: Path, *, knowledge_dir: Path) -> None:
+        stop_dir = (knowledge_dir / self._config.path_prefix).resolve()
         current = start_dir.resolve()
         while current != stop_dir and current.is_dir() and stop_dir in current.parents:
             try:

--- a/src/carapace/session/commands.py
+++ b/src/carapace/session/commands.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 from ..git.store import GitStore
@@ -19,11 +18,8 @@ from .types import ActiveSession
 class SessionCommandHost(Protocol):
     _active: dict[str, ActiveSession]
     _config: Config
-    _git_store: GitStore
-    _knowledge_dir: Path
     _sandbox_mgr: SandboxManager
     _session_mgr: SessionManager
-    _skill_catalog: list[SkillInfo]
 
     async def _broadcast(self, active: ActiveSession, method: str, *args: Any, **kwargs: Any) -> None: ...
     async def _generate_title(self, active: ActiveSession, events: list[dict[str, Any]]) -> str: ...
@@ -53,11 +49,8 @@ class SessionCommandHost(Protocol):
 class SessionCommandMixin:
     _active: dict[str, ActiveSession]
     _config: Config
-    _git_store: GitStore
-    _knowledge_dir: Path
     _sandbox_mgr: SandboxManager
     _session_mgr: SessionManager
-    _skill_catalog: list[SkillInfo]
 
     if TYPE_CHECKING:
 
@@ -235,8 +228,6 @@ class SessionCommandMixin:
             return {"command": "pull", "data": {"message": "No external remote configured."}}
         try:
             summary = await git_store.pull_from_remote()
-            if git_store is self._git_store:
-                self._skill_catalog = self._skill_registry_for_session(session_id).scan()
             return {"command": "pull", "data": {"message": summary}}
         except RuntimeError as exc:
             return {"command": "pull", "data": {"message": f"Pull failed: {exc}"}}

--- a/src/carapace/session/commands.py
+++ b/src/carapace/session/commands.py
@@ -228,6 +228,7 @@ class SessionCommandMixin:
             return {"command": "pull", "data": {"message": "No external remote configured."}}
         try:
             summary = await git_store.pull_from_remote()
+            self._skill_registry_for_session(session_id).invalidate()
             return {"command": "pull", "data": {"message": summary}}
         except RuntimeError as exc:
             return {"command": "pull", "data": {"message": f"Pull failed: {exc}"}}

--- a/src/carapace/session/commands.py
+++ b/src/carapace/session/commands.py
@@ -31,6 +31,9 @@ class SessionCommandHost(Protocol):
     async def _handle_model_selector_command(
         self, active: ActiveSession, arg: str, *, slash_line: str
     ) -> dict[str, Any]: ...
+    def _git_store_for_session(self, session_id: str) -> GitStore: ...
+    def _skill_catalog_for_session(self, session_id: str) -> list[SkillInfo]: ...
+    def _skill_registry_for_session(self, session_id: str) -> SkillRegistry: ...
     def _budget_gauges(self, active: ActiveSession) -> list[Any]: ...
     def _usage_last_llm_payload_row(
         self, active: ActiveSession, source: Literal["agent", "sentinel"]
@@ -64,6 +67,9 @@ class SessionCommandMixin:
         async def _handle_model_selector_command(
             self, active: ActiveSession, arg: str, *, slash_line: str
         ) -> dict[str, Any]: ...
+        def _git_store_for_session(self, session_id: str) -> GitStore: ...
+        def _skill_catalog_for_session(self, session_id: str) -> list[SkillInfo]: ...
+        def _skill_registry_for_session(self, session_id: str) -> SkillRegistry: ...
         def _budget_gauges(self, active: ActiveSession) -> list[Any]: ...
         def _usage_last_llm_payload_row(
             self, active: ActiveSession, source: Literal["agent", "sentinel"]
@@ -108,7 +114,10 @@ class SessionCommandMixin:
             }
 
         if cmd == "/skills":
-            skills = [{"name": s.name, "description": s.description.strip()} for s in self._skill_catalog]
+            skills = [
+                {"name": skill.name, "description": skill.description.strip()}
+                for skill in self._skill_catalog_for_session(session_id)
+            ]
             return {"command": "skills", "data": skills}
 
         if cmd == "/retitle":
@@ -161,10 +170,10 @@ class SessionCommandMixin:
             return self._handle_budget_command(active, parts)
 
         if cmd == "/pull":
-            return await self._handle_pull_command()
+            return await self._handle_pull_command(session_id)
 
         if cmd == "/push":
-            return await self._handle_push_command()
+            return await self._handle_push_command(session_id)
 
         if cmd == "/reload":
             return await self._handle_reload_command(session_id)
@@ -208,24 +217,26 @@ class SessionCommandMixin:
             "data": self._budget_command_payload(active, message=message),
         }
 
-    async def _handle_push_command(self) -> dict[str, Any]:
+    async def _handle_push_command(self, session_id: str) -> dict[str, Any]:
         """Handle the ``/push`` slash command — push to external remote."""
-        if not self._git_store.remote_configured:
+        git_store = self._git_store_for_session(session_id)
+        if not git_store.remote_configured:
             return {"command": "push", "data": {"message": "No external remote configured."}}
         try:
-            await self._git_store.push_to_remote()
+            await git_store.push_to_remote()
             return {"command": "push", "data": {"message": "Pushed to external remote."}}
         except Exception as exc:
             return {"command": "push", "data": {"message": f"Push failed: {exc}"}}
 
-    async def _handle_pull_command(self) -> dict[str, Any]:
+    async def _handle_pull_command(self, session_id: str) -> dict[str, Any]:
         """Handle the ``/pull`` slash command — pull from external remote."""
-        if not self._git_store.remote_configured:
+        git_store = self._git_store_for_session(session_id)
+        if not git_store.remote_configured:
             return {"command": "pull", "data": {"message": "No external remote configured."}}
         try:
-            summary = await self._git_store.pull_from_remote()
-            registry = SkillRegistry(self._knowledge_dir / "skills")
-            self._skill_catalog = registry.scan()
+            summary = await git_store.pull_from_remote()
+            if git_store is self._git_store:
+                self._skill_catalog = self._skill_registry_for_session(session_id).scan()
             return {"command": "pull", "data": {"message": summary}}
         except RuntimeError as exc:
             return {"command": "pull", "data": {"message": f"Pull failed: {exc}"}}

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -29,6 +29,7 @@ from ..agent.deps import Deps
 from ..agent.loop import run_agent_turn as _run_agent_turn
 from ..credentials import SessionCredentialRegistry
 from ..git.store import GitStore
+from ..knowledge import KnowledgeRepoHandle
 from ..models.config import Config
 from ..models.credentials import CredentialRegistryProtocol
 from ..models.session import SessionAttributes, SessionState
@@ -118,6 +119,7 @@ class SessionEngine(
         agent_model: Model | None,
         sandbox_mgr: SandboxManager,
         credential_registry_for_session: Callable[[str], Awaitable[CredentialRegistryProtocol]],
+        knowledge_repo_for_session: Callable[[str], KnowledgeRepoHandle] | None = None,
         model_factory: Callable[[str], Model] | None = None,
         notification_router: NotificationRouter | None = None,
     ) -> None:
@@ -131,6 +133,7 @@ class SessionEngine(
         self._sandbox_mgr = sandbox_mgr
         self._model_factory = model_factory
         self._credential_registry_for_session = credential_registry_for_session
+        self._knowledge_repo_for_session = knowledge_repo_for_session
         self._notification_router = notification_router
         self._active: dict[str, ActiveSession] = {}
         self._llm_semaphore = asyncio.Semaphore(config.agent.max_parallel_llm)
@@ -191,6 +194,29 @@ class SessionEngine(
     def skill_catalog(self) -> list[SkillInfo]:
         return self._skill_catalog
 
+    def _repo_handle_for_session(self, session_id: str) -> KnowledgeRepoHandle | None:
+        if self._knowledge_repo_for_session is None:
+            return None
+        return self._knowledge_repo_for_session(session_id)
+
+    def _knowledge_dir_for_session(self, session_id: str) -> Path:
+        handle = self._repo_handle_for_session(session_id)
+        return handle.knowledge_dir if handle is not None else self._knowledge_dir
+
+    def _git_store_for_session(self, session_id: str) -> GitStore:
+        handle = self._repo_handle_for_session(session_id)
+        return handle.git_store if handle is not None else self._git_store
+
+    def _skill_registry_for_session(self, session_id: str) -> SkillRegistry:
+        handle = self._repo_handle_for_session(session_id)
+        return handle.skill_registry if handle is not None else SkillRegistry(self._knowledge_dir / "skills")
+
+    def _skill_catalog_for_session(self, session_id: str) -> list[SkillInfo]:
+        handle = self._repo_handle_for_session(session_id)
+        if handle is not None:
+            return handle.skill_registry.scan()
+        return self._skill_catalog
+
     @property
     def sandbox_mgr(self) -> SandboxManager:
         return self._sandbox_mgr
@@ -220,10 +246,11 @@ class SessionEngine(
             ask_mode=state.attributes.ask_mode,
             yolo_mode=state.attributes.yolo_mode,
         )
+        knowledge_dir = self._knowledge_dir_for_session(session_id)
         sentinel = Sentinel(
             model=self._config.agent.sentinel_model,
-            knowledge_dir=self._knowledge_dir,
-            skills_dir=self._knowledge_dir / "skills",
+            knowledge_dir=knowledge_dir,
+            skills_dir=knowledge_dir / "skills",
             unattended=state.attributes.unattended,
             ask_mode=state.attributes.ask_mode,
             timeout=timedelta(seconds=self._config.agent.sentinel_timeout_seconds),
@@ -287,7 +314,7 @@ class SessionEngine(
 
     async def _skill_activation_inputs(self, session_id: str, skill_name: str) -> SkillActivationInputs:
         """Return approved env/file inputs for automatic skill activation providers."""
-        registry = SkillRegistry(self._knowledge_dir / "skills")
+        registry = self._skill_registry_for_session(session_id)
         carapace_cfg = registry.get_carapace_config(skill_name)
         if not carapace_cfg or not carapace_cfg.credentials:
             return SkillActivationInputs()
@@ -317,9 +344,9 @@ class SessionEngine(
                 file_credentials.append(SkillFileCredential(path=decl.file, value=value))
         return SkillActivationInputs(environment=env, file_credentials=file_credentials)
 
-    def _skill_command_aliases(self, skill_name: str) -> list[tuple[str, str]]:
+    def _skill_command_aliases(self, session_id: str, skill_name: str) -> list[tuple[str, str]]:
         """Return validated command aliases declared by a skill."""
-        registry = SkillRegistry(self._knowledge_dir / "skills")
+        registry = self._skill_registry_for_session(session_id)
         carapace_cfg = registry.get_carapace_config(skill_name)
         if not carapace_cfg:
             return []
@@ -441,15 +468,17 @@ class SessionEngine(
         def _append_session_events(events: list[dict[str, Any]]) -> None:
             self._session_mgr.append_events(session_id, events)
 
+        knowledge_dir = self._knowledge_dir_for_session(session_id)
+
         return Deps(
             config=self._config,
             data_dir=self._data_dir,
-            knowledge_dir=self._knowledge_dir,
+            knowledge_dir=knowledge_dir,
             session_state=active.state,
             security=active.security,
             sentinel=active.sentinel,
-            git_store=self._git_store,
-            skill_catalog=self._skill_catalog,
+            git_store=self._git_store_for_session(session_id),
+            skill_catalog=self._skill_catalog_for_session(session_id),
             agent_model=agent_model,
             agent_model_id=agent_model_id,
             tool_call_callback=tool_call_callback,

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -554,6 +554,7 @@ class SessionEngine(
             msg = "Agent is busy — cancel first"
             raise RuntimeError(msg)
 
+        source_meta = self._session_mgr.load_meta(session_id)
         source_state = active.state.model_copy(deep=True)
         events = self._truncate_incomplete_events(self._session_mgr.load_events(session_id))
         turns = self._completed_event_turns(events)
@@ -597,6 +598,7 @@ class SessionEngine(
         )
 
         self._session_mgr.save_state(forked_state)
+        self._session_mgr.save_meta(forked_session_id, source_meta.model_copy(deep=True))
         self._session_mgr.save_events(forked_session_id, forked_events)
         self._session_mgr.save_history(forked_session_id, forked_history)
         self._session_mgr.clear_llm_request_state(forked_session_id)

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -29,7 +29,7 @@ from ..agent.deps import Deps
 from ..agent.loop import run_agent_turn as _run_agent_turn
 from ..credentials import SessionCredentialRegistry
 from ..git.store import GitStore
-from ..knowledge import KnowledgeRepoHandle
+from ..knowledge import KnowledgeRepoHandle, KnowledgeRepoResolver
 from ..models.config import Config
 from ..models.credentials import CredentialRegistryProtocol
 from ..models.session import SessionAttributes, SessionState
@@ -112,23 +112,17 @@ class SessionEngine(
         *,
         config: Config,
         data_dir: Path,
-        knowledge_dir: Path,
-        git_store: GitStore,
         session_mgr: SessionManager,
-        skill_catalog: list[SkillInfo],
         agent_model: Model | None,
         sandbox_mgr: SandboxManager,
         credential_registry_for_session: Callable[[str], Awaitable[CredentialRegistryProtocol]],
-        knowledge_repo_for_session: Callable[[str], KnowledgeRepoHandle] | None = None,
+        knowledge_repo_for_session: KnowledgeRepoResolver,
         model_factory: Callable[[str], Model] | None = None,
         notification_router: NotificationRouter | None = None,
     ) -> None:
         self._config = config
         self._data_dir = data_dir
-        self._knowledge_dir = knowledge_dir
-        self._git_store = git_store
         self._session_mgr = session_mgr
-        self._skill_catalog = skill_catalog
         self._agent_model = agent_model
         self._sandbox_mgr = sandbox_mgr
         self._model_factory = model_factory
@@ -190,32 +184,20 @@ class SessionEngine(
     def data_dir(self) -> Path:
         return self._data_dir
 
-    @property
-    def skill_catalog(self) -> list[SkillInfo]:
-        return self._skill_catalog
-
-    def _repo_handle_for_session(self, session_id: str) -> KnowledgeRepoHandle | None:
-        if self._knowledge_repo_for_session is None:
-            return None
+    def _repo_handle_for_session(self, session_id: str) -> KnowledgeRepoHandle:
         return self._knowledge_repo_for_session(session_id)
 
     def _knowledge_dir_for_session(self, session_id: str) -> Path:
-        handle = self._repo_handle_for_session(session_id)
-        return handle.knowledge_dir if handle is not None else self._knowledge_dir
+        return self._repo_handle_for_session(session_id).knowledge_dir
 
     def _git_store_for_session(self, session_id: str) -> GitStore:
-        handle = self._repo_handle_for_session(session_id)
-        return handle.git_store if handle is not None else self._git_store
+        return self._repo_handle_for_session(session_id).git_store
 
     def _skill_registry_for_session(self, session_id: str) -> SkillRegistry:
-        handle = self._repo_handle_for_session(session_id)
-        return handle.skill_registry if handle is not None else SkillRegistry(self._knowledge_dir / "skills")
+        return self._repo_handle_for_session(session_id).skill_registry
 
     def _skill_catalog_for_session(self, session_id: str) -> list[SkillInfo]:
-        handle = self._repo_handle_for_session(session_id)
-        if handle is not None:
-            return handle.skill_registry.scan()
-        return self._skill_catalog
+        return self._repo_handle_for_session(session_id).skill_registry.scan()
 
     @property
     def sandbox_mgr(self) -> SandboxManager:

--- a/src/carapace/skills.py
+++ b/src/carapace/skills.py
@@ -22,6 +22,9 @@ class SkillRegistry:
         self.skills_dir = skills_dir
         self._catalog: list[SkillInfo] | None = None
 
+    def invalidate(self) -> None:
+        self._catalog = None
+
     def scan(self) -> list[SkillInfo]:
         """Scan skills/ directory and load frontmatter only (progressive disclosure)."""
         if self._catalog is not None:

--- a/tests/session_helpers.py
+++ b/tests/session_helpers.py
@@ -190,23 +190,31 @@ def _make_engine(
     config = load_config(tmp_path)
     session_mgr = SessionManager(tmp_path)
     registry = SkillRegistry(tmp_path / "skills")
-    skill_catalog = registry.scan()
     sandbox_mgr = MagicMock(spec=SandboxManager)
     sandbox_mgr.refresh_sandbox_snapshot = AsyncMock()
     sandbox_mgr.reset_session = AsyncMock()
     sandbox_mgr.get_domain_info.return_value = []
     registry_for_session = credential_registry or CredentialRegistry()
+    git_store = MagicMock(spec=GitStore)
 
     async def credential_registry_for_session(_session_id: str) -> CredentialRegistryProtocol:
         return registry_for_session
 
+    if knowledge_repo_for_session is None:
+        handle = KnowledgeRepoHandle(
+            owner="thies",
+            knowledge_dir=tmp_path,
+            git_store=git_store,
+            skill_registry=registry,
+        )
+
+        def knowledge_repo_for_session(_session_id: str) -> KnowledgeRepoHandle:
+            return handle
+
     return SessionEngine(
         config=config,
         data_dir=tmp_path,
-        knowledge_dir=tmp_path,
-        git_store=MagicMock(spec=GitStore),
         session_mgr=session_mgr,
-        skill_catalog=skill_catalog,
         agent_model=None,
         sandbox_mgr=sandbox_mgr,
         credential_registry_for_session=credential_registry_for_session,

--- a/tests/session_helpers.py
+++ b/tests/session_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -12,6 +13,7 @@ from carapace.bootstrap import ensure_data_dir
 from carapace.config import load_config
 from carapace.credentials import CredentialRegistry
 from carapace.git.store import GitStore
+from carapace.knowledge import KnowledgeRepoHandle
 from carapace.models.credentials import CredentialRegistryProtocol
 from carapace.models.tooling import ToolResult
 from carapace.sandbox.manager import SandboxManager
@@ -179,7 +181,11 @@ def _sentinel_set_model_mock(active: ActiveSession) -> MagicMock:
     return cast(MagicMock, cast(Any, active.sentinel.set_model))
 
 
-def _make_engine(tmp_path: Path, credential_registry: CredentialRegistryProtocol | None = None) -> SessionEngine:
+def _make_engine(
+    tmp_path: Path,
+    credential_registry: CredentialRegistryProtocol | None = None,
+    knowledge_repo_for_session: Callable[[str], KnowledgeRepoHandle] | None = None,
+) -> SessionEngine:
     ensure_data_dir(tmp_path)
     config = load_config(tmp_path)
     session_mgr = SessionManager(tmp_path)
@@ -204,5 +210,6 @@ def _make_engine(tmp_path: Path, credential_registry: CredentialRegistryProtocol
         agent_model=None,
         sandbox_mgr=sandbox_mgr,
         credential_registry_for_session=credential_registry_for_session,
+        knowledge_repo_for_session=knowledge_repo_for_session,
         model_factory=lambda _name: TestModel(),
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,14 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from carapace.config import load_config, load_workspace_file, resolve_knowledge_repos_dir, resolve_user_knowledge_dir
+from carapace.config import (
+    _resolve_knowledge_dir,
+    load_config,
+    load_workspace_file,
+    resolve_knowledge_repos_dir,
+    resolve_user_knowledge_dir,
+)
+from carapace.models.config import Config
 
 
 def test_load_config_defaults(tmp_path: Path):
@@ -122,3 +129,10 @@ def test_resolve_user_knowledge_dir_uses_explicit_root(tmp_path: Path) -> None:
 def test_resolve_user_knowledge_dir_rejects_noncanonical_username(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="username must be lowercase"):
         resolve_user_knowledge_dir(tmp_path, "Thies")
+
+
+def test_resolve_knowledge_dir_uses_knowledges_when_config_value_is_empty(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config = Config(knowledge_dir="")
+
+    assert _resolve_knowledge_dir(config_path, config) == (tmp_path / "knowledges").resolve()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from carapace.config import load_config, load_workspace_file
+from carapace.config import load_config, load_workspace_file, resolve_knowledge_repos_dir, resolve_user_knowledge_dir
 
 
 def test_load_config_defaults(tmp_path: Path):
@@ -98,3 +98,16 @@ def test_load_workspace_file(tmp_path: Path):
     (tmp_path / "SECURITY.md").write_text("# Test Policy\nBe safe.")
     result = load_workspace_file(tmp_path, "SECURITY.md")
     assert "Test Policy" in result
+
+
+def test_resolve_knowledge_repos_dir_uses_knowledges_under_data_dir(tmp_path: Path) -> None:
+    assert resolve_knowledge_repos_dir(tmp_path) == (tmp_path / "knowledges").resolve()
+
+
+def test_resolve_user_knowledge_dir_uses_normalized_username(tmp_path: Path) -> None:
+    assert resolve_user_knowledge_dir(tmp_path, "thies") == (tmp_path / "knowledges" / "thies").resolve()
+
+
+def test_resolve_user_knowledge_dir_rejects_noncanonical_username(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="username must be lowercase"):
+        resolve_user_knowledge_dir(tmp_path, "Thies")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,7 @@ def test_load_config_defaults(tmp_path: Path):
     assert cfg.sessions.commit.autosave_inactivity_hours == 4
     assert cfg.sandbox.k8s_session_pvc_size == "1Gi"
     assert cfg.sandbox.k8s_session_pvc_storage_class == ""
+    assert cfg.knowledge_dir == "./knowledges"
 
 
 def test_load_config_creates_missing_file(tmp_path: Path):
@@ -104,8 +105,18 @@ def test_resolve_knowledge_repos_dir_uses_knowledges_under_data_dir(tmp_path: Pa
     assert resolve_knowledge_repos_dir(tmp_path) == (tmp_path / "knowledges").resolve()
 
 
+def test_resolve_knowledge_repos_dir_uses_explicit_root(tmp_path: Path) -> None:
+    explicit = tmp_path / "legacy-knowledge"
+    assert resolve_knowledge_repos_dir(tmp_path, explicit) == explicit.resolve()
+
+
 def test_resolve_user_knowledge_dir_uses_normalized_username(tmp_path: Path) -> None:
     assert resolve_user_knowledge_dir(tmp_path, "thies") == (tmp_path / "knowledges" / "thies").resolve()
+
+
+def test_resolve_user_knowledge_dir_uses_explicit_root(tmp_path: Path) -> None:
+    explicit = tmp_path / "legacy-knowledge"
+    assert resolve_user_knowledge_dir(tmp_path, "thies", knowledge_repos_dir=explicit) == (explicit / "thies").resolve()
 
 
 def test_resolve_user_knowledge_dir_rejects_noncanonical_username(tmp_path: Path) -> None:

--- a/tests/test_context_grants.py
+++ b/tests/test_context_grants.py
@@ -8,6 +8,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from carapace.git.store import GitStore
+from carapace.knowledge import KnowledgeRepoHandle
 from carapace.models.session import SessionState
 from carapace.models.skills import ContextGrant, SkillCredentialDecl, context_grants_session_summary
 from carapace.sandbox.manager import SandboxManager
@@ -16,7 +18,38 @@ from carapace.sandbox.session_lifecycle import SessionContainer
 from carapace.sandbox.state import load_sandbox_snapshot
 from carapace.security.context import ApprovalSource, ContextGrantEntry, CredentialAccessEntry, SessionSecurity
 from carapace.security.sentinel import _format_entry
+from carapace.skills import SkillRegistry
 from tests.runtime_mocks import make_runtime_mock
+
+
+def _sandbox_manager(
+    *,
+    runtime,
+    data_dir: Path,
+    knowledge_dir: Path | None = None,
+    knowledge_repo_for_session=None,
+    **kwargs,
+) -> SandboxManager:
+    if knowledge_repo_for_session is None:
+        if knowledge_dir is None:
+            raise TypeError("knowledge_dir or knowledge_repo_for_session is required in tests")
+        handle = KnowledgeRepoHandle(
+            owner="thies",
+            knowledge_dir=knowledge_dir,
+            git_store=GitStore(knowledge_dir),
+            skill_registry=SkillRegistry(knowledge_dir / "skills"),
+        )
+
+        def knowledge_repo_for_session(_session_id: str) -> KnowledgeRepoHandle:
+            return handle
+
+    return SandboxManager(
+        runtime=runtime,
+        data_dir=data_dir,
+        knowledge_repo_for_session=knowledge_repo_for_session,
+        **kwargs,
+    )
+
 
 # ── ContextGrant model ──────────────────────────────────────────────
 
@@ -157,7 +190,7 @@ class TestSessionStateContextGrants:
 class TestSandboxManagerCredentialCache:
     def _make_manager(self, tmp_path: Path) -> SandboxManager:
         runtime = make_runtime_mock()
-        return SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+        return _sandbox_manager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
 
     def test_cache_and_retrieve(self, tmp_path: Path):
         mgr = self._make_manager(tmp_path)
@@ -179,7 +212,7 @@ class TestSandboxManagerCredentialCache:
     async def test_credential_cache_cleared_on_destroy_session(self, tmp_path: Path):
         runtime = make_runtime_mock()
         runtime.destroy_sandbox = AsyncMock()
-        mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+        mgr = _sandbox_manager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
         mgr.cache_credential("sess-1", "dev/token", "secret-value")
         mgr._sessions["sess-1"] = MagicMock(container_id="c1", session_env={})
         await mgr.destroy_session("sess-1")
@@ -195,7 +228,7 @@ class TestSandboxManagerCredentialCache:
                 shutil.rmtree(workspace)
 
         runtime.destroy_sandbox = AsyncMock(side_effect=destroy_sandbox)
-        mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+        mgr = _sandbox_manager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
         token = mgr._session_lifecycle.get_or_create_token("sess-1")
         mgr._sessions["sess-1"] = MagicMock(container_id="c1", session_env={})
         workspace.mkdir(parents=True)
@@ -210,7 +243,7 @@ class TestSandboxManagerCredentialCache:
     @pytest.mark.anyio
     async def test_cleanup_session_continues_when_snapshot_refresh_fails(self, tmp_path: Path):
         runtime = make_runtime_mock()
-        mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+        mgr = _sandbox_manager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
         mgr._sessions["sess-1"] = MagicMock(container_id="c1", session_env={})
         mgr.refresh_sandbox_snapshot = AsyncMock(side_effect=[RuntimeError("before"), RuntimeError("after")])
 
@@ -295,7 +328,7 @@ class TestSandboxManagerCredentialCache:
         runtime = make_runtime_mock()
         runtime.is_running = AsyncMock(return_value=False)
         runtime.logs = AsyncMock(return_value="carapace sandbox ready")
-        mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+        mgr = _sandbox_manager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
         mgr._sessions["sess-1"] = SessionContainer(
             container_id="container-1",
             session_id="sess-1",
@@ -316,7 +349,7 @@ class TestSandboxManagerCredentialCache:
 class TestSandboxManagerContextTracking:
     def _make_manager(self, tmp_path: Path) -> SandboxManager:
         runtime = make_runtime_mock()
-        return SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+        return _sandbox_manager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
 
     def test_no_contexts_by_default(self, tmp_path: Path):
         mgr = self._make_manager(tmp_path)
@@ -378,7 +411,7 @@ class TestApprovalSource:
 class TestExecNotificationDedupe:
     def _make_manager(self, tmp_path: Path) -> SandboxManager:
         runtime = make_runtime_mock()
-        return SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+        return _sandbox_manager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
 
     # -- domain dedupe --
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -442,3 +442,22 @@ class TestGitHttpHandlerHandle:
             body=b"",
         )
         assert status == 403
+
+    async def test_cross_user_repo_path_returns_403(self):
+        h = GitHttpHandler(
+            knowledge_dir=Path("/tmp/legacy-knowledge"),
+            knowledge_root=Path("/tmp/knowledges"),
+            default_branch="main",
+            owner_for_session=lambda session_id: "thies" if session_id == "sess-1" else "ada",
+        )
+
+        status, _headers, _body = await h.handle(
+            session_id="sess-1",
+            method="GET",
+            path="/git/ada/info/refs",
+            query_string="service=git-upload-pack",
+            content_type=None,
+            body=b"",
+        )
+
+        assert status == 403

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -286,7 +286,8 @@ class TestGitHttpHandlerCgiConversion:
 
     def _handler(self) -> GitHttpHandler:
         return GitHttpHandler(
-            knowledge_dir=Path("/tmp/knowledge"),
+            knowledge_root=Path("/tmp"),
+            owner_for_session=lambda _session_id: "knowledge",
             default_branch="main",
         )
 
@@ -342,7 +343,8 @@ class TestGitHttpHandlerAuth:
 
     def test_authenticate_success(self):
         h = GitHttpHandler(
-            knowledge_dir=Path("/tmp/knowledge"),
+            knowledge_root=Path("/tmp"),
+            owner_for_session=lambda _session_id: "knowledge",
             default_branch="main",
             verify_session_token=lambda sid, tok: sid == "sess-1" and tok == "my-token",
         )
@@ -351,7 +353,8 @@ class TestGitHttpHandlerAuth:
 
     def test_authenticate_invalid_token(self):
         h = GitHttpHandler(
-            knowledge_dir=Path("/tmp/knowledge"),
+            knowledge_root=Path("/tmp"),
+            owner_for_session=lambda _session_id: "knowledge",
             default_branch="main",
             verify_session_token=lambda sid, tok: False,
         )
@@ -360,7 +363,8 @@ class TestGitHttpHandlerAuth:
 
     def test_authenticate_wrong_session(self):
         h = GitHttpHandler(
-            knowledge_dir=Path("/tmp/knowledge"),
+            knowledge_root=Path("/tmp"),
+            owner_for_session=lambda _session_id: "knowledge",
             default_branch="main",
             verify_session_token=lambda sid, tok: sid == "sess-1" and tok == "tok",
         )
@@ -369,7 +373,8 @@ class TestGitHttpHandlerAuth:
 
     def test_authenticate_no_header(self):
         h = GitHttpHandler(
-            knowledge_dir=Path("/tmp/knowledge"),
+            knowledge_root=Path("/tmp"),
+            owner_for_session=lambda _session_id: "knowledge",
             default_branch="main",
             verify_session_token=lambda sid, tok: True,
         )
@@ -385,7 +390,8 @@ class TestGitHttpHandlerHandle:
 
     def _handler(self) -> GitHttpHandler:
         return GitHttpHandler(
-            knowledge_dir=Path("/tmp/knowledge"),
+            knowledge_root=Path("/tmp"),
+            owner_for_session=lambda _session_id: "knowledge",
             default_branch="main",
         )
 
@@ -445,10 +451,9 @@ class TestGitHttpHandlerHandle:
 
     async def test_cross_user_repo_path_returns_403(self):
         h = GitHttpHandler(
-            knowledge_dir=Path("/tmp/legacy-knowledge"),
             knowledge_root=Path("/tmp/knowledges"),
-            default_branch="main",
             owner_for_session=lambda session_id: "thies" if session_id == "sess-1" else "ada",
+            default_branch="main",
         )
 
         status, _headers, _body = await h.handle(

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -16,7 +16,17 @@ def test_import_agent_deps():
 
 
 def test_import_config():
-    from carapace.config import get_data_dir, load_config, load_workspace_file  # noqa: F401
+    from carapace.config import (  # noqa: F401
+        get_data_dir,
+        load_config,
+        load_workspace_file,
+        resolve_knowledge_repos_dir,
+        resolve_user_knowledge_dir,
+    )
+
+
+def test_import_knowledge():
+    from carapace.knowledge import KnowledgeRepoHandle, KnowledgeRepoRegistry  # noqa: F401
 
 
 def test_import_session():

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from carapace.knowledge import KnowledgeRepoRegistry
+from carapace.skills import SkillRegistry
+
+
+def test_knowledge_repo_registry_returns_handle_for_normalized_owner(tmp_path: Path) -> None:
+    registry = KnowledgeRepoRegistry(tmp_path)
+
+    handle = registry.get_for_user("thies")
+
+    assert handle.owner == "thies"
+    assert handle.knowledge_dir == (tmp_path / "knowledges" / "thies").resolve()
+    assert handle.git_store.repo_dir == handle.knowledge_dir
+    assert isinstance(handle.skill_registry, SkillRegistry)
+    assert handle.skill_registry.skills_dir == handle.knowledge_dir / "skills"
+
+
+def test_knowledge_repo_registry_caches_handles_per_owner(tmp_path: Path) -> None:
+    registry = KnowledgeRepoRegistry(tmp_path)
+
+    first = registry.get_for_user("thies")
+    second = registry.get_for_user("thies")
+
+    assert second is first
+
+
+def test_knowledge_repo_registry_ensures_user_repo_directory(tmp_path: Path) -> None:
+    registry = KnowledgeRepoRegistry(tmp_path)
+
+    handle = registry.ensure_user_repo("thies")
+
+    assert handle.knowledge_dir.is_dir()
+
+
+def test_knowledge_repo_registry_resolves_session_owner(tmp_path: Path) -> None:
+    registry = KnowledgeRepoRegistry(tmp_path)
+
+    handle = registry.get_for_session("sess-123", lambda session_id: "ada" if session_id == "sess-123" else "thies")
+
+    assert handle.owner == "ada"
+    assert handle.knowledge_dir == (tmp_path / "knowledges" / "ada").resolve()
+
+
+def test_knowledge_repo_registry_rejects_noncanonical_owner(tmp_path: Path) -> None:
+    registry = KnowledgeRepoRegistry(tmp_path)
+
+    with pytest.raises(ValueError, match="username must be lowercase"):
+        registry.get_for_user("Thies")

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -46,6 +46,16 @@ def test_knowledge_repo_registry_resolves_session_owner(tmp_path: Path) -> None:
     assert handle.knowledge_dir == (tmp_path / "knowledges" / "ada").resolve()
 
 
+def test_knowledge_repo_registry_uses_explicit_repos_dir(tmp_path: Path) -> None:
+    repos_dir = tmp_path / "legacy-knowledge"
+    registry = KnowledgeRepoRegistry(tmp_path, knowledge_repos_dir=repos_dir)
+
+    handle = registry.get_for_user("thies")
+
+    assert registry.knowledge_repos_dir == repos_dir.resolve()
+    assert handle.knowledge_dir == (repos_dir / "thies").resolve()
+
+
 def test_knowledge_repo_registry_rejects_noncanonical_owner(tmp_path: Path) -> None:
     registry = KnowledgeRepoRegistry(tmp_path)
 

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -85,7 +85,6 @@ def _make_channel(tmp_path: Path, *, owner_user: str = "thies", **config_kwargs:
         config=_make_config(**config_kwargs),
         full_config=full_config,
         session_mgr=session_mgr,
-        skill_catalog=[],
         agent_model=None,
         sandbox_mgr=sandbox_mgr,
         engine=_make_engine_mock(),
@@ -148,7 +147,7 @@ def test_matrix_session_created_with_token_owner(tmp_path: Path):
                         access_token="tok_good",
                         device_id="DEV1",
                         user_id="@carapace:example.com",
-                        user="Thies",
+                        user="thies",
                     )
                 ]
             ).model_dump(mode="json", exclude_none=True)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -45,20 +45,19 @@ def test_config_defaults():
     assert ids == {"anthropic:claude-sonnet-4-6", "anthropic:claude-haiku-4-5"}
 
 
-def test_notification_subscription_normalizes_user() -> None:
-    subscription = NotificationSubscription.model_validate(
-        {
-            "id": "sub-1",
-            "user": " Thies ",
-            "endpoint": "https://push.example.test/sub-1",
-            "p256dh": "key",
-            "auth": "auth",
-            "subscribed_at": "2026-05-12T00:00:00Z",
-            "expires_at": "2026-06-12T00:00:00Z",
-        }
-    )
-
-    assert subscription.user == "thies"
+def test_notification_subscription_rejects_non_normalized_user() -> None:
+    with pytest.raises(ValidationError, match="username must not contain leading or trailing whitespace"):
+        NotificationSubscription.model_validate(
+            {
+                "id": "sub-1",
+                "user": " Thies ",
+                "endpoint": "https://push.example.test/sub-1",
+                "p256dh": "key",
+                "auth": "auth",
+                "subscribed_at": "2026-05-12T00:00:00Z",
+                "expires_at": "2026-06-12T00:00:00Z",
+            }
+        )
 
 
 def test_notifications_config_allows_missing_vapid_fields() -> None:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -13,7 +13,8 @@ from carapace.git.store import GitStore
 from carapace.knowledge import KnowledgeRepoHandle
 from carapace.models.skills import SkillCarapaceConfig
 from carapace.sandbox.exec_flow import SandboxExecCoordinator, SandboxExecState
-from carapace.sandbox.manager import _CONTEXT_TUNNEL_HELPER, SandboxManager
+from carapace.sandbox.manager import _CONTEXT_TUNNEL_HELPER
+from carapace.sandbox.manager import SandboxManager as _SandboxManager
 from carapace.sandbox.proxy import ProxyServer, domain_matches
 from carapace.sandbox.runtime import (
     ContainerGoneError,
@@ -26,6 +27,36 @@ from carapace.sandbox.session_lifecycle import SessionContainer
 from carapace.sandbox.skill_activation import SKILL_ACTIVATION_PROVIDERS, SkillActivationRunner
 from carapace.skills import SkillRegistry
 from tests.runtime_mocks import make_runtime_mock
+
+
+def _sandbox_manager(
+    *,
+    runtime: Any,
+    data_dir: Path,
+    knowledge_dir: Path | None = None,
+    knowledge_repo_for_session=None,
+    **kwargs: Any,
+) -> _SandboxManager:
+    if knowledge_repo_for_session is None:
+        if knowledge_dir is None:
+            raise TypeError("knowledge_dir or knowledge_repo_for_session is required in tests")
+        handle = KnowledgeRepoHandle(
+            owner="thies",
+            knowledge_dir=knowledge_dir,
+            git_store=GitStore(knowledge_dir),
+            skill_registry=SkillRegistry(knowledge_dir / "skills"),
+        )
+
+        def knowledge_repo_for_session(_session_id: str) -> KnowledgeRepoHandle:
+            return handle
+
+    return _SandboxManager(
+        runtime=runtime,
+        data_dir=data_dir,
+        knowledge_repo_for_session=knowledge_repo_for_session,
+        **kwargs,
+    )
+
 
 # ── domain_matches ──────────────────────────────────────────────────
 
@@ -208,7 +239,7 @@ async def test_handle_http_supports_absolute_https_urls(monkeypatch: pytest.Monk
 class TestSandboxManagerAllowlists:
     def _make_manager(self, tmp_path: Path):
         runtime = make_runtime_mock()
-        return SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+        return _sandbox_manager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
 
     def test_empty_by_default(self, tmp_path: Path):
         mgr = self._make_manager(tmp_path)
@@ -246,7 +277,7 @@ class TestSandboxManagerAllowlists:
 
     def test_proxy_env_uses_owner_repo_name(self, tmp_path: Path):
         runtime = make_runtime_mock()
-        mgr = SandboxManager(
+        mgr = _sandbox_manager(
             runtime=runtime,
             data_dir=tmp_path,
             knowledge_dir=tmp_path,
@@ -332,7 +363,7 @@ async def test_exec_recreate_preserves_domains(tmp_path: Path):
         ]
     )
 
-    mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+    mgr = _sandbox_manager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
     session_id = "sess-1"
     await mgr.ensure_session(session_id)
     mgr.allow_domains(session_id, {"api.example.com"})
@@ -372,7 +403,7 @@ async def test_exec_recreate_reinjects_credential_files(tmp_path: Path):
     (skill_dir / "SKILL.md").write_text("---\nname: moneydb\n---\nBody.\n")
     (skill_dir / "setup.sh").write_text("#!/bin/sh\n")
 
-    mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+    mgr = _sandbox_manager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
     session_id = "sess-1"
 
     # Register callbacks — the activated-skills callback returns "moneydb",
@@ -429,7 +460,7 @@ async def test_activate_skill_runs_setup_provider_with_activation_inputs(tmp_pat
     (skill_dir / "SKILL.md").write_text("---\nname: cred-setup\n---\nBody.\n")
     (skill_dir / "setup.sh").write_text("#!/bin/sh\n")
 
-    mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+    mgr = _sandbox_manager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
     mgr.set_skill_activation_inputs_callback(
         AsyncMock(
             return_value=SkillActivationInputs(
@@ -474,7 +505,7 @@ async def test_activate_skill_recovers_if_trusted_restore_hits_gone_container(tm
     (skill_dir / "SKILL.md").write_text("---\nname: restore-retry\n---\nBody.\n")
     (skill_dir / "setup.sh").write_text("#!/bin/sh\n")
 
-    mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+    mgr = _sandbox_manager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
 
     result = await mgr.activate_skill("sess-1", "restore-retry")
     assert "setup.sh completed." in result
@@ -500,7 +531,7 @@ async def test_activate_skill_prefers_pnpm_when_package_and_pnpm_lockfiles_exist
     (skill_dir / "package-lock.json").write_text("{}\n")
     (skill_dir / "pnpm-lock.yaml").write_text("lockfileVersion: '9.0'\n")
 
-    mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+    mgr = _sandbox_manager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
 
     result = await mgr.activate_skill("sess-1", "multi-node-lock")
     commands = [call.args[1] for call in runtime.exec.call_args_list]
@@ -535,7 +566,7 @@ async def test_activate_skill_registers_command_aliases_in_image_shim_dir(tmp_pa
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text("---\nname: web\n---\nBody.\n")
 
-    mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+    mgr = _sandbox_manager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
     mgr.set_skill_command_aliases_callback(
         lambda _session_id, skill_name: (
             [("web", "uv run --directory /workspace/skills/web web-search")] if skill_name == "web" else []
@@ -868,7 +899,7 @@ async def test_exec_command_sets_up_and_cleans_up_tunnels(tmp_path: Path):
     runtime.logs = AsyncMock(return_value="carapace sandbox ready")
     runtime.exec = AsyncMock(return_value=ExecResult(exit_code=0, output="ok"))
 
-    mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+    mgr = _sandbox_manager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
 
     result = await mgr.exec_command(
         "sess-1",
@@ -901,7 +932,7 @@ async def test_exec_command_rejects_conflicting_tunnel_local_ports(tmp_path: Pat
     runtime.logs = AsyncMock(return_value="carapace sandbox ready")
     runtime.exec = AsyncMock(return_value=ExecResult(exit_code=0, output="ok"))
 
-    mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+    mgr = _sandbox_manager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
 
     with pytest.raises(ValueError, match=r"Conflicting network\.tunnels declarations"):
         await mgr.exec_command(
@@ -923,7 +954,7 @@ async def test_exec_command_allows_duplicate_tunnel_with_different_descriptions(
     runtime.logs = AsyncMock(return_value="carapace sandbox ready")
     runtime.exec = AsyncMock(return_value=ExecResult(exit_code=0, output="ok"))
 
-    mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+    mgr = _sandbox_manager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
 
     result = await mgr.exec_command(
         "sess-1",
@@ -978,7 +1009,7 @@ async def test_exec_command_recreates_tunnels_before_retry(tmp_path: Path):
         ]
     )
 
-    mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+    mgr = _sandbox_manager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
 
     result = await mgr.exec_command(
         "sess-1",
@@ -1013,7 +1044,7 @@ async def test_exec_command_cleans_up_tunnels_after_command_failure(tmp_path: Pa
         ]
     )
 
-    mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
+    mgr = _sandbox_manager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
 
     result = await mgr.exec_command(
         "sess-1",

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -293,6 +293,38 @@ class TestSandboxManagerAllowlists:
 
         assert env["GIT_REPO_URL"].endswith("/git/ada")
 
+    def test_proxy_env_keeps_two_session_repos_isolated(self, tmp_path: Path):
+        runtime = make_runtime_mock()
+        handles = {
+            "sess-thies": KnowledgeRepoHandle(
+                owner="thies",
+                knowledge_dir=tmp_path / "knowledges" / "thies",
+                git_store=GitStore(tmp_path / "knowledges" / "thies"),
+                skill_registry=SkillRegistry(tmp_path / "knowledges" / "thies" / "skills"),
+            ),
+            "sess-ada": KnowledgeRepoHandle(
+                owner="ada",
+                knowledge_dir=tmp_path / "knowledges" / "ada",
+                git_store=GitStore(tmp_path / "knowledges" / "ada"),
+                skill_registry=SkillRegistry(tmp_path / "knowledges" / "ada" / "skills"),
+            ),
+        }
+
+        def knowledge_repo_for_session(session_id: str) -> KnowledgeRepoHandle:
+            return handles[session_id]
+
+        mgr = _sandbox_manager(
+            runtime=runtime,
+            data_dir=tmp_path,
+            knowledge_repo_for_session=knowledge_repo_for_session,
+        )
+
+        thies_env = mgr._build_proxy_env("sess-thies", "tok-a", "http://172.18.0.2:3128")
+        ada_env = mgr._build_proxy_env("sess-ada", "tok-b", "http://172.18.0.2:3128")
+
+        assert thies_env["GIT_REPO_URL"].endswith("/git/thies")
+        assert ada_env["GIT_REPO_URL"].endswith("/git/ada")
+
     def test_proxy_env_no_git_identity_vars(self, tmp_path: Path):
         """Git identity is configured via git config inside the container, not env vars."""
         mgr = self._make_manager(tmp_path)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -9,6 +9,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from carapace.git.store import GitStore
+from carapace.knowledge import KnowledgeRepoHandle
 from carapace.models.skills import SkillCarapaceConfig
 from carapace.sandbox.exec_flow import SandboxExecCoordinator, SandboxExecState
 from carapace.sandbox.manager import _CONTEXT_TUNNEL_HELPER, SandboxManager
@@ -241,6 +243,24 @@ class TestSandboxManagerAllowlists:
         mgr = self._make_manager(tmp_path)
         env = mgr._build_proxy_env("sess-1", "tok", "http://172.18.0.2:3128")
         assert env["CARAPACE_SESSION_ID"] == "sess-1"
+
+    def test_proxy_env_uses_owner_repo_name(self, tmp_path: Path):
+        runtime = make_runtime_mock()
+        mgr = SandboxManager(
+            runtime=runtime,
+            data_dir=tmp_path,
+            knowledge_dir=tmp_path,
+            knowledge_repo_for_session=lambda _session_id: KnowledgeRepoHandle(
+                owner="ada",
+                knowledge_dir=tmp_path / "knowledges" / "ada",
+                git_store=GitStore(tmp_path / "knowledges" / "ada"),
+                skill_registry=SkillRegistry(tmp_path / "knowledges" / "ada" / "skills"),
+            ),
+        )
+
+        env = mgr._build_proxy_env("sess-1", "tok", "http://172.18.0.2:3128")
+
+        assert env["GIT_REPO_URL"].endswith("/git/ada")
 
     def test_proxy_env_no_git_identity_vars(self, tmp_path: Path):
         """Git identity is configured via git config inside the container, not env vars."""
@@ -517,7 +537,7 @@ async def test_activate_skill_registers_command_aliases_in_image_shim_dir(tmp_pa
 
     mgr = SandboxManager(runtime=runtime, data_dir=tmp_path, knowledge_dir=tmp_path)
     mgr.set_skill_command_aliases_callback(
-        lambda skill_name: (
+        lambda _session_id, skill_name: (
             [("web", "uv run --directory /workspace/skills/web web-search")] if skill_name == "web" else []
         )
     )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -412,6 +412,7 @@ def test_admin_user_create_returns_http_error_when_git_bootstrap_fails(client, a
 
     assert resp.status_code == 500
     assert resp.json()["detail"] == "Git settings reload failed: pull failed"
+    assert srv._auth_store.get_user("ada") is None
     git_store = srv._knowledge_repo_registry.get_for_user("ada").git_store
     git_store.commit.assert_not_awaited()
 
@@ -422,7 +423,20 @@ def test_admin_user_config_patch_does_not_reload_git_when_git_config_is_unchange
     runtime = MagicMock()
     runtime.apply_user_config = AsyncMock()
     monkeypatch.setattr(srv, "_knowledge_git_runtime", runtime, raising=False)
-    srv._auth_store.create_user(username="ada", password="correct-horse-battery", display_name="Ada")
+    srv._auth_store.create_user(
+        username="ada",
+        password="correct-horse-battery",
+        display_name="Ada",
+        config=UserConfig.model_validate(
+            {
+                "git": {
+                    "remote": "https://gitea.example.test/ada/knowledge.git",
+                    "branch": "main",
+                    "token": "secret-token",
+                }
+            }
+        ),
+    )
 
     resp = client.patch(
         "/api/admin/users/ada",
@@ -432,13 +446,30 @@ def test_admin_user_config_patch_does_not_reload_git_when_git_config_is_unchange
 
     assert resp.status_code == 200
     runtime.apply_user_config.assert_not_awaited()
+    user = srv._auth_store.get_user("ada")
+    assert user is not None
+    assert user.config.git.remote == "https://gitea.example.test/ada/knowledge.git"
+    assert user.config.git.token == "secret-token"
 
 
 def test_admin_user_git_config_patch_reloads_git_runtime(client, admin_auth_headers, monkeypatch):
     runtime = MagicMock()
     runtime.apply_user_config = AsyncMock()
     monkeypatch.setattr(srv, "_knowledge_git_runtime", runtime, raising=False)
-    srv._auth_store.create_user(username="ada", password="correct-horse-battery", display_name="Ada")
+    srv._auth_store.create_user(
+        username="ada",
+        password="correct-horse-battery",
+        display_name="Ada",
+        config=UserConfig.model_validate(
+            {
+                "git": {
+                    "remote": "https://gitea.example.test/ada/knowledge.git",
+                    "branch": "main",
+                    "token": "secret-token",
+                }
+            }
+        ),
+    )
 
     resp = client.patch(
         "/api/admin/users/ada",
@@ -450,6 +481,41 @@ def test_admin_user_git_config_patch_reloads_git_runtime(client, admin_auth_head
     runtime.apply_user_config.assert_awaited_once()
     assert runtime.apply_user_config.await_args.args[0] == "ada"
     assert runtime.apply_user_config.await_args.args[1].branch == "prod"
+    assert runtime.apply_user_config.await_args.args[1].token == "secret-token"
+
+
+def test_admin_user_git_config_patch_rolls_back_when_bootstrap_fails(client, admin_auth_headers, monkeypatch):
+    runtime = MagicMock()
+    runtime.apply_user_config = AsyncMock(side_effect=RuntimeError("pull failed"))
+    monkeypatch.setattr(srv, "_knowledge_git_runtime", runtime, raising=False)
+    srv._auth_store.create_user(
+        username="ada",
+        password="correct-horse-battery",
+        display_name="Ada",
+        config=UserConfig.model_validate(
+            {
+                "git": {
+                    "remote": "https://gitea.example.test/ada/knowledge.git",
+                    "branch": "main",
+                    "token": "secret-token",
+                }
+            }
+        ),
+    )
+
+    resp = client.patch(
+        "/api/admin/users/ada",
+        headers=admin_auth_headers,
+        json={"config": {"git": {"remote": "https://gitea.example.test/ada/new.git", "branch": "prod"}}},
+    )
+
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Git settings reload failed: pull failed"
+    user = srv._auth_store.get_user("ada")
+    assert user is not None
+    assert user.config.git.remote == "https://gitea.example.test/ada/knowledge.git"
+    assert user.config.git.branch == "main"
+    assert user.config.git.token == "secret-token"
 
 
 def test_admin_platform_settings_requires_admin_role(client, auth_headers, admin_auth_headers):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -198,6 +198,61 @@ def test_enabled_user_git_configs_skips_disabled_users(tmp_path) -> None:
     assert set(selected) == {"bob"}
 
 
+@pytest.mark.anyio
+async def test_bootstrap_user_knowledge_repo_pulls_remote_before_seeding(tmp_path, monkeypatch) -> None:
+    call_order: list[str] = []
+    git_store = MagicMock(spec=GitStore)
+    git_store.remote_branch = "main"
+    git_store.author_template = "carapace <carapace@%h>"
+    git_store.remote_configured = True
+
+    async def ensure_repo() -> None:
+        call_order.append("ensure_repo")
+
+    async def add_remote(_remote: str, _token: str | None) -> None:
+        call_order.append("add_remote")
+
+    async def pull_from_remote() -> str:
+        call_order.append("pull")
+        return "Already up to date."
+
+    async def commit(_paths, _message: str) -> bool:
+        call_order.append("commit")
+        return True
+
+    async def push_to_remote() -> None:
+        call_order.append("push")
+
+    git_store.ensure_repo = AsyncMock(side_effect=ensure_repo)
+    git_store.add_remote = AsyncMock(side_effect=add_remote)
+    git_store.pull_from_remote = AsyncMock(side_effect=pull_from_remote)
+    git_store.commit = AsyncMock(side_effect=commit)
+    git_store.push_to_remote = AsyncMock(side_effect=push_to_remote)
+    git_store.remove_remote = AsyncMock()
+
+    def ensure_knowledge_dir(_knowledge_dir):
+        call_order.append("seed")
+        return [tmp_path / "knowledges" / "thies" / "USER.md"]
+
+    monkeypatch.setattr(srv, "ensure_knowledge_dir", ensure_knowledge_dir)
+
+    registry = KnowledgeRepoRegistry(tmp_path, git_store_factory=lambda _path: git_store)
+    config = srv.KnowledgeGitConfig(
+        owner="thies",
+        remote="https://gitea.example.test/thies/knowledge.git",
+        branch="prod",
+        author="Thies <thies@example.test>",
+        token="secret-token",
+    )
+
+    await srv._bootstrap_user_knowledge_repo(registry, "thies", config)
+
+    assert call_order == ["ensure_repo", "add_remote", "pull", "seed", "commit", "push"]
+    assert git_store.remote_branch == "prod"
+    assert git_store.author_template == "Thies <thies@example.test>"
+    git_store.remove_remote.assert_not_awaited()
+
+
 @pytest.fixture()
 def auth_headers() -> dict[str, str]:
     return _headers_for_user("thies")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -340,6 +340,47 @@ def test_admin_user_management_requires_admin_role(client, auth_headers, admin_a
     assert login_resp.status_code == 200
 
 
+def test_admin_user_create_bootstraps_enabled_user_repo(client, admin_auth_headers, monkeypatch):
+    bootstrap = AsyncMock()
+    monkeypatch.setattr(srv, "_bootstrap_user_knowledge_repo", bootstrap, raising=False)
+
+    resp = client.post(
+        "/api/admin/users",
+        headers=admin_auth_headers,
+        json={
+            "username": "ada",
+            "password": "correct-horse-battery",
+            "display_name": "Ada",
+            "config": {"git": {"remote": "https://gitea.example.test/ada/knowledge.git", "branch": "prod"}},
+        },
+    )
+
+    assert resp.status_code == 201
+    bootstrap.assert_awaited_once()
+    assert bootstrap.await_args.args[0] is srv._knowledge_repo_registry
+    assert bootstrap.await_args.args[1] == "ada"
+    config = bootstrap.await_args.args[2]
+    assert config.owner == "ada"
+    assert config.remote == "https://gitea.example.test/ada/knowledge.git"
+    assert config.branch == "prod"
+
+
+def test_admin_user_enable_bootstraps_user_repo(client, admin_auth_headers, monkeypatch):
+    bootstrap = AsyncMock()
+    monkeypatch.setattr(srv, "_bootstrap_user_knowledge_repo", bootstrap, raising=False)
+    srv._auth_store.create_user(username="ada", password="correct-horse-battery", display_name="Ada")
+    srv._auth_store.update_user("ada", {"enabled": False})
+
+    resp = client.patch("/api/admin/users/ada", headers=admin_auth_headers, json={"enabled": True})
+
+    assert resp.status_code == 200
+    bootstrap.assert_awaited_once()
+    assert bootstrap.await_args.args[0] is srv._knowledge_repo_registry
+    assert bootstrap.await_args.args[1] == "ada"
+    config = bootstrap.await_args.args[2]
+    assert config.owner == "ada"
+
+
 def test_admin_platform_settings_requires_admin_role(client, auth_headers, admin_auth_headers):
     unauthenticated_resp = client.get("/api/admin/platform/settings")
     assert unauthenticated_resp.status_code == 401

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -44,6 +44,7 @@ from carapace.sandbox.manager import SandboxManager
 from carapace.sandbox.state import SessionSandboxSnapshot
 from carapace.security.context import CredentialAccessEntry
 from carapace.server import app, sandbox_app
+from carapace.server.runtime import KnowledgeGitRuntime
 from carapace.session import SessionEngine, SessionManager
 from carapace.session.archive import SessionArchiveResult, SessionArchiveService
 from carapace.usage import LlmRequestState
@@ -99,13 +100,26 @@ def _setup_server(tmp_path, monkeypatch):
         return cred_reg
 
     git_store = MagicMock(spec=GitStore)
+    git_store.remote_branch = "main"
+    git_store.author_template = "carapace <carapace@%h>"
+    git_store.remote_configured = False
     git_store.commit = AsyncMock(return_value=True)
     git_store.ensure_repo = AsyncMock()
+    git_store.add_remote = AsyncMock()
+    git_store.remove_remote = AsyncMock()
+    git_store.pull_from_remote = AsyncMock(return_value="Already up to date.")
+    git_store.push_to_remote = AsyncMock()
+    git_store.get_remote_url = AsyncMock(return_value=None)
+    git_store.restore_remote = AsyncMock()
     srv._data_dir = tmp_path
     srv._config_path = tmp_path / "config.yaml"
     srv._config = config
     srv._user_credential_registries = {}
     srv._knowledge_repo_registry = KnowledgeRepoRegistry(tmp_path, git_store_factory=lambda _path: git_store)
+    srv._knowledge_git_runtime = KnowledgeGitRuntime(
+        repo_registry=srv._knowledge_repo_registry,
+        sandbox_mgr=sandbox_mgr,
+    )
 
     def knowledge_repo_for_session(session_id: str):
         return srv._knowledge_repo_registry.get_for_user(session_mgr.load_meta(session_id).user)
@@ -341,8 +355,9 @@ def test_admin_user_management_requires_admin_role(client, auth_headers, admin_a
 
 
 def test_admin_user_create_bootstraps_enabled_user_repo(client, admin_auth_headers, monkeypatch):
-    bootstrap = AsyncMock()
-    monkeypatch.setattr(srv, "_bootstrap_user_knowledge_repo", bootstrap, raising=False)
+    runtime = MagicMock()
+    runtime.apply_user_config = AsyncMock()
+    monkeypatch.setattr(srv, "_knowledge_git_runtime", runtime, raising=False)
 
     resp = client.post(
         "/api/admin/users",
@@ -356,29 +371,85 @@ def test_admin_user_create_bootstraps_enabled_user_repo(client, admin_auth_heade
     )
 
     assert resp.status_code == 201
-    bootstrap.assert_awaited_once()
-    assert bootstrap.await_args.args[0] is srv._knowledge_repo_registry
-    assert bootstrap.await_args.args[1] == "ada"
-    config = bootstrap.await_args.args[2]
-    assert config.owner == "ada"
+    runtime.apply_user_config.assert_awaited_once()
+    assert runtime.apply_user_config.await_args.args[0] == "ada"
+    config = runtime.apply_user_config.await_args.args[1]
     assert config.remote == "https://gitea.example.test/ada/knowledge.git"
     assert config.branch == "prod"
+    git_store = srv._knowledge_repo_registry.get_for_user("ada").git_store
+    git_store.commit.assert_awaited_once()
 
 
 def test_admin_user_enable_bootstraps_user_repo(client, admin_auth_headers, monkeypatch):
-    bootstrap = AsyncMock()
-    monkeypatch.setattr(srv, "_bootstrap_user_knowledge_repo", bootstrap, raising=False)
+    runtime = MagicMock()
+    runtime.apply_user_config = AsyncMock()
+    monkeypatch.setattr(srv, "_knowledge_git_runtime", runtime, raising=False)
     srv._auth_store.create_user(username="ada", password="correct-horse-battery", display_name="Ada")
     srv._auth_store.update_user("ada", {"enabled": False})
 
     resp = client.patch("/api/admin/users/ada", headers=admin_auth_headers, json={"enabled": True})
 
     assert resp.status_code == 200
-    bootstrap.assert_awaited_once()
-    assert bootstrap.await_args.args[0] is srv._knowledge_repo_registry
-    assert bootstrap.await_args.args[1] == "ada"
-    config = bootstrap.await_args.args[2]
-    assert config.owner == "ada"
+    runtime.apply_user_config.assert_awaited_once()
+    assert runtime.apply_user_config.await_args.args[0] == "ada"
+
+
+def test_admin_user_create_returns_http_error_when_git_bootstrap_fails(client, admin_auth_headers, monkeypatch):
+    runtime = MagicMock()
+    runtime.apply_user_config = AsyncMock(side_effect=RuntimeError("pull failed"))
+    monkeypatch.setattr(srv, "_knowledge_git_runtime", runtime, raising=False)
+
+    resp = client.post(
+        "/api/admin/users",
+        headers=admin_auth_headers,
+        json={
+            "username": "ada",
+            "password": "correct-horse-battery",
+            "display_name": "Ada",
+            "config": {"git": {"remote": "https://gitea.example.test/ada/knowledge.git"}},
+        },
+    )
+
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Git settings reload failed: pull failed"
+    git_store = srv._knowledge_repo_registry.get_for_user("ada").git_store
+    git_store.commit.assert_not_awaited()
+
+
+def test_admin_user_config_patch_does_not_reload_git_when_git_config_is_unchanged(
+    client, admin_auth_headers, monkeypatch
+):
+    runtime = MagicMock()
+    runtime.apply_user_config = AsyncMock()
+    monkeypatch.setattr(srv, "_knowledge_git_runtime", runtime, raising=False)
+    srv._auth_store.create_user(username="ada", password="correct-horse-battery", display_name="Ada")
+
+    resp = client.patch(
+        "/api/admin/users/ada",
+        headers=admin_auth_headers,
+        json={"config": {"channels": {"matrix": {"enabled": True}}}},
+    )
+
+    assert resp.status_code == 200
+    runtime.apply_user_config.assert_not_awaited()
+
+
+def test_admin_user_git_config_patch_reloads_git_runtime(client, admin_auth_headers, monkeypatch):
+    runtime = MagicMock()
+    runtime.apply_user_config = AsyncMock()
+    monkeypatch.setattr(srv, "_knowledge_git_runtime", runtime, raising=False)
+    srv._auth_store.create_user(username="ada", password="correct-horse-battery", display_name="Ada")
+
+    resp = client.patch(
+        "/api/admin/users/ada",
+        headers=admin_auth_headers,
+        json={"config": {"git": {"remote": "https://gitea.example.test/ada/knowledge.git", "branch": "prod"}}},
+    )
+
+    assert resp.status_code == 200
+    runtime.apply_user_config.assert_awaited_once()
+    assert runtime.apply_user_config.await_args.args[0] == "ada"
+    assert runtime.apply_user_config.await_args.args[1].branch == "prod"
 
 
 def test_admin_platform_settings_requires_admin_role(client, auth_headers, admin_auth_headers):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -21,10 +21,11 @@ import carapace.server.jobs as server_jobs
 import carapace.server.platform_settings as platform_settings
 from carapace.auth import AuthStore
 from carapace.bootstrap import ensure_data_dir
-from carapace.config import load_config
+from carapace.config import load_config, resolve_user_knowledge_dir
 from carapace.credentials import CredentialBackendError, CredentialRegistry
 from carapace.git.store import GitStore
 from carapace.jobs import JobsScheduler, JobsStore
+from carapace.knowledge import KnowledgeRepoRegistry
 from carapace.models.config import AgentConfig
 from carapace.models.credentials import (
     BasicAuthConfig,
@@ -93,6 +94,7 @@ def _setup_server(tmp_path, monkeypatch):
     sandbox_mgr.get_domain_info.return_value = []
     sandbox_mgr.reset_session = AsyncMock()
     sandbox_mgr.destroy_session = AsyncMock()
+    sandbox_mgr.refresh_git_identities = AsyncMock()
 
     cred_reg = CredentialRegistry()
 
@@ -101,10 +103,12 @@ def _setup_server(tmp_path, monkeypatch):
 
     git_store = MagicMock(spec=GitStore)
     git_store.commit = AsyncMock(return_value=True)
+    git_store.ensure_repo = AsyncMock()
     srv._data_dir = tmp_path
     srv._config_path = tmp_path / "config.yaml"
     srv._config = config
     srv._user_credential_registries = {}
+    srv._knowledge_repo_registry = KnowledgeRepoRegistry(tmp_path, git_store_factory=lambda _path: git_store)
     srv._engine = SessionEngine(
         config=config,
         data_dir=tmp_path,
@@ -115,12 +119,18 @@ def _setup_server(tmp_path, monkeypatch):
         agent_model=None,
         sandbox_mgr=sandbox_mgr,
         credential_registry_for_session=credential_registry_for_session,
+        knowledge_repo_for_session=lambda session_id: srv._knowledge_repo_registry.get_for_user(
+            session_mgr.load_meta(session_id).user
+        ),
     )
     srv._session_archive = SessionArchiveService(
         knowledge_dir=tmp_path,
         git_store=git_store,
         session_mgr=session_mgr,
         config=config.sessions.commit,
+        knowledge_repo_for_session=lambda session_id: srv._knowledge_repo_registry.get_for_user(
+            session_mgr.load_meta(session_id).user
+        ),
     )
     srv._jobs_store = JobsStore(tmp_path)
     srv._jobs_scheduler = JobsScheduler(srv._jobs_store)
@@ -138,7 +148,7 @@ def client() -> TestClient:
     return TestClient(app)
 
 
-def test_select_knowledge_git_config_uses_single_enabled_user(tmp_path) -> None:
+def test_enabled_user_git_configs_returns_all_enabled_users(tmp_path) -> None:
     store = AuthStore(tmp_path / "git-owner", srv._config.auth)
     store.create_user(
         username="thies",
@@ -154,39 +164,60 @@ def test_select_knowledge_git_config_uses_single_enabled_user(tmp_path) -> None:
             }
         ),
     )
+    store.create_user(
+        username="ada",
+        password="secret",
+        config=UserConfig.model_validate(
+            {
+                "git": {
+                    "remote": "https://gitea.example.com/ada/knowledge.git",
+                    "branch": "main",
+                }
+            }
+        ),
+    )
 
-    selected = srv._select_knowledge_git_config(store)
+    selected = srv._enabled_user_git_configs(store)
 
-    assert selected.owner == "thies"
-    assert selected.remote == "https://gitea.example.com/team/knowledge.git"
-    assert selected.branch == "dev"
-    assert selected.author == "Thies <thies@example.com>"
-    assert selected.token == "token-value"
+    assert set(selected) == {"ada", "thies"}
+    assert selected["thies"].remote == "https://gitea.example.com/team/knowledge.git"
+    assert selected["thies"].branch == "dev"
+    assert selected["thies"].author == "Thies <thies@example.com>"
+    assert selected["thies"].token == "token-value"
+    assert selected["ada"].remote == "https://gitea.example.com/ada/knowledge.git"
 
 
-def test_select_knowledge_git_config_rejects_multiple_enabled_user_remotes(tmp_path) -> None:
+def test_enabled_user_git_configs_skips_disabled_users(tmp_path) -> None:
     store = AuthStore(tmp_path / "git-owners", srv._config.auth)
-    for username in ("alice", "bob"):
-        store.create_user(
-            username=username,
-            password="secret",
-            config=UserConfig.model_validate({"git": {"remote": f"https://gitea.example.com/{username}.git"}}),
-        )
+    store.create_user(
+        username="alice",
+        password="secret",
+        config=UserConfig.model_validate({"git": {"remote": "https://gitea.example.com/alice.git"}}),
+    )
+    store.update_user("alice", {"enabled": False})
+    store.create_user(
+        username="bob",
+        password="secret",
+        config=UserConfig.model_validate({"git": {"remote": "https://gitea.example.com/bob.git"}}),
+    )
 
-    with pytest.raises(RuntimeError, match="multiple enabled users"):
-        srv._select_knowledge_git_config(store)
+    selected = srv._enabled_user_git_configs(store)
+
+    assert set(selected) == {"bob"}
 
 
 @pytest.fixture()
 def auth_headers() -> dict[str, str]:
-    auth_session = srv._auth_store.create_session(username="thies")
-    token = srv._auth_store.issue_session_token(auth_session)
-    return {"Cookie": f"{srv._config.auth.cookie.name}={token}"}
+    return _headers_for_user("thies")
 
 
 @pytest.fixture()
 def admin_auth_headers() -> dict[str, str]:
-    auth_session = srv._auth_store.create_session(username="admin")
+    return _headers_for_user("admin")
+
+
+def _headers_for_user(username: str) -> dict[str, str]:
+    auth_session = srv._auth_store.create_session(username=username)
     token = srv._auth_store.issue_session_token(auth_session)
     return {"Cookie": f"{srv._config.auth.cookie.name}={token}"}
 
@@ -749,7 +780,7 @@ def test_user_settings_allows_updating_existing_git_remote_for_same_user(client,
         },
     )
     runtime = MagicMock()
-    runtime.apply_config = AsyncMock()
+    runtime.apply_user_config = AsyncMock()
     monkeypatch.setattr(srv, "_knowledge_git_runtime", runtime, raising=False)
 
     resp = client.patch(
@@ -763,10 +794,10 @@ def test_user_settings_allows_updating_existing_git_remote_for_same_user(client,
     assert user is not None
     assert user.config.git.remote == "https://gitea.example.test/thies/knowledge.git"
     assert user.config.git.branch == "dev"
-    runtime.apply_config.assert_awaited_once()
+    runtime.apply_user_config.assert_awaited_once()
 
 
-def test_user_settings_git_conflict_does_not_leak_owner_username(client, admin_auth_headers):
+def test_user_settings_allows_multiple_enabled_users_to_configure_git(client, admin_auth_headers, monkeypatch):
     srv._auth_store.update_user(
         "thies",
         {
@@ -779,6 +810,9 @@ def test_user_settings_git_conflict_does_not_leak_owner_username(client, admin_a
             )
         },
     )
+    runtime = MagicMock()
+    runtime.apply_user_config = AsyncMock()
+    monkeypatch.setattr(srv, "_knowledge_git_runtime", runtime, raising=False)
 
     resp = client.patch(
         "/api/user/settings",
@@ -786,13 +820,11 @@ def test_user_settings_git_conflict_does_not_leak_owner_username(client, admin_a
         json={"git": {"remote": "https://gitea.example.test/admin/knowledge.git"}},
     )
 
-    assert resp.status_code == 400
-    assert resp.json() == {
-        "detail": (
-            "Knowledge Git remote is already configured for another enabled user. "
-            "The shared knowledge repo supports only one enabled remote owner."
-        )
-    }
+    assert resp.status_code == 200
+    user = srv._auth_store.get_user("admin")
+    assert user is not None
+    assert user.config.git.remote == "https://gitea.example.test/admin/knowledge.git"
+    runtime.apply_user_config.assert_awaited_once()
 
 
 def test_user_settings_default_changes_reload_enabled_matrix(client, auth_headers, monkeypatch):
@@ -818,7 +850,7 @@ def test_user_settings_attempts_git_reload_when_matrix_reload_fails(client, auth
     manager = MagicMock()
     manager.reload_user = AsyncMock(side_effect=[HTTPException(status_code=500, detail="matrix failed"), None])
     runtime = MagicMock()
-    runtime.apply_config = AsyncMock()
+    runtime.apply_user_config = AsyncMock()
     monkeypatch.setattr(srv, "_matrix_channel_manager", manager, raising=False)
     monkeypatch.setattr(srv, "_knowledge_git_runtime", runtime, raising=False)
 
@@ -834,12 +866,12 @@ def test_user_settings_attempts_git_reload_when_matrix_reload_fails(client, auth
     assert resp.status_code == 500
     assert "matrix failed" in resp.json()["detail"]
     assert manager.reload_user.await_count == 2
-    assert runtime.apply_config.await_count == 2
+    assert runtime.apply_user_config.await_count == 2
 
 
 def test_user_settings_does_not_persist_git_when_reload_fails(client, auth_headers, monkeypatch):
     runtime = MagicMock()
-    runtime.apply_config = AsyncMock(side_effect=HTTPException(status_code=500, detail="git failed"))
+    runtime.apply_user_config = AsyncMock(side_effect=HTTPException(status_code=500, detail="git failed"))
     monkeypatch.setattr(srv, "_knowledge_git_runtime", runtime, raising=False)
 
     resp = client.patch(
@@ -1415,6 +1447,38 @@ def test_get_session(client, auth_headers):
     assert resp.json()["session_id"] == sid
 
 
+def test_admin_cannot_see_other_users_sessions_in_list(client, admin_auth_headers):
+    srv._auth_store.create_user(username="ada", password="secret")
+    ada_headers = _headers_for_user("ada")
+    create_resp = client.post("/api/sessions", headers=ada_headers)
+
+    assert create_resp.status_code == 200
+
+    list_resp = client.get("/api/sessions", headers=admin_auth_headers)
+
+    assert list_resp.status_code == 200
+    assert list_resp.json()["items"] == []
+
+
+def test_admin_cannot_access_other_users_session_endpoints(client, admin_auth_headers):
+    srv._auth_store.create_user(username="ada", password="secret")
+    ada_headers = _headers_for_user("ada")
+    create_resp = client.post("/api/sessions", headers=ada_headers)
+    sid = create_resp.json()["session_id"]
+
+    history_resp = client.get(f"/api/sessions/{sid}/history", headers=admin_auth_headers)
+    session_resp = client.get(f"/api/sessions/{sid}", headers=admin_auth_headers)
+    sandbox_resp = client.get(f"/api/sessions/{sid}/sandbox", headers=admin_auth_headers)
+    commit_resp = client.post(f"/api/sessions/{sid}/knowledge/commit", headers=admin_auth_headers)
+    delete_resp = client.delete(f"/api/sessions/{sid}", headers=admin_auth_headers)
+
+    assert history_resp.status_code == 404
+    assert session_resp.status_code == 404
+    assert sandbox_resp.status_code == 404
+    assert commit_resp.status_code == 404
+    assert delete_resp.status_code == 404
+
+
 def test_get_session_includes_total_cost_usd(client, auth_headers, monkeypatch):
     create_resp = client.post("/api/sessions", headers=auth_headers)
     sid = create_resp.json()["session_id"]
@@ -1986,7 +2050,7 @@ def test_update_session_archives_non_private_session_into_knowledge_repo(client,
     assert resp.json()["attributes"]["archived"] is True
     archive_path = resp.json()["knowledge_last_archive_path"]
     assert archive_path is not None
-    archive_file = tmp_path / archive_path
+    archive_file = resolve_user_knowledge_dir(tmp_path, "thies") / archive_path
     assert archive_file.exists()
     payload = archive_file.read_text()
     assert '"archived": true' in payload
@@ -2166,7 +2230,7 @@ def test_commit_session_knowledge_writes_archive(client, auth_headers, tmp_path)
     assert data["session"]["message_count"] == 2
     archive_path = data["archive_path"]
     assert archive_path is not None
-    archive_file = tmp_path / archive_path
+    archive_file = resolve_user_knowledge_dir(tmp_path, "thies") / archive_path
     assert archive_file.is_file()
     payload = archive_file.read_text()
     assert sid in payload
@@ -2213,7 +2277,7 @@ def test_delete_session_removes_archived_knowledge(client, auth_headers, tmp_pat
     commit_resp = client.post(f"/api/sessions/{sid}/knowledge/commit", headers=auth_headers)
     archive_path = commit_resp.json()["archive_path"]
     assert archive_path is not None
-    archive_file = tmp_path / archive_path
+    archive_file = resolve_user_knowledge_dir(tmp_path, "thies") / archive_path
     assert archive_file.exists()
 
     resp = client.delete(f"/api/sessions/{sid}", headers=auth_headers)
@@ -2228,7 +2292,7 @@ def test_archiving_session_does_not_remove_knowledge_archive(client, auth_header
     commit_resp = client.post(f"/api/sessions/{sid}/knowledge/commit", headers=auth_headers)
     archive_path = commit_resp.json()["archive_path"]
     assert archive_path is not None
-    archive_file = tmp_path / archive_path
+    archive_file = resolve_user_knowledge_dir(tmp_path, "thies") / archive_path
     assert archive_file.exists()
 
     resp = client.patch(
@@ -2249,7 +2313,7 @@ def test_delete_private_session_keeps_committed_knowledge(client, auth_headers, 
     commit_resp = client.post(f"/api/sessions/{sid}/knowledge/commit", headers=auth_headers)
     archive_path = commit_resp.json()["archive_path"]
     assert archive_path is not None
-    archive_file = tmp_path / archive_path
+    archive_file = resolve_user_knowledge_dir(tmp_path, "thies") / archive_path
     assert archive_file.exists()
 
     patch_resp = client.patch(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -46,7 +46,6 @@ from carapace.security.context import CredentialAccessEntry
 from carapace.server import app, sandbox_app
 from carapace.session import SessionEngine, SessionManager
 from carapace.session.archive import SessionArchiveResult, SessionArchiveService
-from carapace.skills import SkillRegistry
 from carapace.usage import LlmRequestState
 
 _TEST_TOKEN = "test-bearer-token-for-server-tests"
@@ -88,8 +87,6 @@ def _setup_server(tmp_path, monkeypatch):
     config = load_config(tmp_path)
     srv._session_list_cache = _FakeSessionListCache()
     session_mgr = SessionManager(tmp_path, on_change=srv._session_list_cache.invalidate_sync)
-    registry = SkillRegistry(tmp_path / "skills")
-    skill_catalog = registry.scan()
     sandbox_mgr = MagicMock(spec=SandboxManager)
     sandbox_mgr.get_domain_info.return_value = []
     sandbox_mgr.reset_session = AsyncMock()
@@ -109,28 +106,23 @@ def _setup_server(tmp_path, monkeypatch):
     srv._config = config
     srv._user_credential_registries = {}
     srv._knowledge_repo_registry = KnowledgeRepoRegistry(tmp_path, git_store_factory=lambda _path: git_store)
+
+    def knowledge_repo_for_session(session_id: str):
+        return srv._knowledge_repo_registry.get_for_user(session_mgr.load_meta(session_id).user)
+
     srv._engine = SessionEngine(
         config=config,
         data_dir=tmp_path,
-        knowledge_dir=tmp_path,
-        git_store=git_store,
         session_mgr=session_mgr,
-        skill_catalog=skill_catalog,
         agent_model=None,
         sandbox_mgr=sandbox_mgr,
         credential_registry_for_session=credential_registry_for_session,
-        knowledge_repo_for_session=lambda session_id: srv._knowledge_repo_registry.get_for_user(
-            session_mgr.load_meta(session_id).user
-        ),
+        knowledge_repo_for_session=knowledge_repo_for_session,
     )
     srv._session_archive = SessionArchiveService(
-        knowledge_dir=tmp_path,
-        git_store=git_store,
         session_mgr=session_mgr,
         config=config.sessions.commit,
-        knowledge_repo_for_session=lambda session_id: srv._knowledge_repo_registry.get_for_user(
-            session_mgr.load_meta(session_id).user
-        ),
+        knowledge_repo_for_session=knowledge_repo_for_session,
     )
     srv._jobs_store = JobsStore(tmp_path)
     srv._jobs_scheduler = JobsScheduler(srv._jobs_store)
@@ -282,7 +274,7 @@ def test_admin_user_management_requires_admin_role(client, auth_headers, admin_a
     create_resp = client.post(
         "/api/admin/users",
         headers=admin_auth_headers,
-        json={"username": "Ada", "password": "correct-horse-battery", "display_name": "Ada"},
+        json={"username": "ada", "password": "correct-horse-battery", "display_name": "Ada"},
     )
 
     assert create_resp.status_code == 201
@@ -603,7 +595,7 @@ def test_admin_user_update_can_clear_email(client, admin_auth_headers):
         "/api/admin/users",
         headers=admin_auth_headers,
         json={
-            "username": "Ada",
+            "username": "ada",
             "password": "correct-horse-battery",
             "display_name": "Ada",
             "email": "ada@example.test",
@@ -622,7 +614,7 @@ def test_admin_user_config_redacts_and_preserves_backend_password(client, admin_
         "/api/admin/users",
         headers=admin_auth_headers,
         json={
-            "username": "Ada",
+            "username": "ada",
             "password": "correct-horse-battery",
             "display_name": "Ada",
             "config": {

--- a/tests/test_server_runtime.py
+++ b/tests/test_server_runtime.py
@@ -169,3 +169,62 @@ async def test_knowledge_git_runtime_push_callback_checks_current_remote_state(t
     await runtime.push_if_configured("thies")
 
     git_store.push_to_remote.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_knowledge_git_runtime_keeps_other_user_repo_state_unchanged(tmp_path: Path) -> None:
+    def make_git_store(branch: str, author: str) -> MagicMock:
+        git_store = MagicMock(spec=GitStore)
+        git_store.remote_branch = branch
+        git_store.author_template = author
+        git_store.remote_configured = False
+        git_store.add_remote = AsyncMock()
+        git_store.remove_remote = AsyncMock()
+        git_store.ensure_repo = AsyncMock()
+        git_store.pull_from_remote = AsyncMock(return_value="Already up to date.")
+        git_store.push_to_remote = AsyncMock()
+        return git_store
+
+    stores = {
+        "thies": make_git_store("main", "carapace <carapace@%h>"),
+        "ada": make_git_store("stable", "Ada <ada@example.test>"),
+    }
+    repo_registry = KnowledgeRepoRegistry(tmp_path, git_store_factory=lambda path: stores[path.name])
+    sandbox_mgr = MagicMock(spec=SandboxManager)
+    sandbox_mgr.refresh_git_identities = AsyncMock()
+    runtime = KnowledgeGitRuntime(
+        repo_registry=repo_registry,
+        sandbox_mgr=sandbox_mgr,
+        current_configs={
+            "ada": KnowledgeGitConfig(
+                owner="ada",
+                remote="https://git.example.test/ada.git",
+                branch="stable",
+                author="Ada <ada@example.test>",
+                token="ada-token",
+            )
+        },
+    )
+
+    repo_registry.get_for_user("thies")
+    repo_registry.get_for_user("ada")
+
+    thies_config = KnowledgeGitConfig(
+        owner="thies",
+        remote="https://git.example.test/thies.git",
+        branch="prod",
+        author="Thies <thies@example.test>",
+        token="thies-token",
+    )
+
+    await runtime.apply_user_config("thies", thies_config)
+
+    assert runtime.config_for_user("thies") == thies_config
+    assert runtime.config_for_user("ada") is not None
+    assert stores["thies"].remote_branch == "prod"
+    assert stores["thies"].author_template == "Thies <thies@example.test>"
+    stores["thies"].add_remote.assert_awaited_once_with("https://git.example.test/thies.git", "thies-token")
+    stores["ada"].ensure_repo.assert_not_awaited()
+    stores["ada"].add_remote.assert_not_awaited()
+    assert stores["ada"].remote_branch == "stable"
+    assert stores["ada"].author_template == "Ada <ada@example.test>"

--- a/tests/test_server_runtime.py
+++ b/tests/test_server_runtime.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
 from carapace.git.store import GitStore
+from carapace.knowledge import KnowledgeRepoRegistry
 from carapace.models.user import UserConfig
 from carapace.sandbox.manager import SandboxManager
 from carapace.server.runtime import KnowledgeGitConfig, KnowledgeGitRuntime, MatrixChannelManager
@@ -25,6 +27,10 @@ class _FakeMatrixChannel:
         self.stopped = True
 
 
+def _repo_registry(tmp_path: Path, git_store: GitStore) -> KnowledgeRepoRegistry:
+    return KnowledgeRepoRegistry(tmp_path, git_store_factory=lambda _path: git_store)
+
+
 @pytest.mark.anyio
 async def test_matrix_channel_manager_replaces_running_channel() -> None:
     created: list[_FakeMatrixChannel] = []
@@ -37,8 +43,8 @@ async def test_matrix_channel_manager_replaces_running_channel() -> None:
     manager = MatrixChannelManager(channel_factory)
     config = UserConfig.model_validate({"channels": {"matrix": {"enabled": True}}})
 
-    await manager.reload_user("Thies", config)
-    await manager.reload_user("Thies", config)
+    await manager.reload_user("thies", config)
+    await manager.reload_user("thies", config)
 
     assert manager.channel_count == 1
     assert created[0].started is True
@@ -70,45 +76,45 @@ async def test_matrix_channel_manager_stops_old_channel_before_replacement() -> 
 
 
 @pytest.mark.anyio
-async def test_knowledge_git_runtime_applies_remote_and_updates_sandbox_identity() -> None:
+async def test_knowledge_git_runtime_applies_remote_and_updates_sandbox_identity(tmp_path: Path) -> None:
     git_store = MagicMock(spec=GitStore)
     git_store.remote_branch = "main"
     git_store.author_template = "carapace <carapace@%h>"
     git_store.remote_configured = False
     git_store.add_remote = AsyncMock()
     git_store.remove_remote = AsyncMock()
+    git_store.ensure_repo = AsyncMock()
     git_store.pull_from_remote = AsyncMock(return_value="Already up to date.")
     git_store.push_to_remote = AsyncMock()
     sandbox_mgr = MagicMock(spec=SandboxManager)
-    sandbox_mgr.set_git_author = MagicMock()
     sandbox_mgr.refresh_git_identities = AsyncMock()
-    runtime = KnowledgeGitRuntime(git_store=git_store, sandbox_mgr=sandbox_mgr)
+    runtime = KnowledgeGitRuntime(repo_registry=_repo_registry(tmp_path, git_store), sandbox_mgr=sandbox_mgr)
 
-    await runtime.apply_config(
-        KnowledgeGitConfig(
-            owner="thies",
-            remote="https://git.example.test/knowledge.git",
-            branch="prod",
-            author="Thies <thies@example.test>",
-            token="secret-token",
-        )
+    config = KnowledgeGitConfig(
+        owner="thies",
+        remote="https://git.example.test/knowledge.git",
+        branch="prod",
+        author="Thies <thies@example.test>",
+        token="secret-token",
     )
 
+    await runtime.apply_user_config("thies", config)
+
+    assert runtime.config_for_user("thies") == config
     assert git_store.remote_branch == "prod"
     assert git_store.author_template == "Thies <thies@example.test>"
     git_store.add_remote.assert_awaited_once_with("https://git.example.test/knowledge.git", "secret-token")
     git_store.pull_from_remote.assert_awaited_once()
-    sandbox_mgr.set_git_author.assert_called_once_with("Thies <thies@example.test>")
     sandbox_mgr.refresh_git_identities.assert_awaited_once()
 
 
 @pytest.mark.anyio
-async def test_knowledge_git_runtime_rolls_back_when_remote_pull_fails() -> None:
+async def test_knowledge_git_runtime_rolls_back_when_remote_pull_fails(tmp_path: Path) -> None:
     previous = KnowledgeGitConfig(
-        owner="ada",
+        owner="thies",
         remote="https://git.example.test/old.git",
         branch="main",
-        author="Ada <ada@example.test>",
+        author="Thies <thies@example.test>",
         token="old-token",
     )
     git_store = MagicMock(spec=GitStore)
@@ -116,46 +122,50 @@ async def test_knowledge_git_runtime_rolls_back_when_remote_pull_fails() -> None
     git_store.author_template = previous.author
     git_store.add_remote = AsyncMock()
     git_store.remove_remote = AsyncMock()
+    git_store.ensure_repo = AsyncMock()
     git_store.pull_from_remote = AsyncMock(side_effect=RuntimeError("pull failed"))
     sandbox_mgr = MagicMock(spec=SandboxManager)
-    sandbox_mgr.set_git_author = MagicMock()
     sandbox_mgr.refresh_git_identities = AsyncMock()
-    runtime = KnowledgeGitRuntime(git_store=git_store, sandbox_mgr=sandbox_mgr, current_config=previous)
+    runtime = KnowledgeGitRuntime(
+        repo_registry=_repo_registry(tmp_path, git_store),
+        sandbox_mgr=sandbox_mgr,
+        current_configs={"thies": previous},
+    )
 
     with pytest.raises(RuntimeError, match="pull failed"):
-        await runtime.apply_config(
+        await runtime.apply_user_config(
+            "thies",
             KnowledgeGitConfig(
                 owner="thies",
                 remote="https://git.example.test/new.git",
                 branch="prod",
                 author="Thies <thies@example.test>",
                 token="new-token",
-            )
+            ),
         )
 
-    assert runtime.config == previous
+    assert runtime.config_for_user("thies") == previous
     assert git_store.remote_branch == previous.branch
     assert git_store.author_template == previous.author
     assert git_store.add_remote.await_args_list == [
         call("https://git.example.test/new.git", "new-token"),
         call(previous.remote, previous.token),
     ]
-    sandbox_mgr.set_git_author.assert_called_once_with(previous.author)
     sandbox_mgr.refresh_git_identities.assert_awaited_once()
 
 
 @pytest.mark.anyio
-async def test_knowledge_git_runtime_push_callback_checks_current_remote_state() -> None:
+async def test_knowledge_git_runtime_push_callback_checks_current_remote_state(tmp_path: Path) -> None:
     git_store = MagicMock(spec=GitStore)
     git_store.remote_configured = False
     git_store.push_to_remote = AsyncMock()
     sandbox_mgr = MagicMock(spec=SandboxManager)
-    runtime = KnowledgeGitRuntime(git_store=git_store, sandbox_mgr=sandbox_mgr)
+    runtime = KnowledgeGitRuntime(repo_registry=_repo_registry(tmp_path, git_store), sandbox_mgr=sandbox_mgr)
 
-    await runtime.push_if_configured()
+    await runtime.push_if_configured("thies")
     git_store.push_to_remote.assert_not_awaited()
 
     git_store.remote_configured = True
-    await runtime.push_if_configured()
+    await runtime.push_if_configured("thies")
 
     git_store.push_to_remote.assert_awaited_once()

--- a/tests/test_server_runtime.py
+++ b/tests/test_server_runtime.py
@@ -86,6 +86,8 @@ async def test_knowledge_git_runtime_applies_remote_and_updates_sandbox_identity
     git_store.ensure_repo = AsyncMock()
     git_store.pull_from_remote = AsyncMock(return_value="Already up to date.")
     git_store.push_to_remote = AsyncMock()
+    git_store.get_remote_url = AsyncMock(return_value=None)
+    git_store.restore_remote = AsyncMock()
     sandbox_mgr = MagicMock(spec=SandboxManager)
     sandbox_mgr.refresh_git_identities = AsyncMock()
     runtime = KnowledgeGitRuntime(repo_registry=_repo_registry(tmp_path, git_store), sandbox_mgr=sandbox_mgr)
@@ -124,6 +126,8 @@ async def test_knowledge_git_runtime_rolls_back_when_remote_pull_fails(tmp_path:
     git_store.remove_remote = AsyncMock()
     git_store.ensure_repo = AsyncMock()
     git_store.pull_from_remote = AsyncMock(side_effect=RuntimeError("pull failed"))
+    git_store.get_remote_url = AsyncMock(return_value="https://x-access-token:old-token@git.example.test/old.git")
+    git_store.restore_remote = AsyncMock()
     sandbox_mgr = MagicMock(spec=SandboxManager)
     sandbox_mgr.refresh_git_identities = AsyncMock()
     runtime = KnowledgeGitRuntime(
@@ -151,24 +155,80 @@ async def test_knowledge_git_runtime_rolls_back_when_remote_pull_fails(tmp_path:
         call("https://git.example.test/new.git", "new-token"),
         call(previous.remote, previous.token),
     ]
+    git_store.restore_remote.assert_not_awaited()
     sandbox_mgr.refresh_git_identities.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_knowledge_git_runtime_rolls_back_to_existing_remote_when_cache_is_empty(tmp_path: Path) -> None:
+    git_store = MagicMock(spec=GitStore)
+    git_store.remote_branch = "main"
+    git_store.author_template = "Thies <thies@example.test>"
+    git_store.remote_configured = True
+    git_store.add_remote = AsyncMock()
+    git_store.remove_remote = AsyncMock()
+    git_store.ensure_repo = AsyncMock()
+    git_store.pull_from_remote = AsyncMock(side_effect=RuntimeError("pull failed"))
+    git_store.get_remote_url = AsyncMock(return_value="https://x-access-token:old-token@git.example.test/old.git")
+    git_store.restore_remote = AsyncMock()
+    sandbox_mgr = MagicMock(spec=SandboxManager)
+    sandbox_mgr.refresh_git_identities = AsyncMock()
+    runtime = KnowledgeGitRuntime(repo_registry=_repo_registry(tmp_path, git_store), sandbox_mgr=sandbox_mgr)
+
+    with pytest.raises(RuntimeError, match="pull failed"):
+        await runtime.apply_user_config(
+            "thies",
+            KnowledgeGitConfig(
+                owner="thies",
+                remote="https://git.example.test/new.git",
+                branch="prod",
+                author="Thies <thies@example.test>",
+                token="new-token",
+            ),
+        )
+
+    git_store.restore_remote.assert_awaited_once_with("https://x-access-token:old-token@git.example.test/old.git")
+    git_store.remove_remote.assert_not_awaited()
 
 
 @pytest.mark.anyio
 async def test_knowledge_git_runtime_push_callback_checks_current_remote_state(tmp_path: Path) -> None:
     git_store = MagicMock(spec=GitStore)
     git_store.remote_configured = False
+    git_store.remote_branch = "main"
+    git_store.author_template = "carapace <carapace@%h>"
     git_store.push_to_remote = AsyncMock()
+    git_store.add_remote = AsyncMock()
+    git_store.remove_remote = AsyncMock()
+    git_store.ensure_repo = AsyncMock()
+    git_store.pull_from_remote = AsyncMock(return_value="Already up to date.")
+    git_store.get_remote_url = AsyncMock(return_value=None)
+    git_store.restore_remote = AsyncMock()
     sandbox_mgr = MagicMock(spec=SandboxManager)
+    sandbox_mgr.refresh_git_identities = AsyncMock()
     runtime = KnowledgeGitRuntime(repo_registry=_repo_registry(tmp_path, git_store), sandbox_mgr=sandbox_mgr)
 
     await runtime.push_if_configured("thies")
     git_store.push_to_remote.assert_not_awaited()
 
+    await runtime.apply_user_config(
+        "thies",
+        KnowledgeGitConfig(
+            owner="thies",
+            remote="https://git.example.test/thies.git",
+            branch="prod",
+            author="Thies <thies@example.test>",
+            token="secret-token",
+        ),
+    )
+    git_store.remote_branch = "main"
+    git_store.author_template = "carapace <carapace@%h>"
     git_store.remote_configured = True
     await runtime.push_if_configured("thies")
 
     git_store.push_to_remote.assert_awaited_once()
+    assert git_store.remote_branch == "prod"
+    assert git_store.author_template == "Thies <thies@example.test>"
 
 
 @pytest.mark.anyio
@@ -183,6 +243,8 @@ async def test_knowledge_git_runtime_keeps_other_user_repo_state_unchanged(tmp_p
         git_store.ensure_repo = AsyncMock()
         git_store.pull_from_remote = AsyncMock(return_value="Already up to date.")
         git_store.push_to_remote = AsyncMock()
+        git_store.get_remote_url = AsyncMock(return_value=None)
+        git_store.restore_remote = AsyncMock()
         return git_store
 
     stores = {

--- a/tests/test_session_archive.py
+++ b/tests/test_session_archive.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -11,6 +12,32 @@ from carapace.knowledge import KnowledgeRepoHandle
 from carapace.models.config import SessionCommitConfig
 from carapace.session.archive import SessionArchiveService
 from carapace.session.manager import SessionManager
+
+
+def _repo_handle(knowledge_dir: Path, *, git_store: GitStore, owner: str = "thies") -> KnowledgeRepoHandle:
+    return KnowledgeRepoHandle(
+        owner=owner,
+        knowledge_dir=knowledge_dir,
+        git_store=git_store,
+        skill_registry=MagicMock(),
+    )
+
+
+def _archive_service(
+    session_mgr: SessionManager,
+    *,
+    knowledge_dir: Path,
+    git_store: GitStore,
+    config: SessionCommitConfig | None = None,
+    owner: str = "thies",
+    repo_handle: KnowledgeRepoHandle | None = None,
+) -> SessionArchiveService:
+    handle = repo_handle or _repo_handle(knowledge_dir, git_store=git_store, owner=owner)
+    return SessionArchiveService(
+        session_mgr=session_mgr,
+        config=config if config is not None else SessionCommitConfig(),
+        knowledge_repo_for_session=lambda _session_id: handle,
+    )
 
 
 def test_append_events_stamps_timestamp(tmp_path) -> None:
@@ -37,12 +64,7 @@ async def test_archive_service_commits_snapshot(tmp_path) -> None:
     )
     git_store = MagicMock(spec=GitStore)
     git_store.commit = AsyncMock(return_value=True)
-    service = SessionArchiveService(
-        knowledge_dir=tmp_path,
-        git_store=git_store,
-        session_mgr=mgr,
-        config=SessionCommitConfig(),
-    )
+    service = _archive_service(mgr, knowledge_dir=tmp_path, git_store=git_store)
 
     result = await service.commit_session(state.session_id, trigger="manual")
 
@@ -72,8 +94,6 @@ async def test_archive_service_routes_snapshot_to_owner_specific_repo(tmp_path) 
             {"role": "assistant", "content": "world"},
         ],
     )
-    legacy_git_store = MagicMock(spec=GitStore)
-    legacy_git_store.commit = AsyncMock(return_value=True)
     owner_git_store = MagicMock(spec=GitStore)
     owner_git_store.commit = AsyncMock(return_value=True)
     owner_handle = KnowledgeRepoHandle(
@@ -82,26 +102,25 @@ async def test_archive_service_routes_snapshot_to_owner_specific_repo(tmp_path) 
         git_store=owner_git_store,
         skill_registry=MagicMock(),
     )
-    service = SessionArchiveService(
-        knowledge_dir=tmp_path / "legacy-knowledge",
-        git_store=legacy_git_store,
-        session_mgr=mgr,
-        config=SessionCommitConfig(),
-        knowledge_repo_for_session=lambda _session_id: owner_handle,
+    service = _archive_service(
+        mgr,
+        knowledge_dir=owner_handle.knowledge_dir,
+        git_store=owner_git_store,
+        repo_handle=owner_handle,
     )
+    legacy_knowledge_dir = tmp_path / "legacy-knowledge"
 
     result = await service.commit_session(state.session_id, trigger="manual")
 
     assert result.committed is True
     assert result.archive_path is not None
     assert (owner_handle.knowledge_dir / result.archive_path).is_file()
-    assert not ((tmp_path / "legacy-knowledge") / result.archive_path).exists()
+    assert not (legacy_knowledge_dir / result.archive_path).exists()
     owner_git_store.commit.assert_awaited_once_with(
         [result.archive_path],
         f"💾 session: add {state.session_id}",
         session_id=state.session_id,
     )
-    legacy_git_store.commit.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -111,12 +130,7 @@ async def test_archive_service_skips_private_sessions(tmp_path) -> None:
     mgr.append_events(state.session_id, [{"role": "user", "content": "hello"}])
     git_store = MagicMock(spec=GitStore)
     git_store.commit = AsyncMock(return_value=True)
-    service = SessionArchiveService(
-        knowledge_dir=tmp_path,
-        git_store=git_store,
-        session_mgr=mgr,
-        config=SessionCommitConfig(),
-    )
+    service = _archive_service(mgr, knowledge_dir=tmp_path, git_store=git_store)
 
     result = await service.commit_session(state.session_id, trigger="manual")
 
@@ -130,12 +144,7 @@ async def test_archive_service_empty_history_returns_no_archive_path(tmp_path) -
     state = mgr.create_session(user="thies", private=False)
     git_store = MagicMock(spec=GitStore)
     git_store.commit = AsyncMock(return_value=True)
-    service = SessionArchiveService(
-        knowledge_dir=tmp_path,
-        git_store=git_store,
-        session_mgr=mgr,
-        config=SessionCommitConfig(),
-    )
+    service = _archive_service(mgr, knowledge_dir=tmp_path, git_store=git_store)
 
     result = await service.commit_session(state.session_id, trigger="manual")
 
@@ -157,12 +166,7 @@ async def test_archive_service_skips_unchanged_snapshot_for_different_trigger(tm
     )
     git_store = MagicMock(spec=GitStore)
     git_store.commit = AsyncMock(return_value=True)
-    service = SessionArchiveService(
-        knowledge_dir=tmp_path,
-        git_store=git_store,
-        session_mgr=mgr,
-        config=SessionCommitConfig(),
-    )
+    service = _archive_service(mgr, knowledge_dir=tmp_path, git_store=git_store)
 
     first = await service.commit_session(state.session_id, trigger="autosave")
     second = await service.commit_session(state.session_id, trigger="manual")
@@ -188,12 +192,7 @@ async def test_archive_service_preserves_concurrent_privacy_update(tmp_path) -> 
         return True
 
     git_store.commit = AsyncMock(side_effect=commit_with_concurrent_privacy_flip)
-    service = SessionArchiveService(
-        knowledge_dir=tmp_path,
-        git_store=git_store,
-        session_mgr=mgr,
-        config=SessionCommitConfig(),
-    )
+    service = _archive_service(mgr, knowledge_dir=tmp_path, git_store=git_store)
 
     result = await service.commit_session(state.session_id, trigger="manual")
     final_state = mgr.load_state(state.session_id)
@@ -223,12 +222,7 @@ async def test_archive_service_serializes_same_session_commits(tmp_path) -> None
         return True
 
     git_store.commit = AsyncMock(side_effect=delayed_commit)
-    service = SessionArchiveService(
-        knowledge_dir=tmp_path,
-        git_store=git_store,
-        session_mgr=mgr,
-        config=SessionCommitConfig(),
-    )
+    service = _archive_service(mgr, knowledge_dir=tmp_path, git_store=git_store)
 
     first_task = asyncio.create_task(service.commit_session(state.session_id, trigger="manual"))
     await asyncio.sleep(0)
@@ -252,12 +246,7 @@ async def test_archive_service_does_not_persist_export_hash_on_commit_failure(tm
     mgr.append_events(state.session_id, [{"role": "user", "content": "hello"}])
     git_store = MagicMock(spec=GitStore)
     git_store.commit = AsyncMock(side_effect=RuntimeError("git commit failed: boom"))
-    service = SessionArchiveService(
-        knowledge_dir=tmp_path,
-        git_store=git_store,
-        session_mgr=mgr,
-        config=SessionCommitConfig(),
-    )
+    service = _archive_service(mgr, knowledge_dir=tmp_path, git_store=git_store)
 
     with pytest.raises(RuntimeError, match="git commit failed: boom"):
         await service.commit_session(state.session_id, trigger="manual")
@@ -278,12 +267,7 @@ async def test_archive_service_removes_written_file_after_commit_failure(tmp_pat
     mgr.append_events(state.session_id, [{"role": "user", "content": "hello"}])
     git_store = MagicMock(spec=GitStore)
     git_store.commit = AsyncMock(side_effect=RuntimeError("git commit failed: boom"))
-    service = SessionArchiveService(
-        knowledge_dir=tmp_path,
-        git_store=git_store,
-        session_mgr=mgr,
-        config=SessionCommitConfig(),
-    )
+    service = _archive_service(mgr, knowledge_dir=tmp_path, git_store=git_store)
     archive_file = service.archive_absolute_path_for_state(state)
 
     with pytest.raises(RuntimeError, match="git commit failed: boom"):
@@ -301,12 +285,7 @@ async def test_archive_service_cleans_up_lock_after_archive_delete(tmp_path) -> 
     git_store = MagicMock(spec=GitStore)
     git_store.commit = AsyncMock(return_value=True)
     git_store.commit_removals = AsyncMock(return_value=True)
-    service = SessionArchiveService(
-        knowledge_dir=tmp_path,
-        git_store=git_store,
-        session_mgr=mgr,
-        config=SessionCommitConfig(),
-    )
+    service = _archive_service(mgr, knowledge_dir=tmp_path, git_store=git_store)
 
     await service.commit_session(state.session_id, trigger="manual")
     archived_state = mgr.load_state(state.session_id)
@@ -324,12 +303,7 @@ async def test_archive_service_uses_update_title_after_first_commit(tmp_path) ->
     mgr.append_events(state.session_id, [{"role": "user", "content": "hello"}])
     git_store = MagicMock(spec=GitStore)
     git_store.commit = AsyncMock(return_value=True)
-    service = SessionArchiveService(
-        knowledge_dir=tmp_path,
-        git_store=git_store,
-        session_mgr=mgr,
-        config=SessionCommitConfig(),
-    )
+    service = _archive_service(mgr, knowledge_dir=tmp_path, git_store=git_store)
 
     first = await service.commit_session(state.session_id, trigger="manual")
     mgr.append_events(state.session_id, [{"role": "assistant", "content": "world"}])

--- a/tests/test_session_archive.py
+++ b/tests/test_session_archive.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from carapace.git.store import GitStore
+from carapace.knowledge import KnowledgeRepoHandle
 from carapace.models.config import SessionCommitConfig
 from carapace.session.archive import SessionArchiveService
 from carapace.session.manager import SessionManager
@@ -58,6 +59,49 @@ async def test_archive_service_commits_snapshot(tmp_path) -> None:
         f"💾 session: add {state.session_id}",
         session_id=state.session_id,
     )
+
+
+@pytest.mark.asyncio
+async def test_archive_service_routes_snapshot_to_owner_specific_repo(tmp_path) -> None:
+    mgr = SessionManager(tmp_path)
+    state = mgr.create_session(user="ada", private=False)
+    mgr.append_events(
+        state.session_id,
+        [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "world"},
+        ],
+    )
+    legacy_git_store = MagicMock(spec=GitStore)
+    legacy_git_store.commit = AsyncMock(return_value=True)
+    owner_git_store = MagicMock(spec=GitStore)
+    owner_git_store.commit = AsyncMock(return_value=True)
+    owner_handle = KnowledgeRepoHandle(
+        owner="ada",
+        knowledge_dir=tmp_path / "knowledges" / "ada",
+        git_store=owner_git_store,
+        skill_registry=MagicMock(),
+    )
+    service = SessionArchiveService(
+        knowledge_dir=tmp_path / "legacy-knowledge",
+        git_store=legacy_git_store,
+        session_mgr=mgr,
+        config=SessionCommitConfig(),
+        knowledge_repo_for_session=lambda _session_id: owner_handle,
+    )
+
+    result = await service.commit_session(state.session_id, trigger="manual")
+
+    assert result.committed is True
+    assert result.archive_path is not None
+    assert (owner_handle.knowledge_dir / result.archive_path).is_file()
+    assert not ((tmp_path / "legacy-knowledge") / result.archive_path).exists()
+    owner_git_store.commit.assert_awaited_once_with(
+        [result.archive_path],
+        f"💾 session: add {state.session_id}",
+        session_id=state.session_id,
+    )
+    legacy_git_store.commit.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_engine_core.py
+++ b/tests/test_session_engine_core.py
@@ -270,6 +270,7 @@ def test_fork_session_copies_transcript_and_security_context(tmp_path: Path) -> 
     response_part = forked_history[1].parts[0]
     assert isinstance(response_part, TextPart)
     assert response_part.content == "reply one"
+    assert engine.session_mgr.load_meta(forked.session_id).user == "thies"
     assert engine.session_mgr.load_usage(forked.session_id).models == {}
     assert engine.session_mgr.load_sandbox_snapshot(forked.session_id) is None
     assert len(engine.session_mgr.load_events(sid)) == 5

--- a/tests/test_session_engine_core.py
+++ b/tests/test_session_engine_core.py
@@ -27,6 +27,13 @@ from carapace.usage import LlmRequestState, ModelUsage
 from tests.session_helpers import _FakeSubscriber, _make_engine, _patch_sentinel, _without_timestamps
 
 
+async def _drain_background_tasks(active: Any) -> None:
+    if active.agent_task is not None:
+        await asyncio.gather(active.agent_task, return_exceptions=True)
+    while active._pending_sends:
+        await asyncio.gather(*tuple(active._pending_sends), return_exceptions=True)
+
+
 @pytest.mark.anyio
 async def test_skill_activation_inputs_use_context_grant(tmp_path: Path):
     """Automatic skill setup reuses approved env/file credentials from the persisted context grant."""
@@ -562,6 +569,7 @@ def test_user_message_from_self(tmp_path: Path):
         engine = _make_engine(tmp_path)
         state = engine.session_mgr.create_session(user="thies")
         sid = state.session_id
+        active = engine.get_or_activate(sid)
 
         origin = _FakeSubscriber()
         other = _FakeSubscriber()
@@ -577,6 +585,7 @@ def test_user_message_from_self(tmp_path: Path):
 
         assert origin.user_messages == [("hello", True)]
         assert other.user_messages == [("hello", False)]
+        await _drain_background_tasks(active)
 
     with _patch_sentinel():
         asyncio.run(_run())
@@ -589,6 +598,7 @@ def test_user_message_no_origin(tmp_path: Path):
         engine = _make_engine(tmp_path)
         state = engine.session_mgr.create_session(user="thies")
         sid = state.session_id
+        active = engine.get_or_activate(sid)
 
         sub_a = _FakeSubscriber()
         sub_b = _FakeSubscriber()
@@ -604,6 +614,7 @@ def test_user_message_no_origin(tmp_path: Path):
 
         assert sub_a.user_messages == [("hi", False)]
         assert sub_b.user_messages == [("hi", False)]
+        await _drain_background_tasks(active)
 
     with _patch_sentinel():
         asyncio.run(_run())
@@ -697,6 +708,7 @@ def test_finalize_successful_turn_dispatches_attended_notification(tmp_path: Pat
             body="done",
         )
         assert active.pending_notifications == {f"done:{sid}:1:attended_turn_completed": {"sub-1"}}
+        await _drain_background_tasks(active)
 
     with _patch_sentinel():
         asyncio.run(_run())

--- a/tests/test_session_engine_usage.py
+++ b/tests/test_session_engine_usage.py
@@ -9,6 +9,7 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import carapace.usage as usage_mod
+from carapace.knowledge import KnowledgeRepoRegistry
 from carapace.models.session import SessionBudget
 from carapace.usage import LlmRequestRecord, LlmRequestState, ModelUsage
 from tests.session_helpers import (
@@ -222,6 +223,36 @@ def test_handle_slash_command_usage_includes_tool_call_total(tmp_path: Path):
             assert result is not None
             assert result["command"] == "usage"
             assert result["data"]["total_tool_calls"] == 2
+
+        asyncio.run(_run())
+
+
+def test_handle_slash_command_skills_uses_owner_specific_catalog(tmp_path: Path) -> None:
+    with _patch_sentinel():
+        registry = KnowledgeRepoRegistry(tmp_path)
+        thies_skill = registry.ensure_user_repo("thies").knowledge_dir / "skills" / "alpha"
+        thies_skill.mkdir(parents=True)
+        (thies_skill / "SKILL.md").write_text(
+            "---\nname: alpha\ndescription: Owner skill\n---\n",
+            encoding="utf-8",
+        )
+        ada_skill = registry.ensure_user_repo("ada").knowledge_dir / "skills" / "beta"
+        ada_skill.mkdir(parents=True)
+        (ada_skill / "SKILL.md").write_text(
+            "---\nname: beta\ndescription: Other skill\n---\n",
+            encoding="utf-8",
+        )
+
+        engine = _make_engine(tmp_path, knowledge_repo_for_session=lambda _session_id: registry.get_for_user("thies"))
+        state = engine.session_mgr.create_session(user="thies")
+        sid = state.session_id
+        engine.get_or_activate(sid)
+
+        async def _run() -> None:
+            result = await engine.handle_slash_command(sid, "/skills")
+
+            assert result is not None
+            assert result["data"] == [{"name": "alpha", "description": "Owner skill"}]
 
         asyncio.run(_run())
 

--- a/tests/test_session_engine_usage.py
+++ b/tests/test_session_engine_usage.py
@@ -271,6 +271,52 @@ def test_handle_slash_command_skills_stays_owner_scoped_for_two_users(tmp_path: 
         assert engine._knowledge_dir_for_session(thies_sid) != engine._knowledge_dir_for_session(ada_sid)
 
 
+def test_handle_slash_command_pull_invalidates_cached_skill_catalog(tmp_path: Path) -> None:
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path)
+        state = engine.session_mgr.create_session(user="thies")
+        sid = state.session_id
+        engine.get_or_activate(sid)
+
+        alpha_skill = tmp_path / "skills" / "alpha"
+        alpha_skill.mkdir(parents=True)
+        (alpha_skill / "SKILL.md").write_text(
+            "---\nname: alpha\ndescription: Before pull\n---\n",
+            encoding="utf-8",
+        )
+        git_store = engine._git_store_for_session(sid)
+        git_store.remote_configured = True
+
+        async def pull_from_remote() -> str:
+            beta_skill = tmp_path / "skills" / "beta"
+            beta_skill.mkdir(parents=True)
+            (beta_skill / "SKILL.md").write_text(
+                "---\nname: beta\ndescription: Added by pull\n---\n",
+                encoding="utf-8",
+            )
+            return "Pulled"
+
+        git_store.pull_from_remote = AsyncMock(side_effect=pull_from_remote)
+
+        async def _run() -> None:
+            initial = await engine.handle_slash_command(sid, "/skills")
+            assert initial is not None
+            assert initial["data"] == [{"name": "alpha", "description": "Before pull"}]
+
+            pull_result = await engine.handle_slash_command(sid, "/pull")
+            assert pull_result is not None
+            assert pull_result["data"]["message"] == "Pulled"
+
+            refreshed = await engine.handle_slash_command(sid, "/skills")
+            assert refreshed is not None
+            assert refreshed["data"] == [
+                {"name": "alpha", "description": "Before pull"},
+                {"name": "beta", "description": "Added by pull"},
+            ]
+
+        asyncio.run(_run())
+
+
 def test_turn_usage_payload_contains_budget_gauges_without_agent_usage(tmp_path: Path):
     with _patch_sentinel():
         engine = _make_engine(tmp_path)

--- a/tests/test_session_engine_usage.py
+++ b/tests/test_session_engine_usage.py
@@ -227,7 +227,7 @@ def test_handle_slash_command_usage_includes_tool_call_total(tmp_path: Path):
         asyncio.run(_run())
 
 
-def test_handle_slash_command_skills_uses_owner_specific_catalog(tmp_path: Path) -> None:
+def test_handle_slash_command_skills_stays_owner_scoped_for_two_users(tmp_path: Path) -> None:
     with _patch_sentinel():
         registry = KnowledgeRepoRegistry(tmp_path)
         thies_skill = registry.ensure_user_repo("thies").knowledge_dir / "skills" / "alpha"
@@ -243,18 +243,32 @@ def test_handle_slash_command_skills_uses_owner_specific_catalog(tmp_path: Path)
             encoding="utf-8",
         )
 
-        engine = _make_engine(tmp_path, knowledge_repo_for_session=lambda _session_id: registry.get_for_user("thies"))
-        state = engine.session_mgr.create_session(user="thies")
-        sid = state.session_id
-        engine.get_or_activate(sid)
+        engine = None
+
+        def knowledge_repo_for_session(session_id: str):
+            assert engine is not None
+            owner = engine.session_mgr.load_meta(session_id).user
+            return registry.get_for_user(owner)
+
+        engine = _make_engine(tmp_path, knowledge_repo_for_session=knowledge_repo_for_session)
+        thies_state = engine.session_mgr.create_session(user="thies")
+        ada_state = engine.session_mgr.create_session(user="ada")
+        thies_sid = thies_state.session_id
+        ada_sid = ada_state.session_id
+        engine.get_or_activate(thies_sid)
+        engine.get_or_activate(ada_sid)
 
         async def _run() -> None:
-            result = await engine.handle_slash_command(sid, "/skills")
+            thies_result = await engine.handle_slash_command(thies_sid, "/skills")
+            ada_result = await engine.handle_slash_command(ada_sid, "/skills")
 
-            assert result is not None
-            assert result["data"] == [{"name": "alpha", "description": "Owner skill"}]
+            assert thies_result is not None
+            assert ada_result is not None
+            assert thies_result["data"] == [{"name": "alpha", "description": "Owner skill"}]
+            assert ada_result["data"] == [{"name": "beta", "description": "Other skill"}]
 
         asyncio.run(_run())
+        assert engine._knowledge_dir_for_session(thies_sid) != engine._knowledge_dir_for_session(ada_sid)
 
 
 def test_turn_usage_payload_contains_budget_gauges_without_agent_usage(tmp_path: Path):


### PR DESCRIPTION
someone did not pay close enough attention while multi-user was implemented. To be fair, so did the review bots...


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches multi-tenant data isolation, Git HTTP auth paths, startup/bootstrap, and admin settings rollback—incorrect owner resolution could leak or mix user knowledge.
> 
> **Overview**
> Replaces the **single shared** knowledge repo with **one Git-backed repo per user** under `data/knowledges/<normalized-user>/`, and threads that ownership through sessions, sandboxes, Git HTTP, archives, and skills.
> 
> **Runtime:** Introduces `KnowledgeRepoRegistry` and session-scoped resolvers so the engine, sentinel (`SECURITY.md`), sandbox clones, skill catalog, `/pull`/`/push`, and session archive commits all use the **session owner’s** repo. Default config `knowledge_dir` becomes `./knowledges` (parent of per-user dirs). Startup bootstraps **each enabled user** independently (remote pull, seed, push); admin/user create, enable, and git settings changes trigger per-user bootstrap with rollback on failure.
> 
> **Git & isolation:** Removes the old rule that only one enabled user could set an upstream remote. `KnowledgeGitRuntime` and `GitHttpHandler` scope remotes and HTTP paths to the session owner (cross-user repo access returns 403). Post-push upstream sync passes the owner name.
> 
> **API / clients:** Matrix channel no longer takes a global skill catalog. Session fork copies owner meta. Tests and docs updated for multi-user git and per-user archive paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70f2e05f7aaf3ecb5f61a302ae5017fd14c48e85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->