### PR TITLE
✨ feat: agent-drivable CLI (non-interactive session + job control)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,10 @@ carapace is a security-first personal AI agent with LLM-powered security gating.
 
 ## Setup commands
 
-- Install deps: `uv sync`
-- Install with dev deps: `uv sync --dev`
-- Start server: `uv run python -m carapace` (or `uv run carapace-server`)
+- Install client-only deps: `uv sync` (base package is the CLI client; ~16 light deps)
+- Install server stack: `uv sync --extra server`
+- Install with dev deps: `uv sync --dev` (includes the `server` extra)
+- Start server: `uv run python -m carapace` (or `uv run carapace-server`) — needs the `server` extra
 - Start CLI client: `uv run python -m carapace.cli` (or `uv run carapace`)
 - Start frontend: `cd frontend && pnpm install && pnpm dev`
 - Run type checks: `uv run pyrefly check`

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,12 @@ ENV UV_LINK_MODE=copy
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --no-install-project --no-dev
+    uv sync --locked --no-install-project --no-dev --extra server
 
 # Copy project source and install the project itself
 COPY . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --locked --no-dev --extra server
 
 ENV PATH="/app/.venv/bin:$PATH"
 ENTRYPOINT []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,19 +4,28 @@ version = "0.140.5"
 description = "Security-first personal AI agent with rule-based information flow control"
 readme = "README.md"
 requires-python = ">=3.12"
