### PR TITLE
🐛 fix: persist sandbox git identity across pod restarts

### DIFF
--- a/src/carapace/sandbox/session_lifecycle.py
+++ b/src/carapace/sandbox/session_lifecycle.py
@@ -569,19 +569,21 @@ class SandboxSessionLifecycle:
         probe = await self._runtime.exec(container_id, "test -d /workspace/.git", timeout=5)
         if probe.exit_code == 0:
             logger.debug(f"Knowledge repo already present in sandbox for {session_id}")
-            return
-
-        result = await self._runtime.exec(
-            container_id,
-            "git clone $GIT_REPO_URL /workspace",
-            timeout=60,
-            env=env,
-        )
-        if result.exit_code != 0:
-            raise RuntimeError(
-                f"Git clone failed in sandbox for {session_id} (exit {result.exit_code}): {result.output}"
+        else:
+            result = await self._runtime.exec(
+                container_id,
+                "git clone $GIT_REPO_URL /workspace",
+                timeout=60,
+                env=env,
             )
+            if result.exit_code != 0:
+                raise RuntimeError(
+                    f"Git clone failed in sandbox for {session_id} (exit {result.exit_code}): {result.output}"
+                )
 
+        # Always (re)apply identity and hook: both are repo-local, living on the
+        # persistent /workspace PVC, but a fresh pod after suspend/resume may have
+        # raced ahead of the original clone or predate this repo-local scheme.
         await self.setup_git_identity(container_id, session_id)
         await self.install_commit_msg_hook(container_id, session_id)
 
@@ -594,7 +596,14 @@ class SandboxSessionLifecycle:
             )
 
     async def setup_git_identity(self, container_id: str, session_id: str) -> None:
-        """Configure git user.name and user.email inside the sandbox."""
+        """Configure git user.name and user.email for the knowledge repo.
+
+        Written as repo-local config (``/workspace/.git/config``) rather than
+        ``--global``: only ``/workspace`` is on the persistent PVC, so a global
+        ``~/.gitconfig`` would be wiped whenever the pod is recreated (e.g. on
+        suspend/resume), leaving the agent's first commit to fail with an unknown
+        author. Repo-local config survives on the PVC.
+        """
         name_tpl = self._author_for_session(session_id).replace("%s", session_id)
         if "<" in name_tpl and name_tpl.endswith(">"):
             name, _, email = name_tpl.rpartition("<")
@@ -604,8 +613,9 @@ class SandboxSessionLifecycle:
         name_sh = name.replace("%h", "$(hostname)")
         email_sh = email.replace("%h", "$(hostname)")
         cmd = (
-            f"git config --global user.name {shlex.quote(name_sh)} && "
-            f"git config --global user.email {shlex.quote(email_sh)}"
+            "cd /workspace && "
+            f"git config user.name {shlex.quote(name_sh)} && "
+            f"git config user.email {shlex.quote(email_sh)}"
         )
         await self._runtime.exec(container_id, cmd, timeout=10)
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -402,8 +402,12 @@ async def test_exec_recreate_preserves_domains(tmp_path: Path, db_factory):
     runtime.exec = AsyncMock(
         side_effect=[
             _git_exists,  # knowledge repo probe after first create
+            _git_exists,  # setup_git_identity
+            _git_exists,  # install_commit_msg_hook
             ContainerGoneError(),  # exec_command triggers recreate
             _git_exists,  # knowledge repo probe after recreate
+            _git_exists,  # setup_git_identity
+            _git_exists,  # install_commit_msg_hook
             ExecResult(exit_code=0, output="ok"),  # actual command retry
         ]
     )
