### PR TITLE
✨ feat: user-managed scoped API keys

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -1029,7 +1029,8 @@
       "title": "Aktive Schlüssel",
       "empty": "Noch keine API-Schlüssel.",
       "loading": "Schlüssel werden geladen…",
-      "unnamed": "Unbenannter Schlüssel"
+      "unnamed": "Unbenannter Schlüssel",
+      "expired": "Abgelaufen"
     },
     "fields": {
       "created": "Erstellt {timestamp}",

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -1,997 +1,1054 @@
 {
-    "app": {
-        "name": "carapace",
-        "description": "Sicherheitsorientierter persönlicher KI-Agent"
+  "app": {
+    "name": "carapace",
+    "description": "Sicherheitsorientierter persönlicher KI-Agent"
+  },
+  "navigation": {
+    "home": "Start",
+    "settings": "Einstellungen",
+    "jobs": "Jobs",
+    "account": "Konto",
+    "preferences": "Allgemein",
+    "platform": "Admin",
+    "models": "Modelle",
+    "users": "Benutzer",
+    "disconnect": "Trennen",
+    "github": "thiesgerken/carapace",
+    "apiKeys": "API-Schlüssel"
+  },
+  "account": {
+    "menu": "Kontomenü",
+    "openMenu": "Kontomenü öffnen",
+    "unknown": "Unbekannter Benutzer",
+    "logout": "Abmelden"
+  },
+  "accountSettings": {
+    "status": {
+      "loading": "Einstellungen werden geladen",
+      "unavailable": "Einstellungen sind nicht verfügbar",
+      "configured": "konfiguriert",
+      "notSet": "nicht gesetzt"
     },
-    "navigation": {
-        "home": "Start",
-        "settings": "Einstellungen",
-        "jobs": "Jobs",
-        "account": "Konto",
-        "preferences": "Allgemein",
-        "platform": "Admin",
-        "models": "Modelle",
-        "users": "Benutzer",
-        "disconnect": "Trennen",
-        "github": "thiesgerken/carapace"
+    "notices": {
+      "saved": "Gespeichert."
     },
-    "account": {
-        "menu": "Kontomenü",
-        "openMenu": "Kontomenü öffnen",
-        "unknown": "Unbekannter Benutzer",
-        "logout": "Abmelden"
+    "errors": {
+      "load": "Benutzereinstellungen konnten nicht geladen werden",
+      "save": "Benutzereinstellungen konnten nicht aktualisiert werden",
+      "credentialsInvalid": "Zugangsdaten-Backend-Einstellungen sind ungültig",
+      "credentialNameRequired": "Name des Zugangsdaten-Backends ist erforderlich",
+      "credentialNameNoSlash": "Zugangsdaten-Backend-Name {name} darf kein / enthalten",
+      "credentialNameDuplicate": "Zugangsdaten-Backend-Name {name} wird bereits verwendet",
+      "fileBackendDisabled": "Dateibasierte Zugangsdaten-Backends sind auf diesem Server deaktiviert",
+      "basicAuthUsernameRequired": "Basic-Auth-Benutzername ist für {name} erforderlich",
+      "basicAuthPasswordRequired": "Basic-Auth-Passwort ist für {name} erforderlich",
+      "matrixPasswordRequired": "Matrix-Passwort ist erforderlich, wenn Matrix aktiviert ist",
+      "budgetWholeNumber": "{field} muss eine nicht negative ganze Zahl sein.",
+      "budgetNumber": "{field} muss eine nicht negative Zahl sein."
     },
-    "accountSettings": {
-        "status": {
-            "loading": "Einstellungen werden geladen",
-            "unavailable": "Einstellungen sind nicht verfügbar",
-            "configured": "konfiguriert",
-            "notSet": "nicht gesetzt"
+    "sections": {
+      "defaultModels": "Standardmodelle",
+      "defaultBudgets": "Standardbudgets",
+      "matrix": "Matrix",
+      "credentials": "Zugangsdaten",
+      "gitRemote": "Git-Remote"
+    },
+    "fields": {
+      "agent": "Agent",
+      "sentinel": "Sentinel",
+      "title": "Titel",
+      "inputTokens": "Input-Tokens",
+      "outputTokens": "Output-Tokens",
+      "costUsd": "Kosten (in $)",
+      "toolCalls": "Tool-Aufrufe",
+      "enabled": "Aktiviert",
+      "homeserver": "Homeserver",
+      "userId": "Benutzer-ID",
+      "deviceName": "Gerätename",
+      "password": "Passwort",
+      "allowedRooms": "Erlaubte Räume",
+      "allowedUsers": "Erlaubte Benutzer",
+      "remote": "Remote",
+      "branch": "Branch",
+      "author": "Autor",
+      "token": "Token",
+      "name": "Name",
+      "path": "Pfad",
+      "url": "URL",
+      "basicAuth": "Basic Auth",
+      "basicAuthUsername": "Basic-Auth-Benutzername",
+      "basicAuthPassword": "Basic-Auth-Passwort",
+      "expose": "Freigeben",
+      "hide": "Ausblenden"
+    },
+    "defaults": {
+      "serverDefault": "Serverstandard",
+      "currentModel": "{model}"
+    },
+    "placeholders": {
+      "addRoom": "Raum hinzufügen, Enter oder Komma",
+      "addUser": "Benutzer hinzufügen, Enter oder Komma",
+      "addIdentifier": "Kennung hinzufügen, Enter oder Komma"
+    },
+    "tooltips": {
+      "filePath": "Relative Pfade werden vom Arbeitsverzeichnis des Servers aus aufgelöst.",
+      "expose": "Nur diese Zugangsdaten-Kennungen aus diesem Backend erlauben. Leer lassen, um alles außer ausgeblendeten Einträgen zu erlauben.",
+      "hide": "Diese Zugangsdaten-Kennungen aus diesem Backend verweigern. Wird ignoriert, wenn Freigeben gesetzt ist."
+    },
+    "actions": {
+      "save": "Speichern",
+      "saving": "Speichert",
+      "addBitwarden": "Bitwarden",
+      "addFile": "Datei",
+      "remove": "Entfernen",
+      "removeValue": "{value} entfernen",
+      "removeBackend": "Backend entfernen",
+      "removeBackendAria": "{name} entfernen"
+    },
+    "empty": {
+      "credentials": "Keine Zugangsdaten-Backends konfiguriert"
+    },
+    "credentials": {
+      "backendFallback": "Zugangsdaten-Backend",
+      "types": {
+        "file": {
+          "label": "Datei",
+          "description": "Lokale Zugangsdatendatei"
         },
-        "notices": {
-            "saved": "Gespeichert."
-        },
-        "errors": {
-            "load": "Benutzereinstellungen konnten nicht geladen werden",
-            "save": "Benutzereinstellungen konnten nicht aktualisiert werden",
-            "credentialsInvalid": "Zugangsdaten-Backend-Einstellungen sind ungültig",
-            "credentialNameRequired": "Name des Zugangsdaten-Backends ist erforderlich",
-            "credentialNameNoSlash": "Zugangsdaten-Backend-Name {name} darf kein / enthalten",
-            "credentialNameDuplicate": "Zugangsdaten-Backend-Name {name} wird bereits verwendet",
-            "fileBackendDisabled": "Dateibasierte Zugangsdaten-Backends sind auf diesem Server deaktiviert",
-            "basicAuthUsernameRequired": "Basic-Auth-Benutzername ist für {name} erforderlich",
-            "basicAuthPasswordRequired": "Basic-Auth-Passwort ist für {name} erforderlich",
-            "matrixPasswordRequired": "Matrix-Passwort ist erforderlich, wenn Matrix aktiviert ist",
-            "budgetWholeNumber": "{field} muss eine nicht negative ganze Zahl sein.",
-            "budgetNumber": "{field} muss eine nicht negative Zahl sein."
-        },
-        "sections": {
-            "defaultModels": "Standardmodelle",
-            "defaultBudgets": "Standardbudgets",
-            "matrix": "Matrix",
-            "credentials": "Zugangsdaten",
-            "gitRemote": "Git-Remote"
-        },
-        "fields": {
-            "agent": "Agent",
-            "sentinel": "Sentinel",
-            "title": "Titel",
-            "inputTokens": "Input-Tokens",
-            "outputTokens": "Output-Tokens",
-            "costUsd": "Kosten (in $)",
-            "toolCalls": "Tool-Aufrufe",
-            "enabled": "Aktiviert",
-            "homeserver": "Homeserver",
-            "userId": "Benutzer-ID",
-            "deviceName": "Gerätename",
-            "password": "Passwort",
-            "allowedRooms": "Erlaubte Räume",
-            "allowedUsers": "Erlaubte Benutzer",
-            "remote": "Remote",
-            "branch": "Branch",
-            "author": "Autor",
-            "token": "Token",
-            "name": "Name",
-            "path": "Pfad",
-            "url": "URL",
-            "basicAuth": "Basic Auth",
-            "basicAuthUsername": "Basic-Auth-Benutzername",
-            "basicAuthPassword": "Basic-Auth-Passwort",
-            "expose": "Freigeben",
-            "hide": "Ausblenden"
-        },
-        "defaults": {
-            "serverDefault": "Serverstandard",
-            "currentModel": "{model}"
-        },
-        "placeholders": {
-            "addRoom": "Raum hinzufügen, Enter oder Komma",
-            "addUser": "Benutzer hinzufügen, Enter oder Komma",
-            "addIdentifier": "Kennung hinzufügen, Enter oder Komma"
-        },
-        "tooltips": {
-            "filePath": "Relative Pfade werden vom Arbeitsverzeichnis des Servers aus aufgelöst.",
-            "expose": "Nur diese Zugangsdaten-Kennungen aus diesem Backend erlauben. Leer lassen, um alles außer ausgeblendeten Einträgen zu erlauben.",
-            "hide": "Diese Zugangsdaten-Kennungen aus diesem Backend verweigern. Wird ignoriert, wenn Freigeben gesetzt ist."
-        },
-        "actions": {
-            "save": "Speichern",
-            "saving": "Speichert",
-            "addBitwarden": "Bitwarden",
-            "addFile": "Datei",
-            "remove": "Entfernen",
-            "removeValue": "{value} entfernen",
-            "removeBackend": "Backend entfernen",
-            "removeBackendAria": "{name} entfernen"
-        },
-        "empty": {
-            "credentials": "Keine Zugangsdaten-Backends konfiguriert"
-        },
-        "credentials": {
-            "backendFallback": "Zugangsdaten-Backend",
-            "types": {
-                "file": {
-                    "label": "Datei",
-                    "description": "Lokale Zugangsdatendatei"
-                },
-                "bitwarden": {
-                    "label": "Bitwarden",
-                    "description": "Passwortmanager-Proxy"
-                }
-            }
+        "bitwarden": {
+          "label": "Bitwarden",
+          "description": "Passwortmanager-Proxy"
         }
-    },
-    "platformSettings": {
-        "status": {
-            "loading": "Plattformeinstellungen werden geladen",
-            "unavailable": "Plattformeinstellungen sind nicht verfügbar",
-            "readOnly": "Die Konfigurationsdatei ist schreibgeschützt."
-        },
-        "notices": {
-            "saved": "Gespeichert."
-        },
-        "errors": {
-            "load": "Plattformeinstellungen konnten nicht geladen werden",
-            "save": "Plattformeinstellungen konnten nicht aktualisiert werden",
-            "wholeNumber": "{field} muss eine positive ganze Zahl sein.",
-            "nonNegativeWholeNumber": "{field} muss eine nicht negative ganze Zahl sein.",
-            "number": "{field} muss eine nicht negative Zahl sein.",
-            "providerRequired": "Provider ist für Modell {index} erforderlich.",
-            "nameRequired": "Name ist für Modell {index} erforderlich.",
-            "duplicateModel": "Modell-ID {id} wird mehrfach verwendet.",
-            "rawSecretRequired": "Füge einen API-Key für {id} ein oder wähle eine andere Secret-Quelle.",
-            "secretValueRequired": "Secret-Referenz ist für {id} erforderlich.",
-            "defaultRequired": "{field}-Standardmodell ist erforderlich.",
-            "defaultUnknown": "{field}-Standardmodell {id} ist nicht im Katalog."
-        },
-        "sections": {
-            "defaultModels": "Standardmodelle",
-            "defaultBudgets": "Standardbudgets",
-            "catalog": "Modellkatalog"
-        },
-        "fields": {
-            "agent": "Agent",
-            "sentinel": "Sentinel",
-            "title": "Titel",
-            "inputTokens": "Input-Tokens",
-            "outputTokens": "Output-Tokens",
-            "costUsd": "Kosten (in $)",
-            "toolCalls": "Tool-Aufrufe",
-            "provider": "Provider",
-            "name": "Name",
-            "id": "ID",
-            "maxInputTokens": "Max. Input-Tokens",
-            "thinking": "Thinking",
-            "thinkingBudgetTokens": "Thinking-Budget-Tokens",
-            "baseUrl": "Base URL",
-            "vision": "Vision",
-            "visionHint": "Akzeptiert Bildeingaben",
-            "apiKeySource": "API-Key-Quelle",
-            "apiKey": "API-Key",
-            "secretReference": "Secret-Referenz"
-        },
-        "placeholders": {
-            "selectModel": "Modell auswählen",
-            "unlimited": "Unbegrenzt",
-            "generatedId": "provider:name",
-            "keepSecret": "Konfiguriertes Secret behalten"
-        },
-        "actions": {
-            "save": "Speichern",
-            "saving": "Speichert",
-            "addModel": "Modell hinzufügen",
-            "removeModel": "Modell entfernen",
-            "confirmRemoveModel": "Modell \"{name}\" entfernen? Dies kann nicht rückgängig gemacht werden."
-        },
-        "secretSources": {
-            "none": "Keine",
-            "raw": "Direkter Wert",
-            "env": "Umgebungsvariable",
-            "file": "Datei"
-        },
-        "thinking": {
-            "default": "Standard",
-            "true": "Aktiviert",
-            "false": "Deaktiviert",
-            "minimal": "Minimal",
-            "low": "Niedrig",
-            "medium": "Mittel",
-            "high": "Hoch",
-            "xhigh": "Extra hoch"
-        },
-        "units": {
-            "tokens": "Tokens"
-        },
-        "modelRow": "Modell {index}"
-    },
-    "home": {
-        "empty": {
-            "description": "Wähle eine Sitzung aus oder starte eine neue"
-        }
-    },
-    "connect": {
-        "description": "Bei carapace anmelden",
-        "serverLabel": "Server-URL",
-        "usernameLabel": "Benutzername",
-        "usernamePlaceholder": "Benutzername",
-        "passwordLabel": "Passwort",
-        "passwordPlaceholder": "Passwort",
-        "connect": "Verbinden",
-        "connecting": "Verbinde…",
-        "errors": {
-            "serverError": "Serverfehler: {status}",
-            "connectionFailed": "Verbindung fehlgeschlagen"
-        }
-    },
-    "admin": {
-        "title": "Admin",
-        "backToApp": "Zurück zur App",
-        "serverLabel": "Server-URL",
-        "serverPlaceholder": "Kein Server ausgewählt",
-        "users": {
-            "title": "Benutzer",
-            "description": "Globale Plattform-Konten, Rollen und Datenzuordnung.",
-            "savedUsers": "Benutzer",
-            "loading": "Benutzer werden geladen…",
-            "empty": "Keine Benutzer gefunden",
-            "selectUser": "Benutzer auswählen",
-            "you": "Du",
-            "admin": "Admin",
-            "enabled": "Aktiv",
-            "disabled": "Deaktiviert"
-        },
-        "create": {
-            "title": "Neuer Benutzer",
-            "subtitle": "Lokalen Benutzer anlegen"
-        },
-        "fields": {
-            "username": "Benutzername",
-            "password": "Passwort",
-            "newPassword": "Neues Passwort",
-            "keepPassword": "Aktuelles Passwort behalten",
-            "displayName": "Anzeigename",
-            "email": "E-Mail",
-            "roles": "Rollen",
-            "enabled": "Aktiv"
-        },
-        "actions": {
-            "load": "Laden",
-            "loading": "Lädt…",
-            "refresh": "Benutzer aktualisieren",
-            "new": "Neuer Benutzer",
-            "deleteUser": "{username} löschen",
-            "create": "Benutzer anlegen",
-            "creating": "Lege an…",
-            "save": "Änderungen speichern",
-            "saving": "Speichert…"
-        },
-        "notices": {
-            "loaded": "Benutzer geladen.",
-            "created": "{username} angelegt.",
-            "saved": "{username} gespeichert.",
-            "deleted": "{username} gelöscht."
-        },
-        "errors": {
-            "missingCredentials": "Aktueller Ursprung ist nicht verfügbar.",
-            "load": "Benutzer konnten nicht geladen werden.",
-            "create": "Benutzer konnte nicht angelegt werden.",
-            "save": "Benutzer konnte nicht gespeichert werden.",
-            "delete": "Benutzer konnte nicht gelöscht werden."
-        },
-        "confirm": {
-            "deleteUser": "{username} löschen? Bestehende Daten dieses Benutzers bleiben erhalten."
-        },
-        "meta": {
-            "tokenVersion": "Token v{version}",
-            "updated": "Aktualisiert {timestamp}",
-            "lastLogin": "Letzter Login {timestamp}",
-            "never": "nie"
-        }
-    },
-    "preferences": {
-        "title": "Einstellungen",
-        "description": "Persönliche Einstellungen für diesen Browser und deine Nutzung.",
-        "currentLocale": "Aktuelle Oberflächensprache: {locale}",
-        "language": {
-            "label": "Sprache",
-            "description": "Wähle, wie die Oberflächensprache bestimmt wird.",
-            "options": {
-                "system": "System",
-                "en": "English",
-                "de": "Deutsch"
-            }
-        },
-        "theme": {
-            "label": "Darstellung",
-            "description": "Wähle, wie das Farbschema bestimmt wird.",
-            "options": {
-                "system": "System",
-                "light": "Hell",
-                "dark": "Dunkel"
-            }
-        },
-        "chatList": {
-            "label": "Chats",
-            "showArchived": {
-                "label": "Archivierte Chats anzeigen",
-                "description": "Wenn deaktiviert, werden archivierte Chats ausgeblendet und bei Session-Listen direkt nicht vom Server angefragt."
-            }
-        },
-        "notifications": {
-            "title": "Push-Benachrichtigungen",
-            "description": "Liefert Eskalationen und Zug-Ergebnisse an diesen Browser oder die installierte PWA.",
-            "status": {
-                "loading": "Benachrichtigungsunterstützung wird geprüft…",
-                "loadingShort": "Prüfung",
-                "enabled": "Benachrichtigungen sind für diesen Browser aktiviert.",
-                "enabledShort": "Aktiv",
-                "disabled": "Benachrichtigungen sind für diesen Browser deaktiviert.",
-                "disabledShort": "Aus",
-                "unsupported": "Dieser Browser kann im aktuellen Kontext keine Web-Push-Benachrichtigungen empfangen.",
-                "permissionDenied": "Die Browser-Benachrichtigungsfreigabe ist blockiert. Aktiviere sie in Browser- oder Geräteeinstellungen erneut.",
-                "permissionRequired": "Die Benachrichtigungsfreigabe wurde nicht erteilt.",
-                "invalidSubscription": "Der Browser hat eine unvollständige Push-Subscription zurückgegeben.",
-                "loadFailed": "Benachrichtigungseinstellungen konnten nicht geladen werden.",
-                "enableFailed": "Benachrichtigungen konnten nicht aktiviert werden.",
-                "disableFailed": "Benachrichtigungen konnten nicht deaktiviert werden.",
-                "preferencesFailed": "Benachrichtigungseinstellungen konnten nicht aktualisiert werden.",
-                "testFailed": "Testbenachrichtigung konnte nicht gesendet werden.",
-                "testSent": "Testbenachrichtigung gesendet."
-            },
-            "deviceName": {
-                "label": "Gerätename",
-                "placeholder": "Android-Telefon",
-                "hint": "Wird in den serverseitigen Benachrichtigungs-Subscriptions für diesen Browser angezeigt."
-            },
-            "toggle": {
-                "label": "Benachrichtigungen"
-            },
-            "actions": {
-                "enable": "Benachrichtigungen aktivieren",
-                "enabling": "Aktiviere…",
-                "disable": "Benachrichtigungen deaktivieren",
-                "disabling": "Deaktiviere…",
-                "test": "Testbenachrichtigung senden",
-                "testing": "Sende Testbenachrichtigung…"
-            },
-            "preferences": {
-                "label": "Benachrichtigungen senden für",
-                "escalation_pending": "Eskalationen, die Freigabe brauchen",
-                "attended_turn_completed": "Begleitete Sitzungen, wenn ein Zug endet",
-                "unattended_turn_completed": "Unbeaufsichtigte Jobs mit erfolgreichem Abschluss",
-                "unattended_turn_failed": "Unbeaufsichtigte Jobs mit Fehler"
-            },
-            "meta": {
-                "permission": "Browser-Freigabe: {permission}",
-                "heartbeat": "Letzter Heartbeat: {timestamp}",
-                "expires": "Subscription läuft ab: {timestamp}"
-            },
-            "permission": {
-                "default": "nicht angefragt",
-                "granted": "erteilt",
-                "denied": "blockiert"
-            }
-        }
-    },
-    "newSessionButton": {
-        "label": "Neue Sitzung",
-        "chooseOptions": "Sitzungsoptionen auswählen",
-        "private": {
-            "enabledTitle": "Privat",
-            "enabledDescription": "Nicht ins Wissens-Repository aufnehmen.",
-            "disabledTitle": "Speichern",
-            "disabledDescription": "Wird im Wissens-Repository gespeichert."
-        },
-        "ask": {
-            "enabledTitle": "Nur Lesend",
-            "enabledDescription": "Außerhalb der Sandbox nur lesen.",
-            "disabledTitle": "Schreibzugriff",
-            "disabledDescription": "Außerhalb der Sandbox schreiben erlaubt."
-        },
-        "yolo": {
-            "enabledTitle": "YOLO",
-            "enabledDescription": "Alle Tool-Calls sofort erlauben.",
-            "disabledTitle": "Mit Prüfung",
-            "disabledDescription": "Aktionen weiter durch Safe-List und Sentinel prüfen."
-        },
-        "unattended": {
-            "enabledTitle": "Unbeaufsichtigt",
-            "enabledDescription": "Läuft eigenständig ohne Freigabepfad durch dich.",
-            "disabledTitle": "Interaktiv",
-            "disabledDescription": "Bleibt im interaktiven Modus mit Freigabepfad."
-        }
-    },
-    "chatInput": {
-        "disabled": "Eingabe deaktiviert",
-        "sendMessageTooltip": "Nachricht senden (Enter)",
-        "queueInterruptStopTooltip": "Enter zum Einreihen · ⌥Enter zum Unterbrechen · Klicken zum Stoppen",
-        "stopGenerationTooltip": "Generierung stoppen",
-        "queued": "Warteschlange: {message}",
-        "startVoiceInput": "Spracheingabe starten",
-        "stopVoiceInput": "Spracheingabe stoppen",
-        "attachFile": "Datei anhängen",
-        "attachFileUnavailable": "Sandbox starten, um Dateien hochzuladen",
-        "startingSandbox": "Sandbox wird gestartet…",
-        "removeAttachment": "Entfernen",
-        "placeholder": "Nachricht an carapace…",
-        "usageBreakdown": {
-            "systemLine": "System: {percent}%",
-            "userLine": "User: {percent}%",
-            "assistantLine": "Assistant: {percent}%",
-            "toolCallsLine": "Tool-Aufrufe: {percent}%",
-            "toolOutputsLine": "Tool-Ausgaben: {percent}%",
-            "otherLine": "Sonstiges: {percent}%"
-        },
-        "context": {
-            "limit": "Kontextlimit: {tokens} Tokens.",
-            "assumedLimit": "Angenommenes Kontextlimit: {tokens} Tokens.",
-            "lastRequestTokens": "{tokens} API-Tokens (letzte Agent-Anfrage)",
-            "clickForUsage": "Klicken, um /usage an den Agenten zu senden und mehr Details zu sehen.",
-            "tokensLabel": "{tokens} Tokens"
-        },
-        "budget": {
-            "budgetLabel": "Budget für {label}",
-            "current": "Aktuell: {value}",
-            "max": "Maximal: {value}",
-            "remaining": "Verbleibend: {value}",
-            "exhausted": "Budget ausgeschöpft."
-        }
-    },
-    "approval": {
-        "general": {
-            "title": "Freigabe erforderlich",
-            "toolLabel": "Tool:",
-            "reasonLabel": "Grund:",
-            "riskLabel": "Risiko:",
-            "arguments": "Argumente",
-            "allow": "Freigeben",
-            "denyPlaceholder": "Warum sollte das blockiert werden?",
-            "risk": {
-                "high": "hoch",
-                "medium": "mittel",
-                "low": "niedrig"
-            }
-        },
-        "denialNote": {
-            "deny": "Ablehnen",
-            "optionalNote": "Optionale Notiz für den Agenten",
-            "addNote": "Notiz hinzufügen",
-            "hideNote": "Notiz ausblenden"
-        },
-        "credential": {
-            "title": "Zugangsdatenanfrage",
-            "skillLabel": "Skill:",
-            "allow": "Erlauben",
-            "denyPlaceholder": "Warum sollte dieser Zugang blockiert werden?",
-            "decision": {
-                "allow": "Erlaubt",
-                "deny": "Abgelehnt"
-            }
-        },
-        "domainAccess": {
-            "title": "Domain-Zugriffsanfrage",
-            "domainLabel": "Domain:",
-            "triggeredByLabel": "Ausgelöst durch:",
-            "allow": "{domain} erlauben",
-            "denyPlaceholder": "Warum sollte das blockiert werden?",
-            "decision": {
-                "allow": "Erlaubt",
-                "deny": "Abgelehnt"
-            }
-        },
-        "gitPush": {
-            "title": "Git-Push-Anfrage",
-            "refLabel": "Ref:",
-            "reasonLabel": "Grund:",
-            "changedFiles": "{count, plural, one {# geänderte Datei} other {# geänderte Dateien}}",
-            "allow": "Push erlauben",
-            "denyPlaceholder": "Warum sollte dieser Push blockiert werden?",
-            "decision": {
-                "allow": "Erlaubt",
-                "deny": "Abgelehnt"
-            }
-        }
-    },
-    "versionBadge": {
-        "frontend": "Frontend: {version}",
-        "backend": "Backend: {version}",
-        "unknown": "unbekannt",
-        "mismatchTooltip": "Versionen von Frontend- und Backend-Containern stimmen nicht überein.",
-        "mismatchSr": "Frontend- und Backend-Versionen stimmen nicht überein."
-    },
-    "toolCallBadge": {
-        "approvalBadge": {
-            "review": "Prüfung",
-            "skill": "Skill",
-            "bypass": "Bypass",
-            "denied": "abgelehnt"
-        },
-        "fallbacks": {
-            "missingPath": "(Pfad fehlt)",
-            "missingCommand": "(Befehl fehlt)",
-            "missingSkillName": "(skill_name fehlt)",
-            "credential": "Zugangsdaten"
-        },
-        "labels": {
-            "read": "Las",
-            "wrote": "Geschrieben",
-            "replaced": "Ersetzt",
-            "activatedSkill": "Skill aktiviert",
-            "executed": "Ausgeführt",
-            "listedCredentials": "Zugangsdaten aufgelistet",
-            "credentialDenied": "Zugangsdaten abgelehnt",
-            "accessedCredential": "Zugangsdaten verwendet",
-            "domainDenied": "Domain abgelehnt",
-            "accessedDomain": "Domain angefragt",
-            "gitPush": "Git Push",
-            "readAction": "Lese",
-            "write": "Schreibe",
-            "activateSkill": "Aktiviere Skill",
-            "execute": "Führe aus",
-            "listCredentials": "Liste Zugangsdaten auf",
-            "accessCredential": "Zugangsdaten verwenden",
-            "accessDomain": "Domain verwenden",
-            "replace": "Ersetze",
-            "sentFile": "Datei gesendet",
-            "sendFile": "Datei senden"
-        },
-        "summaries": {
-            "readFirstLines": "erste {count} Zeilen von {path}",
-            "readLinesRange": "Zeilen {start} bis {end} von {path}",
-            "writeLines": "{count} Zeilen nach {path} geschrieben",
-            "lineCount": "{count} Zeilen",
-            "lineCountWithReplacement": "{source} Zeilen mit {replacement} Zeilen",
-            "replaceInPath": "{lineSummary} in {path}{suffix}",
-            "allMatchesSuffix": " (alle Treffer)"
-        },
-        "details": {
-            "activateSkillPromptPrefix": "Agent möchte den",
-            "activateSkillPromptSuffix": "Skill aktivieren.",
-            "sentinelLabel": "Sentinel:",
-            "sentinelReviewing": "Dieser Tool-Aufruf wird geprüft.",
-            "userLabel": "Benutzer:",
-            "deniedByUser": "Vom Benutzer abgelehnt.",
-            "contexts": "Kontext:",
-            "domains": "Domains:",
-            "credentials": "Zugangsdaten",
-            "name": "Name",
-            "path": "Pfad",
-            "description": "Beschreibung",
-            "activation": "Aktivierung",
-            "skillInstructions": "Skill-Anweisungen",
-            "source": "Quelle",
-            "replacement": "Ersetzung",
-            "diff": "Diff",
-            "arguments": "Argumente",
-            "result": "Ergebnis"
-        }
-    },
-    "commandResult": {
-        "help": {
-            "command": "Befehl",
-            "description": "Beschreibung"
-        },
-        "rules": {
-            "id": "ID",
-            "trigger": "Auslöser",
-            "mode": "Modus",
-            "status": {
-                "label": "Status",
-                "disabled": "deaktiviert",
-                "alwaysOn": "immer aktiv",
-                "activated": "aktiviert"
-            }
-        },
-        "models": {
-            "type": "Typ",
-            "model": "Modell",
-            "default": "Standard",
-            "available": "Verfügbar:",
-            "provider": "Art",
-            "name": "Name",
-            "context": "Kontext",
-            "contextWindow": "({tokens} Kontext)",
-            "contextWindowShort": "{tokens} Kontext",
-            "noneAvailable": "Keine Modelle verfügbar.",
-            "noMatches": "Keine passenden Modelle.",
-            "filterPlaceholder": "Modelle filtern...",
-            "currentLabel": "Aktuelles Modell:",
-            "defaultLabel": "Standard: {model}"
-        },
-        "usage": {
-            "none": "Noch keine Token-Nutzung aufgezeichnet.",
-            "total": "Gesamt: {total} Tokens ({input} rein + {output} raus)",
-            "toolCalls": "Tool-Aufrufe: {count}",
-            "byModel": "Nach Modell",
-            "byCategory": "Nach Kategorie",
-            "context": "Kontext",
-            "table": {
-                "source": "Quelle",
-                "input": "Eingabe",
-                "output": "Ausgabe",
-                "cacheRead": "Cache gelesen",
-                "cacheWrite": "Cache geschrieben",
-                "requests": "Anfragen",
-                "cost": "Kosten"
-            },
-            "contextTable": {
-                "source": "Quelle",
-                "tokens": "Tokens",
-                "system": "System %",
-                "user": "User %",
-                "assistant": "Assistant %",
-                "toolCalls": "Tool-Aufrufe %",
-                "toolOutputs": "Tool-Ausgaben %",
-                "other": "Sonstiges %"
-            }
-        },
-        "budget": {
-            "none": "Keine Sitzungsbudgets konfiguriert.",
-            "title": "Sitzungsbudgets",
-            "table": {
-                "metric": "Metrik",
-                "current": "Aktuell",
-                "limit": "Limit",
-                "remaining": "Verbleibend",
-                "used": "Verwendet",
-                "blocked": "blockiert"
-            }
-        }
-    },
-    "chatView": {
-        "inputDisabled": {
-            "archived": "Zuerst aus dem Archiv holen",
-            "unattended": "Diese Sitzung ist unbeaufsichtigt. Forke sie zuerst, um hier weiterzumachen."
-        },
-        "waiting": {
-            "processingPrompt": "Prompt wird verarbeitet...",
-            "thinking": "Denke nach...",
-            "generating": "Generiere...",
-            "working": "Arbeite..."
-        },
-        "unknown": "Unbekannt",
-        "status": {
-            "connecting": "Verbinde…",
-            "disconnected": "Getrennt"
-        },
-        "empty": {
-            "start": "Sende eine Nachricht, um loszulegen",
-            "connectingSession": "Verbinde mit Sitzung…"
-        },
-        "errors": {
-            "unexpected": "Unerwarteter Fehler",
-            "resetTarget": "Ziel zum Zurücksetzen konnte nicht aufgelöst werden.",
-            "forkTarget": "Ziel zum Forken konnte nicht aufgelöst werden."
-        },
-        "confirm": {
-            "wipeSandbox": "Sandbox und ihren Speicher für diese Sitzung löschen? Der Chatverlauf bleibt erhalten.",
-            "scaleDownSandbox": "Sandbox für diese Sitzung herunterfahren? Der Speicher bleibt erhalten.",
-            "deleteSession": "Diese Sitzung löschen? Chatverlauf und Sandbox-Status werden entfernt.",
-            "archiveSession": "Diese Sitzung archivieren? Sie verschwindet aus der Standardliste, setzt ihre Sandbox zurück und bleibt im Wissens-Repository erhalten.",
-            "unarchiveSession": "Diese Sitzung aus dem Archiv holen? Sie kehrt in die aktive Sitzungsliste zurück.",
-            "makePrivate": "Diese Sitzung als privat markieren? Bereits vorhandene Commits im Wissens-Repository bleiben in der Git-Historie bestehen."
-        },
-        "actions": {
-            "pin": "Sitzung anheften",
-            "unpin": "Anheftung lösen",
-            "favorite": "Sitzung favorisieren",
-            "unfavorite": "Favorit entfernen",
-            "archive": "Sitzung archivieren",
-            "unarchive": "Sitzung aus dem Archiv holen",
-            "includeInRepo": "Ins Repository aufnehmen",
-            "keepPrivate": "Privat halten",
-            "delete": "Sitzung löschen"
-        },
-        "badges": {
-            "archived": "Archiviert",
-            "private": "Privat",
-            "pinned": "Angeheftet",
-            "favorite": "Favorit",
-            "askMode": "Lese-Modus",
-            "yoloMode": "YOLO",
-            "unattended": "Unbeaufsichtigt",
-            "interactive": "Interaktiv"
-        },
-        "inspector": {
-            "actions": "Aktionen",
-            "session": "Sitzung"
-        },
-        "session": {
-            "title": "Titel",
-            "id": "ID",
-            "copyId": "Sitzungs-ID kopieren",
-            "idCopied": "Sitzungs-ID kopiert",
-            "idCopiedShort": "Kopiert",
-            "source": "Quelle",
-            "created": "Erstellt",
-            "lastActive": "Zuletzt aktiv",
-            "messages": "Nachrichten",
-            "totalCost": "Kosten",
-            "job": "Job",
-            "reference": "Referenz",
-            "modes": "Modi",
-            "askMode": "Lese-Modus",
-            "askModeHelp": "Außerhalb der Sandbox nur lesend arbeiten. Externe Schreibzugriffe werden verweigert.",
-            "yoloMode": "YOLO-Modus",
-            "yoloModeHelp": "Sentinel-Freigaben umgehen und Aktionen sofort erlauben.",
-            "savingPrivate": "Wird gespeichert…",
-            "updatingMode": "Modus wird aktualisiert…"
-        },
-        "source": {
-            "unknown": "Unbekannt",
-            "job": "Job",
-            "web": "Web",
-            "cli": "CLI"
-        },
-        "jobRun": {
-            "title": "Letzter Joblauf",
-            "job": "Job",
-            "ranAt": "Ausgeführt am",
-            "schedule": "Zeitplan",
-            "data": "Daten",
-            "trigger": {
-                "label": "Auslöser",
-                "api": "API",
-                "cron": "Cron",
-                "manual": "Manuell"
-            }
-        },
-        "sandbox": {
-            "title": "Sandbox",
-            "refreshing": "Aktualisiere…",
-            "checking": "Prüfe Sandbox…",
-            "status": {
-                "missing": "Nicht gestartet",
-                "running": "Läuft",
-                "scaled_down": "Heruntergefahren",
-                "pending": "Startet",
-                "stopped": "Gestoppt",
-                "error": "Fehler"
-            },
-            "actions": {
-                "start": "Sandbox starten",
-                "starting": "Sandbox wird gestartet",
-                "scaleDown": "Sandbox herunterfahren",
-                "scalingDown": "Sandbox wird heruntergefahren",
-                "reset": "Sandbox zurücksetzen"
-            },
-            "storage": {
-                "used": "{size} verwendet",
-                "none": "kein Sandbox-Speicher",
-                "allocated": "{size} zugewiesen"
-            },
-            "fields": {
-                "id": "Sandbox-ID"
-            }
-        },
-        "knowledge": {
-            "title": "Wissen",
-            "commit": "Ins Repository committen",
-            "committed": "Committed",
-            "committedToRepo": "In Wissen übernommen",
-            "notCommittedYet": "Noch nicht committed",
-            "savedAt": "Gespeichert {timestamp}",
-            "commitDisabledNoHistory": "Diese Sitzung hat noch keinen Gesprächsverlauf.",
-            "noNewChanges": "{status}. Keine neuen Änderungen zum Committen.",
-            "privateExistingCommits": "Sitzung ist privat. Bereits vorhandene Commits im Wissens-Repository bleiben unverändert.",
-            "privateExcluded": "Sitzung ist privat und wird nicht ins Wissens-Repository committed.",
-            "includedInRepo": "Sitzung wird ins Wissens-Repository aufgenommen.",
-            "badges": {
-                "excluded": "Ausgeschlossen",
-                "missing": "Fehlt",
-                "outdated": "Veraltet",
-                "upToDate": "Aktuell"
-            }
-        },
-        "mobile": {
-            "details": "Details",
-            "done": "Fertig"
-        }
-    },
-    "message": {
-        "copy": "Nachricht kopieren",
-        "copied": "Kopiert",
-        "codeBlock": {
-            "copy": "Code kopieren",
-            "copied": "Kopiert"
-        },
-        "thinking": {
-            "streaming": "Denke nach",
-            "complete": "Nachgedacht"
-        },
-        "thinkingMeta": {
-            "durationStreaming": "seit {duration}",
-            "durationComplete": "{duration} lang",
-            "reasoning": "{count} Tokens"
-        },
-        "actions": {
-            "fork": "Sitzung von hier forken",
-            "retry": "Zug erneut ausführen",
-            "reset": "Unterhaltung zu diesem Zug zurücksetzen"
-        },
-        "finalStatus": {
-            "status": {
-                "success": "Erfolg",
-                "warning": "Warnung"
-            },
-            "notice": "Der Agent hat die Aufgabe mit einer Meldung vom Typ {status} beendet. Die Sitzung ist jetzt schreibgeschützt, du kannst sie aber forken um weiter zu chatten."
-        }
-    },
-    "jobs": {
-        "settingsSections": "Einstellungsbereiche",
-        "savedJobs": "Gespeicherte Jobs",
-        "loading": "Jobs werden geladen...",
-        "paused": "Pausiert",
-        "unattendedTooltip": "Unbeaufsichtigte Sitzungen können Tool-Aufrufe nicht eskalieren",
-        "confirmDelete": "Job {name} löschen?",
-        "summary": {
-            "onDemandOnly": "Nur manuell",
-            "cronTriggerCount": "{count, plural, one {# Cron-Trigger} other {# Cron-Trigger}}"
-        },
-        "validation": {
-            "idRequired": "Job-ID ist erforderlich.",
-            "nameRequired": "Job-Name ist erforderlich.",
-            "promptRequired": "Prompt ist erforderlich.",
-            "persistentSessionIdRequired": "Wähle eine persistente Session-ID oder deaktiviere die Option.",
-            "persistentSessionMustBeAttended": "Jobs mit persistenter Sitzung müssen beaufsichtigt sein.",
-            "sessionModesRequireFreshSession": "Session-Modi brauchen eine neue Sitzung.",
-            "modelOverridesRequireFreshSession": "Modell-Overrides brauchen eine neue Sitzung.",
-            "askAndYoloMutuallyExclusive": "Lese-Modus und YOLO sind gegenseitig ausschließend.",
-            "cronEmpty": "Cron-Ausdrücke dürfen nicht leer sein.",
-            "cronInvalid": "Cron-Ausdruck ist ungültig: {expression}."
-        },
-        "cron": {
-            "invalidExpression": "Ungültiger Cron-Ausdruck."
-        },
-        "triggerKind": {
-            "scheduled": "Geplant",
-            "manual": "Manuell"
-        },
-        "errors": {
-            "load": "Jobs konnten nicht geladen werden.",
-            "refresh": "Jobs konnten nicht aktualisiert werden.",
-            "save": "Job konnte nicht gespeichert werden.",
-            "delete": "Job konnte nicht gelöscht werden.",
-            "run": "Job konnte nicht gestartet werden.",
-            "saveBeforeRun": "Speichere den Job, bevor du ihn startest.",
-            "saveChangesBeforeRun": "Speichere die Änderungen am Job, bevor du ihn startest."
-        },
-        "notices": {
-            "refreshed": "Jobs aktualisiert.",
-            "created": "Job erstellt.",
-            "saved": "Job gespeichert.",
-            "deleted": "Job gelöscht.",
-            "runStartedNewSession": "Ausführung in neuer Sitzung {sessionId} gestartet.",
-            "runStartedSession": "Ausführung in Sitzung {sessionId} gestartet."
-        },
-        "actions": {
-            "refresh": "Jobs aktualisieren",
-            "new": "Neuer Job",
-            "clear": "Leeren",
-            "clearPersistentSession": "Persistente Sitzung entfernen",
-            "delete": "Löschen",
-            "save": "Speichern",
-            "addTrigger": "Trigger hinzufügen",
-            "remove": "Entfernen",
-            "runNow": "Jetzt ausführen"
-        },
-        "empty": {
-            "noJobs": "Noch keine Jobs. Erstelle einen, um Prompts und optionale Cron-Zeitpläne in jobs.yaml zu speichern."
-        },
-        "editor": {
-            "newJob": "Neuer Job",
-            "editing": "Bearbeite {name}",
-            "jobFallback": "Job"
-        },
-        "fields": {
-            "name": "Name",
-            "jobId": "Job-ID",
-            "enabled": "Aktiviert",
-            "enabledHelp": "Pausierte Jobs bleiben in jobs.yaml, werden aber nie per Cron ausgeführt.",
-            "newSession": "Optionen",
-            "newSessionHelp": "Diese Optionen gelten nur für neue Sitzungen, die der Job selbst erstellt.",
-            "unattended": "Unbeaufsichtigt ausführen",
-            "unattendedHelp": "Tool-Aufrufe werden nicht an dich eskaliert.",
-            "persistentSession": "Persistente Sitzung",
-            "persistentSessionToggleHelp": "Verwende eine bestehende Sitzung statt bei jedem Lauf eine neue zu starten.",
-            "persistentSessionDisabled": "Kann im unbeaufsichtigten Modus nicht verwendet werden",
-            "persistentSessionUncheckedHelp": "Aktiviere die Option, um unten eine bestehende Session-ID auszuwählen.",
-            "persistentSessionMissingIdHelp": "Aktiv, aber noch ohne Session-ID. Wähle unten eine bestehende Sitzung aus.",
-            "persistentSessionHelp": "Verwende eine bestehende Sitzung, statt bei jedem Joblauf eine neue zu erstellen.",
-            "persistentSessionActiveHelp": "Aktiv: Diese Session-ID überschreibt die Optionen für neue Sitzungen oben.",
-            "models": "Modelle",
-            "modelsHelp": "Optionale job-spezifische Overrides für neue Sitzungen, die dieser Job erstellt.",
-            "modelsDisabled": "Persistente Sitzungen behalten ihre eigene Modellauswahl.",
-            "modelsLinked": "Modelle verknüpft",
-            "modelsLinkedHelp": "Verknüpft: Änderungen an einem Modell setzen beide Modelle.",
-            "modelsUnlinked": "Modelle getrennt",
-            "modelsUnlinkedHelp": "Getrennt: Agent- und Sentinel-Modell lassen sich unabhängig ändern.",
-            "agentModel": "Agent",
-            "sentinelModel": "Sentinel",
-            "titleModel": "Titel-Modell",
-            "prompt": "Prompt",
-            "expression": "Ausdruck",
-            "timeZone": "Zeitzone",
-            "inputOptional": "Eingabe (optional)"
-        },
-        "placeholders": {
-            "name": "Nächtliche Inbox-Prüfung",
-            "jobId": "naechtliche-inbox-pruefung",
-            "persistentSession": "session-id auswählen",
-            "prompt": "Fasse neue Aufgaben zusammen, priorisiere Dringendes und schlage dann nächste Schritte vor.",
-            "model": "Leer lassen für Standardmodell"
-        },
-        "sections": {
-            "cronTriggers": "Cron-Trigger",
-            "cronTriggersDescription": "Leer lassen für Jobs, die nur manuell gestartet werden.",
-            "noTriggers": "Keine Cron-Trigger konfiguriert.",
-            "runJob": "Job ausführen",
-            "previousInvocations": "Vorherige Ausführungen",
-            "previousInvocationsDescription": "Wähle eine Ausführung, um ihre Sitzung zu öffnen.",
-            "saveToViewHistory": "Speichere diesen Job, um den Ausführungsverlauf zu sehen.",
-            "noInvocations": "Noch keine Ausführungen. Aktualisiere die Sitzungen, um neu abgeschlossene Läufe zu laden.",
-            "ranAt": "Ausgeführt am {timestamp}"
-        }
-    },
-    "sidebar": {
-        "time": {
-            "justNow": "gerade eben"
-        },
-        "messageCount": "{count, plural, one {# Nachricht} other {# Nachrichten}}",
-        "unattendedSession": "Unbeaufsichtigte Sitzung",
-        "privateSession": "Private Sitzung",
-        "knowledgeCommitted": "Alle Änderungen ins Wissens-Repository übernommen",
-        "actions": {
-            "pin": "Sitzung anheften",
-            "unpin": "Sitzung lösen",
-            "favorite": "Sitzung favorisieren",
-            "unfavorite": "Favorit entfernen",
-            "archive": "Sitzung archivieren",
-            "unarchive": "Sitzung aus dem Archiv holen",
-            "delete": "Sitzung löschen",
-            "deleteEmpty": "Leere Sitzung löschen",
-            "shiftSkip": "Shift+Klick überspringt die Bestätigung"
-        },
-        "confirm": {
-            "deleteSession": "Diese Sitzung löschen? Chatverlauf und Sandbox-Status werden entfernt.",
-            "deleteUnpushed": "Diese Sitzung hat {count, plural, one {# Commit} other {# Commits}}, die noch nicht ins Wissens-Repository gepusht wurden. Beim Löschen gehen sie verloren. Trotzdem löschen?",
-            "archiveSession": "Diese Sitzung archivieren? Sie verschwindet aus der Standardliste, setzt ihre Sandbox zurück und bleibt im Wissens-Repository erhalten."
-        },
-        "sections": {
-            "today": "Heute",
-            "yesterday": "Gestern",
-            "last7Days": "Letzte 7 Tage",
-            "last30Days": "Letzte 30 Tage",
-            "archived": "Archiviert",
-            "unknownDate": "Unbekanntes Datum"
-        },
-        "empty": "Noch keine Sitzungen",
-        "loadingMore": "Weitere Sitzungen werden geladen"
-    },
-    "git": {
-        "upToDate": "Aktuell",
-        "noRemote": "Kein Remote konfiguriert",
-        "sandbox": {
-            "label": "Workspace-Sync",
-            "help": "Synchronisiert die Workspace-Sandbox dieser Sitzung mit deinem Wissens-Repository auf dem Server. Die Zähler zeigen, um wie viele Commits dieser Workspace dem Server-Repo voraus (↑) bzw. hinterher (↓) ist.",
-            "notRunning": "Sandbox läuft nicht",
-            "refresh": "Workspace erneut mit dem Server-Repository abgleichen (holt zuerst neue Commits)",
-            "pull": "Commits aus dem Server-Repository in diesen Workspace holen",
-            "push": "Commits dieses Workspace ins Server-Repository übertragen (jeder Push wird vom Sentinel geprüft)"
-        },
-        "global": {
-            "label": "Wissens-Remote",
-            "help": "Synchronisiert dein Wissens-Repository auf dem Server mit seinem externen Git-Remote. Die Zähler zeigen, um wie viele Commits das Server-Repo dem Remote voraus (↑) bzw. hinterher (↓) ist.",
-            "indicatorBehind": "{count, plural, one {# Commit} other {# Commits}} vom Wissens-Remote zu holen",
-            "refresh": "Server-Repository erneut mit dem Remote abgleichen (holt zuerst neue Commits)",
-            "pull": "Commits vom externen Remote ins Server-Repository holen",
-            "push": "Commits des Server-Repositorys ins externe Remote übertragen"
-        },
-        "denied": "Push abgelehnt",
-        "errors": {
-            "status": "Git-Status konnte nicht gelesen werden",
-            "pull": "Pull fehlgeschlagen",
-            "push": "Push fehlgeschlagen"
-        }
+      }
     }
+  },
+  "platformSettings": {
+    "status": {
+      "loading": "Plattformeinstellungen werden geladen",
+      "unavailable": "Plattformeinstellungen sind nicht verfügbar",
+      "readOnly": "Die Konfigurationsdatei ist schreibgeschützt."
+    },
+    "notices": {
+      "saved": "Gespeichert."
+    },
+    "errors": {
+      "load": "Plattformeinstellungen konnten nicht geladen werden",
+      "save": "Plattformeinstellungen konnten nicht aktualisiert werden",
+      "wholeNumber": "{field} muss eine positive ganze Zahl sein.",
+      "nonNegativeWholeNumber": "{field} muss eine nicht negative ganze Zahl sein.",
+      "number": "{field} muss eine nicht negative Zahl sein.",
+      "providerRequired": "Provider ist für Modell {index} erforderlich.",
+      "nameRequired": "Name ist für Modell {index} erforderlich.",
+      "duplicateModel": "Modell-ID {id} wird mehrfach verwendet.",
+      "rawSecretRequired": "Füge einen API-Key für {id} ein oder wähle eine andere Secret-Quelle.",
+      "secretValueRequired": "Secret-Referenz ist für {id} erforderlich.",
+      "defaultRequired": "{field}-Standardmodell ist erforderlich.",
+      "defaultUnknown": "{field}-Standardmodell {id} ist nicht im Katalog."
+    },
+    "sections": {
+      "defaultModels": "Standardmodelle",
+      "defaultBudgets": "Standardbudgets",
+      "catalog": "Modellkatalog"
+    },
+    "fields": {
+      "agent": "Agent",
+      "sentinel": "Sentinel",
+      "title": "Titel",
+      "inputTokens": "Input-Tokens",
+      "outputTokens": "Output-Tokens",
+      "costUsd": "Kosten (in $)",
+      "toolCalls": "Tool-Aufrufe",
+      "provider": "Provider",
+      "name": "Name",
+      "id": "ID",
+      "maxInputTokens": "Max. Input-Tokens",
+      "thinking": "Thinking",
+      "thinkingBudgetTokens": "Thinking-Budget-Tokens",
+      "baseUrl": "Base URL",
+      "vision": "Vision",
+      "visionHint": "Akzeptiert Bildeingaben",
+      "apiKeySource": "API-Key-Quelle",
+      "apiKey": "API-Key",
+      "secretReference": "Secret-Referenz"
+    },
+    "placeholders": {
+      "selectModel": "Modell auswählen",
+      "unlimited": "Unbegrenzt",
+      "generatedId": "provider:name",
+      "keepSecret": "Konfiguriertes Secret behalten"
+    },
+    "actions": {
+      "save": "Speichern",
+      "saving": "Speichert",
+      "addModel": "Modell hinzufügen",
+      "removeModel": "Modell entfernen",
+      "confirmRemoveModel": "Modell \"{name}\" entfernen? Dies kann nicht rückgängig gemacht werden."
+    },
+    "secretSources": {
+      "none": "Keine",
+      "raw": "Direkter Wert",
+      "env": "Umgebungsvariable",
+      "file": "Datei"
+    },
+    "thinking": {
+      "default": "Standard",
+      "true": "Aktiviert",
+      "false": "Deaktiviert",
+      "minimal": "Minimal",
+      "low": "Niedrig",
+      "medium": "Mittel",
+      "high": "Hoch",
+      "xhigh": "Extra hoch"
+    },
+    "units": {
+      "tokens": "Tokens"
+    },
+    "modelRow": "Modell {index}"
+  },
+  "home": {
+    "empty": {
+      "description": "Wähle eine Sitzung aus oder starte eine neue"
+    }
+  },
+  "connect": {
+    "description": "Bei carapace anmelden",
+    "serverLabel": "Server-URL",
+    "usernameLabel": "Benutzername",
+    "usernamePlaceholder": "Benutzername",
+    "passwordLabel": "Passwort",
+    "passwordPlaceholder": "Passwort",
+    "connect": "Verbinden",
+    "connecting": "Verbinde…",
+    "errors": {
+      "serverError": "Serverfehler: {status}",
+      "connectionFailed": "Verbindung fehlgeschlagen"
+    }
+  },
+  "admin": {
+    "title": "Admin",
+    "backToApp": "Zurück zur App",
+    "serverLabel": "Server-URL",
+    "serverPlaceholder": "Kein Server ausgewählt",
+    "users": {
+      "title": "Benutzer",
+      "description": "Globale Plattform-Konten, Rollen und Datenzuordnung.",
+      "savedUsers": "Benutzer",
+      "loading": "Benutzer werden geladen…",
+      "empty": "Keine Benutzer gefunden",
+      "selectUser": "Benutzer auswählen",
+      "you": "Du",
+      "admin": "Admin",
+      "enabled": "Aktiv",
+      "disabled": "Deaktiviert"
+    },
+    "create": {
+      "title": "Neuer Benutzer",
+      "subtitle": "Lokalen Benutzer anlegen"
+    },
+    "fields": {
+      "username": "Benutzername",
+      "password": "Passwort",
+      "newPassword": "Neues Passwort",
+      "keepPassword": "Aktuelles Passwort behalten",
+      "displayName": "Anzeigename",
+      "email": "E-Mail",
+      "roles": "Rollen",
+      "enabled": "Aktiv"
+    },
+    "actions": {
+      "load": "Laden",
+      "loading": "Lädt…",
+      "refresh": "Benutzer aktualisieren",
+      "new": "Neuer Benutzer",
+      "deleteUser": "{username} löschen",
+      "create": "Benutzer anlegen",
+      "creating": "Lege an…",
+      "save": "Änderungen speichern",
+      "saving": "Speichert…"
+    },
+    "notices": {
+      "loaded": "Benutzer geladen.",
+      "created": "{username} angelegt.",
+      "saved": "{username} gespeichert.",
+      "deleted": "{username} gelöscht."
+    },
+    "errors": {
+      "missingCredentials": "Aktueller Ursprung ist nicht verfügbar.",
+      "load": "Benutzer konnten nicht geladen werden.",
+      "create": "Benutzer konnte nicht angelegt werden.",
+      "save": "Benutzer konnte nicht gespeichert werden.",
+      "delete": "Benutzer konnte nicht gelöscht werden."
+    },
+    "confirm": {
+      "deleteUser": "{username} löschen? Bestehende Daten dieses Benutzers bleiben erhalten."
+    },
+    "meta": {
+      "tokenVersion": "Token v{version}",
+      "updated": "Aktualisiert {timestamp}",
+      "lastLogin": "Letzter Login {timestamp}",
+      "never": "nie"
+    }
+  },
+  "preferences": {
+    "title": "Einstellungen",
+    "description": "Persönliche Einstellungen für diesen Browser und deine Nutzung.",
+    "currentLocale": "Aktuelle Oberflächensprache: {locale}",
+    "language": {
+      "label": "Sprache",
+      "description": "Wähle, wie die Oberflächensprache bestimmt wird.",
+      "options": {
+        "system": "System",
+        "en": "English",
+        "de": "Deutsch"
+      }
+    },
+    "theme": {
+      "label": "Darstellung",
+      "description": "Wähle, wie das Farbschema bestimmt wird.",
+      "options": {
+        "system": "System",
+        "light": "Hell",
+        "dark": "Dunkel"
+      }
+    },
+    "chatList": {
+      "label": "Chats",
+      "showArchived": {
+        "label": "Archivierte Chats anzeigen",
+        "description": "Wenn deaktiviert, werden archivierte Chats ausgeblendet und bei Session-Listen direkt nicht vom Server angefragt."
+      }
+    },
+    "notifications": {
+      "title": "Push-Benachrichtigungen",
+      "description": "Liefert Eskalationen und Zug-Ergebnisse an diesen Browser oder die installierte PWA.",
+      "status": {
+        "loading": "Benachrichtigungsunterstützung wird geprüft…",
+        "loadingShort": "Prüfung",
+        "enabled": "Benachrichtigungen sind für diesen Browser aktiviert.",
+        "enabledShort": "Aktiv",
+        "disabled": "Benachrichtigungen sind für diesen Browser deaktiviert.",
+        "disabledShort": "Aus",
+        "unsupported": "Dieser Browser kann im aktuellen Kontext keine Web-Push-Benachrichtigungen empfangen.",
+        "permissionDenied": "Die Browser-Benachrichtigungsfreigabe ist blockiert. Aktiviere sie in Browser- oder Geräteeinstellungen erneut.",
+        "permissionRequired": "Die Benachrichtigungsfreigabe wurde nicht erteilt.",
+        "invalidSubscription": "Der Browser hat eine unvollständige Push-Subscription zurückgegeben.",
+        "loadFailed": "Benachrichtigungseinstellungen konnten nicht geladen werden.",
+        "enableFailed": "Benachrichtigungen konnten nicht aktiviert werden.",
+        "disableFailed": "Benachrichtigungen konnten nicht deaktiviert werden.",
+        "preferencesFailed": "Benachrichtigungseinstellungen konnten nicht aktualisiert werden.",
+        "testFailed": "Testbenachrichtigung konnte nicht gesendet werden.",
+        "testSent": "Testbenachrichtigung gesendet."
+      },
+      "deviceName": {
+        "label": "Gerätename",
+        "placeholder": "Android-Telefon",
+        "hint": "Wird in den serverseitigen Benachrichtigungs-Subscriptions für diesen Browser angezeigt."
+      },
+      "toggle": {
+        "label": "Benachrichtigungen"
+      },
+      "actions": {
+        "enable": "Benachrichtigungen aktivieren",
+        "enabling": "Aktiviere…",
+        "disable": "Benachrichtigungen deaktivieren",
+        "disabling": "Deaktiviere…",
+        "test": "Testbenachrichtigung senden",
+        "testing": "Sende Testbenachrichtigung…"
+      },
+      "preferences": {
+        "label": "Benachrichtigungen senden für",
+        "escalation_pending": "Eskalationen, die Freigabe brauchen",
+        "attended_turn_completed": "Begleitete Sitzungen, wenn ein Zug endet",
+        "unattended_turn_completed": "Unbeaufsichtigte Jobs mit erfolgreichem Abschluss",
+        "unattended_turn_failed": "Unbeaufsichtigte Jobs mit Fehler"
+      },
+      "meta": {
+        "permission": "Browser-Freigabe: {permission}",
+        "heartbeat": "Letzter Heartbeat: {timestamp}",
+        "expires": "Subscription läuft ab: {timestamp}"
+      },
+      "permission": {
+        "default": "nicht angefragt",
+        "granted": "erteilt",
+        "denied": "blockiert"
+      }
+    }
+  },
+  "newSessionButton": {
+    "label": "Neue Sitzung",
+    "chooseOptions": "Sitzungsoptionen auswählen",
+    "private": {
+      "enabledTitle": "Privat",
+      "enabledDescription": "Nicht ins Wissens-Repository aufnehmen.",
+      "disabledTitle": "Speichern",
+      "disabledDescription": "Wird im Wissens-Repository gespeichert."
+    },
+    "ask": {
+      "enabledTitle": "Nur Lesend",
+      "enabledDescription": "Außerhalb der Sandbox nur lesen.",
+      "disabledTitle": "Schreibzugriff",
+      "disabledDescription": "Außerhalb der Sandbox schreiben erlaubt."
+    },
+    "yolo": {
+      "enabledTitle": "YOLO",
+      "enabledDescription": "Alle Tool-Calls sofort erlauben.",
+      "disabledTitle": "Mit Prüfung",
+      "disabledDescription": "Aktionen weiter durch Safe-List und Sentinel prüfen."
+    },
+    "unattended": {
+      "enabledTitle": "Unbeaufsichtigt",
+      "enabledDescription": "Läuft eigenständig ohne Freigabepfad durch dich.",
+      "disabledTitle": "Interaktiv",
+      "disabledDescription": "Bleibt im interaktiven Modus mit Freigabepfad."
+    }
+  },
+  "chatInput": {
+    "disabled": "Eingabe deaktiviert",
+    "sendMessageTooltip": "Nachricht senden (Enter)",
+    "queueInterruptStopTooltip": "Enter zum Einreihen · ⌥Enter zum Unterbrechen · Klicken zum Stoppen",
+    "stopGenerationTooltip": "Generierung stoppen",
+    "queued": "Warteschlange: {message}",
+    "startVoiceInput": "Spracheingabe starten",
+    "stopVoiceInput": "Spracheingabe stoppen",
+    "attachFile": "Datei anhängen",
+    "attachFileUnavailable": "Sandbox starten, um Dateien hochzuladen",
+    "startingSandbox": "Sandbox wird gestartet…",
+    "removeAttachment": "Entfernen",
+    "placeholder": "Nachricht an carapace…",
+    "usageBreakdown": {
+      "systemLine": "System: {percent}%",
+      "userLine": "User: {percent}%",
+      "assistantLine": "Assistant: {percent}%",
+      "toolCallsLine": "Tool-Aufrufe: {percent}%",
+      "toolOutputsLine": "Tool-Ausgaben: {percent}%",
+      "otherLine": "Sonstiges: {percent}%"
+    },
+    "context": {
+      "limit": "Kontextlimit: {tokens} Tokens.",
+      "assumedLimit": "Angenommenes Kontextlimit: {tokens} Tokens.",
+      "lastRequestTokens": "{tokens} API-Tokens (letzte Agent-Anfrage)",
+      "clickForUsage": "Klicken, um /usage an den Agenten zu senden und mehr Details zu sehen.",
+      "tokensLabel": "{tokens} Tokens"
+    },
+    "budget": {
+      "budgetLabel": "Budget für {label}",
+      "current": "Aktuell: {value}",
+      "max": "Maximal: {value}",
+      "remaining": "Verbleibend: {value}",
+      "exhausted": "Budget ausgeschöpft."
+    }
+  },
+  "approval": {
+    "general": {
+      "title": "Freigabe erforderlich",
+      "toolLabel": "Tool:",
+      "reasonLabel": "Grund:",
+      "riskLabel": "Risiko:",
+      "arguments": "Argumente",
+      "allow": "Freigeben",
+      "denyPlaceholder": "Warum sollte das blockiert werden?",
+      "risk": {
+        "high": "hoch",
+        "medium": "mittel",
+        "low": "niedrig"
+      }
+    },
+    "denialNote": {
+      "deny": "Ablehnen",
+      "optionalNote": "Optionale Notiz für den Agenten",
+      "addNote": "Notiz hinzufügen",
+      "hideNote": "Notiz ausblenden"
+    },
+    "credential": {
+      "title": "Zugangsdatenanfrage",
+      "skillLabel": "Skill:",
+      "allow": "Erlauben",
+      "denyPlaceholder": "Warum sollte dieser Zugang blockiert werden?",
+      "decision": {
+        "allow": "Erlaubt",
+        "deny": "Abgelehnt"
+      }
+    },
+    "domainAccess": {
+      "title": "Domain-Zugriffsanfrage",
+      "domainLabel": "Domain:",
+      "triggeredByLabel": "Ausgelöst durch:",
+      "allow": "{domain} erlauben",
+      "denyPlaceholder": "Warum sollte das blockiert werden?",
+      "decision": {
+        "allow": "Erlaubt",
+        "deny": "Abgelehnt"
+      }
+    },
+    "gitPush": {
+      "title": "Git-Push-Anfrage",
+      "refLabel": "Ref:",
+      "reasonLabel": "Grund:",
+      "changedFiles": "{count, plural, one {# geänderte Datei} other {# geänderte Dateien}}",
+      "allow": "Push erlauben",
+      "denyPlaceholder": "Warum sollte dieser Push blockiert werden?",
+      "decision": {
+        "allow": "Erlaubt",
+        "deny": "Abgelehnt"
+      }
+    }
+  },
+  "versionBadge": {
+    "frontend": "Frontend: {version}",
+    "backend": "Backend: {version}",
+    "unknown": "unbekannt",
+    "mismatchTooltip": "Versionen von Frontend- und Backend-Containern stimmen nicht überein.",
+    "mismatchSr": "Frontend- und Backend-Versionen stimmen nicht überein."
+  },
+  "toolCallBadge": {
+    "approvalBadge": {
+      "review": "Prüfung",
+      "skill": "Skill",
+      "bypass": "Bypass",
+      "denied": "abgelehnt"
+    },
+    "fallbacks": {
+      "missingPath": "(Pfad fehlt)",
+      "missingCommand": "(Befehl fehlt)",
+      "missingSkillName": "(skill_name fehlt)",
+      "credential": "Zugangsdaten"
+    },
+    "labels": {
+      "read": "Las",
+      "wrote": "Geschrieben",
+      "replaced": "Ersetzt",
+      "activatedSkill": "Skill aktiviert",
+      "executed": "Ausgeführt",
+      "listedCredentials": "Zugangsdaten aufgelistet",
+      "credentialDenied": "Zugangsdaten abgelehnt",
+      "accessedCredential": "Zugangsdaten verwendet",
+      "domainDenied": "Domain abgelehnt",
+      "accessedDomain": "Domain angefragt",
+      "gitPush": "Git Push",
+      "readAction": "Lese",
+      "write": "Schreibe",
+      "activateSkill": "Aktiviere Skill",
+      "execute": "Führe aus",
+      "listCredentials": "Liste Zugangsdaten auf",
+      "accessCredential": "Zugangsdaten verwenden",
+      "accessDomain": "Domain verwenden",
+      "replace": "Ersetze",
+      "sentFile": "Datei gesendet",
+      "sendFile": "Datei senden"
+    },
+    "summaries": {
+      "readFirstLines": "erste {count} Zeilen von {path}",
+      "readLinesRange": "Zeilen {start} bis {end} von {path}",
+      "writeLines": "{count} Zeilen nach {path} geschrieben",
+      "lineCount": "{count} Zeilen",
+      "lineCountWithReplacement": "{source} Zeilen mit {replacement} Zeilen",
+      "replaceInPath": "{lineSummary} in {path}{suffix}",
+      "allMatchesSuffix": " (alle Treffer)"
+    },
+    "details": {
+      "activateSkillPromptPrefix": "Agent möchte den",
+      "activateSkillPromptSuffix": "Skill aktivieren.",
+      "sentinelLabel": "Sentinel:",
+      "sentinelReviewing": "Dieser Tool-Aufruf wird geprüft.",
+      "userLabel": "Benutzer:",
+      "deniedByUser": "Vom Benutzer abgelehnt.",
+      "contexts": "Kontext:",
+      "domains": "Domains:",
+      "credentials": "Zugangsdaten",
+      "name": "Name",
+      "path": "Pfad",
+      "description": "Beschreibung",
+      "activation": "Aktivierung",
+      "skillInstructions": "Skill-Anweisungen",
+      "source": "Quelle",
+      "replacement": "Ersetzung",
+      "diff": "Diff",
+      "arguments": "Argumente",
+      "result": "Ergebnis"
+    }
+  },
+  "commandResult": {
+    "help": {
+      "command": "Befehl",
+      "description": "Beschreibung"
+    },
+    "rules": {
+      "id": "ID",
+      "trigger": "Auslöser",
+      "mode": "Modus",
+      "status": {
+        "label": "Status",
+        "disabled": "deaktiviert",
+        "alwaysOn": "immer aktiv",
+        "activated": "aktiviert"
+      }
+    },
+    "models": {
+      "type": "Typ",
+      "model": "Modell",
+      "default": "Standard",
+      "available": "Verfügbar:",
+      "provider": "Art",
+      "name": "Name",
+      "context": "Kontext",
+      "contextWindow": "({tokens} Kontext)",
+      "contextWindowShort": "{tokens} Kontext",
+      "noneAvailable": "Keine Modelle verfügbar.",
+      "noMatches": "Keine passenden Modelle.",
+      "filterPlaceholder": "Modelle filtern...",
+      "currentLabel": "Aktuelles Modell:",
+      "defaultLabel": "Standard: {model}"
+    },
+    "usage": {
+      "none": "Noch keine Token-Nutzung aufgezeichnet.",
+      "total": "Gesamt: {total} Tokens ({input} rein + {output} raus)",
+      "toolCalls": "Tool-Aufrufe: {count}",
+      "byModel": "Nach Modell",
+      "byCategory": "Nach Kategorie",
+      "context": "Kontext",
+      "table": {
+        "source": "Quelle",
+        "input": "Eingabe",
+        "output": "Ausgabe",
+        "cacheRead": "Cache gelesen",
+        "cacheWrite": "Cache geschrieben",
+        "requests": "Anfragen",
+        "cost": "Kosten"
+      },
+      "contextTable": {
+        "source": "Quelle",
+        "tokens": "Tokens",
+        "system": "System %",
+        "user": "User %",
+        "assistant": "Assistant %",
+        "toolCalls": "Tool-Aufrufe %",
+        "toolOutputs": "Tool-Ausgaben %",
+        "other": "Sonstiges %"
+      }
+    },
+    "budget": {
+      "none": "Keine Sitzungsbudgets konfiguriert.",
+      "title": "Sitzungsbudgets",
+      "table": {
+        "metric": "Metrik",
+        "current": "Aktuell",
+        "limit": "Limit",
+        "remaining": "Verbleibend",
+        "used": "Verwendet",
+        "blocked": "blockiert"
+      }
+    }
+  },
+  "chatView": {
+    "inputDisabled": {
+      "archived": "Zuerst aus dem Archiv holen",
+      "unattended": "Diese Sitzung ist unbeaufsichtigt. Forke sie zuerst, um hier weiterzumachen."
+    },
+    "waiting": {
+      "processingPrompt": "Prompt wird verarbeitet...",
+      "thinking": "Denke nach...",
+      "generating": "Generiere...",
+      "working": "Arbeite..."
+    },
+    "unknown": "Unbekannt",
+    "status": {
+      "connecting": "Verbinde…",
+      "disconnected": "Getrennt"
+    },
+    "empty": {
+      "start": "Sende eine Nachricht, um loszulegen",
+      "connectingSession": "Verbinde mit Sitzung…"
+    },
+    "errors": {
+      "unexpected": "Unerwarteter Fehler",
+      "resetTarget": "Ziel zum Zurücksetzen konnte nicht aufgelöst werden.",
+      "forkTarget": "Ziel zum Forken konnte nicht aufgelöst werden."
+    },
+    "confirm": {
+      "wipeSandbox": "Sandbox und ihren Speicher für diese Sitzung löschen? Der Chatverlauf bleibt erhalten.",
+      "scaleDownSandbox": "Sandbox für diese Sitzung herunterfahren? Der Speicher bleibt erhalten.",
+      "deleteSession": "Diese Sitzung löschen? Chatverlauf und Sandbox-Status werden entfernt.",
+      "archiveSession": "Diese Sitzung archivieren? Sie verschwindet aus der Standardliste, setzt ihre Sandbox zurück und bleibt im Wissens-Repository erhalten.",
+      "unarchiveSession": "Diese Sitzung aus dem Archiv holen? Sie kehrt in die aktive Sitzungsliste zurück.",
+      "makePrivate": "Diese Sitzung als privat markieren? Bereits vorhandene Commits im Wissens-Repository bleiben in der Git-Historie bestehen."
+    },
+    "actions": {
+      "pin": "Sitzung anheften",
+      "unpin": "Anheftung lösen",
+      "favorite": "Sitzung favorisieren",
+      "unfavorite": "Favorit entfernen",
+      "archive": "Sitzung archivieren",
+      "unarchive": "Sitzung aus dem Archiv holen",
+      "includeInRepo": "Ins Repository aufnehmen",
+      "keepPrivate": "Privat halten",
+      "delete": "Sitzung löschen"
+    },
+    "badges": {
+      "archived": "Archiviert",
+      "private": "Privat",
+      "pinned": "Angeheftet",
+      "favorite": "Favorit",
+      "askMode": "Lese-Modus",
+      "yoloMode": "YOLO",
+      "unattended": "Unbeaufsichtigt",
+      "interactive": "Interaktiv"
+    },
+    "inspector": {
+      "actions": "Aktionen",
+      "session": "Sitzung"
+    },
+    "session": {
+      "title": "Titel",
+      "id": "ID",
+      "copyId": "Sitzungs-ID kopieren",
+      "idCopied": "Sitzungs-ID kopiert",
+      "idCopiedShort": "Kopiert",
+      "source": "Quelle",
+      "created": "Erstellt",
+      "lastActive": "Zuletzt aktiv",
+      "messages": "Nachrichten",
+      "totalCost": "Kosten",
+      "job": "Job",
+      "reference": "Referenz",
+      "modes": "Modi",
+      "askMode": "Lese-Modus",
+      "askModeHelp": "Außerhalb der Sandbox nur lesend arbeiten. Externe Schreibzugriffe werden verweigert.",
+      "yoloMode": "YOLO-Modus",
+      "yoloModeHelp": "Sentinel-Freigaben umgehen und Aktionen sofort erlauben.",
+      "savingPrivate": "Wird gespeichert…",
+      "updatingMode": "Modus wird aktualisiert…"
+    },
+    "source": {
+      "unknown": "Unbekannt",
+      "job": "Job",
+      "web": "Web",
+      "cli": "CLI"
+    },
+    "jobRun": {
+      "title": "Letzter Joblauf",
+      "job": "Job",
+      "ranAt": "Ausgeführt am",
+      "schedule": "Zeitplan",
+      "data": "Daten",
+      "trigger": {
+        "label": "Auslöser",
+        "api": "API",
+        "cron": "Cron",
+        "manual": "Manuell"
+      }
+    },
+    "sandbox": {
+      "title": "Sandbox",
+      "refreshing": "Aktualisiere…",
+      "checking": "Prüfe Sandbox…",
+      "status": {
+        "missing": "Nicht gestartet",
+        "running": "Läuft",
+        "scaled_down": "Heruntergefahren",
+        "pending": "Startet",
+        "stopped": "Gestoppt",
+        "error": "Fehler"
+      },
+      "actions": {
+        "start": "Sandbox starten",
+        "starting": "Sandbox wird gestartet",
+        "scaleDown": "Sandbox herunterfahren",
+        "scalingDown": "Sandbox wird heruntergefahren",
+        "reset": "Sandbox zurücksetzen"
+      },
+      "storage": {
+        "used": "{size} verwendet",
+        "none": "kein Sandbox-Speicher",
+        "allocated": "{size} zugewiesen"
+      },
+      "fields": {
+        "id": "Sandbox-ID"
+      }
+    },
+    "knowledge": {
+      "title": "Wissen",
+      "commit": "Ins Repository committen",
+      "committed": "Committed",
+      "committedToRepo": "In Wissen übernommen",
+      "notCommittedYet": "Noch nicht committed",
+      "savedAt": "Gespeichert {timestamp}",
+      "commitDisabledNoHistory": "Diese Sitzung hat noch keinen Gesprächsverlauf.",
+      "noNewChanges": "{status}. Keine neuen Änderungen zum Committen.",
+      "privateExistingCommits": "Sitzung ist privat. Bereits vorhandene Commits im Wissens-Repository bleiben unverändert.",
+      "privateExcluded": "Sitzung ist privat und wird nicht ins Wissens-Repository committed.",
+      "includedInRepo": "Sitzung wird ins Wissens-Repository aufgenommen.",
+      "badges": {
+        "excluded": "Ausgeschlossen",
+        "missing": "Fehlt",
+        "outdated": "Veraltet",
+        "upToDate": "Aktuell"
+      }
+    },
+    "mobile": {
+      "details": "Details",
+      "done": "Fertig"
+    }
+  },
+  "message": {
+    "copy": "Nachricht kopieren",
+    "copied": "Kopiert",
+    "codeBlock": {
+      "copy": "Code kopieren",
+      "copied": "Kopiert"
+    },
+    "thinking": {
+      "streaming": "Denke nach",
+      "complete": "Nachgedacht"
+    },
+    "thinkingMeta": {
+      "durationStreaming": "seit {duration}",
+      "durationComplete": "{duration} lang",
+      "reasoning": "{count} Tokens"
+    },
+    "actions": {
+      "fork": "Sitzung von hier forken",
+      "retry": "Zug erneut ausführen",
+      "reset": "Unterhaltung zu diesem Zug zurücksetzen"
+    },
+    "finalStatus": {
+      "status": {
+        "success": "Erfolg",
+        "warning": "Warnung"
+      },
+      "notice": "Der Agent hat die Aufgabe mit einer Meldung vom Typ {status} beendet. Die Sitzung ist jetzt schreibgeschützt, du kannst sie aber forken um weiter zu chatten."
+    }
+  },
+  "jobs": {
+    "settingsSections": "Einstellungsbereiche",
+    "savedJobs": "Gespeicherte Jobs",
+    "loading": "Jobs werden geladen...",
+    "paused": "Pausiert",
+    "unattendedTooltip": "Unbeaufsichtigte Sitzungen können Tool-Aufrufe nicht eskalieren",
+    "confirmDelete": "Job {name} löschen?",
+    "summary": {
+      "onDemandOnly": "Nur manuell",
+      "cronTriggerCount": "{count, plural, one {# Cron-Trigger} other {# Cron-Trigger}}"
+    },
+    "validation": {
+      "idRequired": "Job-ID ist erforderlich.",
+      "nameRequired": "Job-Name ist erforderlich.",
+      "promptRequired": "Prompt ist erforderlich.",
+      "persistentSessionIdRequired": "Wähle eine persistente Session-ID oder deaktiviere die Option.",
+      "persistentSessionMustBeAttended": "Jobs mit persistenter Sitzung müssen beaufsichtigt sein.",
+      "sessionModesRequireFreshSession": "Session-Modi brauchen eine neue Sitzung.",
+      "modelOverridesRequireFreshSession": "Modell-Overrides brauchen eine neue Sitzung.",
+      "askAndYoloMutuallyExclusive": "Lese-Modus und YOLO sind gegenseitig ausschließend.",
+      "cronEmpty": "Cron-Ausdrücke dürfen nicht leer sein.",
+      "cronInvalid": "Cron-Ausdruck ist ungültig: {expression}."
+    },
+    "cron": {
+      "invalidExpression": "Ungültiger Cron-Ausdruck."
+    },
+    "triggerKind": {
+      "scheduled": "Geplant",
+      "manual": "Manuell"
+    },
+    "errors": {
+      "load": "Jobs konnten nicht geladen werden.",
+      "refresh": "Jobs konnten nicht aktualisiert werden.",
+      "save": "Job konnte nicht gespeichert werden.",
+      "delete": "Job konnte nicht gelöscht werden.",
+      "run": "Job konnte nicht gestartet werden.",
+      "saveBeforeRun": "Speichere den Job, bevor du ihn startest.",
+      "saveChangesBeforeRun": "Speichere die Änderungen am Job, bevor du ihn startest."
+    },
+    "notices": {
+      "refreshed": "Jobs aktualisiert.",
+      "created": "Job erstellt.",
+      "saved": "Job gespeichert.",
+      "deleted": "Job gelöscht.",
+      "runStartedNewSession": "Ausführung in neuer Sitzung {sessionId} gestartet.",
+      "runStartedSession": "Ausführung in Sitzung {sessionId} gestartet."
+    },
+    "actions": {
+      "refresh": "Jobs aktualisieren",
+      "new": "Neuer Job",
+      "clear": "Leeren",
+      "clearPersistentSession": "Persistente Sitzung entfernen",
+      "delete": "Löschen",
+      "save": "Speichern",
+      "addTrigger": "Trigger hinzufügen",
+      "remove": "Entfernen",
+      "runNow": "Jetzt ausführen"
+    },
+    "empty": {
+      "noJobs": "Noch keine Jobs. Erstelle einen, um Prompts und optionale Cron-Zeitpläne in jobs.yaml zu speichern."
+    },
+    "editor": {
+      "newJob": "Neuer Job",
+      "editing": "Bearbeite {name}",
+      "jobFallback": "Job"
+    },
+    "fields": {
+      "name": "Name",
+      "jobId": "Job-ID",
+      "enabled": "Aktiviert",
+      "enabledHelp": "Pausierte Jobs bleiben in jobs.yaml, werden aber nie per Cron ausgeführt.",
+      "newSession": "Optionen",
+      "newSessionHelp": "Diese Optionen gelten nur für neue Sitzungen, die der Job selbst erstellt.",
+      "unattended": "Unbeaufsichtigt ausführen",
+      "unattendedHelp": "Tool-Aufrufe werden nicht an dich eskaliert.",
+      "persistentSession": "Persistente Sitzung",
+      "persistentSessionToggleHelp": "Verwende eine bestehende Sitzung statt bei jedem Lauf eine neue zu starten.",
+      "persistentSessionDisabled": "Kann im unbeaufsichtigten Modus nicht verwendet werden",
+      "persistentSessionUncheckedHelp": "Aktiviere die Option, um unten eine bestehende Session-ID auszuwählen.",
+      "persistentSessionMissingIdHelp": "Aktiv, aber noch ohne Session-ID. Wähle unten eine bestehende Sitzung aus.",
+      "persistentSessionHelp": "Verwende eine bestehende Sitzung, statt bei jedem Joblauf eine neue zu erstellen.",
+      "persistentSessionActiveHelp": "Aktiv: Diese Session-ID überschreibt die Optionen für neue Sitzungen oben.",
+      "models": "Modelle",
+      "modelsHelp": "Optionale job-spezifische Overrides für neue Sitzungen, die dieser Job erstellt.",
+      "modelsDisabled": "Persistente Sitzungen behalten ihre eigene Modellauswahl.",
+      "modelsLinked": "Modelle verknüpft",
+      "modelsLinkedHelp": "Verknüpft: Änderungen an einem Modell setzen beide Modelle.",
+      "modelsUnlinked": "Modelle getrennt",
+      "modelsUnlinkedHelp": "Getrennt: Agent- und Sentinel-Modell lassen sich unabhängig ändern.",
+      "agentModel": "Agent",
+      "sentinelModel": "Sentinel",
+      "titleModel": "Titel-Modell",
+      "prompt": "Prompt",
+      "expression": "Ausdruck",
+      "timeZone": "Zeitzone",
+      "inputOptional": "Eingabe (optional)"
+    },
+    "placeholders": {
+      "name": "Nächtliche Inbox-Prüfung",
+      "jobId": "naechtliche-inbox-pruefung",
+      "persistentSession": "session-id auswählen",
+      "prompt": "Fasse neue Aufgaben zusammen, priorisiere Dringendes und schlage dann nächste Schritte vor.",
+      "model": "Leer lassen für Standardmodell"
+    },
+    "sections": {
+      "cronTriggers": "Cron-Trigger",
+      "cronTriggersDescription": "Leer lassen für Jobs, die nur manuell gestartet werden.",
+      "noTriggers": "Keine Cron-Trigger konfiguriert.",
+      "runJob": "Job ausführen",
+      "previousInvocations": "Vorherige Ausführungen",
+      "previousInvocationsDescription": "Wähle eine Ausführung, um ihre Sitzung zu öffnen.",
+      "saveToViewHistory": "Speichere diesen Job, um den Ausführungsverlauf zu sehen.",
+      "noInvocations": "Noch keine Ausführungen. Aktualisiere die Sitzungen, um neu abgeschlossene Läufe zu laden.",
+      "ranAt": "Ausgeführt am {timestamp}"
+    }
+  },
+  "sidebar": {
+    "time": {
+      "justNow": "gerade eben"
+    },
+    "messageCount": "{count, plural, one {# Nachricht} other {# Nachrichten}}",
+    "unattendedSession": "Unbeaufsichtigte Sitzung",
+    "privateSession": "Private Sitzung",
+    "knowledgeCommitted": "Alle Änderungen ins Wissens-Repository übernommen",
+    "actions": {
+      "pin": "Sitzung anheften",
+      "unpin": "Sitzung lösen",
+      "favorite": "Sitzung favorisieren",
+      "unfavorite": "Favorit entfernen",
+      "archive": "Sitzung archivieren",
+      "unarchive": "Sitzung aus dem Archiv holen",
+      "delete": "Sitzung löschen",
+      "deleteEmpty": "Leere Sitzung löschen",
+      "shiftSkip": "Shift+Klick überspringt die Bestätigung"
+    },
+    "confirm": {
+      "deleteSession": "Diese Sitzung löschen? Chatverlauf und Sandbox-Status werden entfernt.",
+      "deleteUnpushed": "Diese Sitzung hat {count, plural, one {# Commit} other {# Commits}}, die noch nicht ins Wissens-Repository gepusht wurden. Beim Löschen gehen sie verloren. Trotzdem löschen?",
+      "archiveSession": "Diese Sitzung archivieren? Sie verschwindet aus der Standardliste, setzt ihre Sandbox zurück und bleibt im Wissens-Repository erhalten."
+    },
+    "sections": {
+      "today": "Heute",
+      "yesterday": "Gestern",
+      "last7Days": "Letzte 7 Tage",
+      "last30Days": "Letzte 30 Tage",
+      "archived": "Archiviert",
+      "unknownDate": "Unbekanntes Datum"
+    },
+    "empty": "Noch keine Sitzungen",
+    "loadingMore": "Weitere Sitzungen werden geladen"
+  },
+  "git": {
+    "upToDate": "Aktuell",
+    "noRemote": "Kein Remote konfiguriert",
+    "sandbox": {
+      "label": "Workspace-Sync",
+      "help": "Synchronisiert die Workspace-Sandbox dieser Sitzung mit deinem Wissens-Repository auf dem Server. Die Zähler zeigen, um wie viele Commits dieser Workspace dem Server-Repo voraus (↑) bzw. hinterher (↓) ist.",
+      "notRunning": "Sandbox läuft nicht",
+      "refresh": "Workspace erneut mit dem Server-Repository abgleichen (holt zuerst neue Commits)",
+      "pull": "Commits aus dem Server-Repository in diesen Workspace holen",
+      "push": "Commits dieses Workspace ins Server-Repository übertragen (jeder Push wird vom Sentinel geprüft)"
+    },
+    "global": {
+      "label": "Wissens-Remote",
+      "help": "Synchronisiert dein Wissens-Repository auf dem Server mit seinem externen Git-Remote. Die Zähler zeigen, um wie viele Commits das Server-Repo dem Remote voraus (↑) bzw. hinterher (↓) ist.",
+      "indicatorBehind": "{count, plural, one {# Commit} other {# Commits}} vom Wissens-Remote zu holen",
+      "refresh": "Server-Repository erneut mit dem Remote abgleichen (holt zuerst neue Commits)",
+      "pull": "Commits vom externen Remote ins Server-Repository holen",
+      "push": "Commits des Server-Repositorys ins externe Remote übertragen"
+    },
+    "denied": "Push abgelehnt",
+    "errors": {
+      "status": "Git-Status konnte nicht gelesen werden",
+      "pull": "Pull fehlgeschlagen",
+      "push": "Push fehlgeschlagen"
+    }
+  },
+  "apiKeys": {
+    "title": "API-Schlüssel",
+    "description": "Erstelle langlebige Tokens für Skripte und Integrationen. Verwende sie als 'Authorization: Bearer <token>'.",
+    "create": {
+      "nameLabel": "Name",
+      "namePlaceholder": "z. B. CI-Deploy-Bot",
+      "scopesLabel": "Berechtigungen",
+      "expiryLabel": "Läuft ab nach (Tagen)",
+      "expiryPlaceholder": "Leer lassen für kein Ablaufdatum",
+      "submit": "Schlüssel erstellen",
+      "creating": "Wird erstellt…"
+    },
+    "access": {
+      "none": "Keine",
+      "read": "Lesen",
+      "write": "Schreiben"
+    },
+    "scopes": {
+      "sessions": "Sitzungen",
+      "jobs": "Jobs",
+      "preferences": "Einstellungen",
+      "notifications": "Benachrichtigungen",
+      "history": "Verlauf",
+      "admin": "Administration"
+    },
+    "secret": {
+      "warning": "Kopiere diesen Token jetzt — er wird nicht erneut angezeigt.",
+      "copy": "Token kopieren",
+      "done": "Fertig"
+    },
+    "list": {
+      "title": "Aktive Schlüssel",
+      "empty": "Noch keine API-Schlüssel.",
+      "loading": "Schlüssel werden geladen…",
+      "unnamed": "Unbenannter Schlüssel"
+    },
+    "fields": {
+      "created": "Erstellt {timestamp}",
+      "lastUsed": "Zuletzt verwendet {timestamp}",
+      "expires": "Läuft ab {timestamp}",
+      "never": "nie",
+      "noExpiry": "kein Ablauf"
+    },
+    "actions": {
+      "revoke": "Schlüssel widerrufen"
+    },
+    "confirm": {
+      "revoke": "API-Schlüssel \"{name}\" widerrufen? Dies kann nicht rückgängig gemacht werden."
+    },
+    "errors": {
+      "load": "API-Schlüssel konnten nicht geladen werden.",
+      "create": "API-Schlüssel konnte nicht erstellt werden.",
+      "revoke": "API-Schlüssel konnte nicht widerrufen werden.",
+      "noScopes": "Wähle mindestens eine Berechtigung."
+    }
+  }
 }

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -1,1055 +1,1055 @@
 {
-  "app": {
-    "name": "carapace",
-    "description": "Sicherheitsorientierter persönlicher KI-Agent"
-  },
-  "navigation": {
-    "home": "Start",
-    "settings": "Einstellungen",
-    "jobs": "Jobs",
-    "account": "Konto",
-    "preferences": "Allgemein",
-    "platform": "Admin",
-    "models": "Modelle",
-    "users": "Benutzer",
-    "disconnect": "Trennen",
-    "github": "thiesgerken/carapace",
-    "apiKeys": "API-Schlüssel"
-  },
-  "account": {
-    "menu": "Kontomenü",
-    "openMenu": "Kontomenü öffnen",
-    "unknown": "Unbekannter Benutzer",
-    "logout": "Abmelden"
-  },
-  "accountSettings": {
-    "status": {
-      "loading": "Einstellungen werden geladen",
-      "unavailable": "Einstellungen sind nicht verfügbar",
-      "configured": "konfiguriert",
-      "notSet": "nicht gesetzt"
+    "app": {
+        "name": "carapace",
+        "description": "Sicherheitsorientierter persönlicher KI-Agent"
     },
-    "notices": {
-      "saved": "Gespeichert."
+    "navigation": {
+        "home": "Start",
+        "settings": "Einstellungen",
+        "jobs": "Jobs",
+        "account": "Konto",
+        "preferences": "Allgemein",
+        "platform": "Admin",
+        "models": "Modelle",
+        "users": "Benutzer",
+        "disconnect": "Trennen",
+        "github": "thiesgerken/carapace",
+        "apiKeys": "API-Schlüssel"
     },
-    "errors": {
-      "load": "Benutzereinstellungen konnten nicht geladen werden",
-      "save": "Benutzereinstellungen konnten nicht aktualisiert werden",
-      "credentialsInvalid": "Zugangsdaten-Backend-Einstellungen sind ungültig",
-      "credentialNameRequired": "Name des Zugangsdaten-Backends ist erforderlich",
-      "credentialNameNoSlash": "Zugangsdaten-Backend-Name {name} darf kein / enthalten",
-      "credentialNameDuplicate": "Zugangsdaten-Backend-Name {name} wird bereits verwendet",
-      "fileBackendDisabled": "Dateibasierte Zugangsdaten-Backends sind auf diesem Server deaktiviert",
-      "basicAuthUsernameRequired": "Basic-Auth-Benutzername ist für {name} erforderlich",
-      "basicAuthPasswordRequired": "Basic-Auth-Passwort ist für {name} erforderlich",
-      "matrixPasswordRequired": "Matrix-Passwort ist erforderlich, wenn Matrix aktiviert ist",
-      "budgetWholeNumber": "{field} muss eine nicht negative ganze Zahl sein.",
-      "budgetNumber": "{field} muss eine nicht negative Zahl sein."
+    "account": {
+        "menu": "Kontomenü",
+        "openMenu": "Kontomenü öffnen",
+        "unknown": "Unbekannter Benutzer",
+        "logout": "Abmelden"
     },
-    "sections": {
-      "defaultModels": "Standardmodelle",
-      "defaultBudgets": "Standardbudgets",
-      "matrix": "Matrix",
-      "credentials": "Zugangsdaten",
-      "gitRemote": "Git-Remote"
-    },
-    "fields": {
-      "agent": "Agent",
-      "sentinel": "Sentinel",
-      "title": "Titel",
-      "inputTokens": "Input-Tokens",
-      "outputTokens": "Output-Tokens",
-      "costUsd": "Kosten (in $)",
-      "toolCalls": "Tool-Aufrufe",
-      "enabled": "Aktiviert",
-      "homeserver": "Homeserver",
-      "userId": "Benutzer-ID",
-      "deviceName": "Gerätename",
-      "password": "Passwort",
-      "allowedRooms": "Erlaubte Räume",
-      "allowedUsers": "Erlaubte Benutzer",
-      "remote": "Remote",
-      "branch": "Branch",
-      "author": "Autor",
-      "token": "Token",
-      "name": "Name",
-      "path": "Pfad",
-      "url": "URL",
-      "basicAuth": "Basic Auth",
-      "basicAuthUsername": "Basic-Auth-Benutzername",
-      "basicAuthPassword": "Basic-Auth-Passwort",
-      "expose": "Freigeben",
-      "hide": "Ausblenden"
-    },
-    "defaults": {
-      "serverDefault": "Serverstandard",
-      "currentModel": "{model}"
-    },
-    "placeholders": {
-      "addRoom": "Raum hinzufügen, Enter oder Komma",
-      "addUser": "Benutzer hinzufügen, Enter oder Komma",
-      "addIdentifier": "Kennung hinzufügen, Enter oder Komma"
-    },
-    "tooltips": {
-      "filePath": "Relative Pfade werden vom Arbeitsverzeichnis des Servers aus aufgelöst.",
-      "expose": "Nur diese Zugangsdaten-Kennungen aus diesem Backend erlauben. Leer lassen, um alles außer ausgeblendeten Einträgen zu erlauben.",
-      "hide": "Diese Zugangsdaten-Kennungen aus diesem Backend verweigern. Wird ignoriert, wenn Freigeben gesetzt ist."
-    },
-    "actions": {
-      "save": "Speichern",
-      "saving": "Speichert",
-      "addBitwarden": "Bitwarden",
-      "addFile": "Datei",
-      "remove": "Entfernen",
-      "removeValue": "{value} entfernen",
-      "removeBackend": "Backend entfernen",
-      "removeBackendAria": "{name} entfernen"
-    },
-    "empty": {
-      "credentials": "Keine Zugangsdaten-Backends konfiguriert"
-    },
-    "credentials": {
-      "backendFallback": "Zugangsdaten-Backend",
-      "types": {
-        "file": {
-          "label": "Datei",
-          "description": "Lokale Zugangsdatendatei"
+    "accountSettings": {
+        "status": {
+            "loading": "Einstellungen werden geladen",
+            "unavailable": "Einstellungen sind nicht verfügbar",
+            "configured": "konfiguriert",
+            "notSet": "nicht gesetzt"
         },
-        "bitwarden": {
-          "label": "Bitwarden",
-          "description": "Passwortmanager-Proxy"
+        "notices": {
+            "saved": "Gespeichert."
+        },
+        "errors": {
+            "load": "Benutzereinstellungen konnten nicht geladen werden",
+            "save": "Benutzereinstellungen konnten nicht aktualisiert werden",
+            "credentialsInvalid": "Zugangsdaten-Backend-Einstellungen sind ungültig",
+            "credentialNameRequired": "Name des Zugangsdaten-Backends ist erforderlich",
+            "credentialNameNoSlash": "Zugangsdaten-Backend-Name {name} darf kein / enthalten",
+            "credentialNameDuplicate": "Zugangsdaten-Backend-Name {name} wird bereits verwendet",
+            "fileBackendDisabled": "Dateibasierte Zugangsdaten-Backends sind auf diesem Server deaktiviert",
+            "basicAuthUsernameRequired": "Basic-Auth-Benutzername ist für {name} erforderlich",
+            "basicAuthPasswordRequired": "Basic-Auth-Passwort ist für {name} erforderlich",
+            "matrixPasswordRequired": "Matrix-Passwort ist erforderlich, wenn Matrix aktiviert ist",
+            "budgetWholeNumber": "{field} muss eine nicht negative ganze Zahl sein.",
+            "budgetNumber": "{field} muss eine nicht negative Zahl sein."
+        },
+        "sections": {
+            "defaultModels": "Standardmodelle",
+            "defaultBudgets": "Standardbudgets",
+            "matrix": "Matrix",
+            "credentials": "Zugangsdaten",
+            "gitRemote": "Git-Remote"
+        },
+        "fields": {
+            "agent": "Agent",
+            "sentinel": "Sentinel",
+            "title": "Titel",
+            "inputTokens": "Input-Tokens",
+            "outputTokens": "Output-Tokens",
+            "costUsd": "Kosten (in $)",
+            "toolCalls": "Tool-Aufrufe",
+            "enabled": "Aktiviert",
+            "homeserver": "Homeserver",
+            "userId": "Benutzer-ID",
+            "deviceName": "Gerätename",
+            "password": "Passwort",
+            "allowedRooms": "Erlaubte Räume",
+            "allowedUsers": "Erlaubte Benutzer",
+            "remote": "Remote",
+            "branch": "Branch",
+            "author": "Autor",
+            "token": "Token",
+            "name": "Name",
+            "path": "Pfad",
+            "url": "URL",
+            "basicAuth": "Basic Auth",
+            "basicAuthUsername": "Basic-Auth-Benutzername",
+            "basicAuthPassword": "Basic-Auth-Passwort",
+            "expose": "Freigeben",
+            "hide": "Ausblenden"
+        },
+        "defaults": {
+            "serverDefault": "Serverstandard",
+            "currentModel": "{model}"
+        },
+        "placeholders": {
+            "addRoom": "Raum hinzufügen, Enter oder Komma",
+            "addUser": "Benutzer hinzufügen, Enter oder Komma",
+            "addIdentifier": "Kennung hinzufügen, Enter oder Komma"
+        },
+        "tooltips": {
+            "filePath": "Relative Pfade werden vom Arbeitsverzeichnis des Servers aus aufgelöst.",
+            "expose": "Nur diese Zugangsdaten-Kennungen aus diesem Backend erlauben. Leer lassen, um alles außer ausgeblendeten Einträgen zu erlauben.",
+            "hide": "Diese Zugangsdaten-Kennungen aus diesem Backend verweigern. Wird ignoriert, wenn Freigeben gesetzt ist."
+        },
+        "actions": {
+            "save": "Speichern",
+            "saving": "Speichert",
+            "addBitwarden": "Bitwarden",
+            "addFile": "Datei",
+            "remove": "Entfernen",
+            "removeValue": "{value} entfernen",
+            "removeBackend": "Backend entfernen",
+            "removeBackendAria": "{name} entfernen"
+        },
+        "empty": {
+            "credentials": "Keine Zugangsdaten-Backends konfiguriert"
+        },
+        "credentials": {
+            "backendFallback": "Zugangsdaten-Backend",
+            "types": {
+                "file": {
+                    "label": "Datei",
+                    "description": "Lokale Zugangsdatendatei"
+                },
+                "bitwarden": {
+                    "label": "Bitwarden",
+                    "description": "Passwortmanager-Proxy"
+                }
+            }
         }
-      }
+    },
+    "platformSettings": {
+        "status": {
+            "loading": "Plattformeinstellungen werden geladen",
+            "unavailable": "Plattformeinstellungen sind nicht verfügbar",
+            "readOnly": "Die Konfigurationsdatei ist schreibgeschützt."
+        },
+        "notices": {
+            "saved": "Gespeichert."
+        },
+        "errors": {
+            "load": "Plattformeinstellungen konnten nicht geladen werden",
+            "save": "Plattformeinstellungen konnten nicht aktualisiert werden",
+            "wholeNumber": "{field} muss eine positive ganze Zahl sein.",
+            "nonNegativeWholeNumber": "{field} muss eine nicht negative ganze Zahl sein.",
+            "number": "{field} muss eine nicht negative Zahl sein.",
+            "providerRequired": "Provider ist für Modell {index} erforderlich.",
+            "nameRequired": "Name ist für Modell {index} erforderlich.",
+            "duplicateModel": "Modell-ID {id} wird mehrfach verwendet.",
+            "rawSecretRequired": "Füge einen API-Key für {id} ein oder wähle eine andere Secret-Quelle.",
+            "secretValueRequired": "Secret-Referenz ist für {id} erforderlich.",
+            "defaultRequired": "{field}-Standardmodell ist erforderlich.",
+            "defaultUnknown": "{field}-Standardmodell {id} ist nicht im Katalog."
+        },
+        "sections": {
+            "defaultModels": "Standardmodelle",
+            "defaultBudgets": "Standardbudgets",
+            "catalog": "Modellkatalog"
+        },
+        "fields": {
+            "agent": "Agent",
+            "sentinel": "Sentinel",
+            "title": "Titel",
+            "inputTokens": "Input-Tokens",
+            "outputTokens": "Output-Tokens",
+            "costUsd": "Kosten (in $)",
+            "toolCalls": "Tool-Aufrufe",
+            "provider": "Provider",
+            "name": "Name",
+            "id": "ID",
+            "maxInputTokens": "Max. Input-Tokens",
+            "thinking": "Thinking",
+            "thinkingBudgetTokens": "Thinking-Budget-Tokens",
+            "baseUrl": "Base URL",
+            "vision": "Vision",
+            "visionHint": "Akzeptiert Bildeingaben",
+            "apiKeySource": "API-Key-Quelle",
+            "apiKey": "API-Key",
+            "secretReference": "Secret-Referenz"
+        },
+        "placeholders": {
+            "selectModel": "Modell auswählen",
+            "unlimited": "Unbegrenzt",
+            "generatedId": "provider:name",
+            "keepSecret": "Konfiguriertes Secret behalten"
+        },
+        "actions": {
+            "save": "Speichern",
+            "saving": "Speichert",
+            "addModel": "Modell hinzufügen",
+            "removeModel": "Modell entfernen",
+            "confirmRemoveModel": "Modell \"{name}\" entfernen? Dies kann nicht rückgängig gemacht werden."
+        },
+        "secretSources": {
+            "none": "Keine",
+            "raw": "Direkter Wert",
+            "env": "Umgebungsvariable",
+            "file": "Datei"
+        },
+        "thinking": {
+            "default": "Standard",
+            "true": "Aktiviert",
+            "false": "Deaktiviert",
+            "minimal": "Minimal",
+            "low": "Niedrig",
+            "medium": "Mittel",
+            "high": "Hoch",
+            "xhigh": "Extra hoch"
+        },
+        "units": {
+            "tokens": "Tokens"
+        },
+        "modelRow": "Modell {index}"
+    },
+    "home": {
+        "empty": {
+            "description": "Wähle eine Sitzung aus oder starte eine neue"
+        }
+    },
+    "connect": {
+        "description": "Bei carapace anmelden",
+        "serverLabel": "Server-URL",
+        "usernameLabel": "Benutzername",
+        "usernamePlaceholder": "Benutzername",
+        "passwordLabel": "Passwort",
+        "passwordPlaceholder": "Passwort",
+        "connect": "Verbinden",
+        "connecting": "Verbinde…",
+        "errors": {
+            "serverError": "Serverfehler: {status}",
+            "connectionFailed": "Verbindung fehlgeschlagen"
+        }
+    },
+    "admin": {
+        "title": "Admin",
+        "backToApp": "Zurück zur App",
+        "serverLabel": "Server-URL",
+        "serverPlaceholder": "Kein Server ausgewählt",
+        "users": {
+            "title": "Benutzer",
+            "description": "Globale Plattform-Konten, Rollen und Datenzuordnung.",
+            "savedUsers": "Benutzer",
+            "loading": "Benutzer werden geladen…",
+            "empty": "Keine Benutzer gefunden",
+            "selectUser": "Benutzer auswählen",
+            "you": "Du",
+            "admin": "Admin",
+            "enabled": "Aktiv",
+            "disabled": "Deaktiviert"
+        },
+        "create": {
+            "title": "Neuer Benutzer",
+            "subtitle": "Lokalen Benutzer anlegen"
+        },
+        "fields": {
+            "username": "Benutzername",
+            "password": "Passwort",
+            "newPassword": "Neues Passwort",
+            "keepPassword": "Aktuelles Passwort behalten",
+            "displayName": "Anzeigename",
+            "email": "E-Mail",
+            "roles": "Rollen",
+            "enabled": "Aktiv"
+        },
+        "actions": {
+            "load": "Laden",
+            "loading": "Lädt…",
+            "refresh": "Benutzer aktualisieren",
+            "new": "Neuer Benutzer",
+            "deleteUser": "{username} löschen",
+            "create": "Benutzer anlegen",
+            "creating": "Lege an…",
+            "save": "Änderungen speichern",
+            "saving": "Speichert…"
+        },
+        "notices": {
+            "loaded": "Benutzer geladen.",
+            "created": "{username} angelegt.",
+            "saved": "{username} gespeichert.",
+            "deleted": "{username} gelöscht."
+        },
+        "errors": {
+            "missingCredentials": "Aktueller Ursprung ist nicht verfügbar.",
+            "load": "Benutzer konnten nicht geladen werden.",
+            "create": "Benutzer konnte nicht angelegt werden.",
+            "save": "Benutzer konnte nicht gespeichert werden.",
+            "delete": "Benutzer konnte nicht gelöscht werden."
+        },
+        "confirm": {
+            "deleteUser": "{username} löschen? Bestehende Daten dieses Benutzers bleiben erhalten."
+        },
+        "meta": {
+            "tokenVersion": "Token v{version}",
+            "updated": "Aktualisiert {timestamp}",
+            "lastLogin": "Letzter Login {timestamp}",
+            "never": "nie"
+        }
+    },
+    "preferences": {
+        "title": "Einstellungen",
+        "description": "Persönliche Einstellungen für diesen Browser und deine Nutzung.",
+        "currentLocale": "Aktuelle Oberflächensprache: {locale}",
+        "language": {
+            "label": "Sprache",
+            "description": "Wähle, wie die Oberflächensprache bestimmt wird.",
+            "options": {
+                "system": "System",
+                "en": "English",
+                "de": "Deutsch"
+            }
+        },
+        "theme": {
+            "label": "Darstellung",
+            "description": "Wähle, wie das Farbschema bestimmt wird.",
+            "options": {
+                "system": "System",
+                "light": "Hell",
+                "dark": "Dunkel"
+            }
+        },
+        "chatList": {
+            "label": "Chats",
+            "showArchived": {
+                "label": "Archivierte Chats anzeigen",
+                "description": "Wenn deaktiviert, werden archivierte Chats ausgeblendet und bei Session-Listen direkt nicht vom Server angefragt."
+            }
+        },
+        "notifications": {
+            "title": "Push-Benachrichtigungen",
+            "description": "Liefert Eskalationen und Zug-Ergebnisse an diesen Browser oder die installierte PWA.",
+            "status": {
+                "loading": "Benachrichtigungsunterstützung wird geprüft…",
+                "loadingShort": "Prüfung",
+                "enabled": "Benachrichtigungen sind für diesen Browser aktiviert.",
+                "enabledShort": "Aktiv",
+                "disabled": "Benachrichtigungen sind für diesen Browser deaktiviert.",
+                "disabledShort": "Aus",
+                "unsupported": "Dieser Browser kann im aktuellen Kontext keine Web-Push-Benachrichtigungen empfangen.",
+                "permissionDenied": "Die Browser-Benachrichtigungsfreigabe ist blockiert. Aktiviere sie in Browser- oder Geräteeinstellungen erneut.",
+                "permissionRequired": "Die Benachrichtigungsfreigabe wurde nicht erteilt.",
+                "invalidSubscription": "Der Browser hat eine unvollständige Push-Subscription zurückgegeben.",
+                "loadFailed": "Benachrichtigungseinstellungen konnten nicht geladen werden.",
+                "enableFailed": "Benachrichtigungen konnten nicht aktiviert werden.",
+                "disableFailed": "Benachrichtigungen konnten nicht deaktiviert werden.",
+                "preferencesFailed": "Benachrichtigungseinstellungen konnten nicht aktualisiert werden.",
+                "testFailed": "Testbenachrichtigung konnte nicht gesendet werden.",
+                "testSent": "Testbenachrichtigung gesendet."
+            },
+            "deviceName": {
+                "label": "Gerätename",
+                "placeholder": "Android-Telefon",
+                "hint": "Wird in den serverseitigen Benachrichtigungs-Subscriptions für diesen Browser angezeigt."
+            },
+            "toggle": {
+                "label": "Benachrichtigungen"
+            },
+            "actions": {
+                "enable": "Benachrichtigungen aktivieren",
+                "enabling": "Aktiviere…",
+                "disable": "Benachrichtigungen deaktivieren",
+                "disabling": "Deaktiviere…",
+                "test": "Testbenachrichtigung senden",
+                "testing": "Sende Testbenachrichtigung…"
+            },
+            "preferences": {
+                "label": "Benachrichtigungen senden für",
+                "escalation_pending": "Eskalationen, die Freigabe brauchen",
+                "attended_turn_completed": "Begleitete Sitzungen, wenn ein Zug endet",
+                "unattended_turn_completed": "Unbeaufsichtigte Jobs mit erfolgreichem Abschluss",
+                "unattended_turn_failed": "Unbeaufsichtigte Jobs mit Fehler"
+            },
+            "meta": {
+                "permission": "Browser-Freigabe: {permission}",
+                "heartbeat": "Letzter Heartbeat: {timestamp}",
+                "expires": "Subscription läuft ab: {timestamp}"
+            },
+            "permission": {
+                "default": "nicht angefragt",
+                "granted": "erteilt",
+                "denied": "blockiert"
+            }
+        }
+    },
+    "newSessionButton": {
+        "label": "Neue Sitzung",
+        "chooseOptions": "Sitzungsoptionen auswählen",
+        "private": {
+            "enabledTitle": "Privat",
+            "enabledDescription": "Nicht ins Wissens-Repository aufnehmen.",
+            "disabledTitle": "Speichern",
+            "disabledDescription": "Wird im Wissens-Repository gespeichert."
+        },
+        "ask": {
+            "enabledTitle": "Nur Lesend",
+            "enabledDescription": "Außerhalb der Sandbox nur lesen.",
+            "disabledTitle": "Schreibzugriff",
+            "disabledDescription": "Außerhalb der Sandbox schreiben erlaubt."
+        },
+        "yolo": {
+            "enabledTitle": "YOLO",
+            "enabledDescription": "Alle Tool-Calls sofort erlauben.",
+            "disabledTitle": "Mit Prüfung",
+            "disabledDescription": "Aktionen weiter durch Safe-List und Sentinel prüfen."
+        },
+        "unattended": {
+            "enabledTitle": "Unbeaufsichtigt",
+            "enabledDescription": "Läuft eigenständig ohne Freigabepfad durch dich.",
+            "disabledTitle": "Interaktiv",
+            "disabledDescription": "Bleibt im interaktiven Modus mit Freigabepfad."
+        }
+    },
+    "chatInput": {
+        "disabled": "Eingabe deaktiviert",
+        "sendMessageTooltip": "Nachricht senden (Enter)",
+        "queueInterruptStopTooltip": "Enter zum Einreihen · ⌥Enter zum Unterbrechen · Klicken zum Stoppen",
+        "stopGenerationTooltip": "Generierung stoppen",
+        "queued": "Warteschlange: {message}",
+        "startVoiceInput": "Spracheingabe starten",
+        "stopVoiceInput": "Spracheingabe stoppen",
+        "attachFile": "Datei anhängen",
+        "attachFileUnavailable": "Sandbox starten, um Dateien hochzuladen",
+        "startingSandbox": "Sandbox wird gestartet…",
+        "removeAttachment": "Entfernen",
+        "placeholder": "Nachricht an carapace…",
+        "usageBreakdown": {
+            "systemLine": "System: {percent}%",
+            "userLine": "User: {percent}%",
+            "assistantLine": "Assistant: {percent}%",
+            "toolCallsLine": "Tool-Aufrufe: {percent}%",
+            "toolOutputsLine": "Tool-Ausgaben: {percent}%",
+            "otherLine": "Sonstiges: {percent}%"
+        },
+        "context": {
+            "limit": "Kontextlimit: {tokens} Tokens.",
+            "assumedLimit": "Angenommenes Kontextlimit: {tokens} Tokens.",
+            "lastRequestTokens": "{tokens} API-Tokens (letzte Agent-Anfrage)",
+            "clickForUsage": "Klicken, um /usage an den Agenten zu senden und mehr Details zu sehen.",
+            "tokensLabel": "{tokens} Tokens"
+        },
+        "budget": {
+            "budgetLabel": "Budget für {label}",
+            "current": "Aktuell: {value}",
+            "max": "Maximal: {value}",
+            "remaining": "Verbleibend: {value}",
+            "exhausted": "Budget ausgeschöpft."
+        }
+    },
+    "approval": {
+        "general": {
+            "title": "Freigabe erforderlich",
+            "toolLabel": "Tool:",
+            "reasonLabel": "Grund:",
+            "riskLabel": "Risiko:",
+            "arguments": "Argumente",
+            "allow": "Freigeben",
+            "denyPlaceholder": "Warum sollte das blockiert werden?",
+            "risk": {
+                "high": "hoch",
+                "medium": "mittel",
+                "low": "niedrig"
+            }
+        },
+        "denialNote": {
+            "deny": "Ablehnen",
+            "optionalNote": "Optionale Notiz für den Agenten",
+            "addNote": "Notiz hinzufügen",
+            "hideNote": "Notiz ausblenden"
+        },
+        "credential": {
+            "title": "Zugangsdatenanfrage",
+            "skillLabel": "Skill:",
+            "allow": "Erlauben",
+            "denyPlaceholder": "Warum sollte dieser Zugang blockiert werden?",
+            "decision": {
+                "allow": "Erlaubt",
+                "deny": "Abgelehnt"
+            }
+        },
+        "domainAccess": {
+            "title": "Domain-Zugriffsanfrage",
+            "domainLabel": "Domain:",
+            "triggeredByLabel": "Ausgelöst durch:",
+            "allow": "{domain} erlauben",
+            "denyPlaceholder": "Warum sollte das blockiert werden?",
+            "decision": {
+                "allow": "Erlaubt",
+                "deny": "Abgelehnt"
+            }
+        },
+        "gitPush": {
+            "title": "Git-Push-Anfrage",
+            "refLabel": "Ref:",
+            "reasonLabel": "Grund:",
+            "changedFiles": "{count, plural, one {# geänderte Datei} other {# geänderte Dateien}}",
+            "allow": "Push erlauben",
+            "denyPlaceholder": "Warum sollte dieser Push blockiert werden?",
+            "decision": {
+                "allow": "Erlaubt",
+                "deny": "Abgelehnt"
+            }
+        }
+    },
+    "versionBadge": {
+        "frontend": "Frontend: {version}",
+        "backend": "Backend: {version}",
+        "unknown": "unbekannt",
+        "mismatchTooltip": "Versionen von Frontend- und Backend-Containern stimmen nicht überein.",
+        "mismatchSr": "Frontend- und Backend-Versionen stimmen nicht überein."
+    },
+    "toolCallBadge": {
+        "approvalBadge": {
+            "review": "Prüfung",
+            "skill": "Skill",
+            "bypass": "Bypass",
+            "denied": "abgelehnt"
+        },
+        "fallbacks": {
+            "missingPath": "(Pfad fehlt)",
+            "missingCommand": "(Befehl fehlt)",
+            "missingSkillName": "(skill_name fehlt)",
+            "credential": "Zugangsdaten"
+        },
+        "labels": {
+            "read": "Las",
+            "wrote": "Geschrieben",
+            "replaced": "Ersetzt",
+            "activatedSkill": "Skill aktiviert",
+            "executed": "Ausgeführt",
+            "listedCredentials": "Zugangsdaten aufgelistet",
+            "credentialDenied": "Zugangsdaten abgelehnt",
+            "accessedCredential": "Zugangsdaten verwendet",
+            "domainDenied": "Domain abgelehnt",
+            "accessedDomain": "Domain angefragt",
+            "gitPush": "Git Push",
+            "readAction": "Lese",
+            "write": "Schreibe",
+            "activateSkill": "Aktiviere Skill",
+            "execute": "Führe aus",
+            "listCredentials": "Liste Zugangsdaten auf",
+            "accessCredential": "Zugangsdaten verwenden",
+            "accessDomain": "Domain verwenden",
+            "replace": "Ersetze",
+            "sentFile": "Datei gesendet",
+            "sendFile": "Datei senden"
+        },
+        "summaries": {
+            "readFirstLines": "erste {count} Zeilen von {path}",
+            "readLinesRange": "Zeilen {start} bis {end} von {path}",
+            "writeLines": "{count} Zeilen nach {path} geschrieben",
+            "lineCount": "{count} Zeilen",
+            "lineCountWithReplacement": "{source} Zeilen mit {replacement} Zeilen",
+            "replaceInPath": "{lineSummary} in {path}{suffix}",
+            "allMatchesSuffix": " (alle Treffer)"
+        },
+        "details": {
+            "activateSkillPromptPrefix": "Agent möchte den",
+            "activateSkillPromptSuffix": "Skill aktivieren.",
+            "sentinelLabel": "Sentinel:",
+            "sentinelReviewing": "Dieser Tool-Aufruf wird geprüft.",
+            "userLabel": "Benutzer:",
+            "deniedByUser": "Vom Benutzer abgelehnt.",
+            "contexts": "Kontext:",
+            "domains": "Domains:",
+            "credentials": "Zugangsdaten",
+            "name": "Name",
+            "path": "Pfad",
+            "description": "Beschreibung",
+            "activation": "Aktivierung",
+            "skillInstructions": "Skill-Anweisungen",
+            "source": "Quelle",
+            "replacement": "Ersetzung",
+            "diff": "Diff",
+            "arguments": "Argumente",
+            "result": "Ergebnis"
+        }
+    },
+    "commandResult": {
+        "help": {
+            "command": "Befehl",
+            "description": "Beschreibung"
+        },
+        "rules": {
+            "id": "ID",
+            "trigger": "Auslöser",
+            "mode": "Modus",
+            "status": {
+                "label": "Status",
+                "disabled": "deaktiviert",
+                "alwaysOn": "immer aktiv",
+                "activated": "aktiviert"
+            }
+        },
+        "models": {
+            "type": "Typ",
+            "model": "Modell",
+            "default": "Standard",
+            "available": "Verfügbar:",
+            "provider": "Art",
+            "name": "Name",
+            "context": "Kontext",
+            "contextWindow": "({tokens} Kontext)",
+            "contextWindowShort": "{tokens} Kontext",
+            "noneAvailable": "Keine Modelle verfügbar.",
+            "noMatches": "Keine passenden Modelle.",
+            "filterPlaceholder": "Modelle filtern...",
+            "currentLabel": "Aktuelles Modell:",
+            "defaultLabel": "Standard: {model}"
+        },
+        "usage": {
+            "none": "Noch keine Token-Nutzung aufgezeichnet.",
+            "total": "Gesamt: {total} Tokens ({input} rein + {output} raus)",
+            "toolCalls": "Tool-Aufrufe: {count}",
+            "byModel": "Nach Modell",
+            "byCategory": "Nach Kategorie",
+            "context": "Kontext",
+            "table": {
+                "source": "Quelle",
+                "input": "Eingabe",
+                "output": "Ausgabe",
+                "cacheRead": "Cache gelesen",
+                "cacheWrite": "Cache geschrieben",
+                "requests": "Anfragen",
+                "cost": "Kosten"
+            },
+            "contextTable": {
+                "source": "Quelle",
+                "tokens": "Tokens",
+                "system": "System %",
+                "user": "User %",
+                "assistant": "Assistant %",
+                "toolCalls": "Tool-Aufrufe %",
+                "toolOutputs": "Tool-Ausgaben %",
+                "other": "Sonstiges %"
+            }
+        },
+        "budget": {
+            "none": "Keine Sitzungsbudgets konfiguriert.",
+            "title": "Sitzungsbudgets",
+            "table": {
+                "metric": "Metrik",
+                "current": "Aktuell",
+                "limit": "Limit",
+                "remaining": "Verbleibend",
+                "used": "Verwendet",
+                "blocked": "blockiert"
+            }
+        }
+    },
+    "chatView": {
+        "inputDisabled": {
+            "archived": "Zuerst aus dem Archiv holen",
+            "unattended": "Diese Sitzung ist unbeaufsichtigt. Forke sie zuerst, um hier weiterzumachen."
+        },
+        "waiting": {
+            "processingPrompt": "Prompt wird verarbeitet...",
+            "thinking": "Denke nach...",
+            "generating": "Generiere...",
+            "working": "Arbeite..."
+        },
+        "unknown": "Unbekannt",
+        "status": {
+            "connecting": "Verbinde…",
+            "disconnected": "Getrennt"
+        },
+        "empty": {
+            "start": "Sende eine Nachricht, um loszulegen",
+            "connectingSession": "Verbinde mit Sitzung…"
+        },
+        "errors": {
+            "unexpected": "Unerwarteter Fehler",
+            "resetTarget": "Ziel zum Zurücksetzen konnte nicht aufgelöst werden.",
+            "forkTarget": "Ziel zum Forken konnte nicht aufgelöst werden."
+        },
+        "confirm": {
+            "wipeSandbox": "Sandbox und ihren Speicher für diese Sitzung löschen? Der Chatverlauf bleibt erhalten.",
+            "scaleDownSandbox": "Sandbox für diese Sitzung herunterfahren? Der Speicher bleibt erhalten.",
+            "deleteSession": "Diese Sitzung löschen? Chatverlauf und Sandbox-Status werden entfernt.",
+            "archiveSession": "Diese Sitzung archivieren? Sie verschwindet aus der Standardliste, setzt ihre Sandbox zurück und bleibt im Wissens-Repository erhalten.",
+            "unarchiveSession": "Diese Sitzung aus dem Archiv holen? Sie kehrt in die aktive Sitzungsliste zurück.",
+            "makePrivate": "Diese Sitzung als privat markieren? Bereits vorhandene Commits im Wissens-Repository bleiben in der Git-Historie bestehen."
+        },
+        "actions": {
+            "pin": "Sitzung anheften",
+            "unpin": "Anheftung lösen",
+            "favorite": "Sitzung favorisieren",
+            "unfavorite": "Favorit entfernen",
+            "archive": "Sitzung archivieren",
+            "unarchive": "Sitzung aus dem Archiv holen",
+            "includeInRepo": "Ins Repository aufnehmen",
+            "keepPrivate": "Privat halten",
+            "delete": "Sitzung löschen"
+        },
+        "badges": {
+            "archived": "Archiviert",
+            "private": "Privat",
+            "pinned": "Angeheftet",
+            "favorite": "Favorit",
+            "askMode": "Lese-Modus",
+            "yoloMode": "YOLO",
+            "unattended": "Unbeaufsichtigt",
+            "interactive": "Interaktiv"
+        },
+        "inspector": {
+            "actions": "Aktionen",
+            "session": "Sitzung"
+        },
+        "session": {
+            "title": "Titel",
+            "id": "ID",
+            "copyId": "Sitzungs-ID kopieren",
+            "idCopied": "Sitzungs-ID kopiert",
+            "idCopiedShort": "Kopiert",
+            "source": "Quelle",
+            "created": "Erstellt",
+            "lastActive": "Zuletzt aktiv",
+            "messages": "Nachrichten",
+            "totalCost": "Kosten",
+            "job": "Job",
+            "reference": "Referenz",
+            "modes": "Modi",
+            "askMode": "Lese-Modus",
+            "askModeHelp": "Außerhalb der Sandbox nur lesend arbeiten. Externe Schreibzugriffe werden verweigert.",
+            "yoloMode": "YOLO-Modus",
+            "yoloModeHelp": "Sentinel-Freigaben umgehen und Aktionen sofort erlauben.",
+            "savingPrivate": "Wird gespeichert…",
+            "updatingMode": "Modus wird aktualisiert…"
+        },
+        "source": {
+            "unknown": "Unbekannt",
+            "job": "Job",
+            "web": "Web",
+            "cli": "CLI"
+        },
+        "jobRun": {
+            "title": "Letzter Joblauf",
+            "job": "Job",
+            "ranAt": "Ausgeführt am",
+            "schedule": "Zeitplan",
+            "data": "Daten",
+            "trigger": {
+                "label": "Auslöser",
+                "api": "API",
+                "cron": "Cron",
+                "manual": "Manuell"
+            }
+        },
+        "sandbox": {
+            "title": "Sandbox",
+            "refreshing": "Aktualisiere…",
+            "checking": "Prüfe Sandbox…",
+            "status": {
+                "missing": "Nicht gestartet",
+                "running": "Läuft",
+                "scaled_down": "Heruntergefahren",
+                "pending": "Startet",
+                "stopped": "Gestoppt",
+                "error": "Fehler"
+            },
+            "actions": {
+                "start": "Sandbox starten",
+                "starting": "Sandbox wird gestartet",
+                "scaleDown": "Sandbox herunterfahren",
+                "scalingDown": "Sandbox wird heruntergefahren",
+                "reset": "Sandbox zurücksetzen"
+            },
+            "storage": {
+                "used": "{size} verwendet",
+                "none": "kein Sandbox-Speicher",
+                "allocated": "{size} zugewiesen"
+            },
+            "fields": {
+                "id": "Sandbox-ID"
+            }
+        },
+        "knowledge": {
+            "title": "Wissen",
+            "commit": "Ins Repository committen",
+            "committed": "Committed",
+            "committedToRepo": "In Wissen übernommen",
+            "notCommittedYet": "Noch nicht committed",
+            "savedAt": "Gespeichert {timestamp}",
+            "commitDisabledNoHistory": "Diese Sitzung hat noch keinen Gesprächsverlauf.",
+            "noNewChanges": "{status}. Keine neuen Änderungen zum Committen.",
+            "privateExistingCommits": "Sitzung ist privat. Bereits vorhandene Commits im Wissens-Repository bleiben unverändert.",
+            "privateExcluded": "Sitzung ist privat und wird nicht ins Wissens-Repository committed.",
+            "includedInRepo": "Sitzung wird ins Wissens-Repository aufgenommen.",
+            "badges": {
+                "excluded": "Ausgeschlossen",
+                "missing": "Fehlt",
+                "outdated": "Veraltet",
+                "upToDate": "Aktuell"
+            }
+        },
+        "mobile": {
+            "details": "Details",
+            "done": "Fertig"
+        }
+    },
+    "message": {
+        "copy": "Nachricht kopieren",
+        "copied": "Kopiert",
+        "codeBlock": {
+            "copy": "Code kopieren",
+            "copied": "Kopiert"
+        },
+        "thinking": {
+            "streaming": "Denke nach",
+            "complete": "Nachgedacht"
+        },
+        "thinkingMeta": {
+            "durationStreaming": "seit {duration}",
+            "durationComplete": "{duration} lang",
+            "reasoning": "{count} Tokens"
+        },
+        "actions": {
+            "fork": "Sitzung von hier forken",
+            "retry": "Zug erneut ausführen",
+            "reset": "Unterhaltung zu diesem Zug zurücksetzen"
+        },
+        "finalStatus": {
+            "status": {
+                "success": "Erfolg",
+                "warning": "Warnung"
+            },
+            "notice": "Der Agent hat die Aufgabe mit einer Meldung vom Typ {status} beendet. Die Sitzung ist jetzt schreibgeschützt, du kannst sie aber forken um weiter zu chatten."
+        }
+    },
+    "jobs": {
+        "settingsSections": "Einstellungsbereiche",
+        "savedJobs": "Gespeicherte Jobs",
+        "loading": "Jobs werden geladen...",
+        "paused": "Pausiert",
+        "unattendedTooltip": "Unbeaufsichtigte Sitzungen können Tool-Aufrufe nicht eskalieren",
+        "confirmDelete": "Job {name} löschen?",
+        "summary": {
+            "onDemandOnly": "Nur manuell",
+            "cronTriggerCount": "{count, plural, one {# Cron-Trigger} other {# Cron-Trigger}}"
+        },
+        "validation": {
+            "idRequired": "Job-ID ist erforderlich.",
+            "nameRequired": "Job-Name ist erforderlich.",
+            "promptRequired": "Prompt ist erforderlich.",
+            "persistentSessionIdRequired": "Wähle eine persistente Session-ID oder deaktiviere die Option.",
+            "persistentSessionMustBeAttended": "Jobs mit persistenter Sitzung müssen beaufsichtigt sein.",
+            "sessionModesRequireFreshSession": "Session-Modi brauchen eine neue Sitzung.",
+            "modelOverridesRequireFreshSession": "Modell-Overrides brauchen eine neue Sitzung.",
+            "askAndYoloMutuallyExclusive": "Lese-Modus und YOLO sind gegenseitig ausschließend.",
+            "cronEmpty": "Cron-Ausdrücke dürfen nicht leer sein.",
+            "cronInvalid": "Cron-Ausdruck ist ungültig: {expression}."
+        },
+        "cron": {
+            "invalidExpression": "Ungültiger Cron-Ausdruck."
+        },
+        "triggerKind": {
+            "scheduled": "Geplant",
+            "manual": "Manuell"
+        },
+        "errors": {
+            "load": "Jobs konnten nicht geladen werden.",
+            "refresh": "Jobs konnten nicht aktualisiert werden.",
+            "save": "Job konnte nicht gespeichert werden.",
+            "delete": "Job konnte nicht gelöscht werden.",
+            "run": "Job konnte nicht gestartet werden.",
+            "saveBeforeRun": "Speichere den Job, bevor du ihn startest.",
+            "saveChangesBeforeRun": "Speichere die Änderungen am Job, bevor du ihn startest."
+        },
+        "notices": {
+            "refreshed": "Jobs aktualisiert.",
+            "created": "Job erstellt.",
+            "saved": "Job gespeichert.",
+            "deleted": "Job gelöscht.",
+            "runStartedNewSession": "Ausführung in neuer Sitzung {sessionId} gestartet.",
+            "runStartedSession": "Ausführung in Sitzung {sessionId} gestartet."
+        },
+        "actions": {
+            "refresh": "Jobs aktualisieren",
+            "new": "Neuer Job",
+            "clear": "Leeren",
+            "clearPersistentSession": "Persistente Sitzung entfernen",
+            "delete": "Löschen",
+            "save": "Speichern",
+            "addTrigger": "Trigger hinzufügen",
+            "remove": "Entfernen",
+            "runNow": "Jetzt ausführen"
+        },
+        "empty": {
+            "noJobs": "Noch keine Jobs. Erstelle einen, um Prompts und optionale Cron-Zeitpläne in jobs.yaml zu speichern."
+        },
+        "editor": {
+            "newJob": "Neuer Job",
+            "editing": "Bearbeite {name}",
+            "jobFallback": "Job"
+        },
+        "fields": {
+            "name": "Name",
+            "jobId": "Job-ID",
+            "enabled": "Aktiviert",
+            "enabledHelp": "Pausierte Jobs bleiben in jobs.yaml, werden aber nie per Cron ausgeführt.",
+            "newSession": "Optionen",
+            "newSessionHelp": "Diese Optionen gelten nur für neue Sitzungen, die der Job selbst erstellt.",
+            "unattended": "Unbeaufsichtigt ausführen",
+            "unattendedHelp": "Tool-Aufrufe werden nicht an dich eskaliert.",
+            "persistentSession": "Persistente Sitzung",
+            "persistentSessionToggleHelp": "Verwende eine bestehende Sitzung statt bei jedem Lauf eine neue zu starten.",
+            "persistentSessionDisabled": "Kann im unbeaufsichtigten Modus nicht verwendet werden",
+            "persistentSessionUncheckedHelp": "Aktiviere die Option, um unten eine bestehende Session-ID auszuwählen.",
+            "persistentSessionMissingIdHelp": "Aktiv, aber noch ohne Session-ID. Wähle unten eine bestehende Sitzung aus.",
+            "persistentSessionHelp": "Verwende eine bestehende Sitzung, statt bei jedem Joblauf eine neue zu erstellen.",
+            "persistentSessionActiveHelp": "Aktiv: Diese Session-ID überschreibt die Optionen für neue Sitzungen oben.",
+            "models": "Modelle",
+            "modelsHelp": "Optionale job-spezifische Overrides für neue Sitzungen, die dieser Job erstellt.",
+            "modelsDisabled": "Persistente Sitzungen behalten ihre eigene Modellauswahl.",
+            "modelsLinked": "Modelle verknüpft",
+            "modelsLinkedHelp": "Verknüpft: Änderungen an einem Modell setzen beide Modelle.",
+            "modelsUnlinked": "Modelle getrennt",
+            "modelsUnlinkedHelp": "Getrennt: Agent- und Sentinel-Modell lassen sich unabhängig ändern.",
+            "agentModel": "Agent",
+            "sentinelModel": "Sentinel",
+            "titleModel": "Titel-Modell",
+            "prompt": "Prompt",
+            "expression": "Ausdruck",
+            "timeZone": "Zeitzone",
+            "inputOptional": "Eingabe (optional)"
+        },
+        "placeholders": {
+            "name": "Nächtliche Inbox-Prüfung",
+            "jobId": "naechtliche-inbox-pruefung",
+            "persistentSession": "session-id auswählen",
+            "prompt": "Fasse neue Aufgaben zusammen, priorisiere Dringendes und schlage dann nächste Schritte vor.",
+            "model": "Leer lassen für Standardmodell"
+        },
+        "sections": {
+            "cronTriggers": "Cron-Trigger",
+            "cronTriggersDescription": "Leer lassen für Jobs, die nur manuell gestartet werden.",
+            "noTriggers": "Keine Cron-Trigger konfiguriert.",
+            "runJob": "Job ausführen",
+            "previousInvocations": "Vorherige Ausführungen",
+            "previousInvocationsDescription": "Wähle eine Ausführung, um ihre Sitzung zu öffnen.",
+            "saveToViewHistory": "Speichere diesen Job, um den Ausführungsverlauf zu sehen.",
+            "noInvocations": "Noch keine Ausführungen. Aktualisiere die Sitzungen, um neu abgeschlossene Läufe zu laden.",
+            "ranAt": "Ausgeführt am {timestamp}"
+        }
+    },
+    "sidebar": {
+        "time": {
+            "justNow": "gerade eben"
+        },
+        "messageCount": "{count, plural, one {# Nachricht} other {# Nachrichten}}",
+        "unattendedSession": "Unbeaufsichtigte Sitzung",
+        "privateSession": "Private Sitzung",
+        "knowledgeCommitted": "Alle Änderungen ins Wissens-Repository übernommen",
+        "actions": {
+            "pin": "Sitzung anheften",
+            "unpin": "Sitzung lösen",
+            "favorite": "Sitzung favorisieren",
+            "unfavorite": "Favorit entfernen",
+            "archive": "Sitzung archivieren",
+            "unarchive": "Sitzung aus dem Archiv holen",
+            "delete": "Sitzung löschen",
+            "deleteEmpty": "Leere Sitzung löschen",
+            "shiftSkip": "Shift+Klick überspringt die Bestätigung"
+        },
+        "confirm": {
+            "deleteSession": "Diese Sitzung löschen? Chatverlauf und Sandbox-Status werden entfernt.",
+            "deleteUnpushed": "Diese Sitzung hat {count, plural, one {# Commit} other {# Commits}}, die noch nicht ins Wissens-Repository gepusht wurden. Beim Löschen gehen sie verloren. Trotzdem löschen?",
+            "archiveSession": "Diese Sitzung archivieren? Sie verschwindet aus der Standardliste, setzt ihre Sandbox zurück und bleibt im Wissens-Repository erhalten."
+        },
+        "sections": {
+            "today": "Heute",
+            "yesterday": "Gestern",
+            "last7Days": "Letzte 7 Tage",
+            "last30Days": "Letzte 30 Tage",
+            "archived": "Archiviert",
+            "unknownDate": "Unbekanntes Datum"
+        },
+        "empty": "Noch keine Sitzungen",
+        "loadingMore": "Weitere Sitzungen werden geladen"
+    },
+    "git": {
+        "upToDate": "Aktuell",
+        "noRemote": "Kein Remote konfiguriert",
+        "sandbox": {
+            "label": "Workspace-Sync",
+            "help": "Synchronisiert die Workspace-Sandbox dieser Sitzung mit deinem Wissens-Repository auf dem Server. Die Zähler zeigen, um wie viele Commits dieser Workspace dem Server-Repo voraus (↑) bzw. hinterher (↓) ist.",
+            "notRunning": "Sandbox läuft nicht",
+            "refresh": "Workspace erneut mit dem Server-Repository abgleichen (holt zuerst neue Commits)",
+            "pull": "Commits aus dem Server-Repository in diesen Workspace holen",
+            "push": "Commits dieses Workspace ins Server-Repository übertragen (jeder Push wird vom Sentinel geprüft)"
+        },
+        "global": {
+            "label": "Wissens-Remote",
+            "help": "Synchronisiert dein Wissens-Repository auf dem Server mit seinem externen Git-Remote. Die Zähler zeigen, um wie viele Commits das Server-Repo dem Remote voraus (↑) bzw. hinterher (↓) ist.",
+            "indicatorBehind": "{count, plural, one {# Commit} other {# Commits}} vom Wissens-Remote zu holen",
+            "refresh": "Server-Repository erneut mit dem Remote abgleichen (holt zuerst neue Commits)",
+            "pull": "Commits vom externen Remote ins Server-Repository holen",
+            "push": "Commits des Server-Repositorys ins externe Remote übertragen"
+        },
+        "denied": "Push abgelehnt",
+        "errors": {
+            "status": "Git-Status konnte nicht gelesen werden",
+            "pull": "Pull fehlgeschlagen",
+            "push": "Push fehlgeschlagen"
+        }
+    },
+    "apiKeys": {
+        "title": "API-Schlüssel",
+        "description": "Erstelle langlebige Tokens für Skripte und Integrationen. Verwende sie als 'Authorization: Bearer <token>'.",
+        "create": {
+            "nameLabel": "Name",
+            "namePlaceholder": "z. B. CI-Deploy-Bot",
+            "scopesLabel": "Berechtigungen",
+            "expiryLabel": "Läuft ab nach (Tagen)",
+            "expiryPlaceholder": "Leer lassen für kein Ablaufdatum",
+            "submit": "Schlüssel erstellen",
+            "creating": "Wird erstellt…"
+        },
+        "access": {
+            "none": "Keine",
+            "read": "Lesen",
+            "write": "Schreiben"
+        },
+        "scopes": {
+            "sessions": "Sitzungen",
+            "jobs": "Jobs",
+            "preferences": "Einstellungen",
+            "notifications": "Benachrichtigungen",
+            "history": "Verlauf",
+            "admin": "Administration"
+        },
+        "secret": {
+            "warning": "Kopiere diesen Token jetzt — er wird nicht erneut angezeigt.",
+            "copy": "Token kopieren",
+            "done": "Fertig"
+        },
+        "list": {
+            "title": "Aktive Schlüssel",
+            "empty": "Noch keine API-Schlüssel.",
+            "loading": "Schlüssel werden geladen…",
+            "unnamed": "Unbenannter Schlüssel",
+            "expired": "Abgelaufen"
+        },
+        "fields": {
+            "created": "Erstellt {timestamp}",
+            "lastUsed": "Zuletzt verwendet {timestamp}",
+            "expires": "Läuft ab {timestamp}",
+            "never": "nie",
+            "noExpiry": "kein Ablauf"
+        },
+        "actions": {
+            "revoke": "Schlüssel widerrufen"
+        },
+        "confirm": {
+            "revoke": "API-Schlüssel \"{name}\" widerrufen? Dies kann nicht rückgängig gemacht werden."
+        },
+        "errors": {
+            "load": "API-Schlüssel konnten nicht geladen werden.",
+            "create": "API-Schlüssel konnte nicht erstellt werden.",
+            "revoke": "API-Schlüssel konnte nicht widerrufen werden.",
+            "noScopes": "Wähle mindestens eine Berechtigung."
+        }
     }
-  },
-  "platformSettings": {
-    "status": {
-      "loading": "Plattformeinstellungen werden geladen",
-      "unavailable": "Plattformeinstellungen sind nicht verfügbar",
-      "readOnly": "Die Konfigurationsdatei ist schreibgeschützt."
-    },
-    "notices": {
-      "saved": "Gespeichert."
-    },
-    "errors": {
-      "load": "Plattformeinstellungen konnten nicht geladen werden",
-      "save": "Plattformeinstellungen konnten nicht aktualisiert werden",
-      "wholeNumber": "{field} muss eine positive ganze Zahl sein.",
-      "nonNegativeWholeNumber": "{field} muss eine nicht negative ganze Zahl sein.",
-      "number": "{field} muss eine nicht negative Zahl sein.",
-      "providerRequired": "Provider ist für Modell {index} erforderlich.",
-      "nameRequired": "Name ist für Modell {index} erforderlich.",
-      "duplicateModel": "Modell-ID {id} wird mehrfach verwendet.",
-      "rawSecretRequired": "Füge einen API-Key für {id} ein oder wähle eine andere Secret-Quelle.",
-      "secretValueRequired": "Secret-Referenz ist für {id} erforderlich.",
-      "defaultRequired": "{field}-Standardmodell ist erforderlich.",
-      "defaultUnknown": "{field}-Standardmodell {id} ist nicht im Katalog."
-    },
-    "sections": {
-      "defaultModels": "Standardmodelle",
-      "defaultBudgets": "Standardbudgets",
-      "catalog": "Modellkatalog"
-    },
-    "fields": {
-      "agent": "Agent",
-      "sentinel": "Sentinel",
-      "title": "Titel",
-      "inputTokens": "Input-Tokens",
-      "outputTokens": "Output-Tokens",
-      "costUsd": "Kosten (in $)",
-      "toolCalls": "Tool-Aufrufe",
-      "provider": "Provider",
-      "name": "Name",
-      "id": "ID",
-      "maxInputTokens": "Max. Input-Tokens",
-      "thinking": "Thinking",
-      "thinkingBudgetTokens": "Thinking-Budget-Tokens",
-      "baseUrl": "Base URL",
-      "vision": "Vision",
-      "visionHint": "Akzeptiert Bildeingaben",
-      "apiKeySource": "API-Key-Quelle",
-      "apiKey": "API-Key",
-      "secretReference": "Secret-Referenz"
-    },
-    "placeholders": {
-      "selectModel": "Modell auswählen",
-      "unlimited": "Unbegrenzt",
-      "generatedId": "provider:name",
-      "keepSecret": "Konfiguriertes Secret behalten"
-    },
-    "actions": {
-      "save": "Speichern",
-      "saving": "Speichert",
-      "addModel": "Modell hinzufügen",
-      "removeModel": "Modell entfernen",
-      "confirmRemoveModel": "Modell \"{name}\" entfernen? Dies kann nicht rückgängig gemacht werden."
-    },
-    "secretSources": {
-      "none": "Keine",
-      "raw": "Direkter Wert",
-      "env": "Umgebungsvariable",
-      "file": "Datei"
-    },
-    "thinking": {
-      "default": "Standard",
-      "true": "Aktiviert",
-      "false": "Deaktiviert",
-      "minimal": "Minimal",
-      "low": "Niedrig",
-      "medium": "Mittel",
-      "high": "Hoch",
-      "xhigh": "Extra hoch"
-    },
-    "units": {
-      "tokens": "Tokens"
-    },
-    "modelRow": "Modell {index}"
-  },
-  "home": {
-    "empty": {
-      "description": "Wähle eine Sitzung aus oder starte eine neue"
-    }
-  },
-  "connect": {
-    "description": "Bei carapace anmelden",
-    "serverLabel": "Server-URL",
-    "usernameLabel": "Benutzername",
-    "usernamePlaceholder": "Benutzername",
-    "passwordLabel": "Passwort",
-    "passwordPlaceholder": "Passwort",
-    "connect": "Verbinden",
-    "connecting": "Verbinde…",
-    "errors": {
-      "serverError": "Serverfehler: {status}",
-      "connectionFailed": "Verbindung fehlgeschlagen"
-    }
-  },
-  "admin": {
-    "title": "Admin",
-    "backToApp": "Zurück zur App",
-    "serverLabel": "Server-URL",
-    "serverPlaceholder": "Kein Server ausgewählt",
-    "users": {
-      "title": "Benutzer",
-      "description": "Globale Plattform-Konten, Rollen und Datenzuordnung.",
-      "savedUsers": "Benutzer",
-      "loading": "Benutzer werden geladen…",
-      "empty": "Keine Benutzer gefunden",
-      "selectUser": "Benutzer auswählen",
-      "you": "Du",
-      "admin": "Admin",
-      "enabled": "Aktiv",
-      "disabled": "Deaktiviert"
-    },
-    "create": {
-      "title": "Neuer Benutzer",
-      "subtitle": "Lokalen Benutzer anlegen"
-    },
-    "fields": {
-      "username": "Benutzername",
-      "password": "Passwort",
-      "newPassword": "Neues Passwort",
-      "keepPassword": "Aktuelles Passwort behalten",
-      "displayName": "Anzeigename",
-      "email": "E-Mail",
-      "roles": "Rollen",
-      "enabled": "Aktiv"
-    },
-    "actions": {
-      "load": "Laden",
-      "loading": "Lädt…",
-      "refresh": "Benutzer aktualisieren",
-      "new": "Neuer Benutzer",
-      "deleteUser": "{username} löschen",
-      "create": "Benutzer anlegen",
-      "creating": "Lege an…",
-      "save": "Änderungen speichern",
-      "saving": "Speichert…"
-    },
-    "notices": {
-      "loaded": "Benutzer geladen.",
-      "created": "{username} angelegt.",
-      "saved": "{username} gespeichert.",
-      "deleted": "{username} gelöscht."
-    },
-    "errors": {
-      "missingCredentials": "Aktueller Ursprung ist nicht verfügbar.",
-      "load": "Benutzer konnten nicht geladen werden.",
-      "create": "Benutzer konnte nicht angelegt werden.",
-      "save": "Benutzer konnte nicht gespeichert werden.",
-      "delete": "Benutzer konnte nicht gelöscht werden."
-    },
-    "confirm": {
-      "deleteUser": "{username} löschen? Bestehende Daten dieses Benutzers bleiben erhalten."
-    },
-    "meta": {
-      "tokenVersion": "Token v{version}",
-      "updated": "Aktualisiert {timestamp}",
-      "lastLogin": "Letzter Login {timestamp}",
-      "never": "nie"
-    }
-  },
-  "preferences": {
-    "title": "Einstellungen",
-    "description": "Persönliche Einstellungen für diesen Browser und deine Nutzung.",
-    "currentLocale": "Aktuelle Oberflächensprache: {locale}",
-    "language": {
-      "label": "Sprache",
-      "description": "Wähle, wie die Oberflächensprache bestimmt wird.",
-      "options": {
-        "system": "System",
-        "en": "English",
-        "de": "Deutsch"
-      }
-    },
-    "theme": {
-      "label": "Darstellung",
-      "description": "Wähle, wie das Farbschema bestimmt wird.",
-      "options": {
-        "system": "System",
-        "light": "Hell",
-        "dark": "Dunkel"
-      }
-    },
-    "chatList": {
-      "label": "Chats",
-      "showArchived": {
-        "label": "Archivierte Chats anzeigen",
-        "description": "Wenn deaktiviert, werden archivierte Chats ausgeblendet und bei Session-Listen direkt nicht vom Server angefragt."
-      }
-    },
-    "notifications": {
-      "title": "Push-Benachrichtigungen",
-      "description": "Liefert Eskalationen und Zug-Ergebnisse an diesen Browser oder die installierte PWA.",
-      "status": {
-        "loading": "Benachrichtigungsunterstützung wird geprüft…",
-        "loadingShort": "Prüfung",
-        "enabled": "Benachrichtigungen sind für diesen Browser aktiviert.",
-        "enabledShort": "Aktiv",
-        "disabled": "Benachrichtigungen sind für diesen Browser deaktiviert.",
-        "disabledShort": "Aus",
-        "unsupported": "Dieser Browser kann im aktuellen Kontext keine Web-Push-Benachrichtigungen empfangen.",
-        "permissionDenied": "Die Browser-Benachrichtigungsfreigabe ist blockiert. Aktiviere sie in Browser- oder Geräteeinstellungen erneut.",
-        "permissionRequired": "Die Benachrichtigungsfreigabe wurde nicht erteilt.",
-        "invalidSubscription": "Der Browser hat eine unvollständige Push-Subscription zurückgegeben.",
-        "loadFailed": "Benachrichtigungseinstellungen konnten nicht geladen werden.",
-        "enableFailed": "Benachrichtigungen konnten nicht aktiviert werden.",
-        "disableFailed": "Benachrichtigungen konnten nicht deaktiviert werden.",
-        "preferencesFailed": "Benachrichtigungseinstellungen konnten nicht aktualisiert werden.",
-        "testFailed": "Testbenachrichtigung konnte nicht gesendet werden.",
-        "testSent": "Testbenachrichtigung gesendet."
-      },
-      "deviceName": {
-        "label": "Gerätename",
-        "placeholder": "Android-Telefon",
-        "hint": "Wird in den serverseitigen Benachrichtigungs-Subscriptions für diesen Browser angezeigt."
-      },
-      "toggle": {
-        "label": "Benachrichtigungen"
-      },
-      "actions": {
-        "enable": "Benachrichtigungen aktivieren",
-        "enabling": "Aktiviere…",
-        "disable": "Benachrichtigungen deaktivieren",
-        "disabling": "Deaktiviere…",
-        "test": "Testbenachrichtigung senden",
-        "testing": "Sende Testbenachrichtigung…"
-      },
-      "preferences": {
-        "label": "Benachrichtigungen senden für",
-        "escalation_pending": "Eskalationen, die Freigabe brauchen",
-        "attended_turn_completed": "Begleitete Sitzungen, wenn ein Zug endet",
-        "unattended_turn_completed": "Unbeaufsichtigte Jobs mit erfolgreichem Abschluss",
-        "unattended_turn_failed": "Unbeaufsichtigte Jobs mit Fehler"
-      },
-      "meta": {
-        "permission": "Browser-Freigabe: {permission}",
-        "heartbeat": "Letzter Heartbeat: {timestamp}",
-        "expires": "Subscription läuft ab: {timestamp}"
-      },
-      "permission": {
-        "default": "nicht angefragt",
-        "granted": "erteilt",
-        "denied": "blockiert"
-      }
-    }
-  },
-  "newSessionButton": {
-    "label": "Neue Sitzung",
-    "chooseOptions": "Sitzungsoptionen auswählen",
-    "private": {
-      "enabledTitle": "Privat",
-      "enabledDescription": "Nicht ins Wissens-Repository aufnehmen.",
-      "disabledTitle": "Speichern",
-      "disabledDescription": "Wird im Wissens-Repository gespeichert."
-    },
-    "ask": {
-      "enabledTitle": "Nur Lesend",
-      "enabledDescription": "Außerhalb der Sandbox nur lesen.",
-      "disabledTitle": "Schreibzugriff",
-      "disabledDescription": "Außerhalb der Sandbox schreiben erlaubt."
-    },
-    "yolo": {
-      "enabledTitle": "YOLO",
-      "enabledDescription": "Alle Tool-Calls sofort erlauben.",
-      "disabledTitle": "Mit Prüfung",
-      "disabledDescription": "Aktionen weiter durch Safe-List und Sentinel prüfen."
-    },
-    "unattended": {
-      "enabledTitle": "Unbeaufsichtigt",
-      "enabledDescription": "Läuft eigenständig ohne Freigabepfad durch dich.",
-      "disabledTitle": "Interaktiv",
-      "disabledDescription": "Bleibt im interaktiven Modus mit Freigabepfad."
-    }
-  },
-  "chatInput": {
-    "disabled": "Eingabe deaktiviert",
-    "sendMessageTooltip": "Nachricht senden (Enter)",
-    "queueInterruptStopTooltip": "Enter zum Einreihen · ⌥Enter zum Unterbrechen · Klicken zum Stoppen",
-    "stopGenerationTooltip": "Generierung stoppen",
-    "queued": "Warteschlange: {message}",
-    "startVoiceInput": "Spracheingabe starten",
-    "stopVoiceInput": "Spracheingabe stoppen",
-    "attachFile": "Datei anhängen",
-    "attachFileUnavailable": "Sandbox starten, um Dateien hochzuladen",
-    "startingSandbox": "Sandbox wird gestartet…",
-    "removeAttachment": "Entfernen",
-    "placeholder": "Nachricht an carapace…",
-    "usageBreakdown": {
-      "systemLine": "System: {percent}%",
-      "userLine": "User: {percent}%",
-      "assistantLine": "Assistant: {percent}%",
-      "toolCallsLine": "Tool-Aufrufe: {percent}%",
-      "toolOutputsLine": "Tool-Ausgaben: {percent}%",
-      "otherLine": "Sonstiges: {percent}%"
-    },
-    "context": {
-      "limit": "Kontextlimit: {tokens} Tokens.",
-      "assumedLimit": "Angenommenes Kontextlimit: {tokens} Tokens.",
-      "lastRequestTokens": "{tokens} API-Tokens (letzte Agent-Anfrage)",
-      "clickForUsage": "Klicken, um /usage an den Agenten zu senden und mehr Details zu sehen.",
-      "tokensLabel": "{tokens} Tokens"
-    },
-    "budget": {
-      "budgetLabel": "Budget für {label}",
-      "current": "Aktuell: {value}",
-      "max": "Maximal: {value}",
-      "remaining": "Verbleibend: {value}",
-      "exhausted": "Budget ausgeschöpft."
-    }
-  },
-  "approval": {
-    "general": {
-      "title": "Freigabe erforderlich",
-      "toolLabel": "Tool:",
-      "reasonLabel": "Grund:",
-      "riskLabel": "Risiko:",
-      "arguments": "Argumente",
-      "allow": "Freigeben",
-      "denyPlaceholder": "Warum sollte das blockiert werden?",
-      "risk": {
-        "high": "hoch",
-        "medium": "mittel",
-        "low": "niedrig"
-      }
-    },
-    "denialNote": {
-      "deny": "Ablehnen",
-      "optionalNote": "Optionale Notiz für den Agenten",
-      "addNote": "Notiz hinzufügen",
-      "hideNote": "Notiz ausblenden"
-    },
-    "credential": {
-      "title": "Zugangsdatenanfrage",
-      "skillLabel": "Skill:",
-      "allow": "Erlauben",
-      "denyPlaceholder": "Warum sollte dieser Zugang blockiert werden?",
-      "decision": {
-        "allow": "Erlaubt",
-        "deny": "Abgelehnt"
-      }
-    },
-    "domainAccess": {
-      "title": "Domain-Zugriffsanfrage",
-      "domainLabel": "Domain:",
-      "triggeredByLabel": "Ausgelöst durch:",
-      "allow": "{domain} erlauben",
-      "denyPlaceholder": "Warum sollte das blockiert werden?",
-      "decision": {
-        "allow": "Erlaubt",
-        "deny": "Abgelehnt"
-      }
-    },
-    "gitPush": {
-      "title": "Git-Push-Anfrage",
-      "refLabel": "Ref:",
-      "reasonLabel": "Grund:",
-      "changedFiles": "{count, plural, one {# geänderte Datei} other {# geänderte Dateien}}",
-      "allow": "Push erlauben",
-      "denyPlaceholder": "Warum sollte dieser Push blockiert werden?",
-      "decision": {
-        "allow": "Erlaubt",
-        "deny": "Abgelehnt"
-      }
-    }
-  },
-  "versionBadge": {
-    "frontend": "Frontend: {version}",
-    "backend": "Backend: {version}",
-    "unknown": "unbekannt",
-    "mismatchTooltip": "Versionen von Frontend- und Backend-Containern stimmen nicht überein.",
-    "mismatchSr": "Frontend- und Backend-Versionen stimmen nicht überein."
-  },
-  "toolCallBadge": {
-    "approvalBadge": {
-      "review": "Prüfung",
-      "skill": "Skill",
-      "bypass": "Bypass",
-      "denied": "abgelehnt"
-    },
-    "fallbacks": {
-      "missingPath": "(Pfad fehlt)",
-      "missingCommand": "(Befehl fehlt)",
-      "missingSkillName": "(skill_name fehlt)",
-      "credential": "Zugangsdaten"
-    },
-    "labels": {
-      "read": "Las",
-      "wrote": "Geschrieben",
-      "replaced": "Ersetzt",
-      "activatedSkill": "Skill aktiviert",
-      "executed": "Ausgeführt",
-      "listedCredentials": "Zugangsdaten aufgelistet",
-      "credentialDenied": "Zugangsdaten abgelehnt",
-      "accessedCredential": "Zugangsdaten verwendet",
-      "domainDenied": "Domain abgelehnt",
-      "accessedDomain": "Domain angefragt",
-      "gitPush": "Git Push",
-      "readAction": "Lese",
-      "write": "Schreibe",
-      "activateSkill": "Aktiviere Skill",
-      "execute": "Führe aus",
-      "listCredentials": "Liste Zugangsdaten auf",
-      "accessCredential": "Zugangsdaten verwenden",
-      "accessDomain": "Domain verwenden",
-      "replace": "Ersetze",
-      "sentFile": "Datei gesendet",
-      "sendFile": "Datei senden"
-    },
-    "summaries": {
-      "readFirstLines": "erste {count} Zeilen von {path}",
-      "readLinesRange": "Zeilen {start} bis {end} von {path}",
-      "writeLines": "{count} Zeilen nach {path} geschrieben",
-      "lineCount": "{count} Zeilen",
-      "lineCountWithReplacement": "{source} Zeilen mit {replacement} Zeilen",
-      "replaceInPath": "{lineSummary} in {path}{suffix}",
-      "allMatchesSuffix": " (alle Treffer)"
-    },
-    "details": {
-      "activateSkillPromptPrefix": "Agent möchte den",
-      "activateSkillPromptSuffix": "Skill aktivieren.",
-      "sentinelLabel": "Sentinel:",
-      "sentinelReviewing": "Dieser Tool-Aufruf wird geprüft.",
-      "userLabel": "Benutzer:",
-      "deniedByUser": "Vom Benutzer abgelehnt.",
-      "contexts": "Kontext:",
-      "domains": "Domains:",
-      "credentials": "Zugangsdaten",
-      "name": "Name",
-      "path": "Pfad",
-      "description": "Beschreibung",
-      "activation": "Aktivierung",
-      "skillInstructions": "Skill-Anweisungen",
-      "source": "Quelle",
-      "replacement": "Ersetzung",
-      "diff": "Diff",
-      "arguments": "Argumente",
-      "result": "Ergebnis"
-    }
-  },
-  "commandResult": {
-    "help": {
-      "command": "Befehl",
-      "description": "Beschreibung"
-    },
-    "rules": {
-      "id": "ID",
-      "trigger": "Auslöser",
-      "mode": "Modus",
-      "status": {
-        "label": "Status",
-        "disabled": "deaktiviert",
-        "alwaysOn": "immer aktiv",
-        "activated": "aktiviert"
-      }
-    },
-    "models": {
-      "type": "Typ",
-      "model": "Modell",
-      "default": "Standard",
-      "available": "Verfügbar:",
-      "provider": "Art",
-      "name": "Name",
-      "context": "Kontext",
-      "contextWindow": "({tokens} Kontext)",
-      "contextWindowShort": "{tokens} Kontext",
-      "noneAvailable": "Keine Modelle verfügbar.",
-      "noMatches": "Keine passenden Modelle.",
-      "filterPlaceholder": "Modelle filtern...",
-      "currentLabel": "Aktuelles Modell:",
-      "defaultLabel": "Standard: {model}"
-    },
-    "usage": {
-      "none": "Noch keine Token-Nutzung aufgezeichnet.",
-      "total": "Gesamt: {total} Tokens ({input} rein + {output} raus)",
-      "toolCalls": "Tool-Aufrufe: {count}",
-      "byModel": "Nach Modell",
-      "byCategory": "Nach Kategorie",
-      "context": "Kontext",
-      "table": {
-        "source": "Quelle",
-        "input": "Eingabe",
-        "output": "Ausgabe",
-        "cacheRead": "Cache gelesen",
-        "cacheWrite": "Cache geschrieben",
-        "requests": "Anfragen",
-        "cost": "Kosten"
-      },
-      "contextTable": {
-        "source": "Quelle",
-        "tokens": "Tokens",
-        "system": "System %",
-        "user": "User %",
-        "assistant": "Assistant %",
-        "toolCalls": "Tool-Aufrufe %",
-        "toolOutputs": "Tool-Ausgaben %",
-        "other": "Sonstiges %"
-      }
-    },
-    "budget": {
-      "none": "Keine Sitzungsbudgets konfiguriert.",
-      "title": "Sitzungsbudgets",
-      "table": {
-        "metric": "Metrik",
-        "current": "Aktuell",
-        "limit": "Limit",
-        "remaining": "Verbleibend",
-        "used": "Verwendet",
-        "blocked": "blockiert"
-      }
-    }
-  },
-  "chatView": {
-    "inputDisabled": {
-      "archived": "Zuerst aus dem Archiv holen",
-      "unattended": "Diese Sitzung ist unbeaufsichtigt. Forke sie zuerst, um hier weiterzumachen."
-    },
-    "waiting": {
-      "processingPrompt": "Prompt wird verarbeitet...",
-      "thinking": "Denke nach...",
-      "generating": "Generiere...",
-      "working": "Arbeite..."
-    },
-    "unknown": "Unbekannt",
-    "status": {
-      "connecting": "Verbinde…",
-      "disconnected": "Getrennt"
-    },
-    "empty": {
-      "start": "Sende eine Nachricht, um loszulegen",
-      "connectingSession": "Verbinde mit Sitzung…"
-    },
-    "errors": {
-      "unexpected": "Unerwarteter Fehler",
-      "resetTarget": "Ziel zum Zurücksetzen konnte nicht aufgelöst werden.",
-      "forkTarget": "Ziel zum Forken konnte nicht aufgelöst werden."
-    },
-    "confirm": {
-      "wipeSandbox": "Sandbox und ihren Speicher für diese Sitzung löschen? Der Chatverlauf bleibt erhalten.",
-      "scaleDownSandbox": "Sandbox für diese Sitzung herunterfahren? Der Speicher bleibt erhalten.",
-      "deleteSession": "Diese Sitzung löschen? Chatverlauf und Sandbox-Status werden entfernt.",
-      "archiveSession": "Diese Sitzung archivieren? Sie verschwindet aus der Standardliste, setzt ihre Sandbox zurück und bleibt im Wissens-Repository erhalten.",
-      "unarchiveSession": "Diese Sitzung aus dem Archiv holen? Sie kehrt in die aktive Sitzungsliste zurück.",
-      "makePrivate": "Diese Sitzung als privat markieren? Bereits vorhandene Commits im Wissens-Repository bleiben in der Git-Historie bestehen."
-    },
-    "actions": {
-      "pin": "Sitzung anheften",
-      "unpin": "Anheftung lösen",
-      "favorite": "Sitzung favorisieren",
-      "unfavorite": "Favorit entfernen",
-      "archive": "Sitzung archivieren",
-      "unarchive": "Sitzung aus dem Archiv holen",
-      "includeInRepo": "Ins Repository aufnehmen",
-      "keepPrivate": "Privat halten",
-      "delete": "Sitzung löschen"
-    },
-    "badges": {
-      "archived": "Archiviert",
-      "private": "Privat",
-      "pinned": "Angeheftet",
-      "favorite": "Favorit",
-      "askMode": "Lese-Modus",
-      "yoloMode": "YOLO",
-      "unattended": "Unbeaufsichtigt",
-      "interactive": "Interaktiv"
-    },
-    "inspector": {
-      "actions": "Aktionen",
-      "session": "Sitzung"
-    },
-    "session": {
-      "title": "Titel",
-      "id": "ID",
-      "copyId": "Sitzungs-ID kopieren",
-      "idCopied": "Sitzungs-ID kopiert",
-      "idCopiedShort": "Kopiert",
-      "source": "Quelle",
-      "created": "Erstellt",
-      "lastActive": "Zuletzt aktiv",
-      "messages": "Nachrichten",
-      "totalCost": "Kosten",
-      "job": "Job",
-      "reference": "Referenz",
-      "modes": "Modi",
-      "askMode": "Lese-Modus",
-      "askModeHelp": "Außerhalb der Sandbox nur lesend arbeiten. Externe Schreibzugriffe werden verweigert.",
-      "yoloMode": "YOLO-Modus",
-      "yoloModeHelp": "Sentinel-Freigaben umgehen und Aktionen sofort erlauben.",
-      "savingPrivate": "Wird gespeichert…",
-      "updatingMode": "Modus wird aktualisiert…"
-    },
-    "source": {
-      "unknown": "Unbekannt",
-      "job": "Job",
-      "web": "Web",
-      "cli": "CLI"
-    },
-    "jobRun": {
-      "title": "Letzter Joblauf",
-      "job": "Job",
-      "ranAt": "Ausgeführt am",
-      "schedule": "Zeitplan",
-      "data": "Daten",
-      "trigger": {
-        "label": "Auslöser",
-        "api": "API",
-        "cron": "Cron",
-        "manual": "Manuell"
-      }
-    },
-    "sandbox": {
-      "title": "Sandbox",
-      "refreshing": "Aktualisiere…",
-      "checking": "Prüfe Sandbox…",
-      "status": {
-        "missing": "Nicht gestartet",
-        "running": "Läuft",
-        "scaled_down": "Heruntergefahren",
-        "pending": "Startet",
-        "stopped": "Gestoppt",
-        "error": "Fehler"
-      },
-      "actions": {
-        "start": "Sandbox starten",
-        "starting": "Sandbox wird gestartet",
-        "scaleDown": "Sandbox herunterfahren",
-        "scalingDown": "Sandbox wird heruntergefahren",
-        "reset": "Sandbox zurücksetzen"
-      },
-      "storage": {
-        "used": "{size} verwendet",
-        "none": "kein Sandbox-Speicher",
-        "allocated": "{size} zugewiesen"
-      },
-      "fields": {
-        "id": "Sandbox-ID"
-      }
-    },
-    "knowledge": {
-      "title": "Wissen",
-      "commit": "Ins Repository committen",
-      "committed": "Committed",
-      "committedToRepo": "In Wissen übernommen",
-      "notCommittedYet": "Noch nicht committed",
-      "savedAt": "Gespeichert {timestamp}",
-      "commitDisabledNoHistory": "Diese Sitzung hat noch keinen Gesprächsverlauf.",
-      "noNewChanges": "{status}. Keine neuen Änderungen zum Committen.",
-      "privateExistingCommits": "Sitzung ist privat. Bereits vorhandene Commits im Wissens-Repository bleiben unverändert.",
-      "privateExcluded": "Sitzung ist privat und wird nicht ins Wissens-Repository committed.",
-      "includedInRepo": "Sitzung wird ins Wissens-Repository aufgenommen.",
-      "badges": {
-        "excluded": "Ausgeschlossen",
-        "missing": "Fehlt",
-        "outdated": "Veraltet",
-        "upToDate": "Aktuell"
-      }
-    },
-    "mobile": {
-      "details": "Details",
-      "done": "Fertig"
-    }
-  },
-  "message": {
-    "copy": "Nachricht kopieren",
-    "copied": "Kopiert",
-    "codeBlock": {
-      "copy": "Code kopieren",
-      "copied": "Kopiert"
-    },
-    "thinking": {
-      "streaming": "Denke nach",
-      "complete": "Nachgedacht"
-    },
-    "thinkingMeta": {
-      "durationStreaming": "seit {duration}",
-      "durationComplete": "{duration} lang",
-      "reasoning": "{count} Tokens"
-    },
-    "actions": {
-      "fork": "Sitzung von hier forken",
-      "retry": "Zug erneut ausführen",
-      "reset": "Unterhaltung zu diesem Zug zurücksetzen"
-    },
-    "finalStatus": {
-      "status": {
-        "success": "Erfolg",
-        "warning": "Warnung"
-      },
-      "notice": "Der Agent hat die Aufgabe mit einer Meldung vom Typ {status} beendet. Die Sitzung ist jetzt schreibgeschützt, du kannst sie aber forken um weiter zu chatten."
-    }
-  },
-  "jobs": {
-    "settingsSections": "Einstellungsbereiche",
-    "savedJobs": "Gespeicherte Jobs",
-    "loading": "Jobs werden geladen...",
-    "paused": "Pausiert",
-    "unattendedTooltip": "Unbeaufsichtigte Sitzungen können Tool-Aufrufe nicht eskalieren",
-    "confirmDelete": "Job {name} löschen?",
-    "summary": {
-      "onDemandOnly": "Nur manuell",
-      "cronTriggerCount": "{count, plural, one {# Cron-Trigger} other {# Cron-Trigger}}"
-    },
-    "validation": {
-      "idRequired": "Job-ID ist erforderlich.",
-      "nameRequired": "Job-Name ist erforderlich.",
-      "promptRequired": "Prompt ist erforderlich.",
-      "persistentSessionIdRequired": "Wähle eine persistente Session-ID oder deaktiviere die Option.",
-      "persistentSessionMustBeAttended": "Jobs mit persistenter Sitzung müssen beaufsichtigt sein.",
-      "sessionModesRequireFreshSession": "Session-Modi brauchen eine neue Sitzung.",
-      "modelOverridesRequireFreshSession": "Modell-Overrides brauchen eine neue Sitzung.",
-      "askAndYoloMutuallyExclusive": "Lese-Modus und YOLO sind gegenseitig ausschließend.",
-      "cronEmpty": "Cron-Ausdrücke dürfen nicht leer sein.",
-      "cronInvalid": "Cron-Ausdruck ist ungültig: {expression}."
-    },
-    "cron": {
-      "invalidExpression": "Ungültiger Cron-Ausdruck."
-    },
-    "triggerKind": {
-      "scheduled": "Geplant",
-      "manual": "Manuell"
-    },
-    "errors": {
-      "load": "Jobs konnten nicht geladen werden.",
-      "refresh": "Jobs konnten nicht aktualisiert werden.",
-      "save": "Job konnte nicht gespeichert werden.",
-      "delete": "Job konnte nicht gelöscht werden.",
-      "run": "Job konnte nicht gestartet werden.",
-      "saveBeforeRun": "Speichere den Job, bevor du ihn startest.",
-      "saveChangesBeforeRun": "Speichere die Änderungen am Job, bevor du ihn startest."
-    },
-    "notices": {
-      "refreshed": "Jobs aktualisiert.",
-      "created": "Job erstellt.",
-      "saved": "Job gespeichert.",
-      "deleted": "Job gelöscht.",
-      "runStartedNewSession": "Ausführung in neuer Sitzung {sessionId} gestartet.",
-      "runStartedSession": "Ausführung in Sitzung {sessionId} gestartet."
-    },
-    "actions": {
-      "refresh": "Jobs aktualisieren",
-      "new": "Neuer Job",
-      "clear": "Leeren",
-      "clearPersistentSession": "Persistente Sitzung entfernen",
-      "delete": "Löschen",
-      "save": "Speichern",
-      "addTrigger": "Trigger hinzufügen",
-      "remove": "Entfernen",
-      "runNow": "Jetzt ausführen"
-    },
-    "empty": {
-      "noJobs": "Noch keine Jobs. Erstelle einen, um Prompts und optionale Cron-Zeitpläne in jobs.yaml zu speichern."
-    },
-    "editor": {
-      "newJob": "Neuer Job",
-      "editing": "Bearbeite {name}",
-      "jobFallback": "Job"
-    },
-    "fields": {
-      "name": "Name",
-      "jobId": "Job-ID",
-      "enabled": "Aktiviert",
-      "enabledHelp": "Pausierte Jobs bleiben in jobs.yaml, werden aber nie per Cron ausgeführt.",
-      "newSession": "Optionen",
-      "newSessionHelp": "Diese Optionen gelten nur für neue Sitzungen, die der Job selbst erstellt.",
-      "unattended": "Unbeaufsichtigt ausführen",
-      "unattendedHelp": "Tool-Aufrufe werden nicht an dich eskaliert.",
-      "persistentSession": "Persistente Sitzung",
-      "persistentSessionToggleHelp": "Verwende eine bestehende Sitzung statt bei jedem Lauf eine neue zu starten.",
-      "persistentSessionDisabled": "Kann im unbeaufsichtigten Modus nicht verwendet werden",
-      "persistentSessionUncheckedHelp": "Aktiviere die Option, um unten eine bestehende Session-ID auszuwählen.",
-      "persistentSessionMissingIdHelp": "Aktiv, aber noch ohne Session-ID. Wähle unten eine bestehende Sitzung aus.",
-      "persistentSessionHelp": "Verwende eine bestehende Sitzung, statt bei jedem Joblauf eine neue zu erstellen.",
-      "persistentSessionActiveHelp": "Aktiv: Diese Session-ID überschreibt die Optionen für neue Sitzungen oben.",
-      "models": "Modelle",
-      "modelsHelp": "Optionale job-spezifische Overrides für neue Sitzungen, die dieser Job erstellt.",
-      "modelsDisabled": "Persistente Sitzungen behalten ihre eigene Modellauswahl.",
-      "modelsLinked": "Modelle verknüpft",
-      "modelsLinkedHelp": "Verknüpft: Änderungen an einem Modell setzen beide Modelle.",
-      "modelsUnlinked": "Modelle getrennt",
-      "modelsUnlinkedHelp": "Getrennt: Agent- und Sentinel-Modell lassen sich unabhängig ändern.",
-      "agentModel": "Agent",
-      "sentinelModel": "Sentinel",
-      "titleModel": "Titel-Modell",
-      "prompt": "Prompt",
-      "expression": "Ausdruck",
-      "timeZone": "Zeitzone",
-      "inputOptional": "Eingabe (optional)"
-    },
-    "placeholders": {
-      "name": "Nächtliche Inbox-Prüfung",
-      "jobId": "naechtliche-inbox-pruefung",
-      "persistentSession": "session-id auswählen",
-      "prompt": "Fasse neue Aufgaben zusammen, priorisiere Dringendes und schlage dann nächste Schritte vor.",
-      "model": "Leer lassen für Standardmodell"
-    },
-    "sections": {
-      "cronTriggers": "Cron-Trigger",
-      "cronTriggersDescription": "Leer lassen für Jobs, die nur manuell gestartet werden.",
-      "noTriggers": "Keine Cron-Trigger konfiguriert.",
-      "runJob": "Job ausführen",
-      "previousInvocations": "Vorherige Ausführungen",
-      "previousInvocationsDescription": "Wähle eine Ausführung, um ihre Sitzung zu öffnen.",
-      "saveToViewHistory": "Speichere diesen Job, um den Ausführungsverlauf zu sehen.",
-      "noInvocations": "Noch keine Ausführungen. Aktualisiere die Sitzungen, um neu abgeschlossene Läufe zu laden.",
-      "ranAt": "Ausgeführt am {timestamp}"
-    }
-  },
-  "sidebar": {
-    "time": {
-      "justNow": "gerade eben"
-    },
-    "messageCount": "{count, plural, one {# Nachricht} other {# Nachrichten}}",
-    "unattendedSession": "Unbeaufsichtigte Sitzung",
-    "privateSession": "Private Sitzung",
-    "knowledgeCommitted": "Alle Änderungen ins Wissens-Repository übernommen",
-    "actions": {
-      "pin": "Sitzung anheften",
-      "unpin": "Sitzung lösen",
-      "favorite": "Sitzung favorisieren",
-      "unfavorite": "Favorit entfernen",
-      "archive": "Sitzung archivieren",
-      "unarchive": "Sitzung aus dem Archiv holen",
-      "delete": "Sitzung löschen",
-      "deleteEmpty": "Leere Sitzung löschen",
-      "shiftSkip": "Shift+Klick überspringt die Bestätigung"
-    },
-    "confirm": {
-      "deleteSession": "Diese Sitzung löschen? Chatverlauf und Sandbox-Status werden entfernt.",
-      "deleteUnpushed": "Diese Sitzung hat {count, plural, one {# Commit} other {# Commits}}, die noch nicht ins Wissens-Repository gepusht wurden. Beim Löschen gehen sie verloren. Trotzdem löschen?",
-      "archiveSession": "Diese Sitzung archivieren? Sie verschwindet aus der Standardliste, setzt ihre Sandbox zurück und bleibt im Wissens-Repository erhalten."
-    },
-    "sections": {
-      "today": "Heute",
-      "yesterday": "Gestern",
-      "last7Days": "Letzte 7 Tage",
-      "last30Days": "Letzte 30 Tage",
-      "archived": "Archiviert",
-      "unknownDate": "Unbekanntes Datum"
-    },
-    "empty": "Noch keine Sitzungen",
-    "loadingMore": "Weitere Sitzungen werden geladen"
-  },
-  "git": {
-    "upToDate": "Aktuell",
-    "noRemote": "Kein Remote konfiguriert",
-    "sandbox": {
-      "label": "Workspace-Sync",
-      "help": "Synchronisiert die Workspace-Sandbox dieser Sitzung mit deinem Wissens-Repository auf dem Server. Die Zähler zeigen, um wie viele Commits dieser Workspace dem Server-Repo voraus (↑) bzw. hinterher (↓) ist.",
-      "notRunning": "Sandbox läuft nicht",
-      "refresh": "Workspace erneut mit dem Server-Repository abgleichen (holt zuerst neue Commits)",
-      "pull": "Commits aus dem Server-Repository in diesen Workspace holen",
-      "push": "Commits dieses Workspace ins Server-Repository übertragen (jeder Push wird vom Sentinel geprüft)"
-    },
-    "global": {
-      "label": "Wissens-Remote",
-      "help": "Synchronisiert dein Wissens-Repository auf dem Server mit seinem externen Git-Remote. Die Zähler zeigen, um wie viele Commits das Server-Repo dem Remote voraus (↑) bzw. hinterher (↓) ist.",
-      "indicatorBehind": "{count, plural, one {# Commit} other {# Commits}} vom Wissens-Remote zu holen",
-      "refresh": "Server-Repository erneut mit dem Remote abgleichen (holt zuerst neue Commits)",
-      "pull": "Commits vom externen Remote ins Server-Repository holen",
-      "push": "Commits des Server-Repositorys ins externe Remote übertragen"
-    },
-    "denied": "Push abgelehnt",
-    "errors": {
-      "status": "Git-Status konnte nicht gelesen werden",
-      "pull": "Pull fehlgeschlagen",
-      "push": "Push fehlgeschlagen"
-    }
-  },
-  "apiKeys": {
-    "title": "API-Schlüssel",
-    "description": "Erstelle langlebige Tokens für Skripte und Integrationen. Verwende sie als 'Authorization: Bearer <token>'.",
-    "create": {
-      "nameLabel": "Name",
-      "namePlaceholder": "z. B. CI-Deploy-Bot",
-      "scopesLabel": "Berechtigungen",
-      "expiryLabel": "Läuft ab nach (Tagen)",
-      "expiryPlaceholder": "Leer lassen für kein Ablaufdatum",
-      "submit": "Schlüssel erstellen",
-      "creating": "Wird erstellt…"
-    },
-    "access": {
-      "none": "Keine",
-      "read": "Lesen",
-      "write": "Schreiben"
-    },
-    "scopes": {
-      "sessions": "Sitzungen",
-      "jobs": "Jobs",
-      "preferences": "Einstellungen",
-      "notifications": "Benachrichtigungen",
-      "history": "Verlauf",
-      "admin": "Administration"
-    },
-    "secret": {
-      "warning": "Kopiere diesen Token jetzt — er wird nicht erneut angezeigt.",
-      "copy": "Token kopieren",
-      "done": "Fertig"
-    },
-    "list": {
-      "title": "Aktive Schlüssel",
-      "empty": "Noch keine API-Schlüssel.",
-      "loading": "Schlüssel werden geladen…",
-      "unnamed": "Unbenannter Schlüssel",
-      "expired": "Abgelaufen"
-    },
-    "fields": {
-      "created": "Erstellt {timestamp}",
-      "lastUsed": "Zuletzt verwendet {timestamp}",
-      "expires": "Läuft ab {timestamp}",
-      "never": "nie",
-      "noExpiry": "kein Ablauf"
-    },
-    "actions": {
-      "revoke": "Schlüssel widerrufen"
-    },
-    "confirm": {
-      "revoke": "API-Schlüssel \"{name}\" widerrufen? Dies kann nicht rückgängig gemacht werden."
-    },
-    "errors": {
-      "load": "API-Schlüssel konnten nicht geladen werden.",
-      "create": "API-Schlüssel konnte nicht erstellt werden.",
-      "revoke": "API-Schlüssel konnte nicht widerrufen werden.",
-      "noScopes": "Wähle mindestens eine Berechtigung."
-    }
-  }
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1029,7 +1029,8 @@
       "title": "Active keys",
       "empty": "No API keys yet.",
       "loading": "Loading keys…",
-      "unnamed": "Unnamed key"
+      "unnamed": "Unnamed key",
+      "expired": "Expired"
     },
     "fields": {
       "created": "Created {timestamp}",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1,1055 +1,1055 @@
 {
-  "app": {
-    "name": "carapace",
-    "description": "Security-first personal AI agent"
-  },
-  "navigation": {
-    "home": "Home",
-    "settings": "Settings",
-    "jobs": "Jobs",
-    "account": "Account",
-    "preferences": "Preferences",
-    "platform": "Admin",
-    "models": "Models",
-    "users": "Users",
-    "disconnect": "Disconnect",
-    "github": "thiesgerken/carapace",
-    "apiKeys": "API Keys"
-  },
-  "account": {
-    "menu": "Account menu",
-    "openMenu": "Open account menu",
-    "unknown": "Unknown user",
-    "logout": "Log out"
-  },
-  "accountSettings": {
-    "status": {
-      "loading": "Loading settings",
-      "unavailable": "Settings are unavailable",
-      "configured": "configured",
-      "notSet": "not set"
+    "app": {
+        "name": "carapace",
+        "description": "Security-first personal AI agent"
     },
-    "notices": {
-      "saved": "Saved."
+    "navigation": {
+        "home": "Home",
+        "settings": "Settings",
+        "jobs": "Jobs",
+        "account": "Account",
+        "preferences": "Preferences",
+        "platform": "Admin",
+        "models": "Models",
+        "users": "Users",
+        "disconnect": "Disconnect",
+        "github": "thiesgerken/carapace",
+        "apiKeys": "API Keys"
     },
-    "errors": {
-      "load": "Failed to load user settings",
-      "save": "Failed to update user settings",
-      "credentialsInvalid": "Credential backend settings are invalid",
-      "credentialNameRequired": "Credential backend name is required",
-      "credentialNameNoSlash": "Credential backend name {name} must not contain /",
-      "credentialNameDuplicate": "Credential backend name {name} is already used",
-      "fileBackendDisabled": "File credential backends are disabled on this server",
-      "basicAuthUsernameRequired": "Basic Auth username is required for {name}",
-      "basicAuthPasswordRequired": "Basic Auth password is required for {name}",
-      "matrixPasswordRequired": "Matrix password is required when Matrix is enabled",
-      "budgetWholeNumber": "{field} must be a non-negative whole number.",
-      "budgetNumber": "{field} must be a non-negative number."
+    "account": {
+        "menu": "Account menu",
+        "openMenu": "Open account menu",
+        "unknown": "Unknown user",
+        "logout": "Log out"
     },
-    "sections": {
-      "defaultModels": "Default models",
-      "defaultBudgets": "Default budgets",
-      "matrix": "Matrix",
-      "credentials": "Credentials",
-      "gitRemote": "Git remote"
-    },
-    "fields": {
-      "agent": "Agent",
-      "sentinel": "Sentinel",
-      "title": "Title",
-      "inputTokens": "Input tokens",
-      "outputTokens": "Output tokens",
-      "costUsd": "Cost USD",
-      "toolCalls": "Tool calls",
-      "enabled": "Enabled",
-      "homeserver": "Homeserver",
-      "userId": "User ID",
-      "deviceName": "Device name",
-      "password": "Password",
-      "allowedRooms": "Allowed rooms",
-      "allowedUsers": "Allowed users",
-      "remote": "Remote",
-      "branch": "Branch",
-      "author": "Author",
-      "token": "Token",
-      "name": "Name",
-      "path": "Path",
-      "url": "URL",
-      "basicAuth": "Basic Auth",
-      "basicAuthUsername": "Basic Auth username",
-      "basicAuthPassword": "Basic Auth password",
-      "expose": "Expose",
-      "hide": "Hide"
-    },
-    "defaults": {
-      "serverDefault": "Server default",
-      "currentModel": "{model}"
-    },
-    "placeholders": {
-      "addRoom": "Add room, Enter or comma",
-      "addUser": "Add user, Enter or comma",
-      "addIdentifier": "Add identifier, Enter or comma"
-    },
-    "tooltips": {
-      "filePath": "Relative paths are resolved from the server working directory.",
-      "expose": "Allow only these credential identifiers from this backend. Leave empty to allow everything except hidden entries.",
-      "hide": "Deny these credential identifiers from this backend. Ignored when Expose is set."
-    },
-    "actions": {
-      "save": "Save",
-      "saving": "Saving",
-      "addBitwarden": "Bitwarden",
-      "addFile": "File",
-      "remove": "Remove",
-      "removeValue": "Remove {value}",
-      "removeBackend": "Remove backend",
-      "removeBackendAria": "Remove {name}"
-    },
-    "empty": {
-      "credentials": "No credential backends configured"
-    },
-    "credentials": {
-      "backendFallback": "credential backend",
-      "types": {
-        "file": {
-          "label": "File",
-          "description": "Local credentials file"
+    "accountSettings": {
+        "status": {
+            "loading": "Loading settings",
+            "unavailable": "Settings are unavailable",
+            "configured": "configured",
+            "notSet": "not set"
         },
-        "bitwarden": {
-          "label": "Bitwarden",
-          "description": "Password manager proxy"
+        "notices": {
+            "saved": "Saved."
+        },
+        "errors": {
+            "load": "Failed to load user settings",
+            "save": "Failed to update user settings",
+            "credentialsInvalid": "Credential backend settings are invalid",
+            "credentialNameRequired": "Credential backend name is required",
+            "credentialNameNoSlash": "Credential backend name {name} must not contain /",
+            "credentialNameDuplicate": "Credential backend name {name} is already used",
+            "fileBackendDisabled": "File credential backends are disabled on this server",
+            "basicAuthUsernameRequired": "Basic Auth username is required for {name}",
+            "basicAuthPasswordRequired": "Basic Auth password is required for {name}",
+            "matrixPasswordRequired": "Matrix password is required when Matrix is enabled",
+            "budgetWholeNumber": "{field} must be a non-negative whole number.",
+            "budgetNumber": "{field} must be a non-negative number."
+        },
+        "sections": {
+            "defaultModels": "Default models",
+            "defaultBudgets": "Default budgets",
+            "matrix": "Matrix",
+            "credentials": "Credentials",
+            "gitRemote": "Git remote"
+        },
+        "fields": {
+            "agent": "Agent",
+            "sentinel": "Sentinel",
+            "title": "Title",
+            "inputTokens": "Input tokens",
+            "outputTokens": "Output tokens",
+            "costUsd": "Cost USD",
+            "toolCalls": "Tool calls",
+            "enabled": "Enabled",
+            "homeserver": "Homeserver",
+            "userId": "User ID",
+            "deviceName": "Device name",
+            "password": "Password",
+            "allowedRooms": "Allowed rooms",
+            "allowedUsers": "Allowed users",
+            "remote": "Remote",
+            "branch": "Branch",
+            "author": "Author",
+            "token": "Token",
+            "name": "Name",
+            "path": "Path",
+            "url": "URL",
+            "basicAuth": "Basic Auth",
+            "basicAuthUsername": "Basic Auth username",
+            "basicAuthPassword": "Basic Auth password",
+            "expose": "Expose",
+            "hide": "Hide"
+        },
+        "defaults": {
+            "serverDefault": "Server default",
+            "currentModel": "{model}"
+        },
+        "placeholders": {
+            "addRoom": "Add room, Enter or comma",
+            "addUser": "Add user, Enter or comma",
+            "addIdentifier": "Add identifier, Enter or comma"
+        },
+        "tooltips": {
+            "filePath": "Relative paths are resolved from the server working directory.",
+            "expose": "Allow only these credential identifiers from this backend. Leave empty to allow everything except hidden entries.",
+            "hide": "Deny these credential identifiers from this backend. Ignored when Expose is set."
+        },
+        "actions": {
+            "save": "Save",
+            "saving": "Saving",
+            "addBitwarden": "Bitwarden",
+            "addFile": "File",
+            "remove": "Remove",
+            "removeValue": "Remove {value}",
+            "removeBackend": "Remove backend",
+            "removeBackendAria": "Remove {name}"
+        },
+        "empty": {
+            "credentials": "No credential backends configured"
+        },
+        "credentials": {
+            "backendFallback": "credential backend",
+            "types": {
+                "file": {
+                    "label": "File",
+                    "description": "Local credentials file"
+                },
+                "bitwarden": {
+                    "label": "Bitwarden",
+                    "description": "Password manager proxy"
+                }
+            }
         }
-      }
+    },
+    "platformSettings": {
+        "status": {
+            "loading": "Loading platform settings",
+            "unavailable": "Platform settings are unavailable",
+            "readOnly": "Config file is read-only."
+        },
+        "notices": {
+            "saved": "Saved."
+        },
+        "errors": {
+            "load": "Failed to load platform settings",
+            "save": "Failed to update platform settings",
+            "wholeNumber": "{field} must be a positive whole number.",
+            "nonNegativeWholeNumber": "{field} must be a non-negative whole number.",
+            "number": "{field} must be a non-negative number.",
+            "providerRequired": "Provider is required for model {index}.",
+            "nameRequired": "Name is required for model {index}.",
+            "duplicateModel": "Model id {id} is used more than once.",
+            "rawSecretRequired": "Paste an API key for {id}, or choose another secret source.",
+            "secretValueRequired": "Secret reference is required for {id}.",
+            "defaultRequired": "{field} default model is required.",
+            "defaultUnknown": "{field} default model {id} is not in the catalog."
+        },
+        "sections": {
+            "defaultModels": "Default models",
+            "defaultBudgets": "Default budgets",
+            "catalog": "Model catalog"
+        },
+        "fields": {
+            "agent": "Agent",
+            "sentinel": "Sentinel",
+            "title": "Title",
+            "inputTokens": "Input tokens",
+            "outputTokens": "Output tokens",
+            "costUsd": "Cost USD",
+            "toolCalls": "Tool calls",
+            "provider": "Provider",
+            "name": "Name",
+            "id": "ID",
+            "maxInputTokens": "Max input tokens",
+            "thinking": "Thinking",
+            "thinkingBudgetTokens": "Thinking budget tokens",
+            "baseUrl": "Base URL",
+            "vision": "Vision",
+            "visionHint": "Accepts image input",
+            "apiKeySource": "API key source",
+            "apiKey": "API key",
+            "secretReference": "Secret reference"
+        },
+        "placeholders": {
+            "selectModel": "Select model",
+            "unlimited": "Unlimited",
+            "generatedId": "provider:name",
+            "keepSecret": "Keep configured secret"
+        },
+        "actions": {
+            "save": "Save",
+            "saving": "Saving",
+            "addModel": "Add model",
+            "removeModel": "Remove model",
+            "confirmRemoveModel": "Remove model \"{name}\"? This cannot be undone."
+        },
+        "secretSources": {
+            "none": "None",
+            "raw": "Raw value",
+            "env": "Environment variable",
+            "file": "File"
+        },
+        "thinking": {
+            "default": "Default",
+            "true": "Enabled",
+            "false": "Disabled",
+            "minimal": "Minimal",
+            "low": "Low",
+            "medium": "Medium",
+            "high": "High",
+            "xhigh": "Extra high"
+        },
+        "units": {
+            "tokens": "tokens"
+        },
+        "modelRow": "Model {index}"
+    },
+    "home": {
+        "empty": {
+            "description": "Select a session or start a new one"
+        }
+    },
+    "connect": {
+        "description": "Sign in to carapace",
+        "serverLabel": "Server URL",
+        "usernameLabel": "Username",
+        "usernamePlaceholder": "Username",
+        "passwordLabel": "Password",
+        "passwordPlaceholder": "Password",
+        "connect": "Connect",
+        "connecting": "Connecting…",
+        "errors": {
+            "serverError": "Server error: {status}",
+            "connectionFailed": "Connection failed"
+        }
+    },
+    "admin": {
+        "title": "Admin",
+        "backToApp": "Back to app",
+        "serverLabel": "Server URL",
+        "serverPlaceholder": "No server selected",
+        "users": {
+            "title": "Users",
+            "description": "Global platform accounts, roles, and data ownership.",
+            "savedUsers": "Users",
+            "loading": "Loading users…",
+            "empty": "No users found",
+            "selectUser": "Select a user",
+            "you": "You",
+            "admin": "Admin",
+            "enabled": "Enabled",
+            "disabled": "Disabled"
+        },
+        "create": {
+            "title": "New user",
+            "subtitle": "Create a local user"
+        },
+        "fields": {
+            "username": "Username",
+            "password": "Password",
+            "newPassword": "New password",
+            "keepPassword": "Keep current password",
+            "displayName": "Display name",
+            "email": "Email",
+            "roles": "Roles",
+            "enabled": "Enabled"
+        },
+        "actions": {
+            "load": "Load",
+            "loading": "Loading…",
+            "refresh": "Refresh users",
+            "new": "New user",
+            "deleteUser": "Delete {username}",
+            "create": "Create user",
+            "creating": "Creating…",
+            "save": "Save changes",
+            "saving": "Saving…"
+        },
+        "notices": {
+            "loaded": "Users loaded.",
+            "created": "Created {username}.",
+            "saved": "Saved {username}.",
+            "deleted": "Deleted {username}."
+        },
+        "errors": {
+            "missingCredentials": "Current origin is unavailable.",
+            "load": "Failed to load users.",
+            "create": "Failed to create user.",
+            "save": "Failed to save user.",
+            "delete": "Failed to delete user."
+        },
+        "confirm": {
+            "deleteUser": "Delete {username}? Existing data owned by this user is not deleted."
+        },
+        "meta": {
+            "tokenVersion": "Token v{version}",
+            "updated": "Updated {timestamp}",
+            "lastLogin": "Last login {timestamp}",
+            "never": "never"
+        }
+    },
+    "preferences": {
+        "title": "Preferences",
+        "description": "Personal settings for this browser and your account experience.",
+        "currentLocale": "Current interface language: {locale}",
+        "language": {
+            "label": "Language",
+            "description": "Choose how the interface language is resolved.",
+            "options": {
+                "system": "System",
+                "en": "English",
+                "de": "Deutsch"
+            }
+        },
+        "theme": {
+            "label": "Appearance",
+            "description": "Choose how the color theme is resolved.",
+            "options": {
+                "system": "System",
+                "light": "Light",
+                "dark": "Dark"
+            }
+        },
+        "chatList": {
+            "label": "Chats",
+            "showArchived": {
+                "label": "Show archived chats",
+                "description": "When disabled, archived chats are hidden and session list requests exclude them."
+            }
+        },
+        "notifications": {
+            "title": "Push notifications",
+            "description": "Deliver escalations and turn outcomes to this browser or installed PWA.",
+            "status": {
+                "loading": "Checking notification support…",
+                "loadingShort": "Checking",
+                "enabled": "Notifications are enabled for this browser.",
+                "enabledShort": "Enabled",
+                "disabled": "Notifications are off for this browser.",
+                "disabledShort": "Off",
+                "unsupported": "This browser cannot receive Web Push notifications in the current context.",
+                "permissionDenied": "Browser notification permission is blocked. Re-enable it in browser or device settings.",
+                "permissionRequired": "Notification permission was not granted.",
+                "invalidSubscription": "Browser returned an incomplete push subscription.",
+                "loadFailed": "Failed to load notification settings.",
+                "enableFailed": "Failed to enable notifications.",
+                "disableFailed": "Failed to disable notifications.",
+                "preferencesFailed": "Failed to update notification preferences.",
+                "testFailed": "Failed to send test notification.",
+                "testSent": "Test notification sent."
+            },
+            "deviceName": {
+                "label": "Device name",
+                "placeholder": "Android phone",
+                "hint": "Shown in server-side notification subscriptions for this browser."
+            },
+            "toggle": {
+                "label": "Notifications"
+            },
+            "actions": {
+                "enable": "Enable notifications",
+                "enabling": "Enabling…",
+                "disable": "Disable notifications",
+                "disabling": "Disabling…",
+                "test": "Send test notification",
+                "testing": "Sending test notification…"
+            },
+            "preferences": {
+                "label": "Send notifications for",
+                "escalation_pending": "Escalations that need approval",
+                "attended_turn_completed": "Attended sessions when a turn finishes",
+                "unattended_turn_completed": "Unattended jobs that finish successfully",
+                "unattended_turn_failed": "Unattended jobs that fail"
+            },
+            "meta": {
+                "permission": "Browser permission: {permission}",
+                "heartbeat": "Last heartbeat: {timestamp}",
+                "expires": "Subscription expires: {timestamp}"
+            },
+            "permission": {
+                "default": "not requested",
+                "granted": "granted",
+                "denied": "denied"
+            }
+        }
+    },
+    "newSessionButton": {
+        "label": "New session",
+        "chooseOptions": "Choose session options",
+        "private": {
+            "enabledTitle": "Private",
+            "enabledDescription": "Exclude this session from knowledge commits.",
+            "disabledTitle": "Saved",
+            "disabledDescription": "Can be included in knowledge commits."
+        },
+        "ask": {
+            "enabledTitle": "Read-Only Mode",
+            "enabledDescription": "Read-only outside sandbox. External writes are blocked.",
+            "disabledTitle": "Read and Write Access",
+            "disabledDescription": "Normal permissions. External writes are allowed."
+        },
+        "yolo": {
+            "enabledTitle": "YOLO",
+            "enabledDescription": "Disable sentinel review and allow operations immediately.",
+            "disabledTitle": "Reviewed",
+            "disabledDescription": "Keep actions gated by safe-list and sentinel review."
+        },
+        "unattended": {
+            "enabledTitle": "Unattended",
+            "enabledDescription": "Runs on its own with no user approval path.",
+            "disabledTitle": "With Approval",
+            "disabledDescription": "Stays interactive with a user approval path."
+        }
+    },
+    "chatInput": {
+        "disabled": "Input disabled",
+        "sendMessageTooltip": "Send message (Enter)",
+        "queueInterruptStopTooltip": "Enter to queue · ⌥Enter to interrupt · Click to stop",
+        "stopGenerationTooltip": "Stop generation",
+        "queued": "Queued: {message}",
+        "startVoiceInput": "Start voice input",
+        "stopVoiceInput": "Stop voice input",
+        "attachFile": "Attach file",
+        "attachFileUnavailable": "Start the sandbox to upload files",
+        "startingSandbox": "Starting sandbox…",
+        "removeAttachment": "Remove",
+        "placeholder": "Message carapace…",
+        "usageBreakdown": {
+            "systemLine": "system: {percent}%",
+            "userLine": "user: {percent}%",
+            "assistantLine": "assistant: {percent}%",
+            "toolCallsLine": "tool calls: {percent}%",
+            "toolOutputsLine": "tool outputs: {percent}%",
+            "otherLine": "other: {percent}%"
+        },
+        "context": {
+            "limit": "Context limit: {tokens} tokens.",
+            "assumedLimit": "Assuming a {tokens} context limit.",
+            "lastRequestTokens": "{tokens} API tokens (last agent request)",
+            "clickForUsage": "Click to send /usage to the agent for more details.",
+            "tokensLabel": "{tokens} tokens"
+        },
+        "budget": {
+            "budgetLabel": "{label} budget",
+            "current": "Current: {value}",
+            "max": "Max: {value}",
+            "remaining": "Remaining: {value}",
+            "exhausted": "Budget exhausted."
+        }
+    },
+    "approval": {
+        "general": {
+            "title": "Approval Required",
+            "toolLabel": "Tool:",
+            "reasonLabel": "Reason:",
+            "riskLabel": "Risk:",
+            "arguments": "Arguments",
+            "allow": "Approve",
+            "denyPlaceholder": "Why should this be blocked?",
+            "risk": {
+                "high": "high",
+                "medium": "medium",
+                "low": "low"
+            }
+        },
+        "denialNote": {
+            "deny": "Deny",
+            "optionalNote": "Optional note for the agent",
+            "addNote": "Add note",
+            "hideNote": "Hide note"
+        },
+        "credential": {
+            "title": "Credential Request",
+            "skillLabel": "Skill:",
+            "allow": "Allow",
+            "denyPlaceholder": "Why should this credential access be blocked?",
+            "decision": {
+                "allow": "Allowed",
+                "deny": "Denied"
+            }
+        },
+        "domainAccess": {
+            "title": "Domain Access Request",
+            "domainLabel": "Domain:",
+            "triggeredByLabel": "Triggered by:",
+            "allow": "Allow {domain}",
+            "denyPlaceholder": "Why should this be blocked?",
+            "decision": {
+                "allow": "Allowed",
+                "deny": "Denied"
+            }
+        },
+        "gitPush": {
+            "title": "Git Push Request",
+            "refLabel": "Ref:",
+            "reasonLabel": "Reason:",
+            "changedFiles": "{count, plural, one {# changed file} other {# changed files}}",
+            "allow": "Allow Push",
+            "denyPlaceholder": "Why should this push be blocked?",
+            "decision": {
+                "allow": "Allowed",
+                "deny": "Denied"
+            }
+        }
+    },
+    "versionBadge": {
+        "frontend": "Frontend: {version}",
+        "backend": "Backend: {version}",
+        "unknown": "unknown",
+        "mismatchTooltip": "Version mismatch between frontend and backend containers.",
+        "mismatchSr": "Frontend and backend versions do not match."
+    },
+    "toolCallBadge": {
+        "approvalBadge": {
+            "review": "review",
+            "skill": "skill",
+            "bypass": "bypass",
+            "denied": "denied"
+        },
+        "fallbacks": {
+            "missingPath": "(missing path)",
+            "missingCommand": "(missing command)",
+            "missingSkillName": "(missing skill_name)",
+            "credential": "credential"
+        },
+        "labels": {
+            "read": "read",
+            "wrote": "wrote",
+            "replaced": "replaced",
+            "activatedSkill": "activated skill",
+            "executed": "executed",
+            "listedCredentials": "listed credentials",
+            "credentialDenied": "credential denied",
+            "accessedCredential": "accessed credential",
+            "domainDenied": "domain denied",
+            "accessedDomain": "accessed domain",
+            "gitPush": "git push",
+            "readAction": "read",
+            "write": "write",
+            "activateSkill": "activate skill",
+            "execute": "execute",
+            "listCredentials": "list credentials",
+            "accessCredential": "access credential",
+            "accessDomain": "access domain",
+            "replace": "replace",
+            "sentFile": "sent file",
+            "sendFile": "send file"
+        },
+        "summaries": {
+            "readFirstLines": "first {count} lines of {path}",
+            "readLinesRange": "lines {start} to {end} of {path}",
+            "writeLines": "{count} lines to {path}",
+            "lineCount": "{count} lines",
+            "lineCountWithReplacement": "{source} lines with {replacement} lines",
+            "replaceInPath": "{lineSummary} in {path}{suffix}",
+            "allMatchesSuffix": " (all matches)"
+        },
+        "details": {
+            "activateSkillPromptPrefix": "Agent wants to activate the",
+            "activateSkillPromptSuffix": "skill.",
+            "sentinelLabel": "Sentinel:",
+            "sentinelReviewing": "Reviewing this tool call.",
+            "userLabel": "User:",
+            "deniedByUser": "Denied by user.",
+            "contexts": "Contexts:",
+            "domains": "Domains:",
+            "credentials": "Credentials",
+            "name": "Name",
+            "path": "Path",
+            "description": "Description",
+            "activation": "Activation",
+            "skillInstructions": "Skill Instructions",
+            "source": "Source",
+            "replacement": "Replacement",
+            "diff": "Diff",
+            "arguments": "Arguments",
+            "result": "Result"
+        }
+    },
+    "commandResult": {
+        "help": {
+            "command": "Command",
+            "description": "Description"
+        },
+        "rules": {
+            "id": "ID",
+            "trigger": "Trigger",
+            "mode": "Mode",
+            "status": {
+                "label": "Status",
+                "disabled": "disabled",
+                "alwaysOn": "always-on",
+                "activated": "activated"
+            }
+        },
+        "models": {
+            "type": "Type",
+            "model": "Model",
+            "default": "Default",
+            "available": "Available:",
+            "provider": "Type",
+            "name": "Name",
+            "context": "Context",
+            "contextWindow": "({tokens} ctx)",
+            "contextWindowShort": "{tokens} ctx",
+            "noneAvailable": "No models available.",
+            "noMatches": "No matching models.",
+            "filterPlaceholder": "Filter models...",
+            "currentLabel": "Current model:",
+            "defaultLabel": "Default: {model}"
+        },
+        "usage": {
+            "none": "No token usage recorded yet.",
+            "total": "Total: {total} tokens ({input} in + {output} out)",
+            "toolCalls": "Tool Calls: {count}",
+            "byModel": "By Model",
+            "byCategory": "By Category",
+            "context": "Context",
+            "table": {
+                "source": "Source",
+                "input": "Input",
+                "output": "Output",
+                "cacheRead": "Cache Read",
+                "cacheWrite": "Cache Write",
+                "requests": "Requests",
+                "cost": "Cost"
+            },
+            "contextTable": {
+                "source": "Source",
+                "tokens": "Tokens",
+                "system": "System %",
+                "user": "User %",
+                "assistant": "Assistant %",
+                "toolCalls": "Tool Calls %",
+                "toolOutputs": "Tool Outputs %",
+                "other": "Other %"
+            }
+        },
+        "budget": {
+            "none": "No session budgets configured.",
+            "title": "Session Budgets",
+            "table": {
+                "metric": "Metric",
+                "current": "Current",
+                "limit": "Limit",
+                "remaining": "Remaining",
+                "used": "Used",
+                "blocked": "blocked"
+            }
+        }
+    },
+    "chatView": {
+        "inputDisabled": {
+            "archived": "Unarchive first",
+            "unattended": "This session is unattended. Fork it first to continue here."
+        },
+        "waiting": {
+            "processingPrompt": "Processing prompt...",
+            "thinking": "Thinking...",
+            "generating": "Generating...",
+            "working": "Working..."
+        },
+        "unknown": "Unknown",
+        "status": {
+            "connecting": "Connecting…",
+            "disconnected": "Disconnected"
+        },
+        "empty": {
+            "start": "Send a message to get started",
+            "connectingSession": "Connecting to session…"
+        },
+        "errors": {
+            "unexpected": "Unexpected error",
+            "resetTarget": "Could not resolve reset target.",
+            "forkTarget": "Could not resolve fork target."
+        },
+        "confirm": {
+            "wipeSandbox": "Wipe the sandbox and its storage for this session? Chat history will stay.",
+            "scaleDownSandbox": "Scale down the sandbox for this session? Storage will be kept.",
+            "deleteSession": "Delete this session? Chat history and sandbox state will be removed.",
+            "archiveSession": "Archive this session? It will leave the default list, reset its sandbox, and stay in the knowledge repo.",
+            "unarchiveSession": "Unarchive this session? It will return to the active session list.",
+            "makePrivate": "Mark this session private? Existing knowledge commits will remain in git history."
+        },
+        "actions": {
+            "pin": "Pin session",
+            "unpin": "Unpin session",
+            "favorite": "Favorite session",
+            "unfavorite": "Remove favorite",
+            "archive": "Archive session",
+            "unarchive": "Unarchive session",
+            "includeInRepo": "Include in repo",
+            "keepPrivate": "Keep private",
+            "delete": "Delete session"
+        },
+        "badges": {
+            "archived": "Archived",
+            "private": "Private",
+            "pinned": "Pinned",
+            "favorite": "Favorite",
+            "askMode": "Read-Only Mode",
+            "yoloMode": "YOLO",
+            "unattended": "Unattended",
+            "interactive": "Interactive"
+        },
+        "inspector": {
+            "actions": "Actions",
+            "session": "Session"
+        },
+        "session": {
+            "title": "Title",
+            "id": "ID",
+            "copyId": "Copy session id",
+            "idCopied": "Copied session id",
+            "idCopiedShort": "Copied",
+            "source": "Source",
+            "created": "Created",
+            "lastActive": "Last active",
+            "messages": "Messages",
+            "totalCost": "Cost",
+            "job": "Job",
+            "reference": "Reference",
+            "modes": "Modes",
+            "askMode": "Read-Only Mode",
+            "askModeHelp": "Only read-only work outside the sandbox. External writes are denied.",
+            "yoloMode": "YOLO Mode",
+            "yoloModeHelp": "Bypass sentinel approval and allow actions immediately.",
+            "savingPrivate": "Saving…",
+            "updatingMode": "Updating mode…"
+        },
+        "source": {
+            "unknown": "Unknown",
+            "job": "Job",
+            "web": "Web",
+            "cli": "CLI"
+        },
+        "jobRun": {
+            "title": "Latest Job Run",
+            "job": "Job",
+            "ranAt": "Ran at",
+            "schedule": "Schedule",
+            "data": "Data",
+            "trigger": {
+                "label": "Trigger",
+                "api": "API",
+                "cron": "Cron",
+                "manual": "Manual"
+            }
+        },
+        "sandbox": {
+            "title": "Sandbox",
+            "refreshing": "Refreshing…",
+            "checking": "Checking sandbox…",
+            "status": {
+                "missing": "Not Started",
+                "running": "Running",
+                "scaled_down": "Spun Down",
+                "pending": "Starting Up",
+                "stopped": "Stopped",
+                "error": "Error"
+            },
+            "actions": {
+                "start": "Start sandbox",
+                "starting": "Starting sandbox",
+                "scaleDown": "Scale down sandbox",
+                "scalingDown": "Scaling down sandbox",
+                "reset": "Reset sandbox"
+            },
+            "storage": {
+                "used": "{size} used",
+                "none": "no sandbox storage",
+                "allocated": "{size} allocated"
+            },
+            "fields": {
+                "id": "Sandbox ID"
+            }
+        },
+        "knowledge": {
+            "title": "Knowledge",
+            "commit": "Commit to repo",
+            "committed": "Committed",
+            "committedToRepo": "Committed to knowledge",
+            "notCommittedYet": "Not committed yet",
+            "savedAt": "Saved {timestamp}",
+            "commitDisabledNoHistory": "This session has no conversation history yet.",
+            "noNewChanges": "{status}. No new changes to commit.",
+            "privateExistingCommits": "Session is private. Existing knowledge commits remain unchanged.",
+            "privateExcluded": "Session is private and will not be committed to knowledge.",
+            "includedInRepo": "Session is included in knowledge commits to your repo.",
+            "badges": {
+                "excluded": "Excluded",
+                "missing": "Missing",
+                "outdated": "Outdated",
+                "upToDate": "Up to Date"
+            }
+        },
+        "mobile": {
+            "details": "Details",
+            "done": "Done"
+        }
+    },
+    "message": {
+        "copy": "Copy message",
+        "copied": "Copied",
+        "codeBlock": {
+            "copy": "Copy code",
+            "copied": "Copied"
+        },
+        "thinking": {
+            "streaming": "thinking",
+            "complete": "thought"
+        },
+        "thinkingMeta": {
+            "durationStreaming": "for {duration}",
+            "durationComplete": "for {duration}",
+            "reasoning": "{count} tokens"
+        },
+        "actions": {
+            "fork": "Fork session from here",
+            "retry": "Retry turn",
+            "reset": "Reset conversation to after this turn"
+        },
+        "finalStatus": {
+            "status": {
+                "success": "success",
+                "warning": "warning"
+            },
+            "notice": "The agent has ended its task with a {status} message. The session is now read-only, but you can fork it to continue chatting."
+        }
+    },
+    "jobs": {
+        "settingsSections": "Settings sections",
+        "savedJobs": "Saved Jobs",
+        "loading": "Loading jobs...",
+        "paused": "Paused",
+        "unattendedTooltip": "Unattended sessions cannot escalate tool calls",
+        "confirmDelete": "Delete job {name}?",
+        "summary": {
+            "onDemandOnly": "On-demand only",
+            "cronTriggerCount": "{count, plural, one {# cron trigger} other {# cron triggers}}"
+        },
+        "validation": {
+            "idRequired": "Job ID is required.",
+            "nameRequired": "Job name is required.",
+            "promptRequired": "Prompt is required.",
+            "persistentSessionIdRequired": "Select a persistent session ID or disable the option.",
+            "persistentSessionMustBeAttended": "Persistent-session jobs must be attended.",
+            "sessionModesRequireFreshSession": "Session modes require a fresh session.",
+            "modelOverridesRequireFreshSession": "Model overrides require a fresh session.",
+            "askAndYoloMutuallyExclusive": "Read-only mode and YOLO are mutually exclusive.",
+            "cronEmpty": "Cron expressions must not be empty.",
+            "cronInvalid": "Cron expression is invalid: {expression}."
+        },
+        "cron": {
+            "invalidExpression": "Invalid cron expression."
+        },
+        "triggerKind": {
+            "scheduled": "Scheduled",
+            "manual": "Manual"
+        },
+        "errors": {
+            "load": "Failed to load jobs.",
+            "refresh": "Failed to refresh jobs.",
+            "save": "Failed to save job.",
+            "delete": "Failed to delete job.",
+            "run": "Failed to run job.",
+            "saveBeforeRun": "Save the job before running it.",
+            "saveChangesBeforeRun": "Save job changes before running it."
+        },
+        "notices": {
+            "refreshed": "Jobs refreshed.",
+            "created": "Job created.",
+            "saved": "Job saved.",
+            "deleted": "Job deleted.",
+            "runStartedNewSession": "Run started in new session {sessionId}.",
+            "runStartedSession": "Run started in session {sessionId}."
+        },
+        "actions": {
+            "refresh": "Refresh jobs",
+            "new": "New job",
+            "clear": "Clear",
+            "clearPersistentSession": "Clear persistent session",
+            "delete": "Delete",
+            "save": "Save",
+            "addTrigger": "Add trigger",
+            "remove": "Remove",
+            "runNow": "Run now"
+        },
+        "empty": {
+            "noJobs": "No jobs yet. Create one to store prompts and optional cron schedules in jobs.yaml."
+        },
+        "editor": {
+            "newJob": "New job",
+            "editing": "Editing {name}",
+            "jobFallback": "job"
+        },
+        "fields": {
+            "name": "Name",
+            "jobId": "Job ID",
+            "enabled": "Enabled",
+            "enabledHelp": "Paused jobs stay in jobs.yaml but never run from cron.",
+            "newSession": "Options",
+            "newSessionHelp": "These options only apply to fresh sessions created by this job.",
+            "unattended": "Run unattended",
+            "unattendedHelp": "Tool calls will not be escalated to you.",
+            "persistentSession": "Persistent Session",
+            "persistentSessionToggleHelp": "Reuse an existing session instead of starting a fresh one each run.",
+            "persistentSessionDisabled": "Can't be used in unattended mode",
+            "persistentSessionUncheckedHelp": "Enable this option to choose an existing session ID below.",
+            "persistentSessionMissingIdHelp": "Enabled, but no session ID selected yet. Choose an existing session below.",
+            "persistentSessionHelp": "Reuse an existing session instead of creating a new one on every job invocation.",
+            "persistentSessionActiveHelp": "Active: this session ID overrides the fresh-session options above.",
+            "models": "Models",
+            "modelsHelp": "Optional per-job overrides for fresh sessions created by this job.",
+            "modelsDisabled": "Persistent sessions keep their own model selection.",
+            "modelsLinked": "Models linked",
+            "modelsLinkedHelp": "Linked: changing either model updates both.",
+            "modelsUnlinked": "Models unlinked",
+            "modelsUnlinkedHelp": "Unlinked: agent and sentinel models can be changed independently.",
+            "agentModel": "Agent",
+            "sentinelModel": "Sentinel",
+            "titleModel": "Title Model",
+            "prompt": "Prompt",
+            "expression": "Expression",
+            "timeZone": "Time Zone",
+            "inputOptional": "Input (Optional)"
+        },
+        "placeholders": {
+            "name": "Nightly inbox review",
+            "jobId": "nightly-inbox-review",
+            "persistentSession": "select session ID",
+            "prompt": "Summarize new tasks, triage urgent items, then propose next actions.",
+            "model": "Leave empty for default"
+        },
+        "sections": {
+            "cronTriggers": "Cron Triggers",
+            "cronTriggersDescription": "Leave empty for on-demand jobs.",
+            "noTriggers": "No cron triggers configured.",
+            "runJob": "Run Job",
+            "previousInvocations": "Previous Invocations",
+            "previousInvocationsDescription": "Select an invocation to open its session.",
+            "saveToViewHistory": "Save this job to view invocation history.",
+            "noInvocations": "No invocations yet. Refresh sessions to load newly completed runs.",
+            "ranAt": "Ran at {timestamp}"
+        }
+    },
+    "sidebar": {
+        "time": {
+            "justNow": "just now"
+        },
+        "messageCount": "{count, plural, one {# message} other {# messages}}",
+        "unattendedSession": "Unattended session",
+        "privateSession": "Private session",
+        "knowledgeCommitted": "All changes committed to knowledge",
+        "actions": {
+            "pin": "Pin session",
+            "unpin": "Unpin session",
+            "favorite": "Favorite session",
+            "unfavorite": "Remove favorite",
+            "archive": "Archive session",
+            "unarchive": "Unarchive session",
+            "delete": "Delete session",
+            "deleteEmpty": "Delete empty session",
+            "shiftSkip": "Shift+click to skip confirmation"
+        },
+        "confirm": {
+            "deleteSession": "Delete this session? Chat history and sandbox state will be removed.",
+            "deleteUnpushed": "This session has {count, plural, one {# commit} other {# commits}} not yet pushed to your knowledge repo. Deleting it will discard them. Delete anyway?",
+            "archiveSession": "Archive this session? It will leave the default list, reset its sandbox, and stay in the knowledge repo."
+        },
+        "sections": {
+            "today": "Today",
+            "yesterday": "Yesterday",
+            "last7Days": "Last 7 Days",
+            "last30Days": "Last 30 Days",
+            "archived": "Archived",
+            "unknownDate": "Unknown Date"
+        },
+        "empty": "No sessions yet",
+        "loadingMore": "Loading more sessions"
+    },
+    "git": {
+        "upToDate": "Up to date",
+        "noRemote": "No remote configured",
+        "sandbox": {
+            "label": "Workspace sync",
+            "help": "Sync between this session's sandbox workspace and your knowledge repository on the server. Counts show commits this workspace is ahead (↑) and behind (↓) the server repo.",
+            "notRunning": "Sandbox not running",
+            "refresh": "Re-check the workspace against the server repository (fetches first)",
+            "pull": "Pull commits from the server repository into this workspace",
+            "push": "Push this workspace's commits to the server repository (each push is reviewed by the sentinel)"
+        },
+        "global": {
+            "label": "Knowledge remote",
+            "help": "Sync between your knowledge repository on the server and its external git remote. Counts show commits the server repo is ahead (↑) and behind (↓) the remote.",
+            "indicatorBehind": "{count, plural, one {# commit} other {# commits}} to pull from the knowledge remote",
+            "refresh": "Re-check the server repository against the remote (fetches first)",
+            "pull": "Pull commits from the external remote into the server repository",
+            "push": "Push the server repository's commits to the external remote"
+        },
+        "denied": "Push denied",
+        "errors": {
+            "status": "Could not read git status",
+            "pull": "Pull failed",
+            "push": "Push failed"
+        }
+    },
+    "apiKeys": {
+        "title": "API Keys",
+        "description": "Create long-lived tokens for scripts and integrations. Use them as 'Authorization: Bearer <token>'.",
+        "create": {
+            "nameLabel": "Name",
+            "namePlaceholder": "e.g. CI deploy bot",
+            "scopesLabel": "Scopes",
+            "expiryLabel": "Expires after (days)",
+            "expiryPlaceholder": "Leave empty for no expiry",
+            "submit": "Create key",
+            "creating": "Creating…"
+        },
+        "access": {
+            "none": "None",
+            "read": "Read",
+            "write": "Write"
+        },
+        "scopes": {
+            "sessions": "Sessions",
+            "jobs": "Jobs",
+            "preferences": "Preferences",
+            "notifications": "Notifications",
+            "history": "History",
+            "admin": "Admin"
+        },
+        "secret": {
+            "warning": "Copy this token now — it won't be shown again.",
+            "copy": "Copy token",
+            "done": "Done"
+        },
+        "list": {
+            "title": "Active keys",
+            "empty": "No API keys yet.",
+            "loading": "Loading keys…",
+            "unnamed": "Unnamed key",
+            "expired": "Expired"
+        },
+        "fields": {
+            "created": "Created {timestamp}",
+            "lastUsed": "Last used {timestamp}",
+            "expires": "Expires {timestamp}",
+            "never": "never",
+            "noExpiry": "no expiry"
+        },
+        "actions": {
+            "revoke": "Revoke key"
+        },
+        "confirm": {
+            "revoke": "Revoke API key \"{name}\"? This cannot be undone."
+        },
+        "errors": {
+            "load": "Failed to load API keys.",
+            "create": "Failed to create API key.",
+            "revoke": "Failed to revoke API key.",
+            "noScopes": "Select at least one scope."
+        }
     }
-  },
-  "platformSettings": {
-    "status": {
-      "loading": "Loading platform settings",
-      "unavailable": "Platform settings are unavailable",
-      "readOnly": "Config file is read-only."
-    },
-    "notices": {
-      "saved": "Saved."
-    },
-    "errors": {
-      "load": "Failed to load platform settings",
-      "save": "Failed to update platform settings",
-      "wholeNumber": "{field} must be a positive whole number.",
-      "nonNegativeWholeNumber": "{field} must be a non-negative whole number.",
-      "number": "{field} must be a non-negative number.",
-      "providerRequired": "Provider is required for model {index}.",
-      "nameRequired": "Name is required for model {index}.",
-      "duplicateModel": "Model id {id} is used more than once.",
-      "rawSecretRequired": "Paste an API key for {id}, or choose another secret source.",
-      "secretValueRequired": "Secret reference is required for {id}.",
-      "defaultRequired": "{field} default model is required.",
-      "defaultUnknown": "{field} default model {id} is not in the catalog."
-    },
-    "sections": {
-      "defaultModels": "Default models",
-      "defaultBudgets": "Default budgets",
-      "catalog": "Model catalog"
-    },
-    "fields": {
-      "agent": "Agent",
-      "sentinel": "Sentinel",
-      "title": "Title",
-      "inputTokens": "Input tokens",
-      "outputTokens": "Output tokens",
-      "costUsd": "Cost USD",
-      "toolCalls": "Tool calls",
-      "provider": "Provider",
-      "name": "Name",
-      "id": "ID",
-      "maxInputTokens": "Max input tokens",
-      "thinking": "Thinking",
-      "thinkingBudgetTokens": "Thinking budget tokens",
-      "baseUrl": "Base URL",
-      "vision": "Vision",
-      "visionHint": "Accepts image input",
-      "apiKeySource": "API key source",
-      "apiKey": "API key",
-      "secretReference": "Secret reference"
-    },
-    "placeholders": {
-      "selectModel": "Select model",
-      "unlimited": "Unlimited",
-      "generatedId": "provider:name",
-      "keepSecret": "Keep configured secret"
-    },
-    "actions": {
-      "save": "Save",
-      "saving": "Saving",
-      "addModel": "Add model",
-      "removeModel": "Remove model",
-      "confirmRemoveModel": "Remove model \"{name}\"? This cannot be undone."
-    },
-    "secretSources": {
-      "none": "None",
-      "raw": "Raw value",
-      "env": "Environment variable",
-      "file": "File"
-    },
-    "thinking": {
-      "default": "Default",
-      "true": "Enabled",
-      "false": "Disabled",
-      "minimal": "Minimal",
-      "low": "Low",
-      "medium": "Medium",
-      "high": "High",
-      "xhigh": "Extra high"
-    },
-    "units": {
-      "tokens": "tokens"
-    },
-    "modelRow": "Model {index}"
-  },
-  "home": {
-    "empty": {
-      "description": "Select a session or start a new one"
-    }
-  },
-  "connect": {
-    "description": "Sign in to carapace",
-    "serverLabel": "Server URL",
-    "usernameLabel": "Username",
-    "usernamePlaceholder": "Username",
-    "passwordLabel": "Password",
-    "passwordPlaceholder": "Password",
-    "connect": "Connect",
-    "connecting": "Connecting…",
-    "errors": {
-      "serverError": "Server error: {status}",
-      "connectionFailed": "Connection failed"
-    }
-  },
-  "admin": {
-    "title": "Admin",
-    "backToApp": "Back to app",
-    "serverLabel": "Server URL",
-    "serverPlaceholder": "No server selected",
-    "users": {
-      "title": "Users",
-      "description": "Global platform accounts, roles, and data ownership.",
-      "savedUsers": "Users",
-      "loading": "Loading users…",
-      "empty": "No users found",
-      "selectUser": "Select a user",
-      "you": "You",
-      "admin": "Admin",
-      "enabled": "Enabled",
-      "disabled": "Disabled"
-    },
-    "create": {
-      "title": "New user",
-      "subtitle": "Create a local user"
-    },
-    "fields": {
-      "username": "Username",
-      "password": "Password",
-      "newPassword": "New password",
-      "keepPassword": "Keep current password",
-      "displayName": "Display name",
-      "email": "Email",
-      "roles": "Roles",
-      "enabled": "Enabled"
-    },
-    "actions": {
-      "load": "Load",
-      "loading": "Loading…",
-      "refresh": "Refresh users",
-      "new": "New user",
-      "deleteUser": "Delete {username}",
-      "create": "Create user",
-      "creating": "Creating…",
-      "save": "Save changes",
-      "saving": "Saving…"
-    },
-    "notices": {
-      "loaded": "Users loaded.",
-      "created": "Created {username}.",
-      "saved": "Saved {username}.",
-      "deleted": "Deleted {username}."
-    },
-    "errors": {
-      "missingCredentials": "Current origin is unavailable.",
-      "load": "Failed to load users.",
-      "create": "Failed to create user.",
-      "save": "Failed to save user.",
-      "delete": "Failed to delete user."
-    },
-    "confirm": {
-      "deleteUser": "Delete {username}? Existing data owned by this user is not deleted."
-    },
-    "meta": {
-      "tokenVersion": "Token v{version}",
-      "updated": "Updated {timestamp}",
-      "lastLogin": "Last login {timestamp}",
-      "never": "never"
-    }
-  },
-  "preferences": {
-    "title": "Preferences",
-    "description": "Personal settings for this browser and your account experience.",
-    "currentLocale": "Current interface language: {locale}",
-    "language": {
-      "label": "Language",
-      "description": "Choose how the interface language is resolved.",
-      "options": {
-        "system": "System",
-        "en": "English",
-        "de": "Deutsch"
-      }
-    },
-    "theme": {
-      "label": "Appearance",
-      "description": "Choose how the color theme is resolved.",
-      "options": {
-        "system": "System",
-        "light": "Light",
-        "dark": "Dark"
-      }
-    },
-    "chatList": {
-      "label": "Chats",
-      "showArchived": {
-        "label": "Show archived chats",
-        "description": "When disabled, archived chats are hidden and session list requests exclude them."
-      }
-    },
-    "notifications": {
-      "title": "Push notifications",
-      "description": "Deliver escalations and turn outcomes to this browser or installed PWA.",
-      "status": {
-        "loading": "Checking notification support…",
-        "loadingShort": "Checking",
-        "enabled": "Notifications are enabled for this browser.",
-        "enabledShort": "Enabled",
-        "disabled": "Notifications are off for this browser.",
-        "disabledShort": "Off",
-        "unsupported": "This browser cannot receive Web Push notifications in the current context.",
-        "permissionDenied": "Browser notification permission is blocked. Re-enable it in browser or device settings.",
-        "permissionRequired": "Notification permission was not granted.",
-        "invalidSubscription": "Browser returned an incomplete push subscription.",
-        "loadFailed": "Failed to load notification settings.",
-        "enableFailed": "Failed to enable notifications.",
-        "disableFailed": "Failed to disable notifications.",
-        "preferencesFailed": "Failed to update notification preferences.",
-        "testFailed": "Failed to send test notification.",
-        "testSent": "Test notification sent."
-      },
-      "deviceName": {
-        "label": "Device name",
-        "placeholder": "Android phone",
-        "hint": "Shown in server-side notification subscriptions for this browser."
-      },
-      "toggle": {
-        "label": "Notifications"
-      },
-      "actions": {
-        "enable": "Enable notifications",
-        "enabling": "Enabling…",
-        "disable": "Disable notifications",
-        "disabling": "Disabling…",
-        "test": "Send test notification",
-        "testing": "Sending test notification…"
-      },
-      "preferences": {
-        "label": "Send notifications for",
-        "escalation_pending": "Escalations that need approval",
-        "attended_turn_completed": "Attended sessions when a turn finishes",
-        "unattended_turn_completed": "Unattended jobs that finish successfully",
-        "unattended_turn_failed": "Unattended jobs that fail"
-      },
-      "meta": {
-        "permission": "Browser permission: {permission}",
-        "heartbeat": "Last heartbeat: {timestamp}",
-        "expires": "Subscription expires: {timestamp}"
-      },
-      "permission": {
-        "default": "not requested",
-        "granted": "granted",
-        "denied": "denied"
-      }
-    }
-  },
-  "newSessionButton": {
-    "label": "New session",
-    "chooseOptions": "Choose session options",
-    "private": {
-      "enabledTitle": "Private",
-      "enabledDescription": "Exclude this session from knowledge commits.",
-      "disabledTitle": "Saved",
-      "disabledDescription": "Can be included in knowledge commits."
-    },
-    "ask": {
-      "enabledTitle": "Read-Only Mode",
-      "enabledDescription": "Read-only outside sandbox. External writes are blocked.",
-      "disabledTitle": "Read and Write Access",
-      "disabledDescription": "Normal permissions. External writes are allowed."
-    },
-    "yolo": {
-      "enabledTitle": "YOLO",
-      "enabledDescription": "Disable sentinel review and allow operations immediately.",
-      "disabledTitle": "Reviewed",
-      "disabledDescription": "Keep actions gated by safe-list and sentinel review."
-    },
-    "unattended": {
-      "enabledTitle": "Unattended",
-      "enabledDescription": "Runs on its own with no user approval path.",
-      "disabledTitle": "With Approval",
-      "disabledDescription": "Stays interactive with a user approval path."
-    }
-  },
-  "chatInput": {
-    "disabled": "Input disabled",
-    "sendMessageTooltip": "Send message (Enter)",
-    "queueInterruptStopTooltip": "Enter to queue · ⌥Enter to interrupt · Click to stop",
-    "stopGenerationTooltip": "Stop generation",
-    "queued": "Queued: {message}",
-    "startVoiceInput": "Start voice input",
-    "stopVoiceInput": "Stop voice input",
-    "attachFile": "Attach file",
-    "attachFileUnavailable": "Start the sandbox to upload files",
-    "startingSandbox": "Starting sandbox…",
-    "removeAttachment": "Remove",
-    "placeholder": "Message carapace…",
-    "usageBreakdown": {
-      "systemLine": "system: {percent}%",
-      "userLine": "user: {percent}%",
-      "assistantLine": "assistant: {percent}%",
-      "toolCallsLine": "tool calls: {percent}%",
-      "toolOutputsLine": "tool outputs: {percent}%",
-      "otherLine": "other: {percent}%"
-    },
-    "context": {
-      "limit": "Context limit: {tokens} tokens.",
-      "assumedLimit": "Assuming a {tokens} context limit.",
-      "lastRequestTokens": "{tokens} API tokens (last agent request)",
-      "clickForUsage": "Click to send /usage to the agent for more details.",
-      "tokensLabel": "{tokens} tokens"
-    },
-    "budget": {
-      "budgetLabel": "{label} budget",
-      "current": "Current: {value}",
-      "max": "Max: {value}",
-      "remaining": "Remaining: {value}",
-      "exhausted": "Budget exhausted."
-    }
-  },
-  "approval": {
-    "general": {
-      "title": "Approval Required",
-      "toolLabel": "Tool:",
-      "reasonLabel": "Reason:",
-      "riskLabel": "Risk:",
-      "arguments": "Arguments",
-      "allow": "Approve",
-      "denyPlaceholder": "Why should this be blocked?",
-      "risk": {
-        "high": "high",
-        "medium": "medium",
-        "low": "low"
-      }
-    },
-    "denialNote": {
-      "deny": "Deny",
-      "optionalNote": "Optional note for the agent",
-      "addNote": "Add note",
-      "hideNote": "Hide note"
-    },
-    "credential": {
-      "title": "Credential Request",
-      "skillLabel": "Skill:",
-      "allow": "Allow",
-      "denyPlaceholder": "Why should this credential access be blocked?",
-      "decision": {
-        "allow": "Allowed",
-        "deny": "Denied"
-      }
-    },
-    "domainAccess": {
-      "title": "Domain Access Request",
-      "domainLabel": "Domain:",
-      "triggeredByLabel": "Triggered by:",
-      "allow": "Allow {domain}",
-      "denyPlaceholder": "Why should this be blocked?",
-      "decision": {
-        "allow": "Allowed",
-        "deny": "Denied"
-      }
-    },
-    "gitPush": {
-      "title": "Git Push Request",
-      "refLabel": "Ref:",
-      "reasonLabel": "Reason:",
-      "changedFiles": "{count, plural, one {# changed file} other {# changed files}}",
-      "allow": "Allow Push",
-      "denyPlaceholder": "Why should this push be blocked?",
-      "decision": {
-        "allow": "Allowed",
-        "deny": "Denied"
-      }
-    }
-  },
-  "versionBadge": {
-    "frontend": "Frontend: {version}",
-    "backend": "Backend: {version}",
-    "unknown": "unknown",
-    "mismatchTooltip": "Version mismatch between frontend and backend containers.",
-    "mismatchSr": "Frontend and backend versions do not match."
-  },
-  "toolCallBadge": {
-    "approvalBadge": {
-      "review": "review",
-      "skill": "skill",
-      "bypass": "bypass",
-      "denied": "denied"
-    },
-    "fallbacks": {
-      "missingPath": "(missing path)",
-      "missingCommand": "(missing command)",
-      "missingSkillName": "(missing skill_name)",
-      "credential": "credential"
-    },
-    "labels": {
-      "read": "read",
-      "wrote": "wrote",
-      "replaced": "replaced",
-      "activatedSkill": "activated skill",
-      "executed": "executed",
-      "listedCredentials": "listed credentials",
-      "credentialDenied": "credential denied",
-      "accessedCredential": "accessed credential",
-      "domainDenied": "domain denied",
-      "accessedDomain": "accessed domain",
-      "gitPush": "git push",
-      "readAction": "read",
-      "write": "write",
-      "activateSkill": "activate skill",
-      "execute": "execute",
-      "listCredentials": "list credentials",
-      "accessCredential": "access credential",
-      "accessDomain": "access domain",
-      "replace": "replace",
-      "sentFile": "sent file",
-      "sendFile": "send file"
-    },
-    "summaries": {
-      "readFirstLines": "first {count} lines of {path}",
-      "readLinesRange": "lines {start} to {end} of {path}",
-      "writeLines": "{count} lines to {path}",
-      "lineCount": "{count} lines",
-      "lineCountWithReplacement": "{source} lines with {replacement} lines",
-      "replaceInPath": "{lineSummary} in {path}{suffix}",
-      "allMatchesSuffix": " (all matches)"
-    },
-    "details": {
-      "activateSkillPromptPrefix": "Agent wants to activate the",
-      "activateSkillPromptSuffix": "skill.",
-      "sentinelLabel": "Sentinel:",
-      "sentinelReviewing": "Reviewing this tool call.",
-      "userLabel": "User:",
-      "deniedByUser": "Denied by user.",
-      "contexts": "Contexts:",
-      "domains": "Domains:",
-      "credentials": "Credentials",
-      "name": "Name",
-      "path": "Path",
-      "description": "Description",
-      "activation": "Activation",
-      "skillInstructions": "Skill Instructions",
-      "source": "Source",
-      "replacement": "Replacement",
-      "diff": "Diff",
-      "arguments": "Arguments",
-      "result": "Result"
-    }
-  },
-  "commandResult": {
-    "help": {
-      "command": "Command",
-      "description": "Description"
-    },
-    "rules": {
-      "id": "ID",
-      "trigger": "Trigger",
-      "mode": "Mode",
-      "status": {
-        "label": "Status",
-        "disabled": "disabled",
-        "alwaysOn": "always-on",
-        "activated": "activated"
-      }
-    },
-    "models": {
-      "type": "Type",
-      "model": "Model",
-      "default": "Default",
-      "available": "Available:",
-      "provider": "Type",
-      "name": "Name",
-      "context": "Context",
-      "contextWindow": "({tokens} ctx)",
-      "contextWindowShort": "{tokens} ctx",
-      "noneAvailable": "No models available.",
-      "noMatches": "No matching models.",
-      "filterPlaceholder": "Filter models...",
-      "currentLabel": "Current model:",
-      "defaultLabel": "Default: {model}"
-    },
-    "usage": {
-      "none": "No token usage recorded yet.",
-      "total": "Total: {total} tokens ({input} in + {output} out)",
-      "toolCalls": "Tool Calls: {count}",
-      "byModel": "By Model",
-      "byCategory": "By Category",
-      "context": "Context",
-      "table": {
-        "source": "Source",
-        "input": "Input",
-        "output": "Output",
-        "cacheRead": "Cache Read",
-        "cacheWrite": "Cache Write",
-        "requests": "Requests",
-        "cost": "Cost"
-      },
-      "contextTable": {
-        "source": "Source",
-        "tokens": "Tokens",
-        "system": "System %",
-        "user": "User %",
-        "assistant": "Assistant %",
-        "toolCalls": "Tool Calls %",
-        "toolOutputs": "Tool Outputs %",
-        "other": "Other %"
-      }
-    },
-    "budget": {
-      "none": "No session budgets configured.",
-      "title": "Session Budgets",
-      "table": {
-        "metric": "Metric",
-        "current": "Current",
-        "limit": "Limit",
-        "remaining": "Remaining",
-        "used": "Used",
-        "blocked": "blocked"
-      }
-    }
-  },
-  "chatView": {
-    "inputDisabled": {
-      "archived": "Unarchive first",
-      "unattended": "This session is unattended. Fork it first to continue here."
-    },
-    "waiting": {
-      "processingPrompt": "Processing prompt...",
-      "thinking": "Thinking...",
-      "generating": "Generating...",
-      "working": "Working..."
-    },
-    "unknown": "Unknown",
-    "status": {
-      "connecting": "Connecting…",
-      "disconnected": "Disconnected"
-    },
-    "empty": {
-      "start": "Send a message to get started",
-      "connectingSession": "Connecting to session…"
-    },
-    "errors": {
-      "unexpected": "Unexpected error",
-      "resetTarget": "Could not resolve reset target.",
-      "forkTarget": "Could not resolve fork target."
-    },
-    "confirm": {
-      "wipeSandbox": "Wipe the sandbox and its storage for this session? Chat history will stay.",
-      "scaleDownSandbox": "Scale down the sandbox for this session? Storage will be kept.",
-      "deleteSession": "Delete this session? Chat history and sandbox state will be removed.",
-      "archiveSession": "Archive this session? It will leave the default list, reset its sandbox, and stay in the knowledge repo.",
-      "unarchiveSession": "Unarchive this session? It will return to the active session list.",
-      "makePrivate": "Mark this session private? Existing knowledge commits will remain in git history."
-    },
-    "actions": {
-      "pin": "Pin session",
-      "unpin": "Unpin session",
-      "favorite": "Favorite session",
-      "unfavorite": "Remove favorite",
-      "archive": "Archive session",
-      "unarchive": "Unarchive session",
-      "includeInRepo": "Include in repo",
-      "keepPrivate": "Keep private",
-      "delete": "Delete session"
-    },
-    "badges": {
-      "archived": "Archived",
-      "private": "Private",
-      "pinned": "Pinned",
-      "favorite": "Favorite",
-      "askMode": "Read-Only Mode",
-      "yoloMode": "YOLO",
-      "unattended": "Unattended",
-      "interactive": "Interactive"
-    },
-    "inspector": {
-      "actions": "Actions",
-      "session": "Session"
-    },
-    "session": {
-      "title": "Title",
-      "id": "ID",
-      "copyId": "Copy session id",
-      "idCopied": "Copied session id",
-      "idCopiedShort": "Copied",
-      "source": "Source",
-      "created": "Created",
-      "lastActive": "Last active",
-      "messages": "Messages",
-      "totalCost": "Cost",
-      "job": "Job",
-      "reference": "Reference",
-      "modes": "Modes",
-      "askMode": "Read-Only Mode",
-      "askModeHelp": "Only read-only work outside the sandbox. External writes are denied.",
-      "yoloMode": "YOLO Mode",
-      "yoloModeHelp": "Bypass sentinel approval and allow actions immediately.",
-      "savingPrivate": "Saving…",
-      "updatingMode": "Updating mode…"
-    },
-    "source": {
-      "unknown": "Unknown",
-      "job": "Job",
-      "web": "Web",
-      "cli": "CLI"
-    },
-    "jobRun": {
-      "title": "Latest Job Run",
-      "job": "Job",
-      "ranAt": "Ran at",
-      "schedule": "Schedule",
-      "data": "Data",
-      "trigger": {
-        "label": "Trigger",
-        "api": "API",
-        "cron": "Cron",
-        "manual": "Manual"
-      }
-    },
-    "sandbox": {
-      "title": "Sandbox",
-      "refreshing": "Refreshing…",
-      "checking": "Checking sandbox…",
-      "status": {
-        "missing": "Not Started",
-        "running": "Running",
-        "scaled_down": "Spun Down",
-        "pending": "Starting Up",
-        "stopped": "Stopped",
-        "error": "Error"
-      },
-      "actions": {
-        "start": "Start sandbox",
-        "starting": "Starting sandbox",
-        "scaleDown": "Scale down sandbox",
-        "scalingDown": "Scaling down sandbox",
-        "reset": "Reset sandbox"
-      },
-      "storage": {
-        "used": "{size} used",
-        "none": "no sandbox storage",
-        "allocated": "{size} allocated"
-      },
-      "fields": {
-        "id": "Sandbox ID"
-      }
-    },
-    "knowledge": {
-      "title": "Knowledge",
-      "commit": "Commit to repo",
-      "committed": "Committed",
-      "committedToRepo": "Committed to knowledge",
-      "notCommittedYet": "Not committed yet",
-      "savedAt": "Saved {timestamp}",
-      "commitDisabledNoHistory": "This session has no conversation history yet.",
-      "noNewChanges": "{status}. No new changes to commit.",
-      "privateExistingCommits": "Session is private. Existing knowledge commits remain unchanged.",
-      "privateExcluded": "Session is private and will not be committed to knowledge.",
-      "includedInRepo": "Session is included in knowledge commits to your repo.",
-      "badges": {
-        "excluded": "Excluded",
-        "missing": "Missing",
-        "outdated": "Outdated",
-        "upToDate": "Up to Date"
-      }
-    },
-    "mobile": {
-      "details": "Details",
-      "done": "Done"
-    }
-  },
-  "message": {
-    "copy": "Copy message",
-    "copied": "Copied",
-    "codeBlock": {
-      "copy": "Copy code",
-      "copied": "Copied"
-    },
-    "thinking": {
-      "streaming": "thinking",
-      "complete": "thought"
-    },
-    "thinkingMeta": {
-      "durationStreaming": "for {duration}",
-      "durationComplete": "for {duration}",
-      "reasoning": "{count} tokens"
-    },
-    "actions": {
-      "fork": "Fork session from here",
-      "retry": "Retry turn",
-      "reset": "Reset conversation to after this turn"
-    },
-    "finalStatus": {
-      "status": {
-        "success": "success",
-        "warning": "warning"
-      },
-      "notice": "The agent has ended its task with a {status} message. The session is now read-only, but you can fork it to continue chatting."
-    }
-  },
-  "jobs": {
-    "settingsSections": "Settings sections",
-    "savedJobs": "Saved Jobs",
-    "loading": "Loading jobs...",
-    "paused": "Paused",
-    "unattendedTooltip": "Unattended sessions cannot escalate tool calls",
-    "confirmDelete": "Delete job {name}?",
-    "summary": {
-      "onDemandOnly": "On-demand only",
-      "cronTriggerCount": "{count, plural, one {# cron trigger} other {# cron triggers}}"
-    },
-    "validation": {
-      "idRequired": "Job ID is required.",
-      "nameRequired": "Job name is required.",
-      "promptRequired": "Prompt is required.",
-      "persistentSessionIdRequired": "Select a persistent session ID or disable the option.",
-      "persistentSessionMustBeAttended": "Persistent-session jobs must be attended.",
-      "sessionModesRequireFreshSession": "Session modes require a fresh session.",
-      "modelOverridesRequireFreshSession": "Model overrides require a fresh session.",
-      "askAndYoloMutuallyExclusive": "Read-only mode and YOLO are mutually exclusive.",
-      "cronEmpty": "Cron expressions must not be empty.",
-      "cronInvalid": "Cron expression is invalid: {expression}."
-    },
-    "cron": {
-      "invalidExpression": "Invalid cron expression."
-    },
-    "triggerKind": {
-      "scheduled": "Scheduled",
-      "manual": "Manual"
-    },
-    "errors": {
-      "load": "Failed to load jobs.",
-      "refresh": "Failed to refresh jobs.",
-      "save": "Failed to save job.",
-      "delete": "Failed to delete job.",
-      "run": "Failed to run job.",
-      "saveBeforeRun": "Save the job before running it.",
-      "saveChangesBeforeRun": "Save job changes before running it."
-    },
-    "notices": {
-      "refreshed": "Jobs refreshed.",
-      "created": "Job created.",
-      "saved": "Job saved.",
-      "deleted": "Job deleted.",
-      "runStartedNewSession": "Run started in new session {sessionId}.",
-      "runStartedSession": "Run started in session {sessionId}."
-    },
-    "actions": {
-      "refresh": "Refresh jobs",
-      "new": "New job",
-      "clear": "Clear",
-      "clearPersistentSession": "Clear persistent session",
-      "delete": "Delete",
-      "save": "Save",
-      "addTrigger": "Add trigger",
-      "remove": "Remove",
-      "runNow": "Run now"
-    },
-    "empty": {
-      "noJobs": "No jobs yet. Create one to store prompts and optional cron schedules in jobs.yaml."
-    },
-    "editor": {
-      "newJob": "New job",
-      "editing": "Editing {name}",
-      "jobFallback": "job"
-    },
-    "fields": {
-      "name": "Name",
-      "jobId": "Job ID",
-      "enabled": "Enabled",
-      "enabledHelp": "Paused jobs stay in jobs.yaml but never run from cron.",
-      "newSession": "Options",
-      "newSessionHelp": "These options only apply to fresh sessions created by this job.",
-      "unattended": "Run unattended",
-      "unattendedHelp": "Tool calls will not be escalated to you.",
-      "persistentSession": "Persistent Session",
-      "persistentSessionToggleHelp": "Reuse an existing session instead of starting a fresh one each run.",
-      "persistentSessionDisabled": "Can't be used in unattended mode",
-      "persistentSessionUncheckedHelp": "Enable this option to choose an existing session ID below.",
-      "persistentSessionMissingIdHelp": "Enabled, but no session ID selected yet. Choose an existing session below.",
-      "persistentSessionHelp": "Reuse an existing session instead of creating a new one on every job invocation.",
-      "persistentSessionActiveHelp": "Active: this session ID overrides the fresh-session options above.",
-      "models": "Models",
-      "modelsHelp": "Optional per-job overrides for fresh sessions created by this job.",
-      "modelsDisabled": "Persistent sessions keep their own model selection.",
-      "modelsLinked": "Models linked",
-      "modelsLinkedHelp": "Linked: changing either model updates both.",
-      "modelsUnlinked": "Models unlinked",
-      "modelsUnlinkedHelp": "Unlinked: agent and sentinel models can be changed independently.",
-      "agentModel": "Agent",
-      "sentinelModel": "Sentinel",
-      "titleModel": "Title Model",
-      "prompt": "Prompt",
-      "expression": "Expression",
-      "timeZone": "Time Zone",
-      "inputOptional": "Input (Optional)"
-    },
-    "placeholders": {
-      "name": "Nightly inbox review",
-      "jobId": "nightly-inbox-review",
-      "persistentSession": "select session ID",
-      "prompt": "Summarize new tasks, triage urgent items, then propose next actions.",
-      "model": "Leave empty for default"
-    },
-    "sections": {
-      "cronTriggers": "Cron Triggers",
-      "cronTriggersDescription": "Leave empty for on-demand jobs.",
-      "noTriggers": "No cron triggers configured.",
-      "runJob": "Run Job",
-      "previousInvocations": "Previous Invocations",
-      "previousInvocationsDescription": "Select an invocation to open its session.",
-      "saveToViewHistory": "Save this job to view invocation history.",
-      "noInvocations": "No invocations yet. Refresh sessions to load newly completed runs.",
-      "ranAt": "Ran at {timestamp}"
-    }
-  },
-  "sidebar": {
-    "time": {
-      "justNow": "just now"
-    },
-    "messageCount": "{count, plural, one {# message} other {# messages}}",
-    "unattendedSession": "Unattended session",
-    "privateSession": "Private session",
-    "knowledgeCommitted": "All changes committed to knowledge",
-    "actions": {
-      "pin": "Pin session",
-      "unpin": "Unpin session",
-      "favorite": "Favorite session",
-      "unfavorite": "Remove favorite",
-      "archive": "Archive session",
-      "unarchive": "Unarchive session",
-      "delete": "Delete session",
-      "deleteEmpty": "Delete empty session",
-      "shiftSkip": "Shift+click to skip confirmation"
-    },
-    "confirm": {
-      "deleteSession": "Delete this session? Chat history and sandbox state will be removed.",
-      "deleteUnpushed": "This session has {count, plural, one {# commit} other {# commits}} not yet pushed to your knowledge repo. Deleting it will discard them. Delete anyway?",
-      "archiveSession": "Archive this session? It will leave the default list, reset its sandbox, and stay in the knowledge repo."
-    },
-    "sections": {
-      "today": "Today",
-      "yesterday": "Yesterday",
-      "last7Days": "Last 7 Days",
-      "last30Days": "Last 30 Days",
-      "archived": "Archived",
-      "unknownDate": "Unknown Date"
-    },
-    "empty": "No sessions yet",
-    "loadingMore": "Loading more sessions"
-  },
-  "git": {
-    "upToDate": "Up to date",
-    "noRemote": "No remote configured",
-    "sandbox": {
-      "label": "Workspace sync",
-      "help": "Sync between this session's sandbox workspace and your knowledge repository on the server. Counts show commits this workspace is ahead (↑) and behind (↓) the server repo.",
-      "notRunning": "Sandbox not running",
-      "refresh": "Re-check the workspace against the server repository (fetches first)",
-      "pull": "Pull commits from the server repository into this workspace",
-      "push": "Push this workspace's commits to the server repository (each push is reviewed by the sentinel)"
-    },
-    "global": {
-      "label": "Knowledge remote",
-      "help": "Sync between your knowledge repository on the server and its external git remote. Counts show commits the server repo is ahead (↑) and behind (↓) the remote.",
-      "indicatorBehind": "{count, plural, one {# commit} other {# commits}} to pull from the knowledge remote",
-      "refresh": "Re-check the server repository against the remote (fetches first)",
-      "pull": "Pull commits from the external remote into the server repository",
-      "push": "Push the server repository's commits to the external remote"
-    },
-    "denied": "Push denied",
-    "errors": {
-      "status": "Could not read git status",
-      "pull": "Pull failed",
-      "push": "Push failed"
-    }
-  },
-  "apiKeys": {
-    "title": "API Keys",
-    "description": "Create long-lived tokens for scripts and integrations. Use them as 'Authorization: Bearer <token>'.",
-    "create": {
-      "nameLabel": "Name",
-      "namePlaceholder": "e.g. CI deploy bot",
-      "scopesLabel": "Scopes",
-      "expiryLabel": "Expires after (days)",
-      "expiryPlaceholder": "Leave empty for no expiry",
-      "submit": "Create key",
-      "creating": "Creating…"
-    },
-    "access": {
-      "none": "None",
-      "read": "Read",
-      "write": "Write"
-    },
-    "scopes": {
-      "sessions": "Sessions",
-      "jobs": "Jobs",
-      "preferences": "Preferences",
-      "notifications": "Notifications",
-      "history": "History",
-      "admin": "Admin"
-    },
-    "secret": {
-      "warning": "Copy this token now — it won't be shown again.",
-      "copy": "Copy token",
-      "done": "Done"
-    },
-    "list": {
-      "title": "Active keys",
-      "empty": "No API keys yet.",
-      "loading": "Loading keys…",
-      "unnamed": "Unnamed key",
-      "expired": "Expired"
-    },
-    "fields": {
-      "created": "Created {timestamp}",
-      "lastUsed": "Last used {timestamp}",
-      "expires": "Expires {timestamp}",
-      "never": "never",
-      "noExpiry": "no expiry"
-    },
-    "actions": {
-      "revoke": "Revoke key"
-    },
-    "confirm": {
-      "revoke": "Revoke API key \"{name}\"? This cannot be undone."
-    },
-    "errors": {
-      "load": "Failed to load API keys.",
-      "create": "Failed to create API key.",
-      "revoke": "Failed to revoke API key.",
-      "noScopes": "Select at least one scope."
-    }
-  }
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1,997 +1,1054 @@
 {
-    "app": {
-        "name": "carapace",
-        "description": "Security-first personal AI agent"
+  "app": {
+    "name": "carapace",
+    "description": "Security-first personal AI agent"
+  },
+  "navigation": {
+    "home": "Home",
+    "settings": "Settings",
+    "jobs": "Jobs",
+    "account": "Account",
+    "preferences": "Preferences",
+    "platform": "Admin",
+    "models": "Models",
+    "users": "Users",
+    "disconnect": "Disconnect",
+    "github": "thiesgerken/carapace",
+    "apiKeys": "API Keys"
+  },
+  "account": {
+    "menu": "Account menu",
+    "openMenu": "Open account menu",
+    "unknown": "Unknown user",
+    "logout": "Log out"
+  },
+  "accountSettings": {
+    "status": {
+      "loading": "Loading settings",
+      "unavailable": "Settings are unavailable",
+      "configured": "configured",
+      "notSet": "not set"
     },
-    "navigation": {
-        "home": "Home",
-        "settings": "Settings",
-        "jobs": "Jobs",
-        "account": "Account",
-        "preferences": "Preferences",
-        "platform": "Admin",
-        "models": "Models",
-        "users": "Users",
-        "disconnect": "Disconnect",
-        "github": "thiesgerken/carapace"
+    "notices": {
+      "saved": "Saved."
     },
-    "account": {
-        "menu": "Account menu",
-        "openMenu": "Open account menu",
-        "unknown": "Unknown user",
-        "logout": "Log out"
+    "errors": {
+      "load": "Failed to load user settings",
+      "save": "Failed to update user settings",
+      "credentialsInvalid": "Credential backend settings are invalid",
+      "credentialNameRequired": "Credential backend name is required",
+      "credentialNameNoSlash": "Credential backend name {name} must not contain /",
+      "credentialNameDuplicate": "Credential backend name {name} is already used",
+      "fileBackendDisabled": "File credential backends are disabled on this server",
+      "basicAuthUsernameRequired": "Basic Auth username is required for {name}",
+      "basicAuthPasswordRequired": "Basic Auth password is required for {name}",
+      "matrixPasswordRequired": "Matrix password is required when Matrix is enabled",
+      "budgetWholeNumber": "{field} must be a non-negative whole number.",
+      "budgetNumber": "{field} must be a non-negative number."
     },
-    "accountSettings": {
-        "status": {
-            "loading": "Loading settings",
-            "unavailable": "Settings are unavailable",
-            "configured": "configured",
-            "notSet": "not set"
+    "sections": {
+      "defaultModels": "Default models",
+      "defaultBudgets": "Default budgets",
+      "matrix": "Matrix",
+      "credentials": "Credentials",
+      "gitRemote": "Git remote"
+    },
+    "fields": {
+      "agent": "Agent",
+      "sentinel": "Sentinel",
+      "title": "Title",
+      "inputTokens": "Input tokens",
+      "outputTokens": "Output tokens",
+      "costUsd": "Cost USD",
+      "toolCalls": "Tool calls",
+      "enabled": "Enabled",
+      "homeserver": "Homeserver",
+      "userId": "User ID",
+      "deviceName": "Device name",
+      "password": "Password",
+      "allowedRooms": "Allowed rooms",
+      "allowedUsers": "Allowed users",
+      "remote": "Remote",
+      "branch": "Branch",
+      "author": "Author",
+      "token": "Token",
+      "name": "Name",
+      "path": "Path",
+      "url": "URL",
+      "basicAuth": "Basic Auth",
+      "basicAuthUsername": "Basic Auth username",
+      "basicAuthPassword": "Basic Auth password",
+      "expose": "Expose",
+      "hide": "Hide"
+    },
+    "defaults": {
+      "serverDefault": "Server default",
+      "currentModel": "{model}"
+    },
+    "placeholders": {
+      "addRoom": "Add room, Enter or comma",
+      "addUser": "Add user, Enter or comma",
+      "addIdentifier": "Add identifier, Enter or comma"
+    },
+    "tooltips": {
+      "filePath": "Relative paths are resolved from the server working directory.",
+      "expose": "Allow only these credential identifiers from this backend. Leave empty to allow everything except hidden entries.",
+      "hide": "Deny these credential identifiers from this backend. Ignored when Expose is set."
+    },
+    "actions": {
+      "save": "Save",
+      "saving": "Saving",
+      "addBitwarden": "Bitwarden",
+      "addFile": "File",
+      "remove": "Remove",
+      "removeValue": "Remove {value}",
+      "removeBackend": "Remove backend",
+      "removeBackendAria": "Remove {name}"
+    },
+    "empty": {
+      "credentials": "No credential backends configured"
+    },
+    "credentials": {
+      "backendFallback": "credential backend",
+      "types": {
+        "file": {
+          "label": "File",
+          "description": "Local credentials file"
         },
-        "notices": {
-            "saved": "Saved."
-        },
-        "errors": {
-            "load": "Failed to load user settings",
-            "save": "Failed to update user settings",
-            "credentialsInvalid": "Credential backend settings are invalid",
-            "credentialNameRequired": "Credential backend name is required",
-            "credentialNameNoSlash": "Credential backend name {name} must not contain /",
-            "credentialNameDuplicate": "Credential backend name {name} is already used",
-            "fileBackendDisabled": "File credential backends are disabled on this server",
-            "basicAuthUsernameRequired": "Basic Auth username is required for {name}",
-            "basicAuthPasswordRequired": "Basic Auth password is required for {name}",
-            "matrixPasswordRequired": "Matrix password is required when Matrix is enabled",
-            "budgetWholeNumber": "{field} must be a non-negative whole number.",
-            "budgetNumber": "{field} must be a non-negative number."
-        },
-        "sections": {
-            "defaultModels": "Default models",
-            "defaultBudgets": "Default budgets",
-            "matrix": "Matrix",
-            "credentials": "Credentials",
-            "gitRemote": "Git remote"
-        },
-        "fields": {
-            "agent": "Agent",
-            "sentinel": "Sentinel",
-            "title": "Title",
-            "inputTokens": "Input tokens",
-            "outputTokens": "Output tokens",
-            "costUsd": "Cost USD",
-            "toolCalls": "Tool calls",
-            "enabled": "Enabled",
-            "homeserver": "Homeserver",
-            "userId": "User ID",
-            "deviceName": "Device name",
-            "password": "Password",
-            "allowedRooms": "Allowed rooms",
-            "allowedUsers": "Allowed users",
-            "remote": "Remote",
-            "branch": "Branch",
-            "author": "Author",
-            "token": "Token",
-            "name": "Name",
-            "path": "Path",
-            "url": "URL",
-            "basicAuth": "Basic Auth",
-            "basicAuthUsername": "Basic Auth username",
-            "basicAuthPassword": "Basic Auth password",
-            "expose": "Expose",
-            "hide": "Hide"
-        },
-        "defaults": {
-            "serverDefault": "Server default",
-            "currentModel": "{model}"
-        },
-        "placeholders": {
-            "addRoom": "Add room, Enter or comma",
-            "addUser": "Add user, Enter or comma",
-            "addIdentifier": "Add identifier, Enter or comma"
-        },
-        "tooltips": {
-            "filePath": "Relative paths are resolved from the server working directory.",
-            "expose": "Allow only these credential identifiers from this backend. Leave empty to allow everything except hidden entries.",
-            "hide": "Deny these credential identifiers from this backend. Ignored when Expose is set."
-        },
-        "actions": {
-            "save": "Save",
-            "saving": "Saving",
-            "addBitwarden": "Bitwarden",
-            "addFile": "File",
-            "remove": "Remove",
-            "removeValue": "Remove {value}",
-            "removeBackend": "Remove backend",
-            "removeBackendAria": "Remove {name}"
-        },
-        "empty": {
-            "credentials": "No credential backends configured"
-        },
-        "credentials": {
-            "backendFallback": "credential backend",
-            "types": {
-                "file": {
-                    "label": "File",
-                    "description": "Local credentials file"
-                },
-                "bitwarden": {
-                    "label": "Bitwarden",
-                    "description": "Password manager proxy"
-                }
-            }
+        "bitwarden": {
+          "label": "Bitwarden",
+          "description": "Password manager proxy"
         }
-    },
-    "platformSettings": {
-        "status": {
-            "loading": "Loading platform settings",
-            "unavailable": "Platform settings are unavailable",
-            "readOnly": "Config file is read-only."
-        },
-        "notices": {
-            "saved": "Saved."
-        },
-        "errors": {
-            "load": "Failed to load platform settings",
-            "save": "Failed to update platform settings",
-            "wholeNumber": "{field} must be a positive whole number.",
-            "nonNegativeWholeNumber": "{field} must be a non-negative whole number.",
-            "number": "{field} must be a non-negative number.",
-            "providerRequired": "Provider is required for model {index}.",
-            "nameRequired": "Name is required for model {index}.",
-            "duplicateModel": "Model id {id} is used more than once.",
-            "rawSecretRequired": "Paste an API key for {id}, or choose another secret source.",
-            "secretValueRequired": "Secret reference is required for {id}.",
-            "defaultRequired": "{field} default model is required.",
-            "defaultUnknown": "{field} default model {id} is not in the catalog."
-        },
-        "sections": {
-            "defaultModels": "Default models",
-            "defaultBudgets": "Default budgets",
-            "catalog": "Model catalog"
-        },
-        "fields": {
-            "agent": "Agent",
-            "sentinel": "Sentinel",
-            "title": "Title",
-            "inputTokens": "Input tokens",
-            "outputTokens": "Output tokens",
-            "costUsd": "Cost USD",
-            "toolCalls": "Tool calls",
-            "provider": "Provider",
-            "name": "Name",
-            "id": "ID",
-            "maxInputTokens": "Max input tokens",
-            "thinking": "Thinking",
-            "thinkingBudgetTokens": "Thinking budget tokens",
-            "baseUrl": "Base URL",
-            "vision": "Vision",
-            "visionHint": "Accepts image input",
-            "apiKeySource": "API key source",
-            "apiKey": "API key",
-            "secretReference": "Secret reference"
-        },
-        "placeholders": {
-            "selectModel": "Select model",
-            "unlimited": "Unlimited",
-            "generatedId": "provider:name",
-            "keepSecret": "Keep configured secret"
-        },
-        "actions": {
-            "save": "Save",
-            "saving": "Saving",
-            "addModel": "Add model",
-            "removeModel": "Remove model",
-            "confirmRemoveModel": "Remove model \"{name}\"? This cannot be undone."
-        },
-        "secretSources": {
-            "none": "None",
-            "raw": "Raw value",
-            "env": "Environment variable",
-            "file": "File"
-        },
-        "thinking": {
-            "default": "Default",
-            "true": "Enabled",
-            "false": "Disabled",
-            "minimal": "Minimal",
-            "low": "Low",
-            "medium": "Medium",
-            "high": "High",
-            "xhigh": "Extra high"
-        },
-        "units": {
-            "tokens": "tokens"
-        },
-        "modelRow": "Model {index}"
-    },
-    "home": {
-        "empty": {
-            "description": "Select a session or start a new one"
-        }
-    },
-    "connect": {
-        "description": "Sign in to carapace",
-        "serverLabel": "Server URL",
-        "usernameLabel": "Username",
-        "usernamePlaceholder": "Username",
-        "passwordLabel": "Password",
-        "passwordPlaceholder": "Password",
-        "connect": "Connect",
-        "connecting": "Connecting…",
-        "errors": {
-            "serverError": "Server error: {status}",
-            "connectionFailed": "Connection failed"
-        }
-    },
-    "admin": {
-        "title": "Admin",
-        "backToApp": "Back to app",
-        "serverLabel": "Server URL",
-        "serverPlaceholder": "No server selected",
-        "users": {
-            "title": "Users",
-            "description": "Global platform accounts, roles, and data ownership.",
-            "savedUsers": "Users",
-            "loading": "Loading users…",
-            "empty": "No users found",
-            "selectUser": "Select a user",
-            "you": "You",
-            "admin": "Admin",
-            "enabled": "Enabled",
-            "disabled": "Disabled"
-        },
-        "create": {
-            "title": "New user",
-            "subtitle": "Create a local user"
-        },
-        "fields": {
-            "username": "Username",
-            "password": "Password",
-            "newPassword": "New password",
-            "keepPassword": "Keep current password",
-            "displayName": "Display name",
-            "email": "Email",
-            "roles": "Roles",
-            "enabled": "Enabled"
-        },
-        "actions": {
-            "load": "Load",
-            "loading": "Loading…",
-            "refresh": "Refresh users",
-            "new": "New user",
-            "deleteUser": "Delete {username}",
-            "create": "Create user",
-            "creating": "Creating…",
-            "save": "Save changes",
-            "saving": "Saving…"
-        },
-        "notices": {
-            "loaded": "Users loaded.",
-            "created": "Created {username}.",
-            "saved": "Saved {username}.",
-            "deleted": "Deleted {username}."
-        },
-        "errors": {
-            "missingCredentials": "Current origin is unavailable.",
-            "load": "Failed to load users.",
-            "create": "Failed to create user.",
-            "save": "Failed to save user.",
-            "delete": "Failed to delete user."
-        },
-        "confirm": {
-            "deleteUser": "Delete {username}? Existing data owned by this user is not deleted."
-        },
-        "meta": {
-            "tokenVersion": "Token v{version}",
-            "updated": "Updated {timestamp}",
-            "lastLogin": "Last login {timestamp}",
-            "never": "never"
-        }
-    },
-    "preferences": {
-        "title": "Preferences",
-        "description": "Personal settings for this browser and your account experience.",
-        "currentLocale": "Current interface language: {locale}",
-        "language": {
-            "label": "Language",
-            "description": "Choose how the interface language is resolved.",
-            "options": {
-                "system": "System",
-                "en": "English",
-                "de": "Deutsch"
-            }
-        },
-        "theme": {
-            "label": "Appearance",
-            "description": "Choose how the color theme is resolved.",
-            "options": {
-                "system": "System",
-                "light": "Light",
-                "dark": "Dark"
-            }
-        },
-        "chatList": {
-            "label": "Chats",
-            "showArchived": {
-                "label": "Show archived chats",
-                "description": "When disabled, archived chats are hidden and session list requests exclude them."
-            }
-        },
-        "notifications": {
-            "title": "Push notifications",
-            "description": "Deliver escalations and turn outcomes to this browser or installed PWA.",
-            "status": {
-                "loading": "Checking notification support…",
-                "loadingShort": "Checking",
-                "enabled": "Notifications are enabled for this browser.",
-                "enabledShort": "Enabled",
-                "disabled": "Notifications are off for this browser.",
-                "disabledShort": "Off",
-                "unsupported": "This browser cannot receive Web Push notifications in the current context.",
-                "permissionDenied": "Browser notification permission is blocked. Re-enable it in browser or device settings.",
-                "permissionRequired": "Notification permission was not granted.",
-                "invalidSubscription": "Browser returned an incomplete push subscription.",
-                "loadFailed": "Failed to load notification settings.",
-                "enableFailed": "Failed to enable notifications.",
-                "disableFailed": "Failed to disable notifications.",
-                "preferencesFailed": "Failed to update notification preferences.",
-                "testFailed": "Failed to send test notification.",
-                "testSent": "Test notification sent."
-            },
-            "deviceName": {
-                "label": "Device name",
-                "placeholder": "Android phone",
-                "hint": "Shown in server-side notification subscriptions for this browser."
-            },
-            "toggle": {
-                "label": "Notifications"
-            },
-            "actions": {
-                "enable": "Enable notifications",
-                "enabling": "Enabling…",
-                "disable": "Disable notifications",
-                "disabling": "Disabling…",
-                "test": "Send test notification",
-                "testing": "Sending test notification…"
-            },
-            "preferences": {
-                "label": "Send notifications for",
-                "escalation_pending": "Escalations that need approval",
-                "attended_turn_completed": "Attended sessions when a turn finishes",
-                "unattended_turn_completed": "Unattended jobs that finish successfully",
-                "unattended_turn_failed": "Unattended jobs that fail"
-            },
-            "meta": {
-                "permission": "Browser permission: {permission}",
-                "heartbeat": "Last heartbeat: {timestamp}",
-                "expires": "Subscription expires: {timestamp}"
-            },
-            "permission": {
-                "default": "not requested",
-                "granted": "granted",
-                "denied": "denied"
-            }
-        }
-    },
-    "newSessionButton": {
-        "label": "New session",
-        "chooseOptions": "Choose session options",
-        "private": {
-            "enabledTitle": "Private",
-            "enabledDescription": "Exclude this session from knowledge commits.",
-            "disabledTitle": "Saved",
-            "disabledDescription": "Can be included in knowledge commits."
-        },
-        "ask": {
-            "enabledTitle": "Read-Only Mode",
-            "enabledDescription": "Read-only outside sandbox. External writes are blocked.",
-            "disabledTitle": "Read and Write Access",
-            "disabledDescription": "Normal permissions. External writes are allowed."
-        },
-        "yolo": {
-            "enabledTitle": "YOLO",
-            "enabledDescription": "Disable sentinel review and allow operations immediately.",
-            "disabledTitle": "Reviewed",
-            "disabledDescription": "Keep actions gated by safe-list and sentinel review."
-        },
-        "unattended": {
-            "enabledTitle": "Unattended",
-            "enabledDescription": "Runs on its own with no user approval path.",
-            "disabledTitle": "With Approval",
-            "disabledDescription": "Stays interactive with a user approval path."
-        }
-    },
-    "chatInput": {
-        "disabled": "Input disabled",
-        "sendMessageTooltip": "Send message (Enter)",
-        "queueInterruptStopTooltip": "Enter to queue · ⌥Enter to interrupt · Click to stop",
-        "stopGenerationTooltip": "Stop generation",
-        "queued": "Queued: {message}",
-        "startVoiceInput": "Start voice input",
-        "stopVoiceInput": "Stop voice input",
-        "attachFile": "Attach file",
-        "attachFileUnavailable": "Start the sandbox to upload files",
-        "startingSandbox": "Starting sandbox…",
-        "removeAttachment": "Remove",
-        "placeholder": "Message carapace…",
-        "usageBreakdown": {
-            "systemLine": "system: {percent}%",
-            "userLine": "user: {percent}%",
-            "assistantLine": "assistant: {percent}%",
-            "toolCallsLine": "tool calls: {percent}%",
-            "toolOutputsLine": "tool outputs: {percent}%",
-            "otherLine": "other: {percent}%"
-        },
-        "context": {
-            "limit": "Context limit: {tokens} tokens.",
-            "assumedLimit": "Assuming a {tokens} context limit.",
-            "lastRequestTokens": "{tokens} API tokens (last agent request)",
-            "clickForUsage": "Click to send /usage to the agent for more details.",
-            "tokensLabel": "{tokens} tokens"
-        },
-        "budget": {
-            "budgetLabel": "{label} budget",
-            "current": "Current: {value}",
-            "max": "Max: {value}",
-            "remaining": "Remaining: {value}",
-            "exhausted": "Budget exhausted."
-        }
-    },
-    "approval": {
-        "general": {
-            "title": "Approval Required",
-            "toolLabel": "Tool:",
-            "reasonLabel": "Reason:",
-            "riskLabel": "Risk:",
-            "arguments": "Arguments",
-            "allow": "Approve",
-            "denyPlaceholder": "Why should this be blocked?",
-            "risk": {
-                "high": "high",
-                "medium": "medium",
-                "low": "low"
-            }
-        },
-        "denialNote": {
-            "deny": "Deny",
-            "optionalNote": "Optional note for the agent",
-            "addNote": "Add note",
-            "hideNote": "Hide note"
-        },
-        "credential": {
-            "title": "Credential Request",
-            "skillLabel": "Skill:",
-            "allow": "Allow",
-            "denyPlaceholder": "Why should this credential access be blocked?",
-            "decision": {
-                "allow": "Allowed",
-                "deny": "Denied"
-            }
-        },
-        "domainAccess": {
-            "title": "Domain Access Request",
-            "domainLabel": "Domain:",
-            "triggeredByLabel": "Triggered by:",
-            "allow": "Allow {domain}",
-            "denyPlaceholder": "Why should this be blocked?",
-            "decision": {
-                "allow": "Allowed",
-                "deny": "Denied"
-            }
-        },
-        "gitPush": {
-            "title": "Git Push Request",
-            "refLabel": "Ref:",
-            "reasonLabel": "Reason:",
-            "changedFiles": "{count, plural, one {# changed file} other {# changed files}}",
-            "allow": "Allow Push",
-            "denyPlaceholder": "Why should this push be blocked?",
-            "decision": {
-                "allow": "Allowed",
-                "deny": "Denied"
-            }
-        }
-    },
-    "versionBadge": {
-        "frontend": "Frontend: {version}",
-        "backend": "Backend: {version}",
-        "unknown": "unknown",
-        "mismatchTooltip": "Version mismatch between frontend and backend containers.",
-        "mismatchSr": "Frontend and backend versions do not match."
-    },
-    "toolCallBadge": {
-        "approvalBadge": {
-            "review": "review",
-            "skill": "skill",
-            "bypass": "bypass",
-            "denied": "denied"
-        },
-        "fallbacks": {
-            "missingPath": "(missing path)",
-            "missingCommand": "(missing command)",
-            "missingSkillName": "(missing skill_name)",
-            "credential": "credential"
-        },
-        "labels": {
-            "read": "read",
-            "wrote": "wrote",
-            "replaced": "replaced",
-            "activatedSkill": "activated skill",
-            "executed": "executed",
-            "listedCredentials": "listed credentials",
-            "credentialDenied": "credential denied",
-            "accessedCredential": "accessed credential",
-            "domainDenied": "domain denied",
-            "accessedDomain": "accessed domain",
-            "gitPush": "git push",
-            "readAction": "read",
-            "write": "write",
-            "activateSkill": "activate skill",
-            "execute": "execute",
-            "listCredentials": "list credentials",
-            "accessCredential": "access credential",
-            "accessDomain": "access domain",
-            "replace": "replace",
-            "sentFile": "sent file",
-            "sendFile": "send file"
-        },
-        "summaries": {
-            "readFirstLines": "first {count} lines of {path}",
-            "readLinesRange": "lines {start} to {end} of {path}",
-            "writeLines": "{count} lines to {path}",
-            "lineCount": "{count} lines",
-            "lineCountWithReplacement": "{source} lines with {replacement} lines",
-            "replaceInPath": "{lineSummary} in {path}{suffix}",
-            "allMatchesSuffix": " (all matches)"
-        },
-        "details": {
-            "activateSkillPromptPrefix": "Agent wants to activate the",
-            "activateSkillPromptSuffix": "skill.",
-            "sentinelLabel": "Sentinel:",
-            "sentinelReviewing": "Reviewing this tool call.",
-            "userLabel": "User:",
-            "deniedByUser": "Denied by user.",
-            "contexts": "Contexts:",
-            "domains": "Domains:",
-            "credentials": "Credentials",
-            "name": "Name",
-            "path": "Path",
-            "description": "Description",
-            "activation": "Activation",
-            "skillInstructions": "Skill Instructions",
-            "source": "Source",
-            "replacement": "Replacement",
-            "diff": "Diff",
-            "arguments": "Arguments",
-            "result": "Result"
-        }
-    },
-    "commandResult": {
-        "help": {
-            "command": "Command",
-            "description": "Description"
-        },
-        "rules": {
-            "id": "ID",
-            "trigger": "Trigger",
-            "mode": "Mode",
-            "status": {
-                "label": "Status",
-                "disabled": "disabled",
-                "alwaysOn": "always-on",
-                "activated": "activated"
-            }
-        },
-        "models": {
-            "type": "Type",
-            "model": "Model",
-            "default": "Default",
-            "available": "Available:",
-            "provider": "Type",
-            "name": "Name",
-            "context": "Context",
-            "contextWindow": "({tokens} ctx)",
-            "contextWindowShort": "{tokens} ctx",
-            "noneAvailable": "No models available.",
-            "noMatches": "No matching models.",
-            "filterPlaceholder": "Filter models...",
-            "currentLabel": "Current model:",
-            "defaultLabel": "Default: {model}"
-        },
-        "usage": {
-            "none": "No token usage recorded yet.",
-            "total": "Total: {total} tokens ({input} in + {output} out)",
-            "toolCalls": "Tool Calls: {count}",
-            "byModel": "By Model",
-            "byCategory": "By Category",
-            "context": "Context",
-            "table": {
-                "source": "Source",
-                "input": "Input",
-                "output": "Output",
-                "cacheRead": "Cache Read",
-                "cacheWrite": "Cache Write",
-                "requests": "Requests",
-                "cost": "Cost"
-            },
-            "contextTable": {
-                "source": "Source",
-                "tokens": "Tokens",
-                "system": "System %",
-                "user": "User %",
-                "assistant": "Assistant %",
-                "toolCalls": "Tool Calls %",
-                "toolOutputs": "Tool Outputs %",
-                "other": "Other %"
-            }
-        },
-        "budget": {
-            "none": "No session budgets configured.",
-            "title": "Session Budgets",
-            "table": {
-                "metric": "Metric",
-                "current": "Current",
-                "limit": "Limit",
-                "remaining": "Remaining",
-                "used": "Used",
-                "blocked": "blocked"
-            }
-        }
-    },
-    "chatView": {
-        "inputDisabled": {
-            "archived": "Unarchive first",
-            "unattended": "This session is unattended. Fork it first to continue here."
-        },
-        "waiting": {
-            "processingPrompt": "Processing prompt...",
-            "thinking": "Thinking...",
-            "generating": "Generating...",
-            "working": "Working..."
-        },
-        "unknown": "Unknown",
-        "status": {
-            "connecting": "Connecting…",
-            "disconnected": "Disconnected"
-        },
-        "empty": {
-            "start": "Send a message to get started",
-            "connectingSession": "Connecting to session…"
-        },
-        "errors": {
-            "unexpected": "Unexpected error",
-            "resetTarget": "Could not resolve reset target.",
-            "forkTarget": "Could not resolve fork target."
-        },
-        "confirm": {
-            "wipeSandbox": "Wipe the sandbox and its storage for this session? Chat history will stay.",
-            "scaleDownSandbox": "Scale down the sandbox for this session? Storage will be kept.",
-            "deleteSession": "Delete this session? Chat history and sandbox state will be removed.",
-            "archiveSession": "Archive this session? It will leave the default list, reset its sandbox, and stay in the knowledge repo.",
-            "unarchiveSession": "Unarchive this session? It will return to the active session list.",
-            "makePrivate": "Mark this session private? Existing knowledge commits will remain in git history."
-        },
-        "actions": {
-            "pin": "Pin session",
-            "unpin": "Unpin session",
-            "favorite": "Favorite session",
-            "unfavorite": "Remove favorite",
-            "archive": "Archive session",
-            "unarchive": "Unarchive session",
-            "includeInRepo": "Include in repo",
-            "keepPrivate": "Keep private",
-            "delete": "Delete session"
-        },
-        "badges": {
-            "archived": "Archived",
-            "private": "Private",
-            "pinned": "Pinned",
-            "favorite": "Favorite",
-            "askMode": "Read-Only Mode",
-            "yoloMode": "YOLO",
-            "unattended": "Unattended",
-            "interactive": "Interactive"
-        },
-        "inspector": {
-            "actions": "Actions",
-            "session": "Session"
-        },
-        "session": {
-            "title": "Title",
-            "id": "ID",
-            "copyId": "Copy session id",
-            "idCopied": "Copied session id",
-            "idCopiedShort": "Copied",
-            "source": "Source",
-            "created": "Created",
-            "lastActive": "Last active",
-            "messages": "Messages",
-            "totalCost": "Cost",
-            "job": "Job",
-            "reference": "Reference",
-            "modes": "Modes",
-            "askMode": "Read-Only Mode",
-            "askModeHelp": "Only read-only work outside the sandbox. External writes are denied.",
-            "yoloMode": "YOLO Mode",
-            "yoloModeHelp": "Bypass sentinel approval and allow actions immediately.",
-            "savingPrivate": "Saving…",
-            "updatingMode": "Updating mode…"
-        },
-        "source": {
-            "unknown": "Unknown",
-            "job": "Job",
-            "web": "Web",
-            "cli": "CLI"
-        },
-        "jobRun": {
-            "title": "Latest Job Run",
-            "job": "Job",
-            "ranAt": "Ran at",
-            "schedule": "Schedule",
-            "data": "Data",
-            "trigger": {
-                "label": "Trigger",
-                "api": "API",
-                "cron": "Cron",
-                "manual": "Manual"
-            }
-        },
-        "sandbox": {
-            "title": "Sandbox",
-            "refreshing": "Refreshing…",
-            "checking": "Checking sandbox…",
-            "status": {
-                "missing": "Not Started",
-                "running": "Running",
-                "scaled_down": "Spun Down",
-                "pending": "Starting Up",
-                "stopped": "Stopped",
-                "error": "Error"
-            },
-            "actions": {
-                "start": "Start sandbox",
-                "starting": "Starting sandbox",
-                "scaleDown": "Scale down sandbox",
-                "scalingDown": "Scaling down sandbox",
-                "reset": "Reset sandbox"
-            },
-            "storage": {
-                "used": "{size} used",
-                "none": "no sandbox storage",
-                "allocated": "{size} allocated"
-            },
-            "fields": {
-                "id": "Sandbox ID"
-            }
-        },
-        "knowledge": {
-            "title": "Knowledge",
-            "commit": "Commit to repo",
-            "committed": "Committed",
-            "committedToRepo": "Committed to knowledge",
-            "notCommittedYet": "Not committed yet",
-            "savedAt": "Saved {timestamp}",
-            "commitDisabledNoHistory": "This session has no conversation history yet.",
-            "noNewChanges": "{status}. No new changes to commit.",
-            "privateExistingCommits": "Session is private. Existing knowledge commits remain unchanged.",
-            "privateExcluded": "Session is private and will not be committed to knowledge.",
-            "includedInRepo": "Session is included in knowledge commits to your repo.",
-            "badges": {
-                "excluded": "Excluded",
-                "missing": "Missing",
-                "outdated": "Outdated",
-                "upToDate": "Up to Date"
-            }
-        },
-        "mobile": {
-            "details": "Details",
-            "done": "Done"
-        }
-    },
-    "message": {
-        "copy": "Copy message",
-        "copied": "Copied",
-        "codeBlock": {
-            "copy": "Copy code",
-            "copied": "Copied"
-        },
-        "thinking": {
-            "streaming": "thinking",
-            "complete": "thought"
-        },
-        "thinkingMeta": {
-            "durationStreaming": "for {duration}",
-            "durationComplete": "for {duration}",
-            "reasoning": "{count} tokens"
-        },
-        "actions": {
-            "fork": "Fork session from here",
-            "retry": "Retry turn",
-            "reset": "Reset conversation to after this turn"
-        },
-        "finalStatus": {
-            "status": {
-                "success": "success",
-                "warning": "warning"
-            },
-            "notice": "The agent has ended its task with a {status} message. The session is now read-only, but you can fork it to continue chatting."
-        }
-    },
-    "jobs": {
-        "settingsSections": "Settings sections",
-        "savedJobs": "Saved Jobs",
-        "loading": "Loading jobs...",
-        "paused": "Paused",
-        "unattendedTooltip": "Unattended sessions cannot escalate tool calls",
-        "confirmDelete": "Delete job {name}?",
-        "summary": {
-            "onDemandOnly": "On-demand only",
-            "cronTriggerCount": "{count, plural, one {# cron trigger} other {# cron triggers}}"
-        },
-        "validation": {
-            "idRequired": "Job ID is required.",
-            "nameRequired": "Job name is required.",
-            "promptRequired": "Prompt is required.",
-            "persistentSessionIdRequired": "Select a persistent session ID or disable the option.",
-            "persistentSessionMustBeAttended": "Persistent-session jobs must be attended.",
-            "sessionModesRequireFreshSession": "Session modes require a fresh session.",
-            "modelOverridesRequireFreshSession": "Model overrides require a fresh session.",
-            "askAndYoloMutuallyExclusive": "Read-only mode and YOLO are mutually exclusive.",
-            "cronEmpty": "Cron expressions must not be empty.",
-            "cronInvalid": "Cron expression is invalid: {expression}."
-        },
-        "cron": {
-            "invalidExpression": "Invalid cron expression."
-        },
-        "triggerKind": {
-            "scheduled": "Scheduled",
-            "manual": "Manual"
-        },
-        "errors": {
-            "load": "Failed to load jobs.",
-            "refresh": "Failed to refresh jobs.",
-            "save": "Failed to save job.",
-            "delete": "Failed to delete job.",
-            "run": "Failed to run job.",
-            "saveBeforeRun": "Save the job before running it.",
-            "saveChangesBeforeRun": "Save job changes before running it."
-        },
-        "notices": {
-            "refreshed": "Jobs refreshed.",
-            "created": "Job created.",
-            "saved": "Job saved.",
-            "deleted": "Job deleted.",
-            "runStartedNewSession": "Run started in new session {sessionId}.",
-            "runStartedSession": "Run started in session {sessionId}."
-        },
-        "actions": {
-            "refresh": "Refresh jobs",
-            "new": "New job",
-            "clear": "Clear",
-            "clearPersistentSession": "Clear persistent session",
-            "delete": "Delete",
-            "save": "Save",
-            "addTrigger": "Add trigger",
-            "remove": "Remove",
-            "runNow": "Run now"
-        },
-        "empty": {
-            "noJobs": "No jobs yet. Create one to store prompts and optional cron schedules in jobs.yaml."
-        },
-        "editor": {
-            "newJob": "New job",
-            "editing": "Editing {name}",
-            "jobFallback": "job"
-        },
-        "fields": {
-            "name": "Name",
-            "jobId": "Job ID",
-            "enabled": "Enabled",
-            "enabledHelp": "Paused jobs stay in jobs.yaml but never run from cron.",
-            "newSession": "Options",
-            "newSessionHelp": "These options only apply to fresh sessions created by this job.",
-            "unattended": "Run unattended",
-            "unattendedHelp": "Tool calls will not be escalated to you.",
-            "persistentSession": "Persistent Session",
-            "persistentSessionToggleHelp": "Reuse an existing session instead of starting a fresh one each run.",
-            "persistentSessionDisabled": "Can't be used in unattended mode",
-            "persistentSessionUncheckedHelp": "Enable this option to choose an existing session ID below.",
-            "persistentSessionMissingIdHelp": "Enabled, but no session ID selected yet. Choose an existing session below.",
-            "persistentSessionHelp": "Reuse an existing session instead of creating a new one on every job invocation.",
-            "persistentSessionActiveHelp": "Active: this session ID overrides the fresh-session options above.",
-            "models": "Models",
-            "modelsHelp": "Optional per-job overrides for fresh sessions created by this job.",
-            "modelsDisabled": "Persistent sessions keep their own model selection.",
-            "modelsLinked": "Models linked",
-            "modelsLinkedHelp": "Linked: changing either model updates both.",
-            "modelsUnlinked": "Models unlinked",
-            "modelsUnlinkedHelp": "Unlinked: agent and sentinel models can be changed independently.",
-            "agentModel": "Agent",
-            "sentinelModel": "Sentinel",
-            "titleModel": "Title Model",
-            "prompt": "Prompt",
-            "expression": "Expression",
-            "timeZone": "Time Zone",
-            "inputOptional": "Input (Optional)"
-        },
-        "placeholders": {
-            "name": "Nightly inbox review",
-            "jobId": "nightly-inbox-review",
-            "persistentSession": "select session ID",
-            "prompt": "Summarize new tasks, triage urgent items, then propose next actions.",
-            "model": "Leave empty for default"
-        },
-        "sections": {
-            "cronTriggers": "Cron Triggers",
-            "cronTriggersDescription": "Leave empty for on-demand jobs.",
-            "noTriggers": "No cron triggers configured.",
-            "runJob": "Run Job",
-            "previousInvocations": "Previous Invocations",
-            "previousInvocationsDescription": "Select an invocation to open its session.",
-            "saveToViewHistory": "Save this job to view invocation history.",
-            "noInvocations": "No invocations yet. Refresh sessions to load newly completed runs.",
-            "ranAt": "Ran at {timestamp}"
-        }
-    },
-    "sidebar": {
-        "time": {
-            "justNow": "just now"
-        },
-        "messageCount": "{count, plural, one {# message} other {# messages}}",
-        "unattendedSession": "Unattended session",
-        "privateSession": "Private session",
-        "knowledgeCommitted": "All changes committed to knowledge",
-        "actions": {
-            "pin": "Pin session",
-            "unpin": "Unpin session",
-            "favorite": "Favorite session",
-            "unfavorite": "Remove favorite",
-            "archive": "Archive session",
-            "unarchive": "Unarchive session",
-            "delete": "Delete session",
-            "deleteEmpty": "Delete empty session",
-            "shiftSkip": "Shift+click to skip confirmation"
-        },
-        "confirm": {
-            "deleteSession": "Delete this session? Chat history and sandbox state will be removed.",
-            "deleteUnpushed": "This session has {count, plural, one {# commit} other {# commits}} not yet pushed to your knowledge repo. Deleting it will discard them. Delete anyway?",
-            "archiveSession": "Archive this session? It will leave the default list, reset its sandbox, and stay in the knowledge repo."
-        },
-        "sections": {
-            "today": "Today",
-            "yesterday": "Yesterday",
-            "last7Days": "Last 7 Days",
-            "last30Days": "Last 30 Days",
-            "archived": "Archived",
-            "unknownDate": "Unknown Date"
-        },
-        "empty": "No sessions yet",
-        "loadingMore": "Loading more sessions"
-    },
-    "git": {
-        "upToDate": "Up to date",
-        "noRemote": "No remote configured",
-        "sandbox": {
-            "label": "Workspace sync",
-            "help": "Sync between this session's sandbox workspace and your knowledge repository on the server. Counts show commits this workspace is ahead (↑) and behind (↓) the server repo.",
-            "notRunning": "Sandbox not running",
-            "refresh": "Re-check the workspace against the server repository (fetches first)",
-            "pull": "Pull commits from the server repository into this workspace",
-            "push": "Push this workspace's commits to the server repository (each push is reviewed by the sentinel)"
-        },
-        "global": {
-            "label": "Knowledge remote",
-            "help": "Sync between your knowledge repository on the server and its external git remote. Counts show commits the server repo is ahead (↑) and behind (↓) the remote.",
-            "indicatorBehind": "{count, plural, one {# commit} other {# commits}} to pull from the knowledge remote",
-            "refresh": "Re-check the server repository against the remote (fetches first)",
-            "pull": "Pull commits from the external remote into the server repository",
-            "push": "Push the server repository's commits to the external remote"
-        },
-        "denied": "Push denied",
-        "errors": {
-            "status": "Could not read git status",
-            "pull": "Pull failed",
-            "push": "Push failed"
-        }
+      }
     }
+  },
+  "platformSettings": {
+    "status": {
+      "loading": "Loading platform settings",
+      "unavailable": "Platform settings are unavailable",
+      "readOnly": "Config file is read-only."
+    },
+    "notices": {
+      "saved": "Saved."
+    },
+    "errors": {
+      "load": "Failed to load platform settings",
+      "save": "Failed to update platform settings",
+      "wholeNumber": "{field} must be a positive whole number.",
+      "nonNegativeWholeNumber": "{field} must be a non-negative whole number.",
+      "number": "{field} must be a non-negative number.",
+      "providerRequired": "Provider is required for model {index}.",
+      "nameRequired": "Name is required for model {index}.",
+      "duplicateModel": "Model id {id} is used more than once.",
+      "rawSecretRequired": "Paste an API key for {id}, or choose another secret source.",
+      "secretValueRequired": "Secret reference is required for {id}.",
+      "defaultRequired": "{field} default model is required.",
+      "defaultUnknown": "{field} default model {id} is not in the catalog."
+    },
+    "sections": {
+      "defaultModels": "Default models",
+      "defaultBudgets": "Default budgets",
+      "catalog": "Model catalog"
+    },
+    "fields": {
+      "agent": "Agent",
+      "sentinel": "Sentinel",
+      "title": "Title",
+      "inputTokens": "Input tokens",
+      "outputTokens": "Output tokens",
+      "costUsd": "Cost USD",
+      "toolCalls": "Tool calls",
+      "provider": "Provider",
+      "name": "Name",
+      "id": "ID",
+      "maxInputTokens": "Max input tokens",
+      "thinking": "Thinking",
+      "thinkingBudgetTokens": "Thinking budget tokens",
+      "baseUrl": "Base URL",
+      "vision": "Vision",
+      "visionHint": "Accepts image input",
+      "apiKeySource": "API key source",
+      "apiKey": "API key",
+      "secretReference": "Secret reference"
+    },
+    "placeholders": {
+      "selectModel": "Select model",
+      "unlimited": "Unlimited",
+      "generatedId": "provider:name",
+      "keepSecret": "Keep configured secret"
+    },
+    "actions": {
+      "save": "Save",
+      "saving": "Saving",
+      "addModel": "Add model",
+      "removeModel": "Remove model",
+      "confirmRemoveModel": "Remove model \"{name}\"? This cannot be undone."
+    },
+    "secretSources": {
+      "none": "None",
+      "raw": "Raw value",
+      "env": "Environment variable",
+      "file": "File"
+    },
+    "thinking": {
+      "default": "Default",
+      "true": "Enabled",
+      "false": "Disabled",
+      "minimal": "Minimal",
+      "low": "Low",
+      "medium": "Medium",
+      "high": "High",
+      "xhigh": "Extra high"
+    },
+    "units": {
+      "tokens": "tokens"
+    },
+    "modelRow": "Model {index}"
+  },
+  "home": {
+    "empty": {
+      "description": "Select a session or start a new one"
+    }
+  },
+  "connect": {
+    "description": "Sign in to carapace",
+    "serverLabel": "Server URL",
+    "usernameLabel": "Username",
+    "usernamePlaceholder": "Username",
+    "passwordLabel": "Password",
+    "passwordPlaceholder": "Password",
+    "connect": "Connect",
+    "connecting": "Connecting…",
+    "errors": {
+      "serverError": "Server error: {status}",
+      "connectionFailed": "Connection failed"
+    }
+  },
+  "admin": {
+    "title": "Admin",
+    "backToApp": "Back to app",
+    "serverLabel": "Server URL",
+    "serverPlaceholder": "No server selected",
+    "users": {
+      "title": "Users",
+      "description": "Global platform accounts, roles, and data ownership.",
+      "savedUsers": "Users",
+      "loading": "Loading users…",
+      "empty": "No users found",
+      "selectUser": "Select a user",
+      "you": "You",
+      "admin": "Admin",
+      "enabled": "Enabled",
+      "disabled": "Disabled"
+    },
+    "create": {
+      "title": "New user",
+      "subtitle": "Create a local user"
+    },
+    "fields": {
+      "username": "Username",
+      "password": "Password",
+      "newPassword": "New password",
+      "keepPassword": "Keep current password",
+      "displayName": "Display name",
+      "email": "Email",
+      "roles": "Roles",
+      "enabled": "Enabled"
+    },
+    "actions": {
+      "load": "Load",
+      "loading": "Loading…",
+      "refresh": "Refresh users",
+      "new": "New user",
+      "deleteUser": "Delete {username}",
+      "create": "Create user",
+      "creating": "Creating…",
+      "save": "Save changes",
+      "saving": "Saving…"
+    },
+    "notices": {
+      "loaded": "Users loaded.",
+      "created": "Created {username}.",
+      "saved": "Saved {username}.",
+      "deleted": "Deleted {username}."
+    },
+    "errors": {
+      "missingCredentials": "Current origin is unavailable.",
+      "load": "Failed to load users.",
+      "create": "Failed to create user.",
+      "save": "Failed to save user.",
+      "delete": "Failed to delete user."
+    },
+    "confirm": {
+      "deleteUser": "Delete {username}? Existing data owned by this user is not deleted."
+    },
+    "meta": {
+      "tokenVersion": "Token v{version}",
+      "updated": "Updated {timestamp}",
+      "lastLogin": "Last login {timestamp}",
+      "never": "never"
+    }
+  },
+  "preferences": {
+    "title": "Preferences",
+    "description": "Personal settings for this browser and your account experience.",
+    "currentLocale": "Current interface language: {locale}",
+    "language": {
+      "label": "Language",
+      "description": "Choose how the interface language is resolved.",
+      "options": {
+        "system": "System",
+        "en": "English",
+        "de": "Deutsch"
+      }
+    },
+    "theme": {
+      "label": "Appearance",
+      "description": "Choose how the color theme is resolved.",
+      "options": {
+        "system": "System",
+        "light": "Light",
+        "dark": "Dark"
+      }
+    },
+    "chatList": {
+      "label": "Chats",
+      "showArchived": {
+        "label": "Show archived chats",
+        "description": "When disabled, archived chats are hidden and session list requests exclude them."
+      }
+    },
+    "notifications": {
+      "title": "Push notifications",
+      "description": "Deliver escalations and turn outcomes to this browser or installed PWA.",
+      "status": {
+        "loading": "Checking notification support…",
+        "loadingShort": "Checking",
+        "enabled": "Notifications are enabled for this browser.",
+        "enabledShort": "Enabled",
+        "disabled": "Notifications are off for this browser.",
+        "disabledShort": "Off",
+        "unsupported": "This browser cannot receive Web Push notifications in the current context.",
+        "permissionDenied": "Browser notification permission is blocked. Re-enable it in browser or device settings.",
+        "permissionRequired": "Notification permission was not granted.",
+        "invalidSubscription": "Browser returned an incomplete push subscription.",
+        "loadFailed": "Failed to load notification settings.",
+        "enableFailed": "Failed to enable notifications.",
+        "disableFailed": "Failed to disable notifications.",
+        "preferencesFailed": "Failed to update notification preferences.",
+        "testFailed": "Failed to send test notification.",
+        "testSent": "Test notification sent."
+      },
+      "deviceName": {
+        "label": "Device name",
+        "placeholder": "Android phone",
+        "hint": "Shown in server-side notification subscriptions for this browser."
+      },
+      "toggle": {
+        "label": "Notifications"
+      },
+      "actions": {
+        "enable": "Enable notifications",
+        "enabling": "Enabling…",
+        "disable": "Disable notifications",
+        "disabling": "Disabling…",
+        "test": "Send test notification",
+        "testing": "Sending test notification…"
+      },
+      "preferences": {
+        "label": "Send notifications for",
+        "escalation_pending": "Escalations that need approval",
+        "attended_turn_completed": "Attended sessions when a turn finishes",
+        "unattended_turn_completed": "Unattended jobs that finish successfully",
+        "unattended_turn_failed": "Unattended jobs that fail"
+      },
+      "meta": {
+        "permission": "Browser permission: {permission}",
+        "heartbeat": "Last heartbeat: {timestamp}",
+        "expires": "Subscription expires: {timestamp}"
+      },
+      "permission": {
+        "default": "not requested",
+        "granted": "granted",
+        "denied": "denied"
+      }
+    }
+  },
+  "newSessionButton": {
+    "label": "New session",
+    "chooseOptions": "Choose session options",
+    "private": {
+      "enabledTitle": "Private",
+      "enabledDescription": "Exclude this session from knowledge commits.",
+      "disabledTitle": "Saved",
+      "disabledDescription": "Can be included in knowledge commits."
+    },
+    "ask": {
+      "enabledTitle": "Read-Only Mode",
+      "enabledDescription": "Read-only outside sandbox. External writes are blocked.",
+      "disabledTitle": "Read and Write Access",
+      "disabledDescription": "Normal permissions. External writes are allowed."
+    },
+    "yolo": {
+      "enabledTitle": "YOLO",
+      "enabledDescription": "Disable sentinel review and allow operations immediately.",
+      "disabledTitle": "Reviewed",
+      "disabledDescription": "Keep actions gated by safe-list and sentinel review."
+    },
+    "unattended": {
+      "enabledTitle": "Unattended",
+      "enabledDescription": "Runs on its own with no user approval path.",
+      "disabledTitle": "With Approval",
+      "disabledDescription": "Stays interactive with a user approval path."
+    }
+  },
+  "chatInput": {
+    "disabled": "Input disabled",
+    "sendMessageTooltip": "Send message (Enter)",
+    "queueInterruptStopTooltip": "Enter to queue · ⌥Enter to interrupt · Click to stop",
+    "stopGenerationTooltip": "Stop generation",
+    "queued": "Queued: {message}",
+    "startVoiceInput": "Start voice input",
+    "stopVoiceInput": "Stop voice input",
+    "attachFile": "Attach file",
+    "attachFileUnavailable": "Start the sandbox to upload files",
+    "startingSandbox": "Starting sandbox…",
+    "removeAttachment": "Remove",
+    "placeholder": "Message carapace…",
+    "usageBreakdown": {
+      "systemLine": "system: {percent}%",
+      "userLine": "user: {percent}%",
+      "assistantLine": "assistant: {percent}%",
+      "toolCallsLine": "tool calls: {percent}%",
+      "toolOutputsLine": "tool outputs: {percent}%",
+      "otherLine": "other: {percent}%"
+    },
+    "context": {
+      "limit": "Context limit: {tokens} tokens.",
+      "assumedLimit": "Assuming a {tokens} context limit.",
+      "lastRequestTokens": "{tokens} API tokens (last agent request)",
+      "clickForUsage": "Click to send /usage to the agent for more details.",
+      "tokensLabel": "{tokens} tokens"
+    },
+    "budget": {
+      "budgetLabel": "{label} budget",
+      "current": "Current: {value}",
+      "max": "Max: {value}",
+      "remaining": "Remaining: {value}",
+      "exhausted": "Budget exhausted."
+    }
+  },
+  "approval": {
+    "general": {
+      "title": "Approval Required",
+      "toolLabel": "Tool:",
+      "reasonLabel": "Reason:",
+      "riskLabel": "Risk:",
+      "arguments": "Arguments",
+      "allow": "Approve",
+      "denyPlaceholder": "Why should this be blocked?",
+      "risk": {
+        "high": "high",
+        "medium": "medium",
+        "low": "low"
+      }
+    },
+    "denialNote": {
+      "deny": "Deny",
+      "optionalNote": "Optional note for the agent",
+      "addNote": "Add note",
+      "hideNote": "Hide note"
+    },
+    "credential": {
+      "title": "Credential Request",
+      "skillLabel": "Skill:",
+      "allow": "Allow",
+      "denyPlaceholder": "Why should this credential access be blocked?",
+      "decision": {
+        "allow": "Allowed",
+        "deny": "Denied"
+      }
+    },
+    "domainAccess": {
+      "title": "Domain Access Request",
+      "domainLabel": "Domain:",
+      "triggeredByLabel": "Triggered by:",
+      "allow": "Allow {domain}",
+      "denyPlaceholder": "Why should this be blocked?",
+      "decision": {
+        "allow": "Allowed",
+        "deny": "Denied"
+      }
+    },
+    "gitPush": {
+      "title": "Git Push Request",
+      "refLabel": "Ref:",
+      "reasonLabel": "Reason:",
+      "changedFiles": "{count, plural, one {# changed file} other {# changed files}}",
+      "allow": "Allow Push",
+      "denyPlaceholder": "Why should this push be blocked?",
+      "decision": {
+        "allow": "Allowed",
+        "deny": "Denied"
+      }
+    }
+  },
+  "versionBadge": {
+    "frontend": "Frontend: {version}",
+    "backend": "Backend: {version}",
+    "unknown": "unknown",
+    "mismatchTooltip": "Version mismatch between frontend and backend containers.",
+    "mismatchSr": "Frontend and backend versions do not match."
+  },
+  "toolCallBadge": {
+    "approvalBadge": {
+      "review": "review",
+      "skill": "skill",
+      "bypass": "bypass",
+      "denied": "denied"
+    },
+    "fallbacks": {
+      "missingPath": "(missing path)",
+      "missingCommand": "(missing command)",
+      "missingSkillName": "(missing skill_name)",
+      "credential": "credential"
+    },
+    "labels": {
+      "read": "read",
+      "wrote": "wrote",
+      "replaced": "replaced",
+      "activatedSkill": "activated skill",
+      "executed": "executed",
+      "listedCredentials": "listed credentials",
+      "credentialDenied": "credential denied",
+      "accessedCredential": "accessed credential",
+      "domainDenied": "domain denied",
+      "accessedDomain": "accessed domain",
+      "gitPush": "git push",
+      "readAction": "read",
+      "write": "write",
+      "activateSkill": "activate skill",
+      "execute": "execute",
+      "listCredentials": "list credentials",
+      "accessCredential": "access credential",
+      "accessDomain": "access domain",
+      "replace": "replace",
+      "sentFile": "sent file",
+      "sendFile": "send file"
+    },
+    "summaries": {
+      "readFirstLines": "first {count} lines of {path}",
+      "readLinesRange": "lines {start} to {end} of {path}",
+      "writeLines": "{count} lines to {path}",
+      "lineCount": "{count} lines",
+      "lineCountWithReplacement": "{source} lines with {replacement} lines",
+      "replaceInPath": "{lineSummary} in {path}{suffix}",
+      "allMatchesSuffix": " (all matches)"
+    },
+    "details": {
+      "activateSkillPromptPrefix": "Agent wants to activate the",
+      "activateSkillPromptSuffix": "skill.",
+      "sentinelLabel": "Sentinel:",
+      "sentinelReviewing": "Reviewing this tool call.",
+      "userLabel": "User:",
+      "deniedByUser": "Denied by user.",
+      "contexts": "Contexts:",
+      "domains": "Domains:",
+      "credentials": "Credentials",
+      "name": "Name",
+      "path": "Path",
+      "description": "Description",
+      "activation": "Activation",
+      "skillInstructions": "Skill Instructions",
+      "source": "Source",
+      "replacement": "Replacement",
+      "diff": "Diff",
+      "arguments": "Arguments",
+      "result": "Result"
+    }
+  },
+  "commandResult": {
+    "help": {
+      "command": "Command",
+      "description": "Description"
+    },
+    "rules": {
+      "id": "ID",
+      "trigger": "Trigger",
+      "mode": "Mode",
+      "status": {
+        "label": "Status",
+        "disabled": "disabled",
+        "alwaysOn": "always-on",
+        "activated": "activated"
+      }
+    },
+    "models": {
+      "type": "Type",
+      "model": "Model",
+      "default": "Default",
+      "available": "Available:",
+      "provider": "Type",
+      "name": "Name",
+      "context": "Context",
+      "contextWindow": "({tokens} ctx)",
+      "contextWindowShort": "{tokens} ctx",
+      "noneAvailable": "No models available.",
+      "noMatches": "No matching models.",
+      "filterPlaceholder": "Filter models...",
+      "currentLabel": "Current model:",
+      "defaultLabel": "Default: {model}"
+    },
+    "usage": {
+      "none": "No token usage recorded yet.",
+      "total": "Total: {total} tokens ({input} in + {output} out)",
+      "toolCalls": "Tool Calls: {count}",
+      "byModel": "By Model",
+      "byCategory": "By Category",
+      "context": "Context",
+      "table": {
+        "source": "Source",
+        "input": "Input",
+        "output": "Output",
+        "cacheRead": "Cache Read",
+        "cacheWrite": "Cache Write",
+        "requests": "Requests",
+        "cost": "Cost"
+      },
+      "contextTable": {
+        "source": "Source",
+        "tokens": "Tokens",
+        "system": "System %",
+        "user": "User %",
+        "assistant": "Assistant %",
+        "toolCalls": "Tool Calls %",
+        "toolOutputs": "Tool Outputs %",
+        "other": "Other %"
+      }
+    },
+    "budget": {
+      "none": "No session budgets configured.",
+      "title": "Session Budgets",
+      "table": {
+        "metric": "Metric",
+        "current": "Current",
+        "limit": "Limit",
+        "remaining": "Remaining",
+        "used": "Used",
+        "blocked": "blocked"
+      }
+    }
+  },
+  "chatView": {
+    "inputDisabled": {
+      "archived": "Unarchive first",
+      "unattended": "This session is unattended. Fork it first to continue here."
+    },
+    "waiting": {
+      "processingPrompt": "Processing prompt...",
+      "thinking": "Thinking...",
+      "generating": "Generating...",
+      "working": "Working..."
+    },
+    "unknown": "Unknown",
+    "status": {
+      "connecting": "Connecting…",
+      "disconnected": "Disconnected"
+    },
+    "empty": {
+      "start": "Send a message to get started",
+      "connectingSession": "Connecting to session…"
+    },
+    "errors": {
+      "unexpected": "Unexpected error",
+      "resetTarget": "Could not resolve reset target.",
+      "forkTarget": "Could not resolve fork target."
+    },
+    "confirm": {
+      "wipeSandbox": "Wipe the sandbox and its storage for this session? Chat history will stay.",
+      "scaleDownSandbox": "Scale down the sandbox for this session? Storage will be kept.",
+      "deleteSession": "Delete this session? Chat history and sandbox state will be removed.",
+      "archiveSession": "Archive this session? It will leave the default list, reset its sandbox, and stay in the knowledge repo.",
+      "unarchiveSession": "Unarchive this session? It will return to the active session list.",
+      "makePrivate": "Mark this session private? Existing knowledge commits will remain in git history."
+    },
+    "actions": {
+      "pin": "Pin session",
+      "unpin": "Unpin session",
+      "favorite": "Favorite session",
+      "unfavorite": "Remove favorite",
+      "archive": "Archive session",
+      "unarchive": "Unarchive session",
+      "includeInRepo": "Include in repo",
+      "keepPrivate": "Keep private",
+      "delete": "Delete session"
+    },
+    "badges": {
+      "archived": "Archived",
+      "private": "Private",
+      "pinned": "Pinned",
+      "favorite": "Favorite",
+      "askMode": "Read-Only Mode",
+      "yoloMode": "YOLO",
+      "unattended": "Unattended",
+      "interactive": "Interactive"
+    },
+    "inspector": {
+      "actions": "Actions",
+      "session": "Session"
+    },
+    "session": {
+      "title": "Title",
+      "id": "ID",
+      "copyId": "Copy session id",
+      "idCopied": "Copied session id",
+      "idCopiedShort": "Copied",
+      "source": "Source",
+      "created": "Created",
+      "lastActive": "Last active",
+      "messages": "Messages",
+      "totalCost": "Cost",
+      "job": "Job",
+      "reference": "Reference",
+      "modes": "Modes",
+      "askMode": "Read-Only Mode",
+      "askModeHelp": "Only read-only work outside the sandbox. External writes are denied.",
+      "yoloMode": "YOLO Mode",
+      "yoloModeHelp": "Bypass sentinel approval and allow actions immediately.",
+      "savingPrivate": "Saving…",
+      "updatingMode": "Updating mode…"
+    },
+    "source": {
+      "unknown": "Unknown",
+      "job": "Job",
+      "web": "Web",
+      "cli": "CLI"
+    },
+    "jobRun": {
+      "title": "Latest Job Run",
+      "job": "Job",
+      "ranAt": "Ran at",
+      "schedule": "Schedule",
+      "data": "Data",
+      "trigger": {
+        "label": "Trigger",
+        "api": "API",
+        "cron": "Cron",
+        "manual": "Manual"
+      }
+    },
+    "sandbox": {
+      "title": "Sandbox",
+      "refreshing": "Refreshing…",
+      "checking": "Checking sandbox…",
+      "status": {
+        "missing": "Not Started",
+        "running": "Running",
+        "scaled_down": "Spun Down",
+        "pending": "Starting Up",
+        "stopped": "Stopped",
+        "error": "Error"
+      },
+      "actions": {
+        "start": "Start sandbox",
+        "starting": "Starting sandbox",
+        "scaleDown": "Scale down sandbox",
+        "scalingDown": "Scaling down sandbox",
+        "reset": "Reset sandbox"
+      },
+      "storage": {
+        "used": "{size} used",
+        "none": "no sandbox storage",
+        "allocated": "{size} allocated"
+      },
+      "fields": {
+        "id": "Sandbox ID"
+      }
+    },
+    "knowledge": {
+      "title": "Knowledge",
+      "commit": "Commit to repo",
+      "committed": "Committed",
+      "committedToRepo": "Committed to knowledge",
+      "notCommittedYet": "Not committed yet",
+      "savedAt": "Saved {timestamp}",
+      "commitDisabledNoHistory": "This session has no conversation history yet.",
+      "noNewChanges": "{status}. No new changes to commit.",
+      "privateExistingCommits": "Session is private. Existing knowledge commits remain unchanged.",
+      "privateExcluded": "Session is private and will not be committed to knowledge.",
+      "includedInRepo": "Session is included in knowledge commits to your repo.",
+      "badges": {
+        "excluded": "Excluded",
+        "missing": "Missing",
+        "outdated": "Outdated",
+        "upToDate": "Up to Date"
+      }
+    },
+    "mobile": {
+      "details": "Details",
+      "done": "Done"
+    }
+  },
+  "message": {
+    "copy": "Copy message",
+    "copied": "Copied",
+    "codeBlock": {
+      "copy": "Copy code",
+      "copied": "Copied"
+    },
+    "thinking": {
+      "streaming": "thinking",
+      "complete": "thought"
+    },
+    "thinkingMeta": {
+      "durationStreaming": "for {duration}",
+      "durationComplete": "for {duration}",
+      "reasoning": "{count} tokens"
+    },
+    "actions": {
+      "fork": "Fork session from here",
+      "retry": "Retry turn",
+      "reset": "Reset conversation to after this turn"
+    },
+    "finalStatus": {
+      "status": {
+        "success": "success",
+        "warning": "warning"
+      },
+      "notice": "The agent has ended its task with a {status} message. The session is now read-only, but you can fork it to continue chatting."
+    }
+  },
+  "jobs": {
+    "settingsSections": "Settings sections",
+    "savedJobs": "Saved Jobs",
+    "loading": "Loading jobs...",
+    "paused": "Paused",
+    "unattendedTooltip": "Unattended sessions cannot escalate tool calls",
+    "confirmDelete": "Delete job {name}?",
+    "summary": {
+      "onDemandOnly": "On-demand only",
+      "cronTriggerCount": "{count, plural, one {# cron trigger} other {# cron triggers}}"
+    },
+    "validation": {
+      "idRequired": "Job ID is required.",
+      "nameRequired": "Job name is required.",
+      "promptRequired": "Prompt is required.",
+      "persistentSessionIdRequired": "Select a persistent session ID or disable the option.",
+      "persistentSessionMustBeAttended": "Persistent-session jobs must be attended.",
+      "sessionModesRequireFreshSession": "Session modes require a fresh session.",
+      "modelOverridesRequireFreshSession": "Model overrides require a fresh session.",
+      "askAndYoloMutuallyExclusive": "Read-only mode and YOLO are mutually exclusive.",
+      "cronEmpty": "Cron expressions must not be empty.",
+      "cronInvalid": "Cron expression is invalid: {expression}."
+    },
+    "cron": {
+      "invalidExpression": "Invalid cron expression."
+    },
+    "triggerKind": {
+      "scheduled": "Scheduled",
+      "manual": "Manual"
+    },
+    "errors": {
+      "load": "Failed to load jobs.",
+      "refresh": "Failed to refresh jobs.",
+      "save": "Failed to save job.",
+      "delete": "Failed to delete job.",
+      "run": "Failed to run job.",
+      "saveBeforeRun": "Save the job before running it.",
+      "saveChangesBeforeRun": "Save job changes before running it."
+    },
+    "notices": {
+      "refreshed": "Jobs refreshed.",
+      "created": "Job created.",
+      "saved": "Job saved.",
+      "deleted": "Job deleted.",
+      "runStartedNewSession": "Run started in new session {sessionId}.",
+      "runStartedSession": "Run started in session {sessionId}."
+    },
+    "actions": {
+      "refresh": "Refresh jobs",
+      "new": "New job",
+      "clear": "Clear",
+      "clearPersistentSession": "Clear persistent session",
+      "delete": "Delete",
+      "save": "Save",
+      "addTrigger": "Add trigger",
+      "remove": "Remove",
+      "runNow": "Run now"
+    },
+    "empty": {
+      "noJobs": "No jobs yet. Create one to store prompts and optional cron schedules in jobs.yaml."
+    },
+    "editor": {
+      "newJob": "New job",
+      "editing": "Editing {name}",
+      "jobFallback": "job"
+    },
+    "fields": {
+      "name": "Name",
+      "jobId": "Job ID",
+      "enabled": "Enabled",
+      "enabledHelp": "Paused jobs stay in jobs.yaml but never run from cron.",
+      "newSession": "Options",
+      "newSessionHelp": "These options only apply to fresh sessions created by this job.",
+      "unattended": "Run unattended",
+      "unattendedHelp": "Tool calls will not be escalated to you.",
+      "persistentSession": "Persistent Session",
+      "persistentSessionToggleHelp": "Reuse an existing session instead of starting a fresh one each run.",
+      "persistentSessionDisabled": "Can't be used in unattended mode",
+      "persistentSessionUncheckedHelp": "Enable this option to choose an existing session ID below.",
+      "persistentSessionMissingIdHelp": "Enabled, but no session ID selected yet. Choose an existing session below.",
+      "persistentSessionHelp": "Reuse an existing session instead of creating a new one on every job invocation.",
+      "persistentSessionActiveHelp": "Active: this session ID overrides the fresh-session options above.",
+      "models": "Models",
+      "modelsHelp": "Optional per-job overrides for fresh sessions created by this job.",
+      "modelsDisabled": "Persistent sessions keep their own model selection.",
+      "modelsLinked": "Models linked",
+      "modelsLinkedHelp": "Linked: changing either model updates both.",
+      "modelsUnlinked": "Models unlinked",
+      "modelsUnlinkedHelp": "Unlinked: agent and sentinel models can be changed independently.",
+      "agentModel": "Agent",
+      "sentinelModel": "Sentinel",
+      "titleModel": "Title Model",
+      "prompt": "Prompt",
+      "expression": "Expression",
+      "timeZone": "Time Zone",
+      "inputOptional": "Input (Optional)"
+    },
+    "placeholders": {
+      "name": "Nightly inbox review",
+      "jobId": "nightly-inbox-review",
+      "persistentSession": "select session ID",
+      "prompt": "Summarize new tasks, triage urgent items, then propose next actions.",
+      "model": "Leave empty for default"
+    },
+    "sections": {
+      "cronTriggers": "Cron Triggers",
+      "cronTriggersDescription": "Leave empty for on-demand jobs.",
+      "noTriggers": "No cron triggers configured.",
+      "runJob": "Run Job",
+      "previousInvocations": "Previous Invocations",
+      "previousInvocationsDescription": "Select an invocation to open its session.",
+      "saveToViewHistory": "Save this job to view invocation history.",
+      "noInvocations": "No invocations yet. Refresh sessions to load newly completed runs.",
+      "ranAt": "Ran at {timestamp}"
+    }
+  },
+  "sidebar": {
+    "time": {
+      "justNow": "just now"
+    },
+    "messageCount": "{count, plural, one {# message} other {# messages}}",
+    "unattendedSession": "Unattended session",
+    "privateSession": "Private session",
+    "knowledgeCommitted": "All changes committed to knowledge",
+    "actions": {
+      "pin": "Pin session",
+      "unpin": "Unpin session",
+      "favorite": "Favorite session",
+      "unfavorite": "Remove favorite",
+      "archive": "Archive session",
+      "unarchive": "Unarchive session",
+      "delete": "Delete session",
+      "deleteEmpty": "Delete empty session",
+      "shiftSkip": "Shift+click to skip confirmation"
+    },
+    "confirm": {
+      "deleteSession": "Delete this session? Chat history and sandbox state will be removed.",
+      "deleteUnpushed": "This session has {count, plural, one {# commit} other {# commits}} not yet pushed to your knowledge repo. Deleting it will discard them. Delete anyway?",
+      "archiveSession": "Archive this session? It will leave the default list, reset its sandbox, and stay in the knowledge repo."
+    },
+    "sections": {
+      "today": "Today",
+      "yesterday": "Yesterday",
+      "last7Days": "Last 7 Days",
+      "last30Days": "Last 30 Days",
+      "archived": "Archived",
+      "unknownDate": "Unknown Date"
+    },
+    "empty": "No sessions yet",
+    "loadingMore": "Loading more sessions"
+  },
+  "git": {
+    "upToDate": "Up to date",
+    "noRemote": "No remote configured",
+    "sandbox": {
+      "label": "Workspace sync",
+      "help": "Sync between this session's sandbox workspace and your knowledge repository on the server. Counts show commits this workspace is ahead (↑) and behind (↓) the server repo.",
+      "notRunning": "Sandbox not running",
+      "refresh": "Re-check the workspace against the server repository (fetches first)",
+      "pull": "Pull commits from the server repository into this workspace",
+      "push": "Push this workspace's commits to the server repository (each push is reviewed by the sentinel)"
+    },
+    "global": {
+      "label": "Knowledge remote",
+      "help": "Sync between your knowledge repository on the server and its external git remote. Counts show commits the server repo is ahead (↑) and behind (↓) the remote.",
+      "indicatorBehind": "{count, plural, one {# commit} other {# commits}} to pull from the knowledge remote",
+      "refresh": "Re-check the server repository against the remote (fetches first)",
+      "pull": "Pull commits from the external remote into the server repository",
+      "push": "Push the server repository's commits to the external remote"
+    },
+    "denied": "Push denied",
+    "errors": {
+      "status": "Could not read git status",
+      "pull": "Pull failed",
+      "push": "Push failed"
+    }
+  },
+  "apiKeys": {
+    "title": "API Keys",
+    "description": "Create long-lived tokens for scripts and integrations. Use them as 'Authorization: Bearer <token>'.",
+    "create": {
+      "nameLabel": "Name",
+      "namePlaceholder": "e.g. CI deploy bot",
+      "scopesLabel": "Scopes",
+      "expiryLabel": "Expires after (days)",
+      "expiryPlaceholder": "Leave empty for no expiry",
+      "submit": "Create key",
+      "creating": "Creating…"
+    },
+    "access": {
+      "none": "None",
+      "read": "Read",
+      "write": "Write"
+    },
+    "scopes": {
+      "sessions": "Sessions",
+      "jobs": "Jobs",
+      "preferences": "Preferences",
+      "notifications": "Notifications",
+      "history": "History",
+      "admin": "Admin"
+    },
+    "secret": {
+      "warning": "Copy this token now — it won't be shown again.",
+      "copy": "Copy token",
+      "done": "Done"
+    },
+    "list": {
+      "title": "Active keys",
+      "empty": "No API keys yet.",
+      "loading": "Loading keys…",
+      "unnamed": "Unnamed key"
+    },
+    "fields": {
+      "created": "Created {timestamp}",
+      "lastUsed": "Last used {timestamp}",
+      "expires": "Expires {timestamp}",
+      "never": "never",
+      "noExpiry": "no expiry"
+    },
+    "actions": {
+      "revoke": "Revoke key"
+    },
+    "confirm": {
+      "revoke": "Revoke API key \"{name}\"? This cannot be undone."
+    },
+    "errors": {
+      "load": "Failed to load API keys.",
+      "create": "Failed to create API key.",
+      "revoke": "Failed to revoke API key.",
+      "noScopes": "Select at least one scope."
+    }
+  }
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -128,7 +128,13 @@ function HomeContent() {
   })();
   const initialSettingsTab: SettingsTab = (() => {
     const tab = searchParams.get("tab");
-    if (tab === "jobs" || tab === "platform-models" || tab === "platform-users" || tab === "account") {
+    if (
+      tab === "jobs" ||
+      tab === "platform-models" ||
+      tab === "platform-users" ||
+      tab === "account" ||
+      tab === "api-keys"
+    ) {
       return tab;
     }
     return "preferences";

--- a/frontend/src/components/api-keys-view.tsx
+++ b/frontend/src/components/api-keys-view.tsx
@@ -42,6 +42,7 @@ export function ApiKeysView({ server: serverProp, token, isAdmin }: ApiKeysViewP
   const t = useTranslations("apiKeys");
   const [server, setServer] = useState(() => normalizeServer(serverProp ?? ""));
   const [keys, setKeys] = useState<ApiKeyInfo[]>([]);
+  const [loadedAtMs, setLoadedAtMs] = useState(0);
   const [loading, setLoading] = useState(false);
   const [creating, setCreating] = useState(false);
   const [revokingId, setRevokingId] = useState<string | null>(null);
@@ -70,6 +71,7 @@ export function ApiKeysView({ server: serverProp, token, isAdmin }: ApiKeysViewP
     setError(null);
     try {
       setKeys(await listApiKeys(normalizedServer));
+      setLoadedAtMs(Date.now());
     } catch (loadError) {
       setError(loadError instanceof Error ? loadError.message : t("errors.load"));
     } finally {
@@ -270,14 +272,23 @@ export function ApiKeysView({ server: serverProp, token, isAdmin }: ApiKeysViewP
             </div>
           ) : (
             <div className="space-y-2">
-              {keys.map((key) => (
+              {keys.map((key) => {
+                const expired = key.expires_at != null && Date.parse(key.expires_at) <= loadedAtMs;
+                return (
                 <div key={key.id} className="flex items-start gap-3 rounded-lg border border-border bg-background px-4 py-3">
                   <div className="min-w-0 flex-1">
                     <div className="flex min-w-0 items-center gap-2">
-                      <span className="truncate text-sm font-semibold">{key.name || t("list.unnamed")}</span>
+                      <span className={cn("truncate text-sm font-semibold", expired && "text-muted-foreground")}>
+                        {key.name || t("list.unnamed")}
+                      </span>
                       <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 font-mono text-[11px] text-muted-foreground">
                         {key.prefix}…
                       </span>
+                      {expired ? (
+                        <span className="shrink-0 rounded-full bg-destructive/10 px-2 py-0.5 text-[11px] font-medium text-destructive">
+                          {t("list.expired")}
+                        </span>
+                      ) : null}
                     </div>
                     <div className="mt-1.5 flex flex-wrap gap-1">
                       {key.scopes.map((scope) => (
@@ -303,7 +314,8 @@ export function ApiKeysView({ server: serverProp, token, isAdmin }: ApiKeysViewP
                     {revokingId === key.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
                   </button>
                 </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </div>

--- a/frontend/src/components/api-keys-view.tsx
+++ b/frontend/src/components/api-keys-view.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import { Check, Copy, KeyRound, Loader2, Plus, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+
+import { createApiKey, listApiKeys, revokeApiKey, type ApiKeyInfo } from "@/lib/api";
+import { normalizeServer } from "@/lib/server-url";
+import { getServer } from "@/lib/storage";
+import { cn } from "@/lib/utils";
+
+type Access = "none" | "read" | "write";
+
+const BASE_SCOPES = ["sessions", "jobs", "preferences", "notifications", "history"] as const;
+
+const inputClassName = cn(
+  "w-full rounded-lg border border-border bg-background px-3 py-2 text-base sm:text-sm",
+  "outline-none transition-colors placeholder:text-muted-foreground/50",
+  "focus:border-ring focus:ring-2 focus:ring-ring/30",
+);
+
+const iconButtonClassName = cn(
+  "inline-flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition-colors",
+  "hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50",
+);
+
+function formatTimestamp(value: string | null, fallback: string): string {
+  if (!value) return fallback;
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) return value;
+  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(parsed);
+}
+
+interface ApiKeysViewProps {
+  server: string;
+  token: string;
+  isAdmin: boolean;
+}
+
+export function ApiKeysView({ server: serverProp, token, isAdmin }: ApiKeysViewProps) {
+  void token;
+  const t = useTranslations("apiKeys");
+  const [server, setServer] = useState(() => normalizeServer(serverProp ?? ""));
+  const [keys, setKeys] = useState<ApiKeyInfo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [name, setName] = useState("");
+  const [grants, setGrants] = useState<Record<string, Access>>({});
+  const [expiresInDays, setExpiresInDays] = useState("");
+  const [createdSecret, setCreatedSecret] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const loadedServerRef = useRef<string | null>(null);
+
+  const scopes = isAdmin ? [...BASE_SCOPES, "admin"] : [...BASE_SCOPES];
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      const nextServer = normalizeServer(serverProp ?? getServer());
+      setServer((current) => (current === nextServer ? current : nextServer));
+    }, 0);
+    return () => clearTimeout(timer);
+  }, [serverProp]);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    const normalizedServer = normalizeServer(server);
+    if (!normalizedServer) return;
+    setLoading(true);
+    setError(null);
+    try {
+      setKeys(await listApiKeys(normalizedServer));
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : t("errors.load"));
+    } finally {
+      setLoading(false);
+    }
+  }, [server, t]);
+
+  useEffect(() => {
+    const normalizedServer = normalizeServer(server);
+    if (!normalizedServer || loadedServerRef.current === normalizedServer) return;
+    loadedServerRef.current = normalizedServer;
+    void refresh();
+  }, [refresh, server]);
+
+  function setAccess(scope: string, access: Access): void {
+    setGrants((current) => ({ ...current, [scope]: access }));
+  }
+
+  function selectedScopeStrings(): string[] {
+    return Object.entries(grants)
+      .filter(([, access]) => access !== "none")
+      .map(([scope, access]) => `${scope}:${access}`);
+  }
+
+  async function handleCreate(event: React.FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    const normalizedServer = normalizeServer(server);
+    if (!normalizedServer) return;
+    const selected = selectedScopeStrings();
+    if (selected.length === 0) {
+      setError(t("errors.noScopes"));
+      return;
+    }
+    setCreating(true);
+    setError(null);
+    try {
+      const parsedDays = expiresInDays.trim() ? Number.parseInt(expiresInDays, 10) : null;
+      const result = await createApiKey(normalizedServer, {
+        name: name.trim(),
+        scopes: selected,
+        expires_in_days: parsedDays && parsedDays > 0 ? parsedDays : null,
+      });
+      setCreatedSecret(result.secret);
+      setCopied(false);
+      setName("");
+      setGrants({});
+      setExpiresInDays("");
+      await refresh();
+    } catch (createError) {
+      setError(createError instanceof Error ? createError.message : t("errors.create"));
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleRevoke(key: ApiKeyInfo): Promise<void> {
+    const normalizedServer = normalizeServer(server);
+    if (!normalizedServer) return;
+    if (!window.confirm(t("confirm.revoke", { name: key.name || key.prefix }))) return;
+    setRevokingId(key.id);
+    setError(null);
+    try {
+      await revokeApiKey(normalizedServer, key.id);
+      await refresh();
+    } catch (revokeError) {
+      setError(revokeError instanceof Error ? revokeError.message : t("errors.revoke"));
+    } finally {
+      setRevokingId(null);
+    }
+  }
+
+  async function handleCopy(): Promise<void> {
+    if (!createdSecret) return;
+    await navigator.clipboard.writeText(createdSecret);
+    setCopied(true);
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5 sm:px-6">
+      <div className="mx-auto max-w-3xl space-y-6">
+        <div className="flex items-center gap-3">
+          <div className="rounded-lg border border-border bg-background p-2 text-muted-foreground">
+            <KeyRound className="h-4 w-4" />
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold tracking-tight">{t("title")}</h2>
+            <p className="text-sm text-muted-foreground">{t("description")}</p>
+          </div>
+        </div>
+
+        {error ? (
+          <div className="rounded-2xl border border-border bg-background/88 px-4 py-3 text-sm text-destructive shadow-sm">
+            {error}
+          </div>
+        ) : null}
+
+        {createdSecret ? (
+          <div className="space-y-3 rounded-2xl border border-amber-300 bg-amber-50 px-4 py-3 text-amber-900 shadow-sm">
+            <p className="text-sm font-medium">{t("secret.warning")}</p>
+            <div className="flex items-center gap-2">
+              <code className="min-w-0 flex-1 break-all rounded-md border border-amber-300 bg-background px-3 py-2 font-mono text-xs text-foreground">
+                {createdSecret}
+              </code>
+              <button
+                type="button"
+                onClick={() => void handleCopy()}
+                className={cn(iconButtonClassName, "shrink-0 border border-amber-300")}
+                aria-label={t("secret.copy")}
+                title={t("secret.copy")}
+              >
+                {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+              </button>
+            </div>
+            <button
+              type="button"
+              onClick={() => setCreatedSecret(null)}
+              className="text-sm font-medium underline underline-offset-2"
+            >
+              {t("secret.done")}
+            </button>
+          </div>
+        ) : null}
+
+        <form onSubmit={(event) => void handleCreate(event)} className="space-y-4 rounded-2xl border border-border bg-background/70 p-4">
+          <label className="space-y-1.5">
+            <span className="text-xs font-medium text-muted-foreground">{t("create.nameLabel")}</span>
+            <input
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder={t("create.namePlaceholder")}
+              className={inputClassName}
+            />
+          </label>
+
+          <div className="space-y-2">
+            <span className="text-xs font-medium text-muted-foreground">{t("create.scopesLabel")}</span>
+            <div className="space-y-1.5">
+              {scopes.map((scope) => {
+                const value = grants[scope] ?? "none";
+                return (
+                  <div key={scope} className="flex items-center justify-between gap-3 rounded-lg border border-border/70 bg-background px-3 py-2">
+                    <span className="text-sm font-medium">{t(`scopes.${scope}`)}</span>
+                    <div className="flex items-center gap-1">
+                      {(["none", "read", "write"] as const).map((access) => (
+                        <button
+                          key={access}
+                          type="button"
+                          onClick={() => setAccess(scope, access)}
+                          className={cn(
+                            "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+                            value === access
+                              ? "bg-foreground text-background"
+                              : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                          )}
+                        >
+                          {t(`access.${access}`)}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          <label className="space-y-1.5">
+            <span className="text-xs font-medium text-muted-foreground">{t("create.expiryLabel")}</span>
+            <input
+              type="number"
+              min={1}
+              value={expiresInDays}
+              onChange={(event) => setExpiresInDays(event.target.value)}
+              placeholder={t("create.expiryPlaceholder")}
+              className={inputClassName}
+            />
+          </label>
+
+          <button
+            type="submit"
+            disabled={creating || !server.trim()}
+            className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+            {creating ? t("create.creating") : t("create.submit")}
+          </button>
+        </form>
+
+        <div className="space-y-2">
+          <div className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">{t("list.title")}</div>
+          {loading ? (
+            <div className="flex items-center gap-2 rounded-lg border border-dashed border-border px-4 py-5 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              {t("list.loading")}
+            </div>
+          ) : keys.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-border bg-background/80 px-4 py-6 text-sm text-muted-foreground">
+              {t("list.empty")}
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {keys.map((key) => (
+                <div key={key.id} className="flex items-start gap-3 rounded-lg border border-border bg-background px-4 py-3">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex min-w-0 items-center gap-2">
+                      <span className="truncate text-sm font-semibold">{key.name || t("list.unnamed")}</span>
+                      <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 font-mono text-[11px] text-muted-foreground">
+                        {key.prefix}…
+                      </span>
+                    </div>
+                    <div className="mt-1.5 flex flex-wrap gap-1">
+                      {key.scopes.map((scope) => (
+                        <span key={scope} className="rounded-full bg-accent px-2 py-0.5 font-mono text-[11px] text-accent-foreground">
+                          {scope}
+                        </span>
+                      ))}
+                    </div>
+                    <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground">
+                      <span>{t("fields.created", { timestamp: formatTimestamp(key.created_at, t("fields.never")) })}</span>
+                      <span>{t("fields.lastUsed", { timestamp: formatTimestamp(key.last_used_at, t("fields.never")) })}</span>
+                      <span>{t("fields.expires", { timestamp: formatTimestamp(key.expires_at, t("fields.noExpiry")) })}</span>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => void handleRevoke(key)}
+                    title={t("actions.revoke")}
+                    aria-label={t("actions.revoke")}
+                    className={cn(iconButtonClassName, "hover:bg-destructive/10 hover:text-destructive")}
+                    disabled={revokingId !== null || !server.trim()}
+                  >
+                    {revokingId === key.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/jobs-view.tsx
+++ b/frontend/src/components/jobs-view.tsx
@@ -18,6 +18,7 @@ import {
 import { useAppLocale } from "@/components/locale-provider";
 import { ModelPicker, withSelectedModelOption } from "@/components/model-picker";
 import { AdminUsersPage } from "@/components/admin-users-page";
+import { ApiKeysView } from "@/components/api-keys-view";
 import { PlatformSettingsView } from "@/components/platform-settings-view";
 import { PreferencesView } from "@/components/preferences-view";
 import { UserSettingsView } from "@/components/user-settings-view";
@@ -40,7 +41,7 @@ interface JobsViewProps {
   onTabChange: (tab: SettingsTab) => void;
 }
 
-export type SettingsTab = "jobs" | "platform-models" | "platform-users" | "preferences" | "account";
+export type SettingsTab = "jobs" | "platform-models" | "platform-users" | "preferences" | "account" | "api-keys";
 
 const CRON_EXAMPLE_EXPRESSIONS = [
   "*/15 * * * *",
@@ -639,6 +640,7 @@ export function JobsView({
   const isPlatformUsersTab = effectiveActiveTab === "platform-users";
   const isPreferencesTab = effectiveActiveTab === "preferences";
   const isAccountTab = effectiveActiveTab === "account";
+  const isApiKeysTab = effectiveActiveTab === "api-keys";
   const tabButtonClassName = (selected: boolean): string => cn(
     "rounded-t-lg border border-b-0 px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
     selected
@@ -695,6 +697,18 @@ export function JobsView({
                 className={tabButtonClassName(isJobsTab)}
               >
                 {tRoot("navigation.jobs")}
+              </button>
+              <button
+                id="settings-tab-api-keys"
+                type="button"
+                role="tab"
+                aria-selected={isApiKeysTab}
+                aria-controls="settings-panel-api-keys"
+                tabIndex={isApiKeysTab ? 0 : -1}
+                onClick={() => onTabChange("api-keys")}
+                className={tabButtonClassName(isApiKeysTab)}
+              >
+                {tRoot("navigation.apiKeys")}
               </button>
             </div>
 
@@ -1292,6 +1306,15 @@ export function JobsView({
           className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background/65"
         >
           <UserSettingsView server={server} token={token} />
+        </div>
+      ) : isApiKeysTab ? (
+        <div
+          id="settings-panel-api-keys"
+          role="tabpanel"
+          aria-labelledby="settings-tab-api-keys"
+          className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background/65"
+        >
+          <ApiKeysView server={server} token={token} isAdmin={isAdmin} />
         </div>
       ) : isPlatformModelsTab ? (
         <div

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -311,6 +311,63 @@ export async function deleteAdminUser(
   }
 }
 
+export interface ApiKeyInfo {
+  id: string;
+  name: string;
+  prefix: string;
+  scopes: string[];
+  created_at: string;
+  last_used_at: string | null;
+  expires_at: string | null;
+  revoked_at: string | null;
+}
+
+export interface ApiKeyCreateInput {
+  name: string;
+  scopes: string[];
+  expires_in_days?: number | null;
+}
+
+export interface ApiKeyCreateResult {
+  key: ApiKeyInfo;
+  secret: string;
+}
+
+export async function listApiKeys(server: string): Promise<ApiKeyInfo[]> {
+  const res = await fetch(`${server}/api/keys`, {
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!res.ok) {
+    throw new Error(await readErrorMessage(res, "Failed to list API keys"));
+  }
+  return (await res.json()) as ApiKeyInfo[];
+}
+
+export async function createApiKey(
+  server: string,
+  body: ApiKeyCreateInput,
+): Promise<ApiKeyCreateResult> {
+  const res = await fetch(`${server}/api/keys`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(await readErrorMessage(res, "Failed to create API key"));
+  }
+  return (await res.json()) as ApiKeyCreateResult;
+}
+
+export async function revokeApiKey(server: string, id: string): Promise<void> {
+  const res = await fetch(`${server}/api/keys/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!res.ok) {
+    throw new Error(await readErrorMessage(res, "Failed to revoke API key"));
+  }
+}
+
 export async function getServerMeta(
   server: string,
   token: string,

--- a/prek.toml
+++ b/prek.toml
@@ -26,6 +26,11 @@ id = "check-toml"
 id = "check-json"
 
 [[repos.hooks]]
+id = "pretty-format-json"
+args = ["--autofix", "--indent", "4", "--no-sort-keys", "--no-ensure-ascii"]
+files = "^frontend/messages/.*\\.json$"
+
+[[repos.hooks]]
 id = "check-added-large-files"
 
 [[repos.hooks]]

--- a/src/carapace/api_keys.py
+++ b/src/carapace/api_keys.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import hashlib
+import secrets
+import uuid
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from enum import StrEnum
+
+from loguru import logger
+from pydantic import BaseModel
+from sqlalchemy import select, update
+from sqlalchemy.exc import SQLAlchemyError
+
+from .auth import AuthStore, UserIdentity, has_admin_role, normalize_username
+from .database.engine import SessionFactory
+from .database.models import ApiKeyRow
+
+# Non-secret lookup handle prefix; the full token is "<prefix>.<body>".
+_TOKEN_PREFIX = "ck_"
+# Skip rewriting last_used_at if it was already touched this recently (write contention).
+_LAST_USED_COALESCE_SECONDS = 60
+
+
+class Scope(StrEnum):
+    sessions = "sessions"
+    jobs = "jobs"
+    preferences = "preferences"
+    notifications = "notifications"
+    history = "history"
+    admin = "admin"
+
+
+class Access(StrEnum):
+    read = "read"
+    write = "write"
+
+
+class ApiKeyGrant(BaseModel, frozen=True):
+    scope: Scope
+    access: Access
+
+    def satisfies(self, scope: Scope, access: Access) -> bool:
+        if self.scope != scope:
+            return False
+        return self.access is Access.write or access is Access.read
+
+    def to_str(self) -> str:
+        return f"{self.scope.value}:{self.access.value}"
+
+    @classmethod
+    def parse(cls, raw: str) -> ApiKeyGrant:
+        scope_part, _, access_part = raw.partition(":")
+        return cls(scope=Scope(scope_part), access=Access(access_part or "read"))
+
+
+class ApiKeyInfo(BaseModel):
+    """Safe-to-expose view of an API key (never carries the secret or its hash)."""
+
+    id: str
+    name: str
+    prefix: str
+    scopes: list[str]
+    created_at: datetime
+    last_used_at: datetime | None = None
+    expires_at: datetime | None = None
+    revoked_at: datetime | None = None
+
+    def is_active(self, *, now: datetime | None = None) -> bool:
+        current = now or datetime.now(tz=UTC)
+        if self.revoked_at is not None:
+            return False
+        return self.expires_at is None or self.expires_at > current
+
+
+class ApiKeyStore:
+    def __init__(self, session_factory: SessionFactory, auth_store: AuthStore):
+        self._session_factory = session_factory
+        self._auth = auth_store
+
+    def create_key(
+        self,
+        *,
+        user: str,
+        name: str,
+        grants: Iterable[ApiKeyGrant],
+        expires_at: datetime | None = None,
+    ) -> tuple[ApiKeyInfo, str]:
+        """Create a key and return its info plus the plaintext token (shown once)."""
+        key_user = normalize_username(user)
+        owner = self._auth.get_user(key_user)
+        if owner is None:
+            raise ValueError(f"User {key_user!r} not found")
+        grant_set = _normalize_grants(grants)
+        if not grant_set:
+            raise ValueError("at least one scope is required")
+        if any(g.scope is Scope.admin for g in grant_set) and not has_admin_role(owner.roles):
+            raise ValueError("admin scope requires the admin role")
+
+        now = datetime.now(tz=UTC)
+        prefix = _TOKEN_PREFIX + secrets.token_hex(4)
+        full = f"{prefix}.{secrets.token_urlsafe(32)}"
+        row = ApiKeyRow(
+            id=uuid.uuid4().hex,
+            prefix=prefix,
+            secret_hash=_hash(full),
+            user=key_user,
+            name=name.strip(),
+            scopes=sorted(g.to_str() for g in grant_set),
+            created_at=now,
+            last_used_at=None,
+            expires_at=expires_at,
+            revoked_at=None,
+        )
+        with self._session_factory.begin() as db:
+            db.add(row)
+        return _row_to_info(row), full
+
+    def list_keys(self, user: str) -> list[ApiKeyInfo]:
+        key_user = normalize_username(user)
+        with self._session_factory() as db:
+            rows = db.scalars(
+                select(ApiKeyRow)
+                .where(ApiKeyRow.user == key_user, ApiKeyRow.revoked_at.is_(None))
+                .order_by(ApiKeyRow.created_at.desc())
+            ).all()
+        return [_row_to_info(row) for row in rows]
+
+    def revoke_key(self, *, user: str, key_id: str) -> bool:
+        key_user = normalize_username(user)
+        with self._session_factory.begin() as db:
+            result = db.execute(
+                update(ApiKeyRow)
+                .where(ApiKeyRow.id == key_id, ApiKeyRow.user == key_user, ApiKeyRow.revoked_at.is_(None))
+                .values(revoked_at=datetime.now(tz=UTC))
+            )
+            return result.rowcount > 0  # type: ignore[missing-attribute]
+
+    def validate_key(self, full_token: str) -> tuple[UserIdentity, set[ApiKeyGrant]] | None:
+        """Resolve a plaintext token to its owner identity and effective grants."""
+        prefix, sep, _ = full_token.partition(".")
+        if not sep or not prefix:
+            return None
+        now = datetime.now(tz=UTC)
+        with self._session_factory() as db:
+            row = db.scalar(select(ApiKeyRow).where(ApiKeyRow.prefix == prefix))
+            if row is None:
+                _hash(full_token)  # keep timing roughly constant whether or not the prefix exists
+                return None
+            stored_hash = row.secret_hash
+            row_id = row.id
+            key_user = row.user
+            stored_scopes = list(row.scopes)
+            revoked_at = row.revoked_at
+            expires_at = row.expires_at
+            last_used_at = row.last_used_at
+
+        if revoked_at is not None:
+            return None
+        if expires_at is not None and expires_at <= now:
+            return None
+        if not secrets.compare_digest(stored_hash, _hash(full_token)):
+            return None
+
+        # Key acts as its owner: dies when the user is disabled or deleted. token_version is
+        # intentionally ignored so keys survive password changes.
+        owner = self._auth.get_user(key_user)
+        if owner is None or not owner.enabled:
+            return None
+
+        grants = {ApiKeyGrant.parse(scope) for scope in stored_scopes}
+        if not has_admin_role(owner.roles):
+            grants = {grant for grant in grants if grant.scope is not Scope.admin}
+
+        self._touch_last_used(row_id, last_used_at, now)
+        return owner.identity(key_user), grants
+
+    def _touch_last_used(self, key_id: str, last_used_at: datetime | None, now: datetime) -> None:
+        if last_used_at is not None and (now - last_used_at).total_seconds() < _LAST_USED_COALESCE_SECONDS:
+            return
+        # Best-effort, separate transaction, blind UPDATE — never fail the request on a touch error.
+        try:
+            with self._session_factory.begin() as db:
+                db.execute(update(ApiKeyRow).where(ApiKeyRow.id == key_id).values(last_used_at=now))
+        except SQLAlchemyError as exc:
+            logger.debug(f"api key last_used_at touch failed for {key_id}: {exc}")
+
+
+def _hash(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _normalize_grants(grants: Iterable[ApiKeyGrant]) -> set[ApiKeyGrant]:
+    """Collapse to one grant per scope, preferring write (which implies read)."""
+    by_scope: dict[Scope, Access] = {}
+    for grant in grants:
+        current = by_scope.get(grant.scope)
+        if current is None or grant.access is Access.write:
+            by_scope[grant.scope] = grant.access
+    return {ApiKeyGrant(scope=scope, access=access) for scope, access in by_scope.items()}
+
+
+def _row_to_info(row: ApiKeyRow) -> ApiKeyInfo:
+    return ApiKeyInfo(
+        id=row.id,
+        name=row.name,
+        prefix=row.prefix,
+        scopes=list(row.scopes),
+        created_at=row.created_at,
+        last_used_at=row.last_used_at,
+        expires_at=row.expires_at,
+        revoked_at=row.revoked_at,
+    )

--- a/src/carapace/api_keys.py
+++ b/src/carapace/api_keys.py
@@ -124,7 +124,11 @@ class ApiKeyStore:
                 .where(ApiKeyRow.user == key_user, ApiKeyRow.revoked_at.is_(None))
                 .order_by(ApiKeyRow.created_at.desc())
             ).all()
-        return [_row_to_info(row) for row in rows]
+        # Reflect effective grants: admin scopes don't apply once the owner loses the admin role
+        # (validate_key strips them too), so don't list them as active.
+        owner = self._auth.get_user(key_user)
+        keep_admin = owner is not None and has_admin_role(owner.roles)
+        return [_row_to_info(row, keep_admin=keep_admin) for row in rows]
 
     def revoke_key(self, *, user: str, key_id: str) -> bool:
         key_user = normalize_username(user)
@@ -200,12 +204,13 @@ def _normalize_grants(grants: Iterable[ApiKeyGrant]) -> set[ApiKeyGrant]:
     return {ApiKeyGrant(scope=scope, access=access) for scope, access in by_scope.items()}
 
 
-def _row_to_info(row: ApiKeyRow) -> ApiKeyInfo:
+def _row_to_info(row: ApiKeyRow, *, keep_admin: bool = True) -> ApiKeyInfo:
+    scopes = list(row.scopes) if keep_admin else [s for s in row.scopes if not s.startswith(f"{Scope.admin.value}:")]
     return ApiKeyInfo(
         id=row.id,
         name=row.name,
         prefix=row.prefix,
-        scopes=list(row.scopes),
+        scopes=scopes,
         created_at=row.created_at,
         last_used_at=row.last_used_at,
         expires_at=row.expires_at,

--- a/src/carapace/auth.py
+++ b/src/carapace/auth.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, Field, model_validator
 from sqlalchemy import delete, select, update
 
 from .database.engine import SessionFactory
-from .database.models import ApiKeyRow, AuthSessionRow, User
+from .database.models import AuthSessionRow, User
 from .models.config import AuthConfig
 from .models.user import UserConfig
 from .usernames import normalize_username
@@ -294,14 +294,12 @@ class AuthStore:
             existing = db.get(User, key)
             if existing is None:
                 raise KeyError(key)
-            db.delete(existing)
+            db.delete(existing)  # api_keys cascade-delete via their ON DELETE CASCADE FK
             db.execute(
                 update(AuthSessionRow)
                 .where(AuthSessionRow.user == key, AuthSessionRow.revoked_at.is_(None))
                 .values(revoked_at=now)
             )
-            # Hard-delete API keys so a later user with the same username can't inherit them.
-            db.execute(delete(ApiKeyRow).where(ApiKeyRow.user == key))
 
     def set_password(self, username: str, password: str) -> AuthUser:
         key = normalize_username(username)

--- a/src/carapace/auth.py
+++ b/src/carapace/auth.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, Field, model_validator
 from sqlalchemy import delete, select, update
 
 from .database.engine import SessionFactory
-from .database.models import AuthSessionRow, User
+from .database.models import ApiKeyRow, AuthSessionRow, User
 from .models.config import AuthConfig
 from .models.user import UserConfig
 from .usernames import normalize_username
@@ -300,6 +300,8 @@ class AuthStore:
                 .where(AuthSessionRow.user == key, AuthSessionRow.revoked_at.is_(None))
                 .values(revoked_at=now)
             )
+            # Hard-delete API keys so a later user with the same username can't inherit them.
+            db.execute(delete(ApiKeyRow).where(ApiKeyRow.user == key))
 
     def set_password(self, username: str, password: str) -> AuthUser:
         key = normalize_username(username)

--- a/src/carapace/cli.py
+++ b/src/carapace/cli.py
@@ -92,7 +92,9 @@ def _replay_history(client: httpx.Client, session_id: str, limit: int) -> None:
     try:
         resp = client.get(f"/api/sessions/{session_id}/history", params=params)
         resp.raise_for_status()
-    except httpx.HTTPStatusError:
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 403:
+            console.print("[yellow]Skipping history replay: the API key lacks the 'history:read' scope.[/yellow]")
         return
 
     messages = resp.json()
@@ -758,7 +760,10 @@ def chat(
         "--api-key",
         "-k",
         envvar="CARAPACE_API_KEY",
-        help="API key for Bearer auth (needs the 'sessions' scope). Takes precedence over username/password.",
+        help=(
+            "API key for Bearer auth (needs 'sessions' scope; '--history' replay also needs 'history'). "
+            "Takes precedence over username/password."
+        ),
     ),
     username: str | None = typer.Option(None, "--user", "-u", envvar="CARAPACE_USER", help="Username"),
     password: str | None = typer.Option(None, "--password", envvar="CARAPACE_PASSWORD", help="Password"),

--- a/src/carapace/cli.py
+++ b/src/carapace/cli.py
@@ -758,6 +758,7 @@ def chat(
     api_key: str | None = typer.Option(
         None,
         "--api-key",
+        "--key",
         "-k",
         envvar="CARAPACE_API_KEY",
         help=(
@@ -773,6 +774,8 @@ def chat(
     ),
 ):
     """Start an interactive chat session with the carapace server."""
+    if api_key and (username or password):
+        raise typer.BadParameter("pass either --api-key or --user/--password, not both")
     if api_key:
         client = _api_key_client(server, api_key)
         headers: dict[str, str] = {}  # WebSocket auths via the api_key query parameter instead

--- a/src/carapace/cli.py
+++ b/src/carapace/cli.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 from datetime import datetime
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 import typer
@@ -62,15 +63,27 @@ def _login_client(server: str, username: str | None, password: str | None) -> ht
     return client
 
 
+def _api_key_client(server: str, api_key: str) -> httpx.Client:
+    """Build an authenticated client from an API key (Authorization: Bearer)."""
+    return httpx.Client(base_url=server, headers={"Authorization": f"Bearer {api_key}"})
+
+
 def _cookie_headers(client: httpx.Client) -> dict[str, str]:
     cookie_header = "; ".join(f"{cookie.name}={cookie.value}" for cookie in client.cookies.jar)
     return {"Cookie": cookie_header} if cookie_header else {}
 
 
-def _ws_url(server: str, session_id: str) -> str:
-    """Build WebSocket URL for a session."""
+def _ws_url(server: str, session_id: str, api_key: str | None = None) -> str:
+    """Build WebSocket URL for a session.
+
+    Browsers cannot set ``Authorization`` on a WebSocket, so the chat endpoint also
+    accepts an API key via the ``api_key`` query parameter.
+    """
     base = server.replace("http://", "ws://").replace("https://", "wss://")
-    return f"{base}/api/chat/{session_id}"
+    url = f"{base}/api/chat/{session_id}"
+    if api_key:
+        url += f"?api_key={quote(api_key)}"
+    return url
 
 
 def _replay_history(client: httpx.Client, session_id: str, limit: int) -> None:
@@ -740,6 +753,13 @@ async def _read_server_responses(ws, *, show_tool_events: bool = True) -> None:
 def chat(
     session: str | None = typer.Option(None, "--session", "-s", help="Resume a session by ID"),
     server: str = typer.Option(DEFAULT_SERVER, "--server", envvar="CARAPACE_SERVER", help="Server URL"),
+    api_key: str | None = typer.Option(
+        None,
+        "--api-key",
+        "-k",
+        envvar="CARAPACE_API_KEY",
+        help="API key for Bearer auth (needs the 'sessions' scope). Takes precedence over username/password.",
+    ),
     username: str | None = typer.Option(None, "--user", "-u", envvar="CARAPACE_USER", help="Username"),
     password: str | None = typer.Option(None, "--password", envvar="CARAPACE_PASSWORD", help="Password"),
     list_sessions: bool = typer.Option(False, "--list", "-l", help="List existing sessions"),
@@ -748,8 +768,12 @@ def chat(
     ),
 ):
     """Start an interactive chat session with the carapace server."""
-    client = _login_client(server, username, password)
-    headers = _cookie_headers(client)
+    if api_key:
+        client = _api_key_client(server, api_key)
+        headers: dict[str, str] = {}  # WebSocket auths via the api_key query parameter instead
+    else:
+        client = _login_client(server, username, password)
+        headers = _cookie_headers(client)
 
     if list_sessions:
         sessions: list[dict[str, Any]] = []
@@ -826,7 +850,7 @@ def chat(
     if session and history != 0:
         _replay_history(client, session_id, history)
 
-    url = _ws_url(server, session_id)
+    url = _ws_url(server, session_id, api_key)
     try:
         asyncio.run(_chat_loop(url, headers=headers))
     except Exception as e:

--- a/src/carapace/database/alembic/versions/0003_api_keys.py
+++ b/src/carapace/database/alembic/versions/0003_api_keys.py
@@ -38,6 +38,7 @@ def upgrade() -> None:
         sa.Column("last_used_at", carapace.database.base.UtcDateTime(timezone=True), nullable=True),
         sa.Column("expires_at", carapace.database.base.UtcDateTime(timezone=True), nullable=True),
         sa.Column("revoked_at", carapace.database.base.UtcDateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user"], ["users.username"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
     )
     with op.batch_alter_table("api_keys", schema=None) as batch_op:

--- a/src/carapace/database/alembic/versions/0003_api_keys.py
+++ b/src/carapace/database/alembic/versions/0003_api_keys.py
@@ -1,0 +1,55 @@
+"""api keys
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-06-11 12:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+import carapace.database.base
+
+# revision identifiers, used by Alembic.
+revision: str = "0003"
+down_revision: str | None = "0002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "api_keys",
+        sa.Column("id", sa.String(length=64), nullable=False),
+        sa.Column("prefix", sa.String(length=16), nullable=False),
+        sa.Column("secret_hash", sa.String(length=128), nullable=False),
+        sa.Column("user", sa.String(length=256), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column(
+            "scopes", sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"), nullable=False
+        ),
+        sa.Column("created_at", carapace.database.base.UtcDateTime(timezone=True), nullable=False),
+        sa.Column("last_used_at", carapace.database.base.UtcDateTime(timezone=True), nullable=True),
+        sa.Column("expires_at", carapace.database.base.UtcDateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", carapace.database.base.UtcDateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    with op.batch_alter_table("api_keys", schema=None) as batch_op:
+        batch_op.create_index(batch_op.f("ix_api_keys_prefix"), ["prefix"], unique=True)
+        batch_op.create_index(batch_op.f("ix_api_keys_user"), ["user"], unique=False)
+        batch_op.create_index(batch_op.f("ix_api_keys_expires_at"), ["expires_at"], unique=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("api_keys", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_api_keys_expires_at"))
+        batch_op.drop_index(batch_op.f("ix_api_keys_user"))
+        batch_op.drop_index(batch_op.f("ix_api_keys_prefix"))
+
+    op.drop_table("api_keys")

--- a/src/carapace/database/models.py
+++ b/src/carapace/database/models.py
@@ -169,7 +169,8 @@ class ApiKeyRow(Base):
     id: Mapped[str] = mapped_column(String(64), primary_key=True)  # uuid4 hex
     prefix: Mapped[str] = mapped_column(String(16), unique=True, index=True)  # non-secret lookup handle
     secret_hash: Mapped[str] = mapped_column(String(128))  # sha256 hex of the full token
-    user: Mapped[str] = mapped_column(String(256), index=True)  # normalized username
+    # Owning user; ON DELETE CASCADE drops keys with their user so a reused username can't inherit them.
+    user: Mapped[str] = mapped_column(String(256), ForeignKey("users.username", ondelete="CASCADE"), index=True)
     name: Mapped[str] = mapped_column(Text, default="")
     # Granted scopes as "scope:access" strings (e.g. "sessions:write", "jobs:read").
     scopes: Mapped[list[str]] = mapped_column(JsonType, default=list)

--- a/src/carapace/database/models.py
+++ b/src/carapace/database/models.py
@@ -163,6 +163,22 @@ class SandboxTokenRow(Base):
     token: Mapped[str] = mapped_column(String(128), unique=True, index=True)
 
 
+class ApiKeyRow(Base):
+    __tablename__ = "api_keys"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)  # uuid4 hex
+    prefix: Mapped[str] = mapped_column(String(16), unique=True, index=True)  # non-secret lookup handle
+    secret_hash: Mapped[str] = mapped_column(String(128))  # sha256 hex of the full token
+    user: Mapped[str] = mapped_column(String(256), index=True)  # normalized username
+    name: Mapped[str] = mapped_column(Text, default="")
+    # Granted scopes as "scope:access" strings (e.g. "sessions:write", "jobs:read").
+    scopes: Mapped[list[str]] = mapped_column(JsonType, default=list)
+    created_at: Mapped[datetime] = mapped_column(UtcDateTime)
+    last_used_at: Mapped[datetime | None] = mapped_column(UtcDateTime, nullable=True)
+    expires_at: Mapped[datetime | None] = mapped_column(UtcDateTime, nullable=True, index=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(UtcDateTime, nullable=True)
+
+
 class ModelRow(Base):
     __tablename__ = "models"
 

--- a/src/carapace/server/__init__.py
+++ b/src/carapace/server/__init__.py
@@ -29,6 +29,7 @@ from pydantic_ai.exceptions import UsageLimitExceeded
 from sqlalchemy import Engine
 
 from .. import get_version
+from ..api_keys import ApiKeyStore
 from ..auth import AuthStore
 from ..bootstrap import ensure_data_dir, ensure_knowledge_dir
 from ..cache import SessionListCache
@@ -53,6 +54,7 @@ from ..sandbox.runtime import ContainerRuntime
 from ..session import SessionEngine, SessionManager
 from ..session.archive import SessionArchiveService
 from ..usage import SessionBudgetExceededError
+from .api_keys import router as api_keys_router
 from .auth import router as auth_router
 from .auth import verify_ws_token
 from .history import router as history_router
@@ -94,6 +96,7 @@ _notification_store: NotificationStore
 _notification_presence: NotificationPresenceRegistry
 _notification_router: NotificationRouter
 _auth_store: AuthStore
+_api_key_store: ApiKeyStore
 _platform_store: PlatformSettingsStore
 
 
@@ -305,6 +308,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
         _notification_presence, \
         _notification_router, \
         _auth_store, \
+        _api_key_store, \
         _platform_store
 
     # 1. Build config from env (CARAPACE_DATA_DIR + CARAPACE_* subsections; no config file)
@@ -323,6 +327,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     _config = _platform_store.overlay_config(_config)
 
     _auth_store = AuthStore(_session_factory, _config.auth, _data_dir)
+    _api_key_store = ApiKeyStore(_session_factory, _auth_store)
     if _auth_store.ensure_bootstrap_admin() is not None:
         logger.warning("Created bootstrap admin user 'admin' with password from CARAPACE_TOKEN")
     _knowledge_repo_registry = KnowledgeRepoRegistry(_data_dir)
@@ -734,6 +739,7 @@ router.include_router(platform_settings_router)
 router.include_router(user_settings_router)
 router.include_router(websocket_router)
 router.include_router(auth_router)
+router.include_router(api_keys_router)
 app.include_router(router)
 
 

--- a/src/carapace/server/api_keys.py
+++ b/src/carapace/server/api_keys.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from ..api_keys import ApiKeyGrant, ApiKeyInfo
+from ..auth import UserIdentity
+from .auth import _api_key_store, current_user
+
+router = APIRouter()
+
+MAX_EXPIRY_DAYS = 3650
+
+
+class ApiKeyCreateRequest(BaseModel):
+    name: str = ""
+    scopes: list[str] = Field(default_factory=list)
+    expires_in_days: int | None = Field(default=None, ge=1, le=MAX_EXPIRY_DAYS)
+
+
+class ApiKeyCreateResponse(BaseModel):
+    key: ApiKeyInfo
+    # Plaintext token — returned only here, never again.
+    secret: str
+
+
+def _parse_grants(scopes: list[str]) -> list[ApiKeyGrant]:
+    try:
+        return [ApiKeyGrant.parse(scope) for scope in scopes]
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid scope: {exc}") from exc
+
+
+@router.post("/keys", response_model=ApiKeyCreateResponse, status_code=201)
+async def create_api_key(
+    body: ApiKeyCreateRequest,
+    user: Annotated[UserIdentity, Depends(current_user)],
+) -> ApiKeyCreateResponse:
+    grants = _parse_grants(body.scopes)
+    expires_at = (
+        datetime.now(tz=UTC) + timedelta(days=body.expires_in_days) if body.expires_in_days is not None else None
+    )
+    try:
+        info, secret = _api_key_store().create_key(
+            user=user.username,
+            name=body.name,
+            grants=grants,
+            expires_at=expires_at,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return ApiKeyCreateResponse(key=info, secret=secret)
+
+
+@router.get("/keys", response_model=list[ApiKeyInfo])
+async def list_api_keys(user: Annotated[UserIdentity, Depends(current_user)]) -> list[ApiKeyInfo]:
+    return _api_key_store().list_keys(user.username)
+
+
+@router.delete("/keys/{key_id}", status_code=204)
+async def revoke_api_key(
+    key_id: str,
+    user: Annotated[UserIdentity, Depends(current_user)],
+) -> None:
+    if not _api_key_store().revoke_key(user=user.username, key_id=key_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="API key not found")

--- a/src/carapace/server/auth.py
+++ b/src/carapace/server/auth.py
@@ -266,25 +266,22 @@ async def current_ws_context(websocket: WebSocket) -> AuthContext:
     token = websocket.cookies.get(cookie_name)
     ticket = websocket.query_params.get("ticket")
     api_key = websocket.query_params.get("api_key")
+    # Try each credential in order, falling through on failure (a stale browser cookie must not
+    # block a valid api_key in the query string — mirrors the REST cookie→Bearer fall-through).
     if token:
         identity = _auth_store().validate_session_token(token)
-        return _ws_context_or_close(identity, None)
+        if identity is not None:
+            return AuthContext(identity=identity, grants=None)
     if ticket:
         identity = _auth_store().validate_websocket_token(ticket)
-        return _ws_context_or_close(identity, None)
+        if identity is not None:
+            return AuthContext(identity=identity, grants=None)
     if api_key:
         result = _api_key_store().validate_key(api_key)
-        if result is None:
-            raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
-        identity, grants = result
-        return AuthContext(identity=identity, grants=frozenset(grants))
+        if result is not None:
+            identity, grants = result
+            return AuthContext(identity=identity, grants=frozenset(grants))
     raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
-
-
-def _ws_context_or_close(identity: UserIdentity | None, grants: frozenset[ApiKeyGrant] | None) -> AuthContext:
-    if identity is None:
-        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
-    return AuthContext(identity=identity, grants=grants)
 
 
 async def current_ws_user(websocket: WebSocket) -> UserIdentity:

--- a/src/carapace/server/auth.py
+++ b/src/carapace/server/auth.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response, WebSoc
 from loguru import logger
 from pydantic import BaseModel
 
+from ..api_keys import Access, ApiKeyGrant, ApiKeyStore, Scope
 from ..auth import AuthStore, AuthUser, UserIdentity, has_admin_role, normalize_username
 from ..bootstrap import ensure_knowledge_dir
 from ..models.credentials import BitwardenCredentialBackendConfig
@@ -166,6 +167,15 @@ def _auth_store() -> AuthStore:
     return store
 
 
+def _api_key_store() -> ApiKeyStore:
+    store = getattr(server, "_api_key_store", None)
+    if isinstance(store, ApiKeyStore):
+        return store
+    store = ApiKeyStore(_auth_store()._session_factory, _auth_store())
+    server._api_key_store = store  # type: ignore[attr-defined]
+    return store
+
+
 def _user_response(username: str) -> AdminUserResponse:
     try:
         normalized_username = normalize_username(username)
@@ -189,7 +199,16 @@ def _user_response(username: str) -> AdminUserResponse:
     )
 
 
+class AuthContext(BaseModel):
+    """Resolved principal for a request. ``grants`` is ``None`` for cookie sessions
+    (full access); for API keys it is the set of grants the key carries."""
+
+    identity: UserIdentity
+    grants: frozenset[ApiKeyGrant] | None = None
+
+
 async def current_user(request: Request) -> UserIdentity:
+    """Cookie-session identity only. Used by login-bootstrap and key-management routes."""
     session_cookie = request.cookies.get(server._config.auth.cookie.name)
     if not session_cookie:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
@@ -199,33 +218,99 @@ async def current_user(request: Request) -> UserIdentity:
     return identity
 
 
-async def current_ws_user(websocket: WebSocket) -> UserIdentity:
+async def current_auth_context(request: Request) -> AuthContext:
+    """Resolve identity from the session cookie OR an ``Authorization: Bearer`` API key."""
+    session_cookie = request.cookies.get(server._config.auth.cookie.name)
+    if session_cookie:
+        identity = _auth_store().validate_session_token(session_cookie)
+        if identity is not None:
+            return AuthContext(identity=identity, grants=None)
+
+    authorization = request.headers.get("authorization", "")
+    if authorization.lower().startswith("bearer "):
+        token = authorization[7:].strip()
+        result = _api_key_store().validate_key(token)
+        if result is not None:
+            identity, grants = result
+            return AuthContext(identity=identity, grants=frozenset(grants))
+
+    raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
+
+
+def _enforce_scope(ctx: AuthContext, scope: Scope, access: Access) -> UserIdentity:
+    if ctx.grants is not None and not any(grant.satisfies(scope, access) for grant in ctx.grants):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"API key missing {scope.value}:{access.value} scope",
+        )
+    if scope is Scope.admin and not has_admin_role(ctx.identity.roles):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin role required")
+    return ctx.identity
+
+
+def require(scope: Scope, access: Access):
+    """Build a dependency that requires the given scope/access for API keys.
+
+    Cookie sessions bypass scope checks (full access), except ``admin`` which always
+    requires the admin role.
+    """
+
+    async def dependency(ctx: Annotated[AuthContext, Depends(current_auth_context)]) -> UserIdentity:
+        return _enforce_scope(ctx, scope, access)
+
+    return dependency
+
+
+async def current_ws_context(websocket: WebSocket) -> AuthContext:
     cookie_name = server._config.auth.cookie.name
     token = websocket.cookies.get(cookie_name)
     ticket = websocket.query_params.get("ticket")
+    api_key = websocket.query_params.get("api_key")
     if token:
         identity = _auth_store().validate_session_token(token)
-    elif ticket:
+        return _ws_context_or_close(identity, None)
+    if ticket:
         identity = _auth_store().validate_websocket_token(ticket)
-    else:
-        identity = None
+        return _ws_context_or_close(identity, None)
+    if api_key:
+        result = _api_key_store().validate_key(api_key)
+        if result is None:
+            raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
+        identity, grants = result
+        return AuthContext(identity=identity, grants=frozenset(grants))
+    raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
+
+
+def _ws_context_or_close(identity: UserIdentity | None, grants: frozenset[ApiKeyGrant] | None) -> AuthContext:
     if identity is None:
         raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
-    return identity
+    return AuthContext(identity=identity, grants=grants)
 
 
-async def verify_token(user: Annotated[UserIdentity, Depends(current_user)]) -> UserIdentity:
-    return user
+async def current_ws_user(websocket: WebSocket) -> UserIdentity:
+    return await current_ws_user_scoped(websocket, Scope.sessions, Access.write)
+
+
+async def current_ws_user_scoped(websocket: WebSocket, scope: Scope, access: Access) -> UserIdentity:
+    ctx = await current_ws_context(websocket)
+    if ctx.grants is not None and not any(grant.satisfies(scope, access) for grant in ctx.grants):
+        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
+    if scope is Scope.admin and not has_admin_role(ctx.identity.roles):
+        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
+    return ctx.identity
+
+
+async def verify_token(ctx: Annotated[AuthContext, Depends(current_auth_context)]) -> UserIdentity:
+    """Any authenticated principal (cookie or API key), no scope requirement."""
+    return ctx.identity
 
 
 async def verify_ws_token(websocket: WebSocket) -> UserIdentity:
     return await current_ws_user(websocket)
 
 
-async def verify_admin_user(user: Annotated[UserIdentity, Depends(current_user)]) -> UserIdentity:
-    if not has_admin_role(user.roles):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin role required")
-    return user
+async def verify_admin_user(ctx: Annotated[AuthContext, Depends(current_auth_context)]) -> UserIdentity:
+    return _enforce_scope(ctx, Scope.admin, Access.write)
 
 
 def _enabled_admin_usernames() -> set[str]:
@@ -359,7 +444,9 @@ async def create_websocket_ticket(
 
 
 @router.get("/admin/users", response_model=list[AdminUserResponse])
-async def list_admin_users(_admin_user: Annotated[UserIdentity, Depends(verify_admin_user)]) -> list[AdminUserResponse]:
+async def list_admin_users(
+    _admin_user: Annotated[UserIdentity, Depends(require(Scope.admin, Access.read))],
+) -> list[AdminUserResponse]:
     users = _auth_store().load_users().users
     return [_user_response(username) for username in sorted(users)]
 
@@ -367,7 +454,7 @@ async def list_admin_users(_admin_user: Annotated[UserIdentity, Depends(verify_a
 @router.post("/admin/users", response_model=AdminUserResponse, status_code=201)
 async def create_admin_user(
     body: AdminUserCreateRequest,
-    _admin_user: Annotated[UserIdentity, Depends(verify_admin_user)],
+    _admin_user: Annotated[UserIdentity, Depends(require(Scope.admin, Access.write))],
 ) -> AdminUserResponse:
     store = _auth_store()
     previous_user = store.get_user(body.username)
@@ -394,7 +481,7 @@ async def create_admin_user(
 async def update_admin_user(
     username: str,
     body: AdminUserUpdateRequest,
-    _admin_user: Annotated[UserIdentity, Depends(verify_admin_user)],
+    _admin_user: Annotated[UserIdentity, Depends(require(Scope.admin, Access.write))],
 ) -> AdminUserResponse:
     store = _auth_store()
     existing_user = store.get_user(username)
@@ -433,7 +520,7 @@ async def update_admin_user(
 @router.delete("/admin/users/{username}", status_code=204)
 async def delete_admin_user(
     username: str,
-    admin_user: Annotated[UserIdentity, Depends(verify_admin_user)],
+    admin_user: Annotated[UserIdentity, Depends(require(Scope.admin, Access.write))],
 ) -> Response:
     try:
         normalized_username = normalize_username(username)

--- a/src/carapace/server/history.py
+++ b/src/carapace/server/history.py
@@ -6,11 +6,12 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, model_validator
 from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, ThinkingPart, ToolCallPart, UserPromptPart
 
+from ..api_keys import Access, Scope
 from ..auth import UserIdentity
 from ..models.tooling import SentFileInfo, normalize_tool_call_args
 from ..security.context import ApprovalSource, ApprovalVerdict
 from ..ws_models import Attachment, FinalStatus
-from .auth import verify_token
+from .auth import require
 from .state import server_module
 
 server = server_module()
@@ -85,7 +86,7 @@ class HistoryMessage(BaseModel):
 @router.get("/sessions/{session_id}/history", response_model=list[HistoryMessage])
 async def get_session_history(
     session_id: str,
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.history, Access.read))],
     limit: Annotated[int, Query()] = -1,
 ) -> list[HistoryMessage]:
     if server._engine.session_mgr.load_state(session_id) is None or not server._engine.session_mgr.is_owned_by(

--- a/src/carapace/server/jobs.py
+++ b/src/carapace/server/jobs.py
@@ -8,12 +8,13 @@ from fastapi import APIRouter, Depends, HTTPException, Response
 from loguru import logger
 from pydantic import BaseModel
 
+from ..api_keys import Access, Scope
 from ..auth import UserIdentity
 from ..jobs import build_job_run_message
 from ..models.jobs import JobDefinition, JobDefinitionInput, JobsFile
 from ..models.session import SessionJobRunContext
 from ..user_defaults import apply_job_model_defaults, effective_user_budget
-from .auth import verify_token
+from .auth import require
 from .sessions import SessionInfo, _session_info_from_state
 from .state import server_module
 
@@ -156,14 +157,14 @@ async def _run_job_definition(
 
 
 @router.get("/jobs", response_model=JobsFile)
-async def list_jobs(user: Annotated[UserIdentity, Depends(verify_token)]) -> JobsFile:
+async def list_jobs(user: Annotated[UserIdentity, Depends(require(Scope.jobs, Access.read))]) -> JobsFile:
     return JobsFile(jobs=server._jobs_store.list_jobs_for_user(user.username))
 
 
 @router.post("/jobs", response_model=JobDefinition, status_code=201)
 async def create_job(
     body: JobDefinitionInput,
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.jobs, Access.write))],
 ) -> JobDefinition:
     job = JobDefinition.model_validate({**body.model_dump(mode="json"), "user": user.username})
     try:
@@ -173,7 +174,9 @@ async def create_job(
 
 
 @router.get("/jobs/{job_id}", response_model=JobDefinition)
-async def get_job(job_id: str, user: Annotated[UserIdentity, Depends(verify_token)]) -> JobDefinition:
+async def get_job(
+    job_id: str, user: Annotated[UserIdentity, Depends(require(Scope.jobs, Access.read))]
+) -> JobDefinition:
     job = server._jobs_store.get_job_for_user(job_id, user.username)
     if job is None:
         raise HTTPException(status_code=404, detail="Job not found")
@@ -184,7 +187,7 @@ async def get_job(job_id: str, user: Annotated[UserIdentity, Depends(verify_toke
 async def update_job(
     job_id: str,
     body: JobDefinitionInput,
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.jobs, Access.write))],
 ) -> JobDefinition:
     if body.id != job_id:
         raise HTTPException(status_code=400, detail="Job id in path and body must match")
@@ -199,7 +202,9 @@ async def update_job(
 
 
 @router.delete("/jobs/{job_id}", status_code=204)
-async def delete_job(job_id: str, user: Annotated[UserIdentity, Depends(verify_token)]) -> Response:
+async def delete_job(
+    job_id: str, user: Annotated[UserIdentity, Depends(require(Scope.jobs, Access.write))]
+) -> Response:
     if server._jobs_store.get_job_for_user(job_id, user.username) is None:
         raise HTTPException(status_code=404, detail="Job not found")
     deleted = server._jobs_store.delete_job(job_id)
@@ -211,7 +216,7 @@ async def delete_job(job_id: str, user: Annotated[UserIdentity, Depends(verify_t
 @router.post("/jobs/{job_id}/run", response_model=JobRunResult)
 async def run_job(
     job_id: str,
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.jobs, Access.write))],
     body: JobRunRequest | None = None,
 ) -> JobRunResult:
     job = server._jobs_store.get_job_for_user(job_id, user.username)

--- a/src/carapace/server/notifications.py
+++ b/src/carapace/server/notifications.py
@@ -6,6 +6,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Response
 from pydantic import BaseModel, field_validator
 
+from ..api_keys import Access, Scope
 from ..auth import UserIdentity
 from ..notifications.models import (
     NotificationClientType,
@@ -13,7 +14,7 @@ from ..notifications.models import (
     NotificationPreferences,
     NotificationSubscription,
 )
-from .auth import verify_token
+from .auth import require
 from .state import server_module
 
 server = server_module()
@@ -135,7 +136,7 @@ async def _set_notification_presence(
 
 @router.get("/notifications/subscriptions", response_model=list[NotificationSubscriptionResponse])
 async def list_notification_subscriptions(
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.notifications, Access.read))],
 ) -> list[NotificationSubscriptionResponse]:
     server._notification_store.cleanup_expired()
     subscriptions = server._notification_store.list_subscriptions(user=user.username)
@@ -145,7 +146,7 @@ async def list_notification_subscriptions(
 @router.post("/notifications/subscriptions", response_model=NotificationSubscriptionResponse)
 async def upsert_notification_subscription(
     request: NotificationSubscriptionCreateRequest,
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.notifications, Access.write))],
 ) -> NotificationSubscriptionResponse:
     server._notification_store.cleanup_expired()
     prefs = _default_notification_preferences()
@@ -166,7 +167,7 @@ async def upsert_notification_subscription(
 @router.delete("/notifications/subscriptions/{subscription_id}", status_code=204)
 async def delete_notification_subscription(
     subscription_id: str,
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.notifications, Access.write))],
 ) -> Response:
     subscription = _owned_notification_subscription(subscription_id, user)
     server._notification_store.delete_subscription(subscription.id)
@@ -180,7 +181,7 @@ async def delete_notification_subscription(
 async def patch_notification_subscription_preferences(
     subscription_id: str,
     request: NotificationPreferencesPatch,
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.notifications, Access.write))],
 ) -> NotificationSubscriptionResponse:
     subscription = _owned_notification_subscription(subscription_id, user)
     updated = subscription.model_copy(update={"notification_prefs": request.apply(subscription.notification_prefs)})
@@ -194,7 +195,7 @@ async def patch_notification_subscription_preferences(
 )
 async def test_notification_subscription(
     subscription_id: str,
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.notifications, Access.write))],
 ) -> NotificationTestResponse:
     server._notification_store.cleanup_expired()
     subscription = _owned_notification_subscription(subscription_id, user)
@@ -208,7 +209,7 @@ async def test_notification_subscription(
 async def update_notification_presence(
     subscription_id: str,
     request: NotificationPresenceRequest,
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.notifications, Access.write))],
 ) -> dict[str, bool]:
     subscription = _owned_notification_subscription(subscription_id, user)
     if not server._engine.session_mgr.is_owned_by(request.session_id, user.username):
@@ -229,7 +230,7 @@ async def update_notification_presence(
 @router.post("/notifications/presence")
 async def update_interactive_presence(
     request: InteractivePresenceRequest,
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.notifications, Access.write))],
 ) -> dict[str, bool]:
     if not server._engine.session_mgr.is_owned_by(request.session_id, user.username):
         raise HTTPException(status_code=404, detail="Session not found")

--- a/src/carapace/server/platform_settings.py
+++ b/src/carapace/server/platform_settings.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic_ai.models import Model
 
+from ..api_keys import Access, Scope
 from ..llm import make_model_factory
 from ..models.config import (
     OPENAI_COMPATIBLE_PROVIDERS,
@@ -19,7 +20,7 @@ from ..models.config import (
     agent_available_model_entries,
 )
 from ..models.session import SessionBudget
-from .auth import verify_admin_user
+from .auth import require
 from .state import server_module
 
 server = server_module()
@@ -259,7 +260,7 @@ def _apply_runtime_config(
 
 @router.get("/admin/platform/settings", response_model=PlatformSettingsResponse)
 async def get_platform_settings(
-    _admin: Annotated[object, Depends(verify_admin_user)],
+    _admin: Annotated[object, Depends(require(Scope.admin, Access.read))],
 ) -> PlatformSettingsResponse:
     return _response()
 
@@ -267,7 +268,7 @@ async def get_platform_settings(
 @router.patch("/admin/platform/settings", response_model=PlatformSettingsResponse)
 async def update_platform_settings(
     body: PlatformSettingsPatch,
-    _admin: Annotated[object, Depends(verify_admin_user)],
+    _admin: Annotated[object, Depends(require(Scope.admin, Access.write))],
 ) -> PlatformSettingsResponse:
     # Build + validate the new agent config (AgentConfig() re-runs the defaults∈catalog check),
     # then a candidate Config so the runtime model factory can be built before we persist anything.

--- a/src/carapace/server/session_sandbox.py
+++ b/src/carapace/server/session_sandbox.py
@@ -6,11 +6,12 @@ from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
+from ..api_keys import Access, Scope
 from ..auth import UserIdentity
 from ..sandbox.manager import UploadError, UploadTooLargeError
 from ..sandbox.state import SessionSandboxSnapshot
 from ..session import sent_files
-from .auth import verify_token
+from .auth import require
 from .state import server_module
 
 MAX_UPLOAD_BYTES = 50 * 1024 * 1024
@@ -30,7 +31,7 @@ def _load_owned_session(session_id: str, user: UserIdentity):
 @router.get("/sessions/{session_id}/sandbox", response_model=SessionSandboxSnapshot)
 async def get_session_sandbox(
     session_id: str,
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.read))],
 ) -> SessionSandboxSnapshot:
     _load_owned_session(session_id, user)
     snapshot = server._engine.session_mgr.load_sandbox_snapshot(session_id)
@@ -40,7 +41,7 @@ async def get_session_sandbox(
 @router.post("/sessions/{session_id}/sandbox/up", response_model=SessionSandboxSnapshot)
 async def start_session_sandbox(
     session_id: str,
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.write))],
 ) -> SessionSandboxSnapshot:
     state = _load_owned_session(session_id, user)
     if state.attributes.archived:
@@ -55,7 +56,7 @@ async def start_session_sandbox(
 @router.post("/sessions/{session_id}/sandbox/down", response_model=SessionSandboxSnapshot)
 async def stop_session_sandbox(
     session_id: str,
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.write))],
 ) -> SessionSandboxSnapshot:
     state = _load_owned_session(session_id, user)
     if state.attributes.archived:
@@ -78,7 +79,7 @@ class UploadedFile(BaseModel):
 @router.post("/sessions/{session_id}/sandbox/files", response_model=UploadedFile)
 async def upload_session_sandbox_file(
     session_id: str,
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.write))],
     file: Annotated[UploadFile, File()],
 ) -> UploadedFile:
     state = _load_owned_session(session_id, user)
@@ -133,7 +134,7 @@ async def upload_session_sandbox_file(
 async def download_sent_file(
     session_id: str,
     file_id: str,
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.read))],
     download: Annotated[bool, Query()] = False,
 ) -> FileResponse:
     _load_owned_session(session_id, user)
@@ -153,7 +154,7 @@ async def download_sent_file(
 @router.post("/sessions/{session_id}/sandbox/wipe", response_model=SessionSandboxSnapshot)
 async def wipe_session_sandbox(
     session_id: str,
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.write))],
 ) -> SessionSandboxSnapshot:
     state = _load_owned_session(session_id, user)
     if state.attributes.archived:

--- a/src/carapace/server/sessions.py
+++ b/src/carapace/server/sessions.py
@@ -9,12 +9,13 @@ from loguru import logger
 from pydantic import BaseModel, ValidationError, field_validator, model_validator
 from pydantic_ai.messages import ModelMessage
 
+from ..api_keys import Access, Scope
 from ..auth import UserIdentity
 from ..models.git import GitActionResult, GlobalGitStatus, SandboxGitStatus
 from ..models.session import SessionAttributes, SessionJobRunContext, SessionState
 from ..sandbox.state import SessionSandboxSnapshot
 from ..user_defaults import apply_user_model_defaults, effective_user_budget
-from .auth import verify_token
+from .auth import require
 from .history import _history_from_messages
 from .state import server_module
 
@@ -258,7 +259,7 @@ async def _list_session_page(
 
 @router.post("/sessions", response_model=SessionInfo)
 async def create_session(
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.write))],
     body: SessionCreateRequest | None = None,
 ) -> SessionInfo:
     body = body or SessionCreateRequest()
@@ -279,7 +280,7 @@ async def create_session(
 
 @router.get("/sessions", response_model=SessionListPage)
 async def list_sessions(
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.read))],
     include_message_count: bool = False,
     include_archived: bool = False,
     limit: int = Query(default=50, ge=1, le=200),
@@ -295,7 +296,9 @@ async def list_sessions(
 
 
 @router.get("/sessions/{session_id}", response_model=SessionInfo)
-async def get_session(session_id: str, user: Annotated[UserIdentity, Depends(verify_token)]) -> SessionInfo:
+async def get_session(
+    session_id: str, user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.read))]
+) -> SessionInfo:
     state = _load_owned_state(session_id, user)
     sandbox = server._engine.session_mgr.load_sandbox_snapshot(session_id)
     return SessionInfo.from_state(
@@ -310,7 +313,7 @@ async def get_session(session_id: str, user: Annotated[UserIdentity, Depends(ver
 async def update_session(
     session_id: str,
     body: SessionUpdateRequest,
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.write))],
 ) -> SessionInfo:
     state = _load_owned_state(session_id, user)
 
@@ -413,7 +416,7 @@ async def update_session(
 async def fork_session(
     session_id: str,
     body: SessionForkRequest,
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.write))],
 ) -> SessionInfo:
     _load_owned_state(session_id, user)
 
@@ -444,7 +447,7 @@ async def fork_session(
 @router.post("/sessions/{session_id}/knowledge/commit", response_model=SessionArchiveCommitResponse)
 async def commit_session_knowledge(
     session_id: str,
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.write))],
 ) -> SessionArchiveCommitResponse:
     state = _load_owned_state(session_id, user)
     if not server._session_archive.enabled:
@@ -479,7 +482,9 @@ async def commit_session_knowledge(
 
 
 @router.delete("/sessions/{session_id}", status_code=204)
-async def delete_session(session_id: str, user: Annotated[UserIdentity, Depends(verify_token)]) -> None:
+async def delete_session(
+    session_id: str, user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.write))]
+) -> None:
     state = _load_owned_state(session_id, user)
     server._engine.deactivate(session_id)
     await server._engine.sandbox_mgr.destroy_session(session_id)
@@ -500,7 +505,7 @@ async def delete_session(session_id: str, user: Annotated[UserIdentity, Depends(
 @router.get("/sessions/{session_id}/sandbox/git", response_model=SandboxGitStatus)
 async def get_sandbox_git(
     session_id: str,
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.read))],
     fetch: Annotated[bool, Query()] = True,
 ) -> SandboxGitStatus:
     _load_owned_state(session_id, user)
@@ -512,13 +517,17 @@ async def get_sandbox_git(
 
 
 @router.post("/sessions/{session_id}/sandbox/git/pull", response_model=GitActionResult)
-async def pull_sandbox_git(session_id: str, user: Annotated[UserIdentity, Depends(verify_token)]) -> GitActionResult:
+async def pull_sandbox_git(
+    session_id: str, user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.write))]
+) -> GitActionResult:
     _load_owned_state(session_id, user)
     return await server._engine.sandbox_mgr.sandbox_git_pull(session_id)
 
 
 @router.post("/sessions/{session_id}/sandbox/git/push", response_model=GitActionResult)
-async def push_sandbox_git(session_id: str, user: Annotated[UserIdentity, Depends(verify_token)]) -> GitActionResult:
+async def push_sandbox_git(
+    session_id: str, user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.write))]
+) -> GitActionResult:
     _load_owned_state(session_id, user)
     return await server._engine.sandbox_mgr.sandbox_git_push(session_id)
 
@@ -529,7 +538,9 @@ async def push_sandbox_git(session_id: str, user: Annotated[UserIdentity, Depend
 
 
 @router.get("/git/status", response_model=GlobalGitStatus)
-async def get_global_git(user: Annotated[UserIdentity, Depends(verify_token)]) -> GlobalGitStatus:
+async def get_global_git(
+    user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.read))],
+) -> GlobalGitStatus:
     try:
         configured, ahead, behind = await server._knowledge_git_runtime.status_for_user(user.username)
     except Exception as exc:
@@ -539,7 +550,9 @@ async def get_global_git(user: Annotated[UserIdentity, Depends(verify_token)]) -
 
 
 @router.post("/git/pull", response_model=GitActionResult)
-async def pull_global_git(user: Annotated[UserIdentity, Depends(verify_token)]) -> GitActionResult:
+async def pull_global_git(
+    user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.write))],
+) -> GitActionResult:
     try:
         ok, message = await server._knowledge_git_runtime.pull_for_user(user.username)
     except Exception as exc:
@@ -548,7 +561,9 @@ async def pull_global_git(user: Annotated[UserIdentity, Depends(verify_token)]) 
 
 
 @router.post("/git/push", response_model=GitActionResult)
-async def push_global_git(user: Annotated[UserIdentity, Depends(verify_token)]) -> GitActionResult:
+async def push_global_git(
+    user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.write))],
+) -> GitActionResult:
     try:
         ok, message = await server._knowledge_git_runtime.push_for_user(user.username)
     except Exception as exc:

--- a/src/carapace/server/user_settings.py
+++ b/src/carapace/server/user_settings.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
+from ..api_keys import Access, Scope
 from ..auth import AuthStore, UserIdentity, normalize_username
 from ..credentials.registry import file_credential_backend_allowed_from_env
 from ..models.credentials import (
@@ -19,7 +20,7 @@ from ..models.credentials import (
 from ..models.matrix import MatrixChannelConfig, MatrixTokensFile
 from ..models.session import SessionBudget
 from ..models.user import UserConfig, UserDefaultModelsConfig, UserGitConfig
-from .auth import verify_token
+from .auth import require
 from .state import server_module
 
 server = server_module()
@@ -469,14 +470,16 @@ def _apply_git_patch(config: UserConfig, patch: GitSettingsPatch) -> None:
 
 
 @router.get("/user/settings", response_model=UserSettingsResponse)
-async def get_user_settings(user: Annotated[UserIdentity, Depends(verify_token)]) -> UserSettingsResponse:
+async def get_user_settings(
+    user: Annotated[UserIdentity, Depends(require(Scope.preferences, Access.read))],
+) -> UserSettingsResponse:
     return _settings_response(user.username)
 
 
 @router.patch("/user/settings", response_model=UserSettingsResponse)
 async def update_user_settings(
     body: UserSettingsPatch,
-    user: Annotated[UserIdentity, Depends(verify_token)],
+    user: Annotated[UserIdentity, Depends(require(Scope.preferences, Access.write))],
 ) -> UserSettingsResponse:
     stored_user = _auth_store().get_user(user.username)
     if stored_user is None:

--- a/src/carapace/server/websocket.py
+++ b/src/carapace/server/websocket.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, Query, WebSocket, WebSocketDisconnect
 from loguru import logger
 from pydantic import BaseModel
 
+from ..api_keys import Access, Scope
 from ..auth import UserIdentity
 from ..models.tooling import ToolResult, normalize_tool_call_args
 from ..notifications.models import NotificationClientType
@@ -44,7 +45,7 @@ from ..ws_models import (
     UserMessageNotification,
     parse_client_message,
 )
-from .auth import verify_token, verify_ws_token
+from .auth import require, verify_ws_token
 from .notifications import _set_notification_presence
 from .state import server_module
 
@@ -81,12 +82,14 @@ def _llm_activity_payload(activity: LlmRequestState | None) -> LlmActivity | Non
 
 
 @router.get("/commands")
-async def list_commands(_user: Annotated[UserIdentity, Depends(verify_token)]) -> list[dict[str, str]]:
+async def list_commands(
+    _user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.read))],
+) -> list[dict[str, str]]:
     return SLASH_COMMANDS
 
 
 @router.get("/meta", response_model=ServerMeta)
-async def get_meta(_user: Annotated[UserIdentity, Depends(verify_token)]) -> ServerMeta:
+async def get_meta(_user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.read))]) -> ServerMeta:
     return ServerMeta(version=server._APP_VERSION)
 
 
@@ -99,7 +102,9 @@ async def get_vapid_public_key() -> VapidPublicKeyResponse:
 
 
 @router.get("/models")
-async def list_models(_user: Annotated[UserIdentity, Depends(verify_token)]) -> list[dict[str, Any]]:
+async def list_models(
+    _user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.read))],
+) -> list[dict[str, Any]]:
     return [e.model_dump(mode="json", by_alias=True) for e in server._engine.available_model_entries]
 
 

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -83,6 +83,15 @@ def test_key_dies_when_user_disabled_or_deleted(stores):
     assert keys.validate_key(secret) is None
 
 
+def test_recreated_user_does_not_inherit_old_keys(stores):
+    auth, keys = stores
+    _info, secret = keys.create_key(user="thies", name="ci", grants=[_read_grant(Scope.jobs, Access.read)])
+    auth.delete_user("thies")
+    auth.create_user(username="thies", password="a-fresh-password", display_name="Thies")
+    assert keys.validate_key(secret) is None
+    assert keys.list_keys("thies") == []
+
+
 def test_key_survives_password_change(stores):
     auth, keys = stores
     _info, secret = keys.create_key(user="thies", name="ci", grants=[_read_grant(Scope.jobs, Access.read)])

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -1,0 +1,171 @@
+"""API key store + grant tests (no LLM tokens needed)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from carapace.api_keys import Access, ApiKeyGrant, ApiKeyStore, Scope
+from carapace.auth import AuthStore
+from carapace.database.models import ApiKeyRow
+from carapace.models.config import AuthConfig
+
+
+@pytest.fixture
+def stores(db_factory, tmp_path):
+    auth = AuthStore(db_factory, AuthConfig(), tmp_path)
+    auth.create_user(username="thies", password="secret-password", display_name="Thies")
+    auth.create_user(username="admin", password="admin-password", roles=["admin"])
+    return auth, ApiKeyStore(db_factory, auth)
+
+
+def _read_grant(scope: Scope, access: Access) -> ApiKeyGrant:
+    return ApiKeyGrant(scope=scope, access=access)
+
+
+def test_create_and_validate_round_trip(stores):
+    _auth, keys = stores
+    info, secret = keys.create_key(user="thies", name="ci", grants=[_read_grant(Scope.sessions, Access.write)])
+    assert secret.startswith("ck_")
+    result = keys.validate_key(secret)
+    assert result is not None
+    identity, grants = result
+    assert identity.username == "thies"
+    assert grants == {_read_grant(Scope.sessions, Access.write)}
+    assert info.scopes == ["sessions:write"]
+
+
+def test_secret_is_hashed_at_rest(stores, db_factory):
+    _auth, keys = stores
+    _info, secret = keys.create_key(user="thies", name="ci", grants=[_read_grant(Scope.jobs, Access.read)])
+    with db_factory() as db:
+        rows = db.query(ApiKeyRow).all()
+        assert len(rows) == 1
+        assert secret not in rows[0].secret_hash
+        assert rows[0].secret_hash != secret
+        assert len(rows[0].secret_hash) == 64  # sha256 hex
+
+
+def test_validate_rejects_unknown_and_wrong_secret(stores):
+    _auth, keys = stores
+    _info, secret = keys.create_key(user="thies", name="ci", grants=[_read_grant(Scope.jobs, Access.read)])
+    assert keys.validate_key("ck_deadbeef.nope") is None
+    assert keys.validate_key("garbage-without-dot") is None
+    prefix = secret.split(".", 1)[0]
+    assert keys.validate_key(f"{prefix}.wrongbody") is None
+
+
+def test_validate_rejects_revoked(stores):
+    _auth, keys = stores
+    info, secret = keys.create_key(user="thies", name="ci", grants=[_read_grant(Scope.jobs, Access.read)])
+    assert keys.revoke_key(user="thies", key_id=info.id) is True
+    assert keys.validate_key(secret) is None
+
+
+def test_validate_rejects_expired(stores):
+    _auth, keys = stores
+    past = datetime.now(tz=UTC) - timedelta(seconds=1)
+    _info, secret = keys.create_key(
+        user="thies", name="ci", grants=[_read_grant(Scope.jobs, Access.read)], expires_at=past
+    )
+    assert keys.validate_key(secret) is None
+
+
+def test_key_dies_when_user_disabled_or_deleted(stores):
+    auth, keys = stores
+    _info, secret = keys.create_key(user="thies", name="ci", grants=[_read_grant(Scope.jobs, Access.read)])
+    auth.update_user("thies", {"enabled": False})
+    assert keys.validate_key(secret) is None
+    auth.update_user("thies", {"enabled": True})
+    assert keys.validate_key(secret) is not None
+    auth.delete_user("thies")
+    assert keys.validate_key(secret) is None
+
+
+def test_key_survives_password_change(stores):
+    auth, keys = stores
+    _info, secret = keys.create_key(user="thies", name="ci", grants=[_read_grant(Scope.jobs, Access.read)])
+    auth.set_password("thies", "a-brand-new-password")
+    assert keys.validate_key(secret) is not None
+
+
+def test_admin_grant_requires_admin_role(stores):
+    _auth, keys = stores
+    with pytest.raises(ValueError, match="admin"):
+        keys.create_key(user="thies", name="x", grants=[_read_grant(Scope.admin, Access.write)])
+    info, _secret = keys.create_key(user="admin", name="x", grants=[_read_grant(Scope.admin, Access.write)])
+    assert info.scopes == ["admin:write"]
+
+
+def test_admin_grant_stripped_after_demotion(stores):
+    auth, keys = stores
+    _info, secret = keys.create_key(user="admin", name="x", grants=[_read_grant(Scope.admin, Access.write)])
+    result = keys.validate_key(secret)
+    assert result is not None and result[1] == {_read_grant(Scope.admin, Access.write)}
+    auth.update_user("admin", {"roles": []})
+    result = keys.validate_key(secret)
+    assert result is not None and result[1] == set()
+
+
+def test_create_requires_at_least_one_scope(stores):
+    _auth, keys = stores
+    with pytest.raises(ValueError, match="scope"):
+        keys.create_key(user="thies", name="x", grants=[])
+
+
+def test_revoke_is_owner_scoped(stores):
+    _auth, keys = stores
+    info, _secret = keys.create_key(user="admin", name="x", grants=[_read_grant(Scope.jobs, Access.read)])
+    assert keys.revoke_key(user="thies", key_id=info.id) is False
+    assert keys.revoke_key(user="admin", key_id=info.id) is True
+
+
+def test_list_keys_excludes_revoked(stores):
+    _auth, keys = stores
+    info, _secret = keys.create_key(user="thies", name="a", grants=[_read_grant(Scope.jobs, Access.read)])
+    keys.create_key(user="thies", name="b", grants=[_read_grant(Scope.sessions, Access.read)])
+    keys.revoke_key(user="thies", key_id=info.id)
+    listed = keys.list_keys("thies")
+    assert [k.name for k in listed] == ["b"]
+
+
+def test_last_used_touched_and_coalesced(stores, db_factory):
+    _auth, keys = stores
+    _info, secret = keys.create_key(user="thies", name="ci", grants=[_read_grant(Scope.jobs, Access.read)])
+    keys.validate_key(secret)
+    with db_factory() as db:
+        first = db.query(ApiKeyRow).one().last_used_at
+    assert first is not None
+    keys.validate_key(secret)  # within coalesce window -> no rewrite
+    with db_factory() as db:
+        second = db.query(ApiKeyRow).one().last_used_at
+    assert second == first
+
+
+def test_write_grant_implies_read_but_not_vice_versa():
+    write = _read_grant(Scope.sessions, Access.write)
+    read = _read_grant(Scope.sessions, Access.read)
+    assert write.satisfies(Scope.sessions, Access.read)
+    assert write.satisfies(Scope.sessions, Access.write)
+    assert read.satisfies(Scope.sessions, Access.read)
+    assert not read.satisfies(Scope.sessions, Access.write)
+    assert not write.satisfies(Scope.jobs, Access.read)
+
+
+def test_write_grant_collapses_redundant_read(stores):
+    _auth, keys = stores
+    info, _secret = keys.create_key(
+        user="thies",
+        name="ci",
+        grants=[_read_grant(Scope.sessions, Access.read), _read_grant(Scope.sessions, Access.write)],
+    )
+    assert info.scopes == ["sessions:write"]
+
+
+def test_grant_parse_round_trip():
+    grant = ApiKeyGrant.parse("jobs:write")
+    assert grant == _read_grant(Scope.jobs, Access.write)
+    assert grant.to_str() == "jobs:write"
+    with pytest.raises(ValueError):
+        ApiKeyGrant.parse("bogus:write")

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -117,6 +117,18 @@ def test_admin_grant_stripped_after_demotion(stores):
     assert result is not None and result[1] == set()
 
 
+def test_list_keys_drops_admin_scope_after_demotion(stores):
+    auth, keys = stores
+    keys.create_key(
+        user="admin",
+        name="x",
+        grants=[_read_grant(Scope.admin, Access.write), _read_grant(Scope.jobs, Access.read)],
+    )
+    assert keys.list_keys("admin")[0].scopes == ["admin:write", "jobs:read"]
+    auth.update_user("admin", {"roles": []})
+    assert keys.list_keys("admin")[0].scopes == ["jobs:read"]
+
+
 def test_create_requires_at_least_one_scope(stores):
     _auth, keys = stores
     with pytest.raises(ValueError, match="scope"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ import pytest
 from typer.testing import CliRunner
 
 import carapace.cli as cli_module
-from carapace.cli import _render_escalation_request, _replay_history, app
+from carapace.cli import _render_escalation_request, _replay_history, _ws_url, app
 
 runner = CliRunner()
 
@@ -33,6 +33,35 @@ def test_chat_help():
     assert "--server" in output
     assert "--user" in output
     assert "--password" in output
+    assert "--api-key" in output
+
+
+def test_ws_url_appends_api_key():
+    assert _ws_url("http://example.test", "s1") == "ws://example.test/api/chat/s1"
+    assert _ws_url("https://example.test", "s1", "ck_a.b c") == "wss://example.test/api/chat/s1?api_key=ck_a.b%20c"
+
+
+def test_chat_api_key_uses_bearer_and_skips_login(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeClient:
+        def __init__(self, base_url: str, headers: dict[str, str] | None = None):
+            assert base_url == "http://example.test"
+            assert headers == {"Authorization": "Bearer ck_secret"}
+
+        def post(self, *args: object, **kwargs: object):
+            raise AssertionError("API-key auth must not call /api/auth/login")
+
+        def get(self, url: str, *, params: dict[str, str] | None = None):
+            assert url == "/api/sessions"
+            return _FakeHttpResponse({"items": [], "has_more": False, "next_cursor": None})
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(cli_module.httpx, "Client", _FakeClient)
+
+    result = runner.invoke(app, ["chat", "--server", "http://example.test", "--api-key", "ck_secret", "--list"])
+    assert result.exit_code == 0
+    assert "No existing sessions." in _strip_ansi(result.output)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,6 +34,13 @@ def test_chat_help():
     assert "--user" in output
     assert "--password" in output
     assert "--api-key" in output
+    assert "--key" in output
+
+
+def test_chat_rejects_api_key_with_credentials() -> None:
+    result = runner.invoke(app, ["chat", "--api-key", "ck_secret", "--user", "thies"])
+    assert result.exit_code != 0
+    assert "not both" in _strip_ansi(result.output)
 
 
 def test_ws_url_appends_api_key():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3101,6 +3101,18 @@ def test_ws_api_key_with_sessions_write_connects(client, auth_headers):
         _consume_status(ws)
 
 
+def test_ws_stale_cookie_falls_through_to_api_key(client, auth_headers):
+    create_resp = client.post("/api/sessions", headers=auth_headers, json={"channel_type": "web"})
+    sid = create_resp.json()["session_id"]
+    _info, secret = srv._api_key_store.create_key(
+        user="thies", name="ws", grants=[ApiKeyGrant(scope=Scope.sessions, access=Access.write)]
+    )
+    # A stale/invalid session cookie must not block a valid api_key in the query string.
+    stale_cookie = {"cookie": f"{srv._config.auth.cookie.name}=not-a-valid-token"}
+    with client.websocket_connect(f"/api/chat/{sid}?api_key={secret}", headers=stale_cookie) as ws:
+        _consume_status(ws)
+
+
 def test_ws_api_key_read_only_rejected(client, auth_headers):
     create_resp = client.post("/api/sessions", headers=auth_headers, json={"channel_type": "web"})
     sid = create_resp.json()["session_id"]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -19,6 +19,7 @@ from sqlalchemy import select
 import carapace.server as srv
 import carapace.server.jobs as server_jobs
 import carapace.server.platform_settings as platform_settings
+from carapace.api_keys import Access, ApiKeyGrant, ApiKeyStore, Scope
 from carapace.auth import AuthStore
 from carapace.bootstrap import ensure_data_dir
 from carapace.config import build_config, resolve_user_knowledge_dir
@@ -145,6 +146,7 @@ def _setup_server(tmp_path, monkeypatch, db_factory):
     srv._auth_store = AuthStore(db_factory, config.auth, tmp_path)
     srv._auth_store.create_user(username="admin", password="admin-secret", display_name="Admin", roles=["admin"])
     srv._auth_store.create_user(username="thies", password="secret", display_name="Thies")
+    srv._api_key_store = ApiKeyStore(db_factory, srv._auth_store)
     srv._notification_store = NotificationStore(db_factory)
     srv._notification_presence = NotificationPresenceRegistry(
         ttl=timedelta(seconds=config.notifications.presence_ttl_seconds)
@@ -286,7 +288,98 @@ def _headers_for_user(username: str) -> dict[str, str]:
     return {"Cookie": f"{srv._config.auth.cookie.name}={token}"}
 
 
+def _api_key_headers(username: str, grants: list[ApiKeyGrant]) -> dict[str, str]:
+    _info, secret = srv._api_key_store.create_key(user=username, name="test", grants=grants)
+    return {"Authorization": f"Bearer {secret}"}
+
+
 # --- Auth ---
+
+
+def test_api_key_read_scope_allows_get_but_not_write():
+    headers = _api_key_headers("thies", [ApiKeyGrant(scope=Scope.sessions, access=Access.read)])
+    client = TestClient(app)
+    assert client.get("/api/sessions", headers=headers).status_code == 200
+    assert client.post("/api/sessions", headers=headers, json={}).status_code == 403
+
+
+def test_api_key_write_scope_allows_write():
+    headers = _api_key_headers("thies", [ApiKeyGrant(scope=Scope.sessions, access=Access.write)])
+    client = TestClient(app)
+    assert client.get("/api/sessions", headers=headers).status_code == 200
+    assert client.post("/api/sessions", headers=headers, json={}).status_code == 200
+
+
+def test_api_key_wrong_scope_forbidden():
+    headers = _api_key_headers("thies", [ApiKeyGrant(scope=Scope.jobs, access=Access.write)])
+    client = TestClient(app)
+    assert client.get("/api/jobs", headers=headers).status_code == 200
+    assert client.get("/api/sessions", headers=headers).status_code == 403
+
+
+def test_api_key_admin_scope_requires_admin_role():
+    # non-admin cannot even mint an admin-scoped key
+    with pytest.raises(ValueError, match="admin"):
+        srv._api_key_store.create_key(
+            user="thies", name="x", grants=[ApiKeyGrant(scope=Scope.admin, access=Access.write)]
+        )
+    headers = _api_key_headers("admin", [ApiKeyGrant(scope=Scope.admin, access=Access.write)])
+    client = TestClient(app)
+    assert client.get("/api/admin/users", headers=headers).status_code == 200
+
+
+def test_api_key_admin_grant_decays_when_role_removed():
+    headers = _api_key_headers("admin", [ApiKeyGrant(scope=Scope.admin, access=Access.write)])
+    client = TestClient(app)
+    assert client.get("/api/admin/users", headers=headers).status_code == 200
+    srv._auth_store.create_user(username="admin2", password="admin-secret-2", roles=["admin"])
+    srv._auth_store.update_user("admin", {"roles": []})
+    assert client.get("/api/admin/users", headers=headers).status_code == 403
+
+
+def test_api_key_dies_when_user_disabled():
+    headers = _api_key_headers("thies", [ApiKeyGrant(scope=Scope.sessions, access=Access.read)])
+    client = TestClient(app)
+    assert client.get("/api/sessions", headers=headers).status_code == 200
+    srv._auth_store.update_user("thies", {"enabled": False})
+    assert client.get("/api/sessions", headers=headers).status_code == 401
+
+
+def test_api_key_management_requires_cookie_not_key():
+    cookie = _headers_for_user("thies")
+    client = TestClient(app)
+    resp = client.post("/api/keys", headers=cookie, json={"name": "ci", "scopes": ["sessions:read"]})
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["secret"]
+    secret = body["secret"]
+    # the freshly minted key cannot itself create or list keys (cookie-only management)
+    key_headers = {"Authorization": f"Bearer {secret}"}
+    assert (
+        client.post("/api/keys", headers=key_headers, json={"name": "x", "scopes": ["sessions:read"]}).status_code
+        == 401
+    )
+    assert client.get("/api/keys", headers=key_headers).status_code == 401
+
+
+def test_list_api_keys_omits_secret():
+    cookie = _headers_for_user("thies")
+    client = TestClient(app)
+    client.post("/api/keys", headers=cookie, json={"name": "ci", "scopes": ["jobs:write"]})
+    listed = client.get("/api/keys", headers=cookie).json()
+    assert len(listed) == 1
+    assert "secret" not in listed[0]
+    assert "secret_hash" not in listed[0]
+    assert listed[0]["scopes"] == ["jobs:write"]
+
+
+def test_revoke_other_users_key_returns_404():
+    info, _secret = srv._api_key_store.create_key(
+        user="admin", name="k", grants=[ApiKeyGrant(scope=Scope.jobs, access=Access.read)]
+    )
+    cookie = _headers_for_user("thies")
+    client = TestClient(app)
+    assert client.delete(f"/api/keys/{info.id}", headers=cookie).status_code == 404
 
 
 def test_no_auth_returns_401(client):
@@ -2996,6 +3089,26 @@ def test_ws_ticket_allows_cookie_free_websocket(client, auth_headers):
 
     with client.websocket_connect(f"/api/chat/{sid}?ticket={ticket}") as ws:
         _consume_status(ws)
+
+
+def test_ws_api_key_with_sessions_write_connects(client, auth_headers):
+    create_resp = client.post("/api/sessions", headers=auth_headers, json={"channel_type": "web"})
+    sid = create_resp.json()["session_id"]
+    _info, secret = srv._api_key_store.create_key(
+        user="thies", name="ws", grants=[ApiKeyGrant(scope=Scope.sessions, access=Access.write)]
+    )
+    with client.websocket_connect(f"/api/chat/{sid}?api_key={secret}") as ws:
+        _consume_status(ws)
+
+
+def test_ws_api_key_read_only_rejected(client, auth_headers):
+    create_resp = client.post("/api/sessions", headers=auth_headers, json={"channel_type": "web"})
+    sid = create_resp.json()["session_id"]
+    _info, secret = srv._api_key_store.create_key(
+        user="thies", name="ws", grants=[ApiKeyGrant(scope=Scope.sessions, access=Access.read)]
+    )
+    with pytest.raises(Exception), client.websocket_connect(f"/api/chat/{sid}?api_key={secret}"):  # noqa: B017
+        pass
 
 
 def _consume_status(ws):


### PR DESCRIPTION
## What

Users can now create and manage long-lived **API keys** from the web UI. A key acts **as its owning user** but its **scopes narrow access** — read/write per route group: `sessions`, `jobs`, `preferences`, `notifications`, `history`, `admin`.

## Design

- **Opaque, hashed tokens** — `ck_<prefix>.<body>`, only a sha256 hash stored, prefix-indexed lookup, plaintext shown once. New `api_keys` table + alembic `0003`.
- **Bounded by owner** — key dies when the user is disabled/deleted, **survives password change**, and the `admin` grant is stripped live if the user loses the admin role.
- **Self-service only** — each user manages their own keys.
- **Enforced via a FastAPI dependency** — `Depends(require(scope, access))` on every `/api` route. Cookie sessions keep full access (admin scope still needs the admin role); API keys must hold the matching grant. Write implies read.
- **Channels** — `Authorization: Bearer <key>` on REST `/api`, plus the chat WebSocket via `?api_key=` (`sessions:write`). Sandbox API untouched (it has its own per-session tokens).
- **Cookie-only management** — `POST/GET/DELETE /api/keys` require an interactive session; a leaked key cannot mint or list keys (anti privilege-escalation, GitHub-PAT model).

## Layout

- `api_keys.py` — `ApiKeyStore`, `Scope`/`Access`/`ApiKeyGrant`.
- `server/auth.py` — `current_auth_context`, `require()`, WS api-key path.
- `server/api_keys.py` — key-management router.
- `database/models.py` + `alembic/0003` — `ApiKeyRow`.
- Frontend — API Keys settings tab + `api-keys-view.tsx`, api client, en/de i18n.

## One decision to confirm

Chat-WS metadata GETs (`/commands`, `/meta`, `/models`) are gated as `sessions:read`, so a sessions-scoped key can drive a full chat client.

## Verification

- `uv run pyrefly check` — 0 errors
- `uv run pytest` — 943 pass (new `tests/test_api_keys.py` + scope/WS integration tests in `test_server.py`)
- migration up/down/up on fresh sqlite — ok
- `pnpm build` + `tsc` + `eslint` clean, 60 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication and authorization across the entire API and WebSockets; mis-scoped routes or key validation bugs could expose or over-privilege access.
> 
> **Overview**
> Adds **scoped, long-lived API keys** so scripts and integrations can call the API as the owning user with narrowed permissions (`sessions`, `jobs`, `preferences`, `notifications`, `history`, `admin` × read/write).
> 
> **Backend:** New `api_keys` table (Alembic `0003`), `ApiKeyStore` with hashed `ck_<prefix>.<body>` tokens, expiry/revoke, and owner lifecycle rules (disabled/deleted user invalidates keys; admin scope stripped if role is lost). Auth gains `current_auth_context` and `require(scope, access)` on REST routes; cookie sessions stay full-access except admin still needs the role. Keys authenticate via `Authorization: Bearer` on REST and `?api_key=` on chat WebSockets (`sessions:write`). **`POST/GET/DELETE /api/keys` are cookie-only** so a leaked key cannot mint more keys.
> 
> **Frontend:** New **API Keys** settings tab (`api-keys-view.tsx`), client helpers, URL `tab=api-keys`, en/de strings.
> 
> **CLI:** `chat` accepts `--api-key` / `CARAPACE_API_KEY` instead of password login, with scope-aware history replay messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52824c10e6870f8c989e984a4b1c07b5cfc274d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->