### PR TITLE
🐛fix: confine /usage tables to horizontal scroll on mobile

### DIFF
--- a/frontend/src/components/command-result.tsx
+++ b/frontend/src/components/command-result.tsx
@@ -521,6 +521,7 @@ function UsageView({ data }: { data: UsagePayload }) {
         <p className="mb-1 text-xs font-medium text-muted-foreground">
           {title}
         </p>
+        <div className="overflow-x-auto">
         <table className="w-full">
           <thead>
             <tr className="border-b border-border text-left text-xs text-muted-foreground">
@@ -573,6 +574,7 @@ function UsageView({ data }: { data: UsagePayload }) {
             ))}
           </tbody>
         </table>
+        </div>
       </div>
     );
   }
@@ -618,6 +620,7 @@ function UsageView({ data }: { data: UsagePayload }) {
           <p className="mb-1 text-xs font-medium text-muted-foreground">
             {t("usage.context")}
           </p>
+          <div className="overflow-x-auto">
           <table className="w-full">
             <thead>
               <tr className="border-b border-border text-left text-xs text-muted-foreground">
@@ -679,6 +682,7 @@ function UsageView({ data }: { data: UsagePayload }) {
               ))}
             </tbody>
           </table>
+          </div>
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
## Problem
On narrow/mobile screens the `/usage` output was wider than the viewport. The tables had no horizontal-scroll container, so the overflow propagated to the document and the **whole app** scrolled sideways.

## Fix
Wrap both usage tables (`renderTable` helper for By Model/By Category, and the context table) in `overflow-x-auto`, matching the existing `/models` pattern (`command-result.tsx:139`). Now only the table scrolls; the app shell stays fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS wrappers with no logic, data, or API changes.
> 
> **Overview**
> Fixes **mobile layout** for `/usage` command output: wide tables no longer force horizontal scrolling of the whole app.
> 
> Wraps the **By Model / By Category** tables (`renderTable` in `UsageView`) and the **context breakdown** table in `overflow-x-auto` containers, matching the existing `/models` table pattern in the same file. Overflow is confined to each table so the app shell stays fixed on narrow viewports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5659f816513891a6615fb17e401a0016f834f6c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->