@@ -432,8 +436,12 @@ async def test_exec_recreate_reinjects_credential_files(tmp_path: Path, db_facto
     runtime.exec = AsyncMock(
         side_effect=[
             _ok,  # _clone_knowledge_repo probe after first create
+            _ok,  # setup_git_identity
+            _ok,  # install_commit_msg_hook
             ContainerGoneError(),  # exec_command triggers recreate
             _ok,  # _clone_knowledge_repo probe after recreate
+            _ok,  # setup_git_identity
+            _ok,  # install_commit_msg_hook
             _ok,  # git checkout SKILL.md
             _ok,  # git checkout setup.sh
             _ok,  # _file_write_in_container (credential materialization)
@@ -471,13 +479,13 @@ async def test_exec_recreate_reinjects_credential_files(tmp_path: Path, db_facto
     activation_cb.assert_awaited_once_with(session_id, "moneydb")
 
     # Verify upstream restore is used for trusted provider files.
-    restore_call = runtime.exec.call_args_list[4]
+    restore_call = runtime.exec.call_args_list[8]
     assert "git checkout @{upstream} -- skills/moneydb/setup.sh" in restore_call.args[1]
 
     # Verify the credential file was written into the new container via exec.
-    # The 6th exec call (index 5) is the _file_write_in_container for the
-    # credential — check that it targeted the correct workdir.
-    write_call = runtime.exec.call_args_list[5]
+    # Index 9 is the _file_write_in_container for the credential — check that
+    # it targeted the correct workdir.
+    write_call = runtime.exec.call_args_list[9]
     shell_cmd = write_call.args[1]
     assert "/tmp/creds/api_key.json" in shell_cmd
     assert base64.b64encode(b"secret-key-value").decode() in shell_cmd
@@ -494,6 +502,8 @@ async def test_activate_skill_runs_setup_provider_with_activation_inputs(tmp_pat
     runtime.exec = AsyncMock(
         side_effect=[
             ExecResult(exit_code=0, output=""),  # _clone_knowledge_repo probe after create
+            ExecResult(exit_code=0, output=""),  # setup_git_identity
+            ExecResult(exit_code=0, output=""),  # install_commit_msg_hook
             ExecResult(exit_code=0, output=""),  # git checkout SKILL.md
             ExecResult(exit_code=0, output=""),  # git checkout setup.sh
             ExecResult(exit_code=0, output=""),  # credential file write
@@ -521,12 +531,12 @@ async def test_activate_skill_runs_setup_provider_with_activation_inputs(tmp_pat
     result = await mgr.activate_skill("sess-1", "cred-setup")
     assert "setup.sh completed." in result
 
-    setup_call = runtime.exec.call_args_list[4]
+    setup_call = runtime.exec.call_args_list[6]
     assert setup_call.args[1] == "sh ./setup.sh"
     assert setup_call.kwargs.get("workdir") == "/workspace/skills/cred-setup"
     assert setup_call.kwargs.get("env") == {"API_TOKEN": "secret-token"}
 
-    restore_call = runtime.exec.call_args_list[2]
+    restore_call = runtime.exec.call_args_list[4]
     assert "git checkout @{upstream} -- skills/cred-setup/setup.sh" in restore_call.args[1]
 
 
@@ -540,8 +550,12 @@ async def test_activate_skill_recovers_if_trusted_restore_hits_gone_container(tm
     runtime.exec = AsyncMock(
         side_effect=[
             ExecResult(exit_code=0, output=""),  # _clone_knowledge_repo probe after first create
+            ExecResult(exit_code=0, output=""),  # setup_git_identity
+            ExecResult(exit_code=0, output=""),  # install_commit_msg_hook
             ContainerGoneError(),  # trusted restore triggers recreate
             ExecResult(exit_code=0, output=""),  # _clone_knowledge_repo probe after recreate
+            ExecResult(exit_code=0, output=""),  # setup_git_identity
+            ExecResult(exit_code=0, output=""),  # install_commit_msg_hook
             ExecResult(exit_code=0, output=""),  # retried git checkout SKILL.md
             ExecResult(exit_code=0, output=""),  # git checkout setup.sh
             ExecResult(exit_code=0, output=""),  # setup.sh execution
@@ -560,7 +574,7 @@ async def test_activate_skill_recovers_if_trusted_restore_hits_gone_container(tm
     assert "setup.sh completed." in result
     assert runtime.create_sandbox.await_count == 2
 
-    restore_retry_call = runtime.exec.call_args_list[4]
+    restore_retry_call = runtime.exec.call_args_list[8]
     assert "git checkout @{upstream} -- skills/restore-retry/setup.sh" in restore_retry_call.args[1]
 
 
@@ -607,6 +621,8 @@ async def test_activate_skill_registers_command_aliases_in_image_shim_dir(tmp_pa
     runtime.exec = AsyncMock(
         side_effect=[
             ExecResult(exit_code=0, output=""),  # _clone_knowledge_repo probe after create
+            ExecResult(exit_code=0, output=""),  # setup_git_identity
+            ExecResult(exit_code=0, output=""),  # install_commit_msg_hook
             ExecResult(exit_code=0, output=""),  # git checkout SKILL.md
             ExecResult(exit_code=0, output=""),  # command alias registration
         ]
@@ -629,7 +645,7 @@ async def test_activate_skill_registers_command_aliases_in_image_shim_dir(tmp_pa
     assert "Command aliases registered: web." in result
     assert "PATH" not in mgr.get_session_env("sess-1")
 
-    register_call = runtime.exec.call_args_list[2]
+    register_call = runtime.exec.call_args_list[4]
     shell_cmd = register_call.args[1]
     wrapper = '#!/bin/sh\nexec uv run --directory /workspace/skills/web web-search "$@"\n'
     assert "/workspace/.carapace/bin/web" in shell_cmd
@@ -1047,19 +1063,23 @@ async def test_exec_command_recreates_tunnels_before_retry(tmp_path: Path, db_fa
     _ok = ExecResult(exit_code=0, output="")
     runtime.exec = AsyncMock(
         side_effect=[
+            _ok,  # clone probe (create)
+            _ok,  # setup_git_identity
+            _ok,  # install_commit_msg_hook
+            _ok,  # tunnel prep
             _ok,
             _ok,
             _ok,
+            ContainerGoneError(),  # command exec triggers recreate
+            _ok,  # clone probe (recreate)
+            _ok,  # setup_git_identity
+            _ok,  # install_commit_msg_hook
+            _ok,  # tunnel prep
             _ok,
             _ok,
-            ContainerGoneError(),
             _ok,
-            _ok,
-            _ok,
-            _ok,
-            _ok,
-            ExecResult(exit_code=0, output="ok"),
-            _ok,
+            ExecResult(exit_code=0, output="ok"),  # retried command
+            _ok,  # cleanup
         ]
     )
 
@@ -1089,13 +1109,15 @@ async def test_exec_command_cleans_up_tunnels_after_command_failure(tmp_path: Pa
     runtime.logs = AsyncMock(return_value="carapace sandbox ready")
     runtime.exec = AsyncMock(
         side_effect=[
+            ExecResult(exit_code=0, output=""),  # clone probe
+            ExecResult(exit_code=0, output=""),  # setup_git_identity
+            ExecResult(exit_code=0, output=""),  # install_commit_msg_hook
+            ExecResult(exit_code=0, output=""),  # tunnel prep
             ExecResult(exit_code=0, output=""),
             ExecResult(exit_code=0, output=""),
             ExecResult(exit_code=0, output=""),
-            ExecResult(exit_code=0, output=""),
-            ExecResult(exit_code=0, output=""),
-            ExecResult(exit_code=5, output="mail failed"),
-            ExecResult(exit_code=0, output=""),
+            ExecResult(exit_code=5, output="mail failed"),  # command
+            ExecResult(exit_code=0, output=""),  # cleanup
         ]
     )
 


### PR DESCRIPTION
## Problem

Agents in carapace frequently had to set their git identity by hand because the first commit failed with an unknown-author error.

**Root cause:** `setup_git_identity` configured identity via `git config --global`, which writes `~/.gitconfig` on the **ephemeral container rootfs**. Only `/workspace` and `/tmp` are on the persistent PVC. Suspending a sandbox scales its StatefulSet to 0 and resuming scales back to 1, producing a **fresh pod** — the global `~/.gitconfig` is gone, but the cloned repo on `/workspace` survives. `clone_knowledge_repo` early-returns when `/workspace/.git` already exists, so identity was never re-applied → first commit fails.

## Fix

- Write identity as **repo-local** config (`cd /workspace && git config user.name/.email`) instead of `--global`. It lives in `/workspace/.git/config` on the PVC and survives pod recreation.
- Re-apply identity + commit-msg hook even when the repo already exists, so sessions cloned under the old global scheme self-heal on next ensure.

## Tests

Updated mocked `runtime.exec` sequences/index assertions in `test_proxy.py` (each clone now performs 2 extra execs). Full suite: 916 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sandbox git bootstrap only; behavior is more resilient on resume with no auth or data-model changes.
> 
> **Overview**
> Fixes sandbox agents failing their first commit with unknown-author errors after suspend/resume or pod recreation.
> 
> **`setup_git_identity`** now writes **repo-local** `user.name` / `user.email` under `/workspace` (`git config` after `cd /workspace`) instead of `git config --global`, so identity lives on the persistent PVC rather than ephemeral `~/.gitconfig`.
> 
> **`clone_knowledge_repo`** no longer skips setup when `/workspace/.git` already exists: it still clones only when needed, but **always** re-runs git identity and the commit-msg hook so resumed pods and repos created under the old global scheme self-heal.
> 
> **Tests** in `test_proxy.py` extend mocked `runtime.exec` side effects and adjust call-index assertions for the two extra execs per knowledge-repo setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8f669eea4d90b1bb9e0eebfba7c800ace6a67a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->