### PR TITLE
🐛 fix: Run auto-titling off the session busy path

### DIFF
--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -668,11 +668,13 @@ class SessionEngine(
             active.llm_request_state = None
             active.llm_request_thinking.clear()
 
-    async def _generate_title(self, active: ActiveSession, events: list[dict[str, Any]]) -> str:
+    async def _generate_title(
+        self, active: ActiveSession, events: list[dict[str, Any]], *, track_activity: bool = True
+    ) -> str:
         session_id = active.state.session_id
         try:
             async with self._llm_semaphore:
-                with self.llm_request_recording(active):
+                with self.llm_request_recording(active, track_activity=track_activity):
                     self._assert_llm_budget_available(active)
                     title = await generate_title(
                         events,

--- a/src/carapace/session/turns.py
+++ b/src/carapace/session/turns.py
@@ -160,7 +160,9 @@ class SessionTurnHost(Protocol):
 
     async def _clear_llm_request_state(self, active: ActiveSession) -> None: ...
 
-    async def _generate_title(self, active: ActiveSession, events: list[dict[str, Any]]) -> str: ...
+    async def _generate_title(
+        self, active: ActiveSession, events: list[dict[str, Any]], *, track_activity: bool = True
+    ) -> str: ...
 
 
 class SessionTurnMixin(SessionTurnHost):

--- a/src/carapace/session/turns.py
+++ b/src/carapace/session/turns.py
@@ -532,7 +532,7 @@ class SessionTurnMixin(SessionTurnHost):
         if _non_slash_user_message_count(events) not in (1, 3):
             return
         task = asyncio.create_task(
-            self._generate_title(active, events),
+            self._generate_title(active, events, track_activity=False),
             name=f"title-{session_id}",
         )
         active._pending_sends.add(task)

--- a/src/carapace/session/usage_budget.py
+++ b/src/carapace/session/usage_budget.py
@@ -256,33 +256,44 @@ class SessionUsageBudgetMixin:
         return f"Set cost budget to ${budget.cost_usd:.4f}."
 
     @contextlib.contextmanager
-    def llm_request_recording(self, active: ActiveSession):
+    def llm_request_recording(self, active: ActiveSession, *, track_activity: bool = True):
+        """Record LLM requests for *active* into its request log.
+
+        When *track_activity* is False (e.g. background auto-titling), the recorder still appends
+        the audit record but does NOT mutate or broadcast ``active.llm_request_state`` — the
+        session never appears busy and a concurrent real turn's activity state is left untouched.
+        """
         engine = self
         session_id = active.state.session_id
 
         class Sink:
             async def on_request_started(self, state: LlmRequestState) -> None:
                 active.llm_request_thinking.pop(state.request_id, None)
-                await engine._set_llm_request_state(active, state)
+                if track_activity:
+                    await engine._set_llm_request_state(active, state)
 
             async def on_request_completed(self, record: LlmRequestRecord) -> None:
-                thinking_content = active.llm_request_thinking.pop(record.request_id or "", "")
-                if thinking_content:
-                    thinking_event: dict[str, Any] = {
-                        "role": "thinking",
-                        "content": thinking_content,
-                    }
-                    if record.request_id:
-                        thinking_event["request_id"] = record.request_id
-                    row = usage_last_request_row(record)
-                    if row is not None and row["reasoning_duration_ms"] is not None:
-                        thinking_event["reasoning_duration_ms"] = row["reasoning_duration_ms"]
-                    if row is not None and row["reasoning_tokens"] is not None:
-                        thinking_event["reasoning_tokens"] = row["reasoning_tokens"]
-                    engine._session_mgr.append_events(session_id, [thinking_event])
+                if track_activity:
+                    thinking_content = active.llm_request_thinking.pop(record.request_id or "", "")
+                    if thinking_content:
+                        thinking_event: dict[str, Any] = {
+                            "role": "thinking",
+                            "content": thinking_content,
+                        }
+                        if record.request_id:
+                            thinking_event["request_id"] = record.request_id
+                        row = usage_last_request_row(record)
+                        if row is not None and row["reasoning_duration_ms"] is not None:
+                            thinking_event["reasoning_duration_ms"] = row["reasoning_duration_ms"]
+                        if row is not None and row["reasoning_tokens"] is not None:
+                            thinking_event["reasoning_tokens"] = row["reasoning_tokens"]
+                        engine._session_mgr.append_events(session_id, [thinking_event])
+                else:
+                    active.llm_request_thinking.pop(record.request_id or "", None)
                 active.llm_request_log.records.append(record)
                 engine._session_mgr.save_llm_request_log(session_id, active.llm_request_log)
-                await engine._clear_llm_request_state(active)
+                if track_activity:
+                    await engine._clear_llm_request_state(active)
 
         with llm_request_sink_scope(Sink()):
             yield

--- a/tests/test_session_engine_models.py
+++ b/tests/test_session_engine_models.py
@@ -257,6 +257,87 @@ def test_generate_title_records_titler_request_log(tmp_path: Path):
         asyncio.run(_run())
 
 
+def _emit_titler_request() -> str:
+    """Drive the active llm-request sink as the titler would, returning a fixed title."""
+
+    async def _fake(*_args: Any, **_kwargs: Any) -> str:
+        observer = usage_mod._llm_request_sink.get()
+        assert observer is not None
+        started_at = datetime.now(tz=UTC)
+        await observer.on_request_started(
+            LlmRequestState(
+                request_id="req-title",
+                source="titler",
+                model_name="anthropic:claude-haiku-4-5",
+                started_at=started_at,
+            )
+        )
+        await observer.on_request_completed(
+            LlmRequestRecord(
+                ts=started_at + timedelta(seconds=1),
+                request_id="req-title",
+                source="titler",
+                model_name="anthropic:claude-haiku-4-5",
+                started_at=started_at,
+                completed_at=started_at + timedelta(seconds=1),
+            )
+        )
+        return "📌 hello"
+
+    return _fake  # type: ignore[return-value]
+
+
+def test_generate_title_untracked_is_invisible(tmp_path: Path):
+    """Background auto-title (track_activity=False) never broadcasts llm activity or sets state."""
+
+    async def _run() -> None:
+        engine = _make_engine(tmp_path)
+        sid = engine.session_mgr.create_session(user="thies").session_id
+        active = engine.get_or_activate(sid)
+        sub = _FakeSubscriber()
+        engine.subscribe(sid, sub)
+
+        with patch("carapace.session.engine.generate_title", new=AsyncMock(side_effect=_emit_titler_request())):
+            title = await engine._generate_title(active, [{"role": "user", "content": "hello"}], track_activity=False)
+
+        assert title == "📌 hello"
+        # invisible: no busy signal, no lingering activity state
+        assert sub.llm_activity_updates == []
+        assert active.llm_request_state is None
+        assert engine.session_mgr.load_llm_request_state(sid) is None
+        # final title still reaches clients
+        assert sub.title_updates and sub.title_updates[0][0] == "📌 hello"
+        # audit record is still kept
+        assert active.llm_request_log.records[-1].source == "titler"
+
+    with _patch_sentinel():
+        asyncio.run(_run())
+
+
+def test_generate_title_tracked_emits_activity(tmp_path: Path):
+    """Visible path (slash commands, track_activity default) still broadcasts llm activity."""
+
+    async def _run() -> None:
+        engine = _make_engine(tmp_path)
+        sid = engine.session_mgr.create_session(user="thies").session_id
+        active = engine.get_or_activate(sid)
+        sub = _FakeSubscriber()
+        engine.subscribe(sid, sub)
+
+        with patch("carapace.session.engine.generate_title", new=AsyncMock(side_effect=_emit_titler_request())):
+            title = await engine._generate_title(active, [{"role": "user", "content": "hello"}])
+
+        assert title == "📌 hello"
+        # started -> state set, completed -> cleared to None
+        assert sub.llm_activity_updates
+        assert sub.llm_activity_updates[0] is not None
+        assert sub.llm_activity_updates[-1] is None
+        assert active.llm_request_state is None
+
+    with _patch_sentinel():
+        asyncio.run(_run())
+
+
 def test_handle_slash_command_inactive_session(tmp_path: Path):
     """handle_slash_command returns None for a session that isn't active."""
     engine = _make_engine(tmp_path)


### PR DESCRIPTION
## Problem
Auto-titling already runs fire-and-forget (`turns.py`), but its LLM call was wrapped in `llm_request_recording`, which sets `active.llm_request_state` and broadcasts `on_llm_activity`. Result: the session looks **busy** while a background title generates, and the title's activity state clobbers a concurrently running turn's state.

## Fix
- `llm_request_recording(track_activity=True)` — when `False`, keeps the audit-log record + usage tracking but skips `_set/_clear_llm_request_state` (no `on_llm_activity` broadcast, no state write).
- `_generate_title(track_activity=True)` forwards the flag.
- Auto-title scheduler passes `track_activity=False`.

`/retitle` and `/model title` stay visible/blocking (explicit user actions). Shared `_llm_semaphore` unchanged.

## Tests
- New: `test_generate_title_untracked_is_invisible` — no `on_llm_activity`, `llm_request_state` untouched, title still broadcast, audit record kept.
- New: `test_generate_title_tracked_emits_activity` — visible path still emits start/clear activity.
- Existing titling tests pass (usage + log recording intact). `28 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to LLM activity visibility for background titling; default tracked behavior unchanged for agent turns and explicit retitle.
> 
> **Overview**
> Background auto-titling no longer makes the session look **busy** or overwrite in-flight turn LLM activity.
> 
> **`llm_request_recording`** gains **`track_activity`** (default **`True`**). When **`False`**, it still appends audit log entries and persists usage, but skips **`_set/_clear_llm_request_state`**, **`on_llm_activity`** broadcasts, and thinking transcript events. **`_generate_title`** forwards the flag; **`_schedule_title_generation_if_needed`** passes **`track_activity=False`**. Explicit **`/retitle`** (and similar user-driven title paths) keep the default visible behavior.
> 
> Tests cover untracked invisibility vs tracked activity emission while title updates and titler audit records remain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac9f6a566b2478150aa70fd96d63693b3b521a69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->