+# Base deps cover only the `carapace` CLI client (cli.py + payloads.py), so a
+# plain `pip install carapace` is a light client install. The server, agent,
+# database, and integration stack lives in the `server` extra below — install
+# `carapace[server]` to run carapace-server / carapace-migrate.
 dependencies = [
-    "pydantic-ai>=1.59,<2",
     "typer>=0.23,<1",
+    "rich>=15,<16",
+    "httpx>=0.28,<1",
+    "websockets>=16,<17",
+    "python-dotenv>=1.2,<2",
+]
+
+[project.optional-dependencies]
+server = [
+    "pydantic-ai>=1.59,<2",
     "pyyaml>=6,<7",
     "croniter>=6,<7",
-    "rich>=15,<16",
-    "python-dotenv>=1.2,<2",
     "tenacity>=9,<10",
     "logfire[httpx]>=4,<5",
     "fastapi>=0.115,<1",
     "python-multipart>=0.0.20,<1",
     "uvicorn[standard]>=0.40,<1",
-    "websockets>=16,<17",
     "pydantic-settings>=2,<3",
     "genai-prices>=0.0.53",
     "docker>=7,<8",
@@ -41,7 +50,9 @@ carapace-server = "carapace.server:main"
 carapace-migrate = "carapace.database.cli:app"
 
 [dependency-groups]
+# Dev/test/type-check needs the full server stack.
 dev = [
+    "carapace[server]",
     "pyrefly>=1.0.0",
     "pytest",
     "pytest-asyncio",

--- a/src/carapace/assets/skills/carapace/REFERENCE.md
+++ b/src/carapace/assets/skills/carapace/REFERENCE.md
@@ -1,0 +1,96 @@
+# carapace CLI Skill — Reference
+
+Maintainer/operator notes. Runtime instructions for the agent live in `SKILL.md`.
+
+## What this skill does
+
+Bundles the carapace CLI inside the sandbox so an agent can drive a carapace server
+non-interactively: manage sessions, send messages, resolve approvals, and manage jobs
+(see `SKILL.md` for the command surface). It is a thin packaging layer — the actual CLI
+is the `carapace` console script installed from the carapace package itself.
+
+## Required setup (per deployment)
+
+This skill ships with **placeholders** and will not work until an operator fills them in.
+
+### 1. Create a scoped API key
+
+In the carapace UI, create a scoped API key with the minimum scopes the agent needs
+(typically `sessions:read`, `sessions:write`, and `jobs:*` depending on the task).
+
+### 2. Store the key in the vault
+
+Put the API key in your credential vault and note its `<backend>/<id>` path. Then edit
+`SKILL.md` frontmatter, replacing the placeholder:
+
+```yaml
+credentials:
+  - vault_path: <backend>/<your-carapace-api-key-id>   # <-- your vault path
+    description: carapace API key (Bearer) for driving the server
+    env_var: CARAPACE_API_KEY
+```
+
+On `use_skill`, carapace fetches this through the sentinel, asks for approval once, and
+injects it as `CARAPACE_API_KEY` for the session. The CLI reads it automatically — the
+value is never placed on a command line.
+
+### 3. Set the server domain (TWO places, same value)
+
+The sandbox blocks loopback and internal hostnames (`localhost`, `127.0.0.1`,
+`*.internal`, `*.svc`, …), so the CLI must reach the deployment's **public** API domain.
+Replace `carapace.example.com` in both spots in `SKILL.md`:
+
+```yaml
+network:
+  domains:
+    - carapace.example.com            # <-- 1. proxy allowlist
+
+commands:
+  - name: carapace
+    command: sh -c 'CARAPACE_SERVER="https://carapace.example.com" ...'   # <-- 2. CLI target
+```
+
+Both must match. `network.domains` opens the proxy; `CARAPACE_SERVER` tells the CLI where
+to connect.
+
+## Why no uv.lock
+
+`uv sync --locked` (the bundled uv provider) would require a committed `uv.lock`, but
+locking a `git+https://…carapace.git` dependency pins a specific commit that goes stale as
+carapace evolves. Instead this skill ships only `pyproject.toml` + `setup.sh`; `setup.sh`
+runs `uv sync` at activation (network open), resolving carapace fresh each time and writing
+an ephemeral lock inside the sandbox. Trade-off: builds are not byte-reproducible, but they
+always track the current default branch.
+
+## Install weight
+
+The base `carapace` package is CLI-only — ~16 deps (typer, rich, httpx, websockets,
+python-dotenv + their small transitive set), **no compiled wheels**, so `uv sync` at
+activation takes seconds. The heavy server/agent stack (fastapi, sqlalchemy, docker, kr8s,
+the LLM SDKs, …) lives in the `carapace[server]` extra and is deliberately not installed
+here. Do not add `[server]` to this skill's dependency — the client needs none of it.
+
+## File layout
+
+```text
+skills/carapace/
+  SKILL.md         # frontmatter (network/credentials/commands) + agent instructions
+  REFERENCE.md     # this file
+  pyproject.toml   # git dependency on the carapace package
+  setup.sh         # `uv sync` at activation (network open)
+```
+
+## Command alias mechanics
+
+The `carapace` alias is registered as a shim on `PATH`. It wraps:
+
+```sh
+sh -c 'CARAPACE_SERVER="https://carapace.example.com" exec uv run --no-sync \
+    --directory /workspace/skills/carapace carapace "$@"' carapace
+```
+
+- `CARAPACE_SERVER` is baked in (non-secret) so the agent never passes `--server`.
+- `--no-sync` keeps command-time invocations off the network (the proxy would block the
+  GitHub install anyway); all installing happens in `setup.sh`.
+- `uv run` prepends the project venv's `bin` to `PATH`, so the inner `carapace` resolves to
+  the installed console script, not the shim.

--- a/src/carapace/assets/skills/carapace/SKILL.md
+++ b/src/carapace/assets/skills/carapace/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: carapace
+description: >-
+  Drive a carapace server non-interactively from inside the sandbox: list/inspect/create/update
+  sessions, send messages and wait for turns, resolve pending approvals by id, and manage jobs
+  (list/get/create/update/delete/run). Use this to let the agent configure, read, start, and
+  interact with carapace sessions and jobs over the JSON CLI. Requires a scoped API key in the vault.
+metadata:
+  carapace:
+    network:
+      # Replace with your deployment's public API domain. The sandbox blocks
+      # loopback/internal hosts, so 127.0.0.1 / localhost will NOT work.
+      domains:
+        - carapace.example.com
+    credentials:
+      # Create a scoped API key in the carapace UI, store it in your vault, and
+      # point vault_path at it. See REFERENCE.md.
+      - vault_path: <backend>/<your-carapace-api-key-id>
+        description: carapace API key (Bearer) for driving the server
+        env_var: CARAPACE_API_KEY
+    commands:
+      # CARAPACE_SERVER must match the network.domains entry above. Edit both when
+      # you change the deployment domain.
+      - name: carapace
+        command: sh -c 'CARAPACE_SERVER="https://carapace.example.com" exec uv run --no-sync --directory /workspace/skills/carapace carapace "$@"' carapace
+---
+
+# carapace CLI
+
+Drive a carapace server over its non-interactive JSON CLI. Authentication is automatic:
+`CARAPACE_API_KEY` (from the vault) and `CARAPACE_SERVER` (baked into the `carapace` command)
+are already set once the skill is active — never pass `--api-key` on the command line.
+
+## Exposed Commands
+
+- `carapace`: the carapace CLI, pre-authenticated against the configured server.
+
+All sub-commands emit JSON to stdout and never render markdown/LaTeX (agent text passes through
+verbatim). **Do not use `carapace chat`** — it is the interactive human REPL and refuses on a
+non-TTY. Use the sub-commands below instead.
+
+## Exit codes
+
+- `0` ok
+- `1` error (details in the JSON `error` field)
+- `2` needs_approval — a turn paused on an approval/escalation request
+- `3` timeout — `--wait` timed out; the turn keeps running server-side
+
+## Sessions
+
+```bash
+carapace session list [--archived] [--limit N]
+carapace session get <session_id>
+carapace session create [--ask|--yolo|--unattended] [--model M] [--sentinel-model M] [--channel cli]
+carapace session update <session_id> [--ask|--yolo|--unattended] [--model M] \
+    [--archive|--unarchive] [--pin|--unpin] [--favorite|--unfavorite]
+carapace session history <session_id> [--limit N]   # messages + pending approvals
+carapace session pending <session_id>               # just pending approval/escalation requests
+carapace session send <session_id> "<message>" [--wait/--no-wait] [--timeout S] [--stream]
+carapace session cancel <session_id>                # cancel the running turn
+```
+
+`session send --wait` (default) drives one turn over the WebSocket and returns when it ends.
+If the turn pauses on an approval/escalation it **aborts without cancelling**, exits `2`, and
+returns the request's `id` plus ready-to-run `allow_command` / `deny_command`. With `--stream`,
+token/thinking/tool events go to **stderr** while stdout carries the final JSON.
+
+## Approvals
+
+Resolve one specific pending request by its unique `id` (from `session pending`/`history` or a
+`needs_approval` result):
+
+```bash
+carapace approval allow <session_id> <request_id> [-m "note"] [--wait] [--timeout S]
+carapace approval deny  <session_id> <request_id> [-m "note"] [--wait] [--timeout S]
+```
+
+Unknown ids return `{"status":"not_found"}` and exit `1`. With `--wait`, the resumed turn is
+read and returned like `session send`.
+
+## Jobs
+
+```bash
+carapace job list
+carapace job get <job_id>
+carapace job create -f <file|->          # JobDefinition JSON ('-' reads stdin)
+carapace job update <job_id> -f <file|->  # replace
+carapace job delete <job_id>
+carapace job run <job_id> [--input PAYLOAD] [--wait/--no-wait] [--timeout S]
+```
+
+## Typical loop (drive a session to completion)
+
+```bash
+sid=$(carapace session create --unattended | jq -r .session_id)
+carapace session send "$sid" "do the thing" --wait
+# exit 2 -> read the JSON, then:
+carapace approval allow "$sid" "<request_id>" --wait
+# repeat until exit 0 (status "done")
+```

--- a/src/carapace/assets/skills/carapace/pyproject.toml
+++ b/src/carapace/assets/skills/carapace/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "carapace-cli-skill"
+version = "0.1.0"
+description = "Drive a carapace server from inside the sandbox via the carapace CLI."
+requires-python = ">=3.12"
+# Installs the real carapace CLI (the `carapace` console script) from the default
+# branch on GitHub. The base carapace package is CLI-only (~16 light deps, no
+# compiled wheels) — the server/agent stack lives in the `carapace[server]` extra,
+# which is NOT pulled here. The install runs at activation (setup.sh, network open).
+dependencies = ["carapace @ git+https://github.com/thiesgerken/carapace.git"]

--- a/src/carapace/assets/skills/carapace/setup.sh
+++ b/src/carapace/assets/skills/carapace/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+# Activation runs with the network open, so the git install of carapace (and its
+# full dependency tree) happens here. `carapace` commands later run with
+# `uv run --no-sync` against this venv, so they never touch the network/proxy.
+uv sync
+
+echo "carapace CLI installed"

--- a/src/carapace/cli.py
+++ b/src/carapace/cli.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
+import sys
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from pathlib import Path
+from typing import Any, NoReturn
 from urllib.parse import quote
 
 import httpx
@@ -766,6 +770,7 @@ def chat(
     history: int = typer.Option(
         -1, "--history", "-H", help="Number of past messages to show on resume (-1 = all, 0 = none)"
     ),
+    force: bool = typer.Option(False, "--force", help="Bypass the interactive-terminal check"),
 ):
     """Start an interactive chat session with the carapace server."""
     if api_key:
@@ -823,6 +828,21 @@ def chat(
         client.close()
         raise typer.Exit()
 
+    if not force and not (sys.stdin.isatty() and sys.stdout.isatty()):
+        client.close()
+        typer.echo(
+            json.dumps(
+                {
+                    "status": "error",
+                    "error": "chat is interactive but stdin/stdout is not a TTY",
+                    "hint": "use the non-interactive commands: 'carapace session send/history/get/list', "
+                    "'carapace approval allow/deny', 'carapace job ...' (or pass --force)",
+                }
+            ),
+            err=True,
+        )
+        raise typer.Exit(1)
+
     # Create or resume session
     if session:
         try:
@@ -857,6 +877,497 @@ def chat(
         console.print(f"[red]Connection error: {e}[/red]")
     finally:
         client.close()
+
+
+# --- Agent-facing (non-interactive) commands ---------------------------------
+#
+# These emit JSON to stdout and never render markdown/LaTeX — agent text passes through
+# verbatim. Exit codes: 0 ok, 1 error, 2 needs_approval, 3 timeout.
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+EXIT_NEEDS_APPROVAL = 2
+EXIT_TIMEOUT = 3
+
+# Server->client request type -> approval "kind".
+_APPROVAL_TYPES = {
+    "approval_request": "tool",
+    "domain_access_approval_request": "domain_access",
+    "proxy_approval_request": "domain_access",
+    "credential_approval_request": "credential_access",
+    "git_push_approval_request": "git_push",
+}
+
+
+@dataclass
+class _AgentCtx:
+    server: str
+    api_key: str | None
+    client: httpx.Client
+    ws_headers: dict[str, str]
+
+
+def _resolve_ctx(server: str, api_key: str | None, username: str | None, password: str | None) -> _AgentCtx:
+    if api_key:
+        return _AgentCtx(server=server, api_key=api_key, client=_api_key_client(server, api_key), ws_headers={})
+    client = _login_client(server, username, password)
+    return _AgentCtx(server=server, api_key=None, client=client, ws_headers=_cookie_headers(client))
+
+
+def _agent_auth(
+    ctx: typer.Context,
+    server: str = typer.Option(DEFAULT_SERVER, "--server", envvar="CARAPACE_SERVER", help="Server URL"),
+    api_key: str | None = typer.Option(
+        None, "--api-key", "-k", envvar="CARAPACE_API_KEY", help="API key (Bearer). Takes precedence over login."
+    ),
+    username: str | None = typer.Option(None, "--user", "-u", envvar="CARAPACE_USER", help="Username"),
+    password: str | None = typer.Option(None, "--password", envvar="CARAPACE_PASSWORD", help="Password"),
+) -> None:
+    ctx.obj = _resolve_ctx(server, api_key, username, password)
+
+
+def _print_json(obj: Any) -> None:
+    typer.echo(json.dumps(obj, ensure_ascii=False, indent=2, default=str))
+
+
+def _fail(detail: str, *, code: int = EXIT_ERROR, status: str = "error", **extra: Any) -> NoReturn:
+    _print_json({"status": status, "error": detail, **extra})
+    raise typer.Exit(code)
+
+
+def _safe_detail(resp: httpx.Response) -> str:
+    try:
+        body = resp.json()
+    except ValueError:
+        return resp.text
+    if isinstance(body, dict) and "detail" in body:
+        return str(body["detail"])
+    return resp.text
+
+
+def _request_json(
+    cli: _AgentCtx, method: str, path: str, *, params: dict[str, Any] | None = None, json_body: Any = None
+) -> Any:
+    try:
+        resp = cli.client.request(method, path, params=params, json=json_body)
+    except httpx.HTTPError as exc:
+        _fail(f"request failed: {exc}")
+    if resp.status_code >= 400:
+        _fail(_safe_detail(resp), http_status=resp.status_code)
+    if resp.status_code == 204:
+        return None
+    return resp.json()
+
+
+def _read_json_input(path: str) -> Any:
+    raw = sys.stdin.read() if path == "-" else Path(path).read_text(encoding="utf-8")
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        _fail(f"invalid JSON in {path!r}: {exc}")
+
+
+def _approval_info(msg: dict[str, Any], session_id: str) -> dict[str, Any]:
+    kind = _APPROVAL_TYPES.get(msg.get("type", ""), "unknown")
+    request_id = msg.get("tool_call_id") if kind == "tool" else msg.get("request_id")
+    request = {"id": request_id, "kind": kind, **{k: v for k, v in msg.items() if k != "type"}}
+    return {
+        "request": request,
+        "allow_command": f"carapace approval allow {session_id} {request_id}",
+        "deny_command": f"carapace approval deny {session_id} {request_id}",
+    }
+
+
+async def _read_turn(ws: Any, *, session_id: str, timeout: float, stream: bool) -> tuple[dict[str, Any], int]:
+    """Read server frames until a terminal signal, an approval request, or timeout."""
+    try:
+        async with asyncio.timeout(timeout):
+            while True:
+                msg = json.loads(await ws.recv())
+                match msg.get("type"):
+                    case "done":
+                        return {"status": "done", "content": msg.get("content", ""), "usage": msg.get("usage")}, EXIT_OK
+                    case "error":
+                        return {"status": "error", "detail": msg.get("detail", "")}, EXIT_ERROR
+                    case "cancelled":
+                        return {"status": "cancelled", "detail": msg.get("detail", "")}, EXIT_OK
+                    case "command_result":
+                        return {
+                            "status": "command_result",
+                            "command": msg.get("command"),
+                            "data": msg.get("data"),
+                        }, EXIT_OK
+                    case t if t in _APPROVAL_TYPES:
+                        return {"status": "needs_approval", **_approval_info(msg, session_id)}, EXIT_NEEDS_APPROVAL
+                    case t if stream and t in ("token", "thinking", "tool_call", "tool_result"):
+                        typer.echo(
+                            json.dumps(
+                                {"event": t, **{k: v for k, v in msg.items() if k != "type"}},
+                                ensure_ascii=False,
+                                default=str,
+                            ),
+                            err=True,
+                        )
+                    case _:
+                        continue  # status, llm_activity, user_message, session_title — ignore
+    except TimeoutError:
+        # Leave the turn running server-side; the caller can re-read history later.
+        return {"status": "timeout"}, EXIT_TIMEOUT
+
+
+async def _drive_turn(
+    cli: _AgentCtx,
+    session_id: str,
+    *,
+    message: str | None = None,
+    approval: dict[str, Any] | None = None,
+    wait: bool,
+    timeout: float,
+    stream: bool = False,
+) -> tuple[dict[str, Any], int]:
+    url = _ws_url(cli.server, session_id, cli.api_key)
+    try:
+        ws = await websockets.asyncio.client.connect(url, additional_headers=cli.ws_headers)
+    except (OSError, InvalidHandshake, ConnectionClosed) as exc:
+        return {"status": "error", "error": f"connection failed: {exc}"}, EXIT_ERROR
+    try:
+        if message is not None:
+            await ws.send(json.dumps({"type": "message", "content": message}))
+        elif approval is not None:
+            await ws.send(json.dumps(approval))
+        if not wait:
+            return {"status": "submitted"}, EXIT_OK
+        return await _read_turn(ws, session_id=session_id, timeout=timeout, stream=stream)
+    except ConnectionClosed as exc:
+        return {"status": "error", "error": f"connection closed: {exc}"}, EXIT_ERROR
+    finally:
+        with contextlib.suppress(Exception):
+            await ws.close()
+
+
+def _emit_turn(cli: _AgentCtx, result: dict[str, Any], code: int) -> None:
+    _print_json(result)
+    cli.client.close()
+    raise typer.Exit(code)
+
+
+# --- session sub-app ---
+
+session_app = typer.Typer(help="Manage and drive sessions (non-interactive, JSON output).", no_args_is_help=True)
+job_app = typer.Typer(help="Manage jobs (non-interactive, JSON output).", no_args_is_help=True)
+approval_app = typer.Typer(help="Resolve pending approval/escalation requests by id.", no_args_is_help=True)
+for _sub in (session_app, job_app, approval_app):
+    _sub.callback()(_agent_auth)
+
+
+@session_app.command("list")
+def session_list(
+    ctx: typer.Context,
+    archived: bool = typer.Option(False, "--archived", help="Include archived sessions"),
+    limit: int = typer.Option(-1, "--limit", help="Max sessions to return (-1 = all)"),
+) -> None:
+    """List sessions."""
+    cli: _AgentCtx = ctx.obj
+    sessions: list[dict[str, Any]] = []
+    cursor: str | None = None
+    while True:
+        params: dict[str, Any] = {"include_message_count": "true", "limit": 200}
+        if archived:
+            params["include_archived"] = "true"
+        if cursor is not None:
+            params["cursor"] = cursor
+        payload = _request_json(cli, "GET", "/api/sessions", params=params)
+        if isinstance(payload, list):
+            sessions.extend(payload)
+            break
+        page = dict_or_empty(payload)
+        sessions.extend(list_of_dicts(page.get("items")))
+        if not page.get("has_more", False):
+            break
+        next_cursor = page.get("next_cursor")
+        if not isinstance(next_cursor, str) or not next_cursor:
+            break
+        cursor = next_cursor
+    if limit >= 0:
+        sessions = sessions[:limit]
+    _print_json(sessions)
+    cli.client.close()
+
+
+@session_app.command("get")
+def session_get(ctx: typer.Context, session_id: str = typer.Argument(...)) -> None:
+    """Show a single session."""
+    cli: _AgentCtx = ctx.obj
+    _print_json(_request_json(cli, "GET", f"/api/sessions/{session_id}"))
+    cli.client.close()
+
+
+@session_app.command("create")
+def session_create(
+    ctx: typer.Context,
+    ask: bool = typer.Option(False, "--ask", help="Ask before every action"),
+    yolo: bool = typer.Option(False, "--yolo", help="Auto-approve everything"),
+    unattended: bool = typer.Option(False, "--unattended", help="Unattended mode"),
+    model: str | None = typer.Option(None, "--model", help="Agent model name"),
+    sentinel_model: str | None = typer.Option(None, "--sentinel-model", help="Sentinel model name"),
+    channel: str = typer.Option("cli", "--channel", help="Channel type"),
+) -> None:
+    """Create a session."""
+    cli: _AgentCtx = ctx.obj
+    body: dict[str, Any] = {"channel_type": channel}
+    if ask:
+        body["ask_mode"] = True
+    if yolo:
+        body["yolo_mode"] = True
+    if unattended:
+        body["unattended"] = True
+    created = _request_json(cli, "POST", "/api/sessions", json_body=body)
+    if model is not None or sentinel_model is not None:
+        update: dict[str, Any] = {}
+        if model is not None:
+            update["agent_model_name"] = model
+        if sentinel_model is not None:
+            update["sentinel_model_name"] = sentinel_model
+        created = _request_json(cli, "PATCH", f"/api/sessions/{created['session_id']}", json_body=update)
+    _print_json(created)
+    cli.client.close()
+
+
+@session_app.command("update")
+def session_update(
+    ctx: typer.Context,
+    session_id: str = typer.Argument(...),
+    ask: bool = typer.Option(False, "--ask"),
+    yolo: bool = typer.Option(False, "--yolo"),
+    unattended: bool = typer.Option(False, "--unattended"),
+    model: str | None = typer.Option(None, "--model"),
+    sentinel_model: str | None = typer.Option(None, "--sentinel-model"),
+    archived: bool | None = typer.Option(None, "--archive/--unarchive"),
+    pinned: bool | None = typer.Option(None, "--pin/--unpin"),
+    favorite: bool | None = typer.Option(None, "--favorite/--unfavorite"),
+) -> None:
+    """Update session settings (modes, models, flags)."""
+    cli: _AgentCtx = ctx.obj
+    attributes: dict[str, Any] = {}
+    if ask:
+        attributes["ask_mode"] = True
+    if yolo:
+        attributes["yolo_mode"] = True
+    if unattended:
+        attributes["unattended"] = True
+    if archived is not None:
+        attributes["archived"] = archived
+    if pinned is not None:
+        attributes["pinned"] = pinned
+    if favorite is not None:
+        attributes["favorite"] = favorite
+    body: dict[str, Any] = {}
+    if attributes:
+        body["attributes"] = attributes
+    if model is not None:
+        body["agent_model_name"] = model
+    if sentinel_model is not None:
+        body["sentinel_model_name"] = sentinel_model
+    if not body:
+        _fail("nothing to update")
+    _print_json(_request_json(cli, "PATCH", f"/api/sessions/{session_id}", json_body=body))
+    cli.client.close()
+
+
+def _pending_with_hints(cli: _AgentCtx, session_id: str) -> dict[str, Any]:
+    data = _request_json(cli, "GET", f"/api/sessions/{session_id}/pending-approvals")
+    for entry in [*data.get("approvals", []), *data.get("escalations", [])]:
+        rid = entry.get("id")
+        entry["allow_command"] = f"carapace approval allow {session_id} {rid}"
+        entry["deny_command"] = f"carapace approval deny {session_id} {rid}"
+    return data
+
+
+@session_app.command("history")
+def session_history(
+    ctx: typer.Context,
+    session_id: str = typer.Argument(...),
+    limit: int = typer.Option(-1, "--limit", help="Number of past messages (-1 = all)"),
+) -> None:
+    """Show a session's message history plus any pending approval requests."""
+    cli: _AgentCtx = ctx.obj
+    messages = _request_json(cli, "GET", f"/api/sessions/{session_id}/history", params={"limit": limit})
+    _print_json({"messages": messages, "pending": _pending_with_hints(cli, session_id)})
+    cli.client.close()
+
+
+@session_app.command("pending")
+def session_pending(ctx: typer.Context, session_id: str = typer.Argument(...)) -> None:
+    """List pending approval/escalation requests for a session."""
+    cli: _AgentCtx = ctx.obj
+    _print_json(_pending_with_hints(cli, session_id))
+    cli.client.close()
+
+
+@session_app.command("send")
+def session_send(
+    ctx: typer.Context,
+    session_id: str = typer.Argument(...),
+    content: str = typer.Argument(...),
+    wait: bool = typer.Option(True, "--wait/--no-wait", help="Wait for the turn to finish"),
+    timeout: float = typer.Option(120.0, "--timeout", help="Seconds to wait before giving up"),
+    stream: bool = typer.Option(False, "--stream", help="Emit token/tool events to stderr while waiting"),
+) -> None:
+    """Send input to a session and (by default) wait for the next turn to finish."""
+    cli: _AgentCtx = ctx.obj
+    result, code = asyncio.run(_drive_turn(cli, session_id, message=content, wait=wait, timeout=timeout, stream=stream))
+    _emit_turn(cli, result, code)
+
+
+@session_app.command("cancel")
+def session_cancel(ctx: typer.Context, session_id: str = typer.Argument(...)) -> None:
+    """Cancel the running turn of a session."""
+    cli: _AgentCtx = ctx.obj
+    result, code = asyncio.run(_drive_turn(cli, session_id, approval={"type": "cancel"}, wait=False, timeout=0.0))
+    if result.get("status") == "submitted":
+        result = {"status": "cancelled"}
+    _emit_turn(cli, result, code)
+
+
+# --- approval sub-app ---
+
+
+def _resolve_approval(
+    ctx: typer.Context,
+    session_id: str,
+    request_id: str,
+    *,
+    allow: bool,
+    message: str | None,
+    wait: bool,
+    timeout: float,
+) -> None:
+    cli: _AgentCtx = ctx.obj
+    data = _request_json(cli, "GET", f"/api/sessions/{session_id}/pending-approvals")
+    entry = next(
+        (e for e in [*data.get("approvals", []), *data.get("escalations", [])] if e.get("id") == request_id), None
+    )
+    if entry is None:
+        _print_json({"status": "not_found", "session_id": session_id, "request_id": request_id})
+        cli.client.close()
+        raise typer.Exit(EXIT_ERROR)
+    if entry.get("kind") == "tool":
+        response = {"type": "approval_response", "tool_call_id": request_id, "approved": allow, "message": message}
+    else:
+        response = {
+            "type": "escalation_response",
+            "request_id": request_id,
+            "decision": "allow" if allow else "deny",
+            "message": message,
+        }
+    result, code = asyncio.run(_drive_turn(cli, session_id, approval=response, wait=wait, timeout=timeout))
+    if not wait and result.get("status") == "submitted":
+        result = {"status": "resolved", "id": request_id, "decision": "allow" if allow else "deny"}
+    _emit_turn(cli, result, code)
+
+
+@approval_app.command("allow")
+def approval_allow(
+    ctx: typer.Context,
+    session_id: str = typer.Argument(...),
+    request_id: str = typer.Argument(..., help="Unique id of the pending request"),
+    message: str | None = typer.Option(None, "--message", "-m"),
+    wait: bool = typer.Option(False, "--wait/--no-wait", help="Wait for the resumed turn to finish"),
+    timeout: float = typer.Option(120.0, "--timeout"),
+) -> None:
+    """Approve a specific pending request by id."""
+    _resolve_approval(ctx, session_id, request_id, allow=True, message=message, wait=wait, timeout=timeout)
+
+
+@approval_app.command("deny")
+def approval_deny(
+    ctx: typer.Context,
+    session_id: str = typer.Argument(...),
+    request_id: str = typer.Argument(..., help="Unique id of the pending request"),
+    message: str | None = typer.Option(None, "--message", "-m"),
+    wait: bool = typer.Option(False, "--wait/--no-wait", help="Wait for the resumed turn to finish"),
+    timeout: float = typer.Option(120.0, "--timeout"),
+) -> None:
+    """Deny a specific pending request by id."""
+    _resolve_approval(ctx, session_id, request_id, allow=False, message=message, wait=wait, timeout=timeout)
+
+
+# --- job sub-app ---
+
+
+@job_app.command("list")
+def job_list(ctx: typer.Context) -> None:
+    """List jobs."""
+    cli: _AgentCtx = ctx.obj
+    _print_json(_request_json(cli, "GET", "/api/jobs"))
+    cli.client.close()
+
+
+@job_app.command("get")
+def job_get(ctx: typer.Context, job_id: str = typer.Argument(...)) -> None:
+    """Show a single job."""
+    cli: _AgentCtx = ctx.obj
+    _print_json(_request_json(cli, "GET", f"/api/jobs/{job_id}"))
+    cli.client.close()
+
+
+@job_app.command("create")
+def job_create(
+    ctx: typer.Context,
+    file: str = typer.Option(..., "--file", "-f", help="JobDefinition JSON file ('-' for stdin)"),
+) -> None:
+    """Create a job from a JobDefinition JSON document."""
+    cli: _AgentCtx = ctx.obj
+    _print_json(_request_json(cli, "POST", "/api/jobs", json_body=_read_json_input(file)))
+    cli.client.close()
+
+
+@job_app.command("update")
+def job_update(
+    ctx: typer.Context,
+    job_id: str = typer.Argument(...),
+    file: str = typer.Option(..., "--file", "-f", help="JobDefinition JSON file ('-' for stdin)"),
+) -> None:
+    """Replace a job from a JobDefinition JSON document."""
+    cli: _AgentCtx = ctx.obj
+    _print_json(_request_json(cli, "PUT", f"/api/jobs/{job_id}", json_body=_read_json_input(file)))
+    cli.client.close()
+
+
+@job_app.command("delete")
+def job_delete(ctx: typer.Context, job_id: str = typer.Argument(...)) -> None:
+    """Delete a job."""
+    cli: _AgentCtx = ctx.obj
+    _request_json(cli, "DELETE", f"/api/jobs/{job_id}")
+    _print_json({"status": "deleted", "job_id": job_id})
+    cli.client.close()
+
+
+@job_app.command("run")
+def job_run(
+    ctx: typer.Context,
+    job_id: str = typer.Argument(...),
+    input_: str | None = typer.Option(None, "--input", help="Input payload passed to the job"),
+    wait: bool = typer.Option(False, "--wait/--no-wait", help="Wait for the started turn to finish"),
+    timeout: float = typer.Option(120.0, "--timeout"),
+) -> None:
+    """Run a job now."""
+    cli: _AgentCtx = ctx.obj
+    body = {"data": input_} if input_ is not None else None
+    run = _request_json(cli, "POST", f"/api/jobs/{job_id}/run", json_body=body)
+    out: dict[str, Any] = {"run": run}
+    if not wait:
+        _print_json(out)
+        cli.client.close()
+        return
+    result, code = asyncio.run(_drive_turn(cli, run["session_id"], wait=True, timeout=timeout))
+    out["turn"] = result
+    _emit_turn(cli, out, code)
+
+
+app.add_typer(session_app, name="session")
+app.add_typer(job_app, name="job")
+app.add_typer(approval_app, name="approval")
 
 
 if __name__ == "__main__":

--- a/src/carapace/cli.py
+++ b/src/carapace/cli.py
@@ -978,6 +978,26 @@ def _approval_info(msg: dict[str, Any], session_id: str) -> dict[str, Any]:
     }
 
 
+def _last_assistant_content(cli: _AgentCtx, session_id: str) -> str:
+    """Return the most recent assistant message text from history (best-effort, "" on failure).
+
+    Used to recover the outcome of a turn whose terminal WebSocket frame was missed; for a
+    failed/cancelled turn this surfaces the persisted terminal message instead of nothing.
+    """
+    try:
+        resp = cli.client.get(f"/api/sessions/{session_id}/history", params={"limit": 20})
+        resp.raise_for_status()
+        messages = resp.json()
+    except (httpx.HTTPError, ValueError):
+        return ""
+    if not isinstance(messages, list):
+        return ""
+    for msg in reversed(messages):
+        if isinstance(msg, dict) and msg.get("role") == "assistant":
+            return str(msg.get("content", ""))
+    return ""
+
+
 async def _read_turn(
     ws: Any, *, session_id: str, timeout: float, stream: bool, observe: bool = False
 ) -> tuple[dict[str, Any], int]:
@@ -985,8 +1005,10 @@ async def _read_turn(
 
     When *observe* is set the caller is a pure observer that did not start the turn over
     this socket (e.g. ``job run --wait``): the turn was kicked off via REST beforehand.  If
-    it already finished, the server replays no ``done`` frame, only the on-connect ``status``
-    with ``agent_running=False`` — treat that as completion instead of waiting for a timeout.
+    it already finished, the server replays no terminal frame, only the on-connect ``status``
+    with ``agent_running=False``.  The status frame carries no outcome (the real ``done`` /
+    ``error`` / ``cancelled`` is gone), so report a neutral ``finished`` rather than guessing
+    success — the caller backfills the result from history.
     """
     try:
         async with asyncio.timeout(timeout):
@@ -996,7 +1018,7 @@ async def _read_turn(
                     case "done":
                         return {"status": "done", "content": msg.get("content", ""), "usage": msg.get("usage")}, EXIT_OK
                     case "status" if observe and msg.get("agent_running") is False:
-                        return {"status": "done", "content": "", "usage": msg.get("usage")}, EXIT_OK
+                        return {"status": "finished", "usage": msg.get("usage")}, EXIT_OK
                     case "error":
                         return {"status": "error", "detail": msg.get("detail", "")}, EXIT_ERROR
                     case "cancelled":
@@ -1050,7 +1072,12 @@ async def _drive_turn(
         # Pure observer (no frame sent on this socket): the turn was started elsewhere
         # (e.g. `job run` via REST), so a finished turn surfaces only as an on-connect status.
         observe = message is None and approval is None
-        return await _read_turn(ws, session_id=session_id, timeout=timeout, stream=stream, observe=observe)
+        result, code = await _read_turn(ws, session_id=session_id, timeout=timeout, stream=stream, observe=observe)
+        # The terminal frame was missed; recover the actual outcome text from history so a
+        # failed/cancelled turn is not reported as an empty success.
+        if result.get("status") == "finished":
+            result["content"] = _last_assistant_content(cli, session_id)
+        return result, code
     except ConnectionClosed as exc:
         return {"status": "error", "error": f"connection closed: {exc}"}, EXIT_ERROR
     finally:

--- a/src/carapace/cli.py
+++ b/src/carapace/cli.py
@@ -978,8 +978,16 @@ def _approval_info(msg: dict[str, Any], session_id: str) -> dict[str, Any]:
     }
 
 
-async def _read_turn(ws: Any, *, session_id: str, timeout: float, stream: bool) -> tuple[dict[str, Any], int]:
-    """Read server frames until a terminal signal, an approval request, or timeout."""
+async def _read_turn(
+    ws: Any, *, session_id: str, timeout: float, stream: bool, observe: bool = False
+) -> tuple[dict[str, Any], int]:
+    """Read server frames until a terminal signal, an approval request, or timeout.
+
+    When *observe* is set the caller is a pure observer that did not start the turn over
+    this socket (e.g. ``job run --wait``): the turn was kicked off via REST beforehand.  If
+    it already finished, the server replays no ``done`` frame, only the on-connect ``status``
+    with ``agent_running=False`` — treat that as completion instead of waiting for a timeout.
+    """
     try:
         async with asyncio.timeout(timeout):
             while True:
@@ -987,6 +995,8 @@ async def _read_turn(ws: Any, *, session_id: str, timeout: float, stream: bool) 
                 match msg.get("type"):
                     case "done":
                         return {"status": "done", "content": msg.get("content", ""), "usage": msg.get("usage")}, EXIT_OK
+                    case "status" if observe and msg.get("agent_running") is False:
+                        return {"status": "done", "content": "", "usage": msg.get("usage")}, EXIT_OK
                     case "error":
                         return {"status": "error", "detail": msg.get("detail", "")}, EXIT_ERROR
                     case "cancelled":
@@ -1037,7 +1047,10 @@ async def _drive_turn(
             await ws.send(json.dumps(approval))
         if not wait:
             return {"status": "submitted"}, EXIT_OK
-        return await _read_turn(ws, session_id=session_id, timeout=timeout, stream=stream)
+        # Pure observer (no frame sent on this socket): the turn was started elsewhere
+        # (e.g. `job run` via REST), so a finished turn surfaces only as an on-connect status.
+        observe = message is None and approval is None
+        return await _read_turn(ws, session_id=session_id, timeout=timeout, stream=stream, observe=observe)
     except ConnectionClosed as exc:
         return {"status": "error", "error": f"connection closed: {exc}"}, EXIT_ERROR
     finally:

--- a/src/carapace/server/sessions.py
+++ b/src/carapace/server/sessions.py
@@ -497,6 +497,31 @@ async def delete_session(
         raise HTTPException(status_code=404, detail="Session not found")
 
 
+class PendingApprovalsResponse(BaseModel):
+    # Heterogeneous payloads: each entry carries an "id" plus a "kind" and kind-specific fields,
+    # mirroring what the WebSocket handler replays to connecting clients.
+    approvals: list[dict[str, Any]] = []
+    escalations: list[dict[str, Any]] = []
+
+
+@router.get("/sessions/{session_id}/pending-approvals", response_model=PendingApprovalsResponse)
+async def get_pending_approvals(
+    session_id: str,
+    user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.read))],
+) -> PendingApprovalsResponse:
+    """List approval/escalation requests the running turn is currently parked on (by id)."""
+    _load_owned_state(session_id, user)
+    active = server._engine.get_active(session_id)
+    if active is None:
+        return PendingApprovalsResponse()
+    approvals = [
+        {"id": pa.get("tool_call_id", ""), "kind": "tool", **{k: v for k, v in pa.items() if k != "type"}}
+        for pa in active.pending_approval_requests
+    ]
+    escalations = [{"id": pe.get("request_id", ""), **pe} for pe in active.pending_escalations]
+    return PendingApprovalsResponse(approvals=approvals, escalations=escalations)
+
+
 # ----------------------------------------------------------------------
 # Sandbox git (B1: /workspace clone ↔ backend repo)
 # ----------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -270,6 +270,32 @@ def test_read_turn_times_out() -> None:
     assert result["status"] == "timeout"
 
 
+def test_read_turn_observe_status_already_finished() -> None:
+    # job run --wait: turn finished before connect -> only an on-connect status, no done frame.
+    ws = _FakeWS([{"type": "status", "agent_running": False, "usage": {"total": 1}}])
+    result, code = asyncio.run(_read_turn(ws, session_id="s1", timeout=5, stream=False, observe=True))
+    assert code == 0
+    assert result["status"] == "done"
+    assert result["usage"] == {"total": 1}
+
+
+def test_read_turn_observe_status_running_waits_for_done() -> None:
+    # Still running on connect: ignore the status, wait for the real done frame.
+    ws = _FakeWS([{"type": "status", "agent_running": True}, {"type": "done", "content": "ok", "usage": {}}])
+    result, code = asyncio.run(_read_turn(ws, session_id="s1", timeout=5, stream=False, observe=True))
+    assert code == 0
+    assert result["status"] == "done"
+    assert result["content"] == "ok"
+
+
+def test_read_turn_status_ignored_when_not_observing() -> None:
+    # send/approval path: the on-connect status (agent_running False, pre-send) must not terminate.
+    ws = _FakeWS([{"type": "status", "agent_running": False}])
+    result, code = asyncio.run(_read_turn(ws, session_id="s1", timeout=0.05, stream=False))
+    assert code == 3
+    assert result["status"] == "timeout"
+
+
 def test_approval_info_escalation() -> None:
     info = _approval_info({"type": "domain_access_approval_request", "request_id": "r1", "domain": "x.test"}, "s1")
     assert info["request"]["id"] == "r1"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import re
+from types import SimpleNamespace
 from typing import ClassVar
 from unittest.mock import patch
 
@@ -10,7 +11,15 @@ import pytest
 from typer.testing import CliRunner
 
 import carapace.cli as cli_module
-from carapace.cli import _approval_info, _read_turn, _render_escalation_request, _replay_history, _ws_url, app
+from carapace.cli import (
+    _approval_info,
+    _last_assistant_content,
+    _read_turn,
+    _render_escalation_request,
+    _replay_history,
+    _ws_url,
+    app,
+)
 
 runner = CliRunner()
 
@@ -271,11 +280,12 @@ def test_read_turn_times_out() -> None:
 
 
 def test_read_turn_observe_status_already_finished() -> None:
-    # job run --wait: turn finished before connect -> only an on-connect status, no done frame.
+    # job run --wait: turn finished before connect -> only an on-connect status, no terminal frame.
+    # Reported as neutral "finished" (not a fabricated "done" success), with usage carried over.
     ws = _FakeWS([{"type": "status", "agent_running": False, "usage": {"total": 1}}])
     result, code = asyncio.run(_read_turn(ws, session_id="s1", timeout=5, stream=False, observe=True))
     assert code == 0
-    assert result["status"] == "done"
+    assert result["status"] == "finished"
     assert result["usage"] == {"total": 1}
 
 
@@ -294,6 +304,27 @@ def test_read_turn_status_ignored_when_not_observing() -> None:
     result, code = asyncio.run(_read_turn(ws, session_id="s1", timeout=0.05, stream=False))
     assert code == 3
     assert result["status"] == "timeout"
+
+
+def test_last_assistant_content_returns_latest_assistant() -> None:
+    # A failed/cancelled turn persists its terminal message as the last assistant event;
+    # the observer backfill surfaces that instead of an empty success.
+    history = [
+        {"role": "user", "content": "go"},
+        {"role": "assistant", "content": "first"},
+        {"role": "tool_call", "tool": "bash"},
+        {"role": "assistant", "content": "The previous turn failed before completion."},
+    ]
+    cli = SimpleNamespace(client=SimpleNamespace(get=lambda url, *, params=None: _FakeHttpResponse(history)))
+    assert _last_assistant_content(cli, "s1") == "The previous turn failed before completion."  # type: ignore[arg-type]
+
+
+def test_last_assistant_content_tolerates_errors() -> None:
+    def _boom(url: str, *, params: object = None) -> None:
+        raise cli_module.httpx.ConnectError("down")
+
+    cli = SimpleNamespace(client=SimpleNamespace(get=_boom))
+    assert _last_assistant_content(cli, "s1") == ""  # type: ignore[arg-type]
 
 
 def test_approval_info_escalation() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,14 +1,16 @@
 """CLI smoke tests (no LLM tokens needed)."""
 
 import asyncio
+import json
 import re
+from typing import ClassVar
 from unittest.mock import patch
 
 import pytest
 from typer.testing import CliRunner
 
 import carapace.cli as cli_module
-from carapace.cli import _render_escalation_request, _replay_history, _ws_url, app
+from carapace.cli import _approval_info, _read_turn, _render_escalation_request, _replay_history, _ws_url, app
 
 runner = CliRunner()
 
@@ -184,3 +186,153 @@ def test_replay_history_uses_authenticated_client(monkeypatch: pytest.MonkeyPatc
     _replay_history(_FakeClient(), "session-1", 25)  # type: ignore[arg-type]
 
     assert seen_requests == [("/api/sessions/session-1/history", {"limit": 25})]
+
+
+# --- agent (non-interactive) commands ---
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: object = None):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = ""
+
+    def json(self) -> object:
+        return self._payload
+
+
+class _FakeAgentClient:
+    """Records REST calls; returns queued responses keyed by (method, path-prefix)."""
+
+    calls: ClassVar[list[tuple[str, str, dict[str, object] | None]]] = []
+    responses: ClassVar[dict[tuple[str, str], _FakeResponse]] = {}
+
+    def __init__(self, base_url: str, headers: dict[str, str] | None = None):
+        self.base_url = base_url
+
+    def request(self, method: str, path: str, *, params=None, json=None):
+        _FakeAgentClient.calls.append((method, path, json))
+        return _FakeAgentClient.responses.get((method, path), _FakeResponse(200, {}))
+
+    def close(self) -> None:
+        return None
+
+
+class _FakeWS:
+    def __init__(self, frames: list[dict[str, object]]):
+        self._frames = list(frames)
+        self.sent: list[dict[str, object]] = []
+
+    async def recv(self) -> str:
+        if self._frames:
+            return json.dumps(self._frames.pop(0))
+        await asyncio.sleep(10)  # block so an outer timeout fires
+        raise AssertionError("unreachable")
+
+    async def send(self, data: str) -> None:
+        self.sent.append(json.loads(data))
+
+    async def close(self) -> None:
+        return None
+
+
+def test_chat_refuses_non_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli_module.sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(cli_module.sys.stdout, "isatty", lambda: False)
+    monkeypatch.setattr(cli_module.httpx, "Client", _FakeAgentClient)
+    result = runner.invoke(app, ["chat", "--server", "http://example.test", "--api-key", "ck_x"])
+    assert result.exit_code == 1
+    assert "not a TTY" in _strip_ansi(result.output)
+
+
+def test_read_turn_done_keeps_markup() -> None:
+    ws = _FakeWS([{"type": "status"}, {"type": "done", "content": "# Title $x^2$", "usage": {}}])
+    result, code = asyncio.run(_read_turn(ws, session_id="s1", timeout=5, stream=False))
+    assert code == 0
+    assert result["status"] == "done"
+    assert result["content"] == "# Title $x^2$"  # markup preserved verbatim
+
+
+def test_read_turn_aborts_on_approval() -> None:
+    ws = _FakeWS([{"type": "approval_request", "tool_call_id": "tc1", "tool": "bash", "args": {}}])
+    result, code = asyncio.run(_read_turn(ws, session_id="s1", timeout=5, stream=False))
+    assert code == 2
+    assert result["status"] == "needs_approval"
+    assert result["request"]["id"] == "tc1"
+    assert result["allow_command"] == "carapace approval allow s1 tc1"
+    assert result["deny_command"] == "carapace approval deny s1 tc1"
+
+
+def test_read_turn_times_out() -> None:
+    ws = _FakeWS([])
+    result, code = asyncio.run(_read_turn(ws, session_id="s1", timeout=0.05, stream=False))
+    assert code == 3
+    assert result["status"] == "timeout"
+
+
+def test_approval_info_escalation() -> None:
+    info = _approval_info({"type": "domain_access_approval_request", "request_id": "r1", "domain": "x.test"}, "s1")
+    assert info["request"]["id"] == "r1"
+    assert info["request"]["kind"] == "domain_access"
+    assert info["allow_command"] == "carapace approval allow s1 r1"
+
+
+def test_session_get_emits_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    _FakeAgentClient.calls = []
+    _FakeAgentClient.responses = {("GET", "/api/sessions/s1"): _FakeResponse(200, {"session_id": "s1"})}
+    monkeypatch.setattr(cli_module.httpx, "Client", _FakeAgentClient)
+    result = runner.invoke(app, ["session", "get", "s1"], env={"CARAPACE_API_KEY": "ck_x"})
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {"session_id": "s1"}
+    assert ("GET", "/api/sessions/s1", None) in _FakeAgentClient.calls
+
+
+def test_session_create_sends_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    _FakeAgentClient.calls = []
+    _FakeAgentClient.responses = {("POST", "/api/sessions"): _FakeResponse(200, {"session_id": "s2"})}
+    monkeypatch.setattr(cli_module.httpx, "Client", _FakeAgentClient)
+    result = runner.invoke(app, ["session", "create", "--yolo"], env={"CARAPACE_API_KEY": "ck_x"})
+    assert result.exit_code == 0
+    assert ("POST", "/api/sessions", {"channel_type": "cli", "yolo_mode": True}) in _FakeAgentClient.calls
+
+
+def test_approval_allow_sends_tool_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_request(cli, method, path, **kwargs):
+        return {"approvals": [{"id": "tc1", "kind": "tool"}], "escalations": []}
+
+    async def fake_drive(cli, session_id, *, approval=None, wait, timeout, **kwargs):
+        captured["approval"] = approval
+        return {"status": "submitted"}, 0
+
+    monkeypatch.setattr(cli_module, "_request_json", fake_request)
+    monkeypatch.setattr(cli_module, "_drive_turn", fake_drive)
+    monkeypatch.setattr(cli_module.httpx, "Client", _FakeAgentClient)
+    result = runner.invoke(app, ["approval", "allow", "s1", "tc1"], env={"CARAPACE_API_KEY": "ck_x"})
+    assert result.exit_code == 0
+    assert captured["approval"] == {
+        "type": "approval_response",
+        "tool_call_id": "tc1",
+        "approved": True,
+        "message": None,
+    }
+
+
+def test_approval_deny_unknown_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli_module, "_request_json", lambda *a, **k: {"approvals": [], "escalations": []})
+    monkeypatch.setattr(cli_module.httpx, "Client", _FakeAgentClient)
+    result = runner.invoke(app, ["approval", "deny", "s1", "nope"], env={"CARAPACE_API_KEY": "ck_x"})
+    assert result.exit_code == 1
+    assert json.loads(result.output)["status"] == "not_found"
+
+
+def test_job_create_reads_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    _FakeAgentClient.calls = []
+    _FakeAgentClient.responses = {("POST", "/api/jobs"): _FakeResponse(201, {"id": "j1"})}
+    monkeypatch.setattr(cli_module.httpx, "Client", _FakeAgentClient)
+    result = runner.invoke(
+        app, ["job", "create", "--file", "-"], input='{"name":"j"}', env={"CARAPACE_API_KEY": "ck_x"}
+    )
+    assert result.exit_code == 0
+    assert ("POST", "/api/jobs", {"name": "j"}) in _FakeAgentClient.calls

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -382,6 +382,48 @@ def test_revoke_other_users_key_returns_404():
     assert client.delete(f"/api/keys/{info.id}", headers=cookie).status_code == 404
 
 
+def _create_session(headers: dict[str, str]) -> str:
+    resp = TestClient(app).post("/api/sessions", headers=headers, json={"channel_type": "web"})
+    assert resp.status_code == 200
+    return resp.json()["session_id"]
+
+
+def test_pending_approvals_empty_when_idle(auth_headers):
+    sid = _create_session(auth_headers)
+    resp = TestClient(app).get(f"/api/sessions/{sid}/pending-approvals", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json() == {"approvals": [], "escalations": []}
+
+
+def test_pending_approvals_lists_by_id(auth_headers):
+    sid = _create_session(auth_headers)
+    active = srv._engine.get_or_activate(sid)
+    active.pending_approval_requests.append(
+        {"type": "approval_request", "tool_call_id": "tc1", "tool": "bash", "args": {}, "risk_level": "high"}
+    )
+    active.pending_escalations.append(
+        {"request_id": "r1", "kind": "domain_access", "domain": "x.test", "command": "curl"}
+    )
+    body = TestClient(app).get(f"/api/sessions/{sid}/pending-approvals", headers=auth_headers).json()
+    assert body["approvals"][0]["id"] == "tc1"
+    assert body["approvals"][0]["kind"] == "tool"
+    assert "type" not in body["approvals"][0]
+    assert body["escalations"][0]["id"] == "r1"
+    assert body["escalations"][0]["kind"] == "domain_access"
+
+
+def test_pending_approvals_non_owner_404(auth_headers, admin_auth_headers):
+    sid = _create_session(auth_headers)
+    resp = TestClient(app).get(f"/api/sessions/{sid}/pending-approvals", headers=admin_auth_headers)
+    assert resp.status_code == 404
+
+
+def test_pending_approvals_api_key_read_scope(auth_headers):
+    sid = _create_session(auth_headers)
+    headers = _api_key_headers("thies", [ApiKeyGrant(scope=Scope.sessions, access=Access.read)])
+    assert TestClient(app).get(f"/api/sessions/{sid}/pending-approvals", headers=headers).status_code == 200
+
+
 def test_no_auth_returns_401(client):
     resp = client.get("/api/sessions")
     assert resp.status_code in (401, 403)

--- a/uv.lock
+++ b/uv.lock
@@ -384,6 +384,15 @@ name = "carapace"
 version = "0.140.5"
 source = { editable = "." }
 dependencies = [
+    { name = "httpx" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typer" },
+    { name = "websockets" },
+]
+
+[package.optional-dependencies]
+server = [
     { name = "alembic" },
     { name = "croniter" },
     { name = "docker" },
@@ -399,23 +408,20 @@ dependencies = [
     { name = "pwdlib", extra = ["argon2"] },
     { name = "pydantic-ai" },
     { name = "pydantic-settings" },
-    { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "pywebpush" },
     { name = "pyyaml" },
     { name = "redis" },
-    { name = "rich" },
     { name = "sqlalchemy" },
     { name = "tenacity" },
     { name = "tiktoken" },
-    { name = "typer" },
     { name = "types-docker" },
     { name = "uvicorn", extra = ["standard"] },
-    { name = "websockets" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "carapace", extra = ["server"] },
     { name = "pyrefly" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -426,38 +432,41 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "alembic", specifier = ">=1.18,<2" },
-    { name = "croniter", specifier = ">=6,<7" },
-    { name = "docker", specifier = ">=7,<8" },
-    { name = "fastapi", specifier = ">=0.115,<1" },
-    { name = "genai-prices", specifier = ">=0.0.53" },
-    { name = "joserfc", specifier = ">=1.6.5" },
-    { name = "kr8s", specifier = ">=0.20,<1" },
-    { name = "logfire", extras = ["httpx"], specifier = ">=4,<5" },
-    { name = "loguru", specifier = ">=0.7.3" },
-    { name = "markdown", specifier = ">=3,<4" },
-    { name = "matrix-nio", specifier = ">=0.25,<1" },
-    { name = "psycopg", extras = ["binary"], specifier = ">=3.3,<4" },
-    { name = "pwdlib", extras = ["argon2"], specifier = ">=0.3.0" },
-    { name = "pydantic-ai", specifier = ">=1.59,<2" },
-    { name = "pydantic-settings", specifier = ">=2,<3" },
+    { name = "alembic", marker = "extra == 'server'", specifier = ">=1.18,<2" },
+    { name = "croniter", marker = "extra == 'server'", specifier = ">=6,<7" },
+    { name = "docker", marker = "extra == 'server'", specifier = ">=7,<8" },
+    { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.115,<1" },
+    { name = "genai-prices", marker = "extra == 'server'", specifier = ">=0.0.53" },
+    { name = "httpx", specifier = ">=0.28,<1" },
+    { name = "joserfc", marker = "extra == 'server'", specifier = ">=1.6.5" },
+    { name = "kr8s", marker = "extra == 'server'", specifier = ">=0.20,<1" },
+    { name = "logfire", extras = ["httpx"], marker = "extra == 'server'", specifier = ">=4,<5" },
+    { name = "loguru", marker = "extra == 'server'", specifier = ">=0.7.3" },
+    { name = "markdown", marker = "extra == 'server'", specifier = ">=3,<4" },
+    { name = "matrix-nio", marker = "extra == 'server'", specifier = ">=0.25,<1" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'server'", specifier = ">=3.3,<4" },
+    { name = "pwdlib", extras = ["argon2"], marker = "extra == 'server'", specifier = ">=0.3.0" },
+    { name = "pydantic-ai", marker = "extra == 'server'", specifier = ">=1.59,<2" },
+    { name = "pydantic-settings", marker = "extra == 'server'", specifier = ">=2,<3" },
     { name = "python-dotenv", specifier = ">=1.2,<2" },
-    { name = "python-multipart", specifier = ">=0.0.20,<1" },
-    { name = "pywebpush", specifier = ">=2,<3" },
-    { name = "pyyaml", specifier = ">=6,<7" },
-    { name = "redis", specifier = ">=8,<9" },
+    { name = "python-multipart", marker = "extra == 'server'", specifier = ">=0.0.20,<1" },
+    { name = "pywebpush", marker = "extra == 'server'", specifier = ">=2,<3" },
+    { name = "pyyaml", marker = "extra == 'server'", specifier = ">=6,<7" },
+    { name = "redis", marker = "extra == 'server'", specifier = ">=8,<9" },
     { name = "rich", specifier = ">=15,<16" },
-    { name = "sqlalchemy", specifier = ">=2.0,<2.1" },
-    { name = "tenacity", specifier = ">=9,<10" },
-    { name = "tiktoken", specifier = ">=0.8,<1" },
+    { name = "sqlalchemy", marker = "extra == 'server'", specifier = ">=2.0,<2.1" },
+    { name = "tenacity", marker = "extra == 'server'", specifier = ">=9,<10" },
+    { name = "tiktoken", marker = "extra == 'server'", specifier = ">=0.8,<1" },
     { name = "typer", specifier = ">=0.23,<1" },
-    { name = "types-docker", specifier = ">=7.1.0.20260518" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.40,<1" },
+    { name = "types-docker", marker = "extra == 'server'", specifier = ">=7.1.0.20260518" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.40,<1" },
     { name = "websockets", specifier = ">=16,<17" },
 ]
+provides-extras = ["server"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "carapace", extras = ["server"] },
     { name = "pyrefly", specifier = ">=1.0.0" },
     { name = "pytest" },
     { name = "pytest-asyncio" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces automation paths over sessions, approvals, and jobs via API keys/WebSockets, plus an install-layout change that requires `carapace[server]` for the server—misconfigured installs or scoped keys could break deployments or widen what an agent can do.
> 
> **Overview**
> Adds a **JSON-first CLI** so agents and scripts can drive carapace without the interactive `chat` REPL: `carapace session`, `approval`, and `job` subcommands wrap REST + WebSocket turns with stable exit codes (`needs_approval`, `timeout`, etc.), optional `--stream` to stderr, and ready-made `allow_command` / `deny_command` hints when a turn blocks on approvals.
> 
> **`carapace chat`** now **refuses non-TTY** stdin/stdout (unless `--force`) and points callers at the new commands. The server gains **`GET /api/sessions/{id}/pending-approvals`** so the CLI can list and resolve pending tool/escalation requests by id.
> 
> **Packaging** splits the default install into a **light CLI-only** base (`httpx`, `websockets`, …) and moves FastAPI, pydantic-ai, DB, etc. into the **`server` optional extra** (`carapace[server]`); Dockerfile and dev deps are updated accordingly.
> 
> A bundled **sandbox `carapace` skill** (setup + docs) installs the CLI from git and documents vault API key + public `CARAPACE_SERVER` configuration for in-sandbox automation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6980b7267dd33ade673487400d9906ad2c9b32b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->