### PR TITLE
🐛 fix: back off websocket reconnects when connection flaps

### DIFF
--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -6,6 +6,10 @@ import type { ClientMessage, ServerMessage } from "@/lib/types";
 type Status = "disconnected" | "connecting" | "connected";
 
 const RECONNECT_DELAYS = [500, 1000, 2000, 4000];
+// A connection must stay open at least this long before it counts as "stable"
+// and the backoff resets. Prevents a tight reconnect loop when the backend
+// accepts the socket then immediately drops it (half-ready after a restart).
+const STABLE_CONNECTION_MS = 5000;
 
 export function useWebSocket(
   url: string | null,
@@ -26,6 +30,7 @@ export function useWebSocket(
   const connect = useCallback(() => {
     if (!url || unmountedRef.current) return;
     let opened = false;
+    let openedAt = 0;
 
     // Close any existing connection before opening a new one
     if (wsRef.current) {
@@ -47,8 +52,11 @@ export function useWebSocket(
     ws.onopen = () => {
       if (wsRef.current !== ws) return; // stale
       opened = true;
+      openedAt = Date.now();
       setStatus("connected");
-      retriesRef.current = 0;
+      // Do NOT reset retries here: a connection that opens then immediately
+      // drops must keep backing off. Reset happens in onclose once the socket
+      // has stayed open past STABLE_CONNECTION_MS.
     };
 
     ws.onclose = () => {
@@ -57,6 +65,9 @@ export function useWebSocket(
       wsRef.current = null;
       if (opened) {
         onDisconnectRef.current?.();
+        if (Date.now() - openedAt >= STABLE_CONNECTION_MS) {
+          retriesRef.current = 0;
+        }
       }
 
       if (unmountedRef.current) return;


### PR DESCRIPTION
## Problem

Reported as the frontend going into a "rapid reload cycle" after the backend was briefly down.

There is no page-reload code in the frontend. The actual cause is a WebSocket reconnect storm: `use-websocket.ts` reset the reconnect backoff to 0 the instant `onopen` fired. When the backend bounces and comes back half-ready (accepts the socket, then immediately drops it), the backoff never grew → tight 500ms reconnect loop. Each cycle flips connection `status` and fires `onWsDisconnect`, re-rendering chat-view repeatedly — looks like the page reloading every half second.

## Fix

Reset the backoff only after the socket has stayed open past `STABLE_CONNECTION_MS` (5s). A flapping connection now escalates to the 4s cap instead of hammering.

## Test

`use-websocket.test.tsx` passes; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to client reconnect timing in `use-websocket.ts`; no auth or server behavior changes.
> 
> **Overview**
> Fixes a **reconnect storm** in `useWebSocket` when the backend accepts a socket then drops it quickly (e.g. after restart).
> 
> **Before:** `retriesRef` reset to `0` on every `onopen`, so flap cycles always retried at **500ms** and repeatedly toggled `status` / `onDisconnect` (felt like rapid page reloads).
> 
> **After:** Introduces `STABLE_CONNECTION_MS` (5s) and only resets backoff in `onclose` if the connection stayed open at least that long. Short-lived opens keep escalating through `[500, 1000, 2000, 4000]` ms delays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78c46b5b6ce6c2b059ca95b752ebec361e7c8420. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->