### PR TITLE
💚 ci: publish pr docker images + helm chart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
             oci://ghcr.io/${{ github.repository_owner }}/charts
 
       - name: Upload PR Helm chart artifact
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275cb4f3dfe5 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: carapace-chart-pr${{ github.event.pull_request.number }}
           path: dist/carapace-${{ steps.package.outputs.chart_version }}.tgz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,3 +152,76 @@ jobs:
           tags: ghcr.io/${{ github.repository }}-bitwarden-cli:pr${{ github.event.pull_request.number }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  helm-publish-pr:
+    runs-on: ubuntu-latest
+    needs:
+      [
+        helm-lint,
+        docker-backend,
+        docker-frontend,
+        docker-sandbox,
+        docker-bitwarden-cli,
+      ]
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
+      - name: Package PR Helm chart
+        id: package
+        run: |
+          base_version=$(awk '/^version:/ { print $2; exit }' charts/carapace/Chart.yaml)
+          pr_number='${{ github.event.pull_request.number }}'
+          chart_version="${base_version}-pr.${pr_number}"
+          app_version="pr${pr_number}"
+
+          mkdir -p dist
+          helm package charts/carapace \
+            --destination dist \
+            --version "$chart_version" \
+            --app-version "$app_version"
+
+          echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
+          echo "app_version=$app_version" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push PR Helm chart to GHCR
+        run: |
+          helm push \
+            "dist/carapace-${{ steps.package.outputs.chart_version }}.tgz" \
+            oci://ghcr.io/${{ github.repository_owner }}/charts
+
+      - name: Upload PR Helm chart artifact
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275cb4f3dfe5 # v4
+        with:
+          name: carapace-chart-pr${{ github.event.pull_request.number }}
+          path: dist/carapace-${{ steps.package.outputs.chart_version }}.tgz
+
+      - name: Print PR preview tags
+        run: |
+          echo "::notice title=PR preview image tag::${{ steps.package.outputs.app_version }}"
+          echo "::notice title=PR preview chart version::${{ steps.package.outputs.chart_version }}"
+          echo "Use image tag: ${{ steps.package.outputs.app_version }}"
+          echo "Use chart version: ${{ steps.package.outputs.chart_version }}"
+
+          {
+            echo "## PR preview artifacts"
+            echo
+            echo "Use image tag: ${{ steps.package.outputs.app_version }}"
+            echo "Use chart version: ${{ steps.package.outputs.chart_version }}"
+            echo
+            echo "Images:"
+            echo "- ghcr.io/${{ github.repository }}:${{ steps.package.outputs.app_version }}"
+            echo "- ghcr.io/${{ github.repository }}-frontend:${{ steps.package.outputs.app_version }}"
+            echo "- ghcr.io/${{ github.repository }}-sandbox:${{ steps.package.outputs.app_version }}"
+            echo "- ghcr.io/${{ github.repository }}-bitwarden-cli:${{ steps.package.outputs.app_version }}"
+            echo
+            echo "Chart:"
+            echo "- oci://ghcr.io/${{ github.repository_owner }}/charts/carapace --version ${{ steps.package.outputs.chart_version }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/charts/carapace/README.md
+++ b/charts/carapace/README.md
@@ -59,6 +59,20 @@ helmCharts:
     valuesFile: values.yaml
 ```
 
+Pull request builds also publish preview images tagged as `pr<PR number>` and a matching OCI chart package. The preview chart uses `appVersion=pr<PR number>`, so the default image tags resolve to the PR images automatically.
+
+Example for PR 99 when the base chart version is `0.28.0`:
+
+```bash
+helm install carapace oci://ghcr.io/thiesgerken/charts/carapace \
+  --namespace carapace \
+  --version 0.28.0-pr.99 \
+  --set ingress.hostname=carapace.example.com \
+  --set 'envFrom[0].secretRef.name=carapace-secrets'
+```
+
+The chart version stays tied to the chart's current base version. If `Chart.yaml` moves to `0.29.0`, the preview for PR 99 becomes `0.29.0-pr.99`.
+
 ## Upgrade
 
 ```bash
@@ -75,7 +89,7 @@ helm uninstall carapace -n carapace
 
 ## Configuration
 
-All images default to the chart's `appVersion` tag, which is kept in sync with the project version by semantic-release.
+All images default to the chart's `appVersion` tag. Release charts use the semantic-release project version, and PR preview charts use `pr<PR number>`.
 
 ### Required configuration
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "pretest": "pnpm prepare:emoji",
     "test": "node --import tsx --test src/lib/*.test.ts src/components/*.test.tsx src/hooks/*.test.tsx test/*.test.js"
   },
   "dependencies": {

--- a/tests/test_tool_output_limit.py
+++ b/tests/test_tool_output_limit.py
@@ -24,17 +24,16 @@ def test_truncate_tool_output_truncates():
     assert "limit 4" in out
 
 
-def test_truncate_exec_output_with_saved_path_includes_read_hint():
+def test_truncate_exec_output_with_saved_path_includes_saved_path():
     text = "abcdefghij" * 80
     spill_path = "/tmp/out.txt"
 
     out = truncate_exec_output_with_saved_path(text, 320, spill_path)
-    preview, _, suffix = out.partition("\n\n[Output truncated:")
+    preview, _, suffix = out.partition("\n\n[Output truncated")
 
     assert len(out) <= 320
     assert len(preview) == 160
     assert preview == text[:160]
     assert spill_path in out
-    assert f'read(path="{spill_path}")' in out
-    assert suffix.lstrip().startswith("800 characters total")
-    assert "800 characters total" in out
+    assert suffix.startswith(", showing only 160 of 800 characters.Full output saved to /tmp/out.txt.]")
+    assert "800 characters total" not in out


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to CI publishing, documentation, frontend test prep, and test expectations for user-facing truncation text—no auth or runtime security logic changes.
> 
> **Overview**
> Adds a **`helm-publish-pr`** CI job (after image builds and helm lint) that packages the carapace chart as **`{Chart.yaml version}-pr.{N}`** with **`appVersion=pr{N}`**, pushes it to **GHCR OCI**, uploads a workflow artifact, and writes **PR preview** image/chart tags to the job summary and notices.
> 
> Documents how to **install PR preview** charts and clarifies that default image tags follow **`appVersion`** for release vs PR builds.
> 
> Runs **`prepare:emoji`** before frontend tests via a new **`pretest`** script.
> 
> Aligns **`truncate_exec_output_with_saved_path`** tests with the current truncation footer (saved path text, no `read()` hint or duplicate character-count line).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb1f051ffffbd0d72c2342002c71f11bcaaf581e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->