### PR TITLE
✨ Interleave intermediate assistant text with tool calls

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -859,7 +859,9 @@
         "turn": "Runde {n}",
         "messageInTurn": "Nachricht {i} von {n}",
         "tools": "{count, plural, one {# Tool} other {# Tools}}",
-        "tokens": "{in} rein, {out} raus"
+        "tokens": "{in} rein, {out} raus",
+        "tps": "{n} Tok/s",
+        "ttft": "{value} TTFT"
     },
     "jobs": {
         "settingsSections": "Einstellungsbereiche",

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -857,6 +857,7 @@
     },
     "turnMeta": {
         "turn": "Runde {n}",
+        "messageInTurn": "Nachricht {i} von {n}",
         "tools": "{count, plural, one {# Tool} other {# Tools}}",
         "tokens": "{in} rein, {out} raus"
     },

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -857,6 +857,7 @@
     },
     "turnMeta": {
         "turn": "turn {n}",
+        "messageInTurn": "message {i} of {n}",
         "tools": "{count, plural, one {# tool} other {# tools}}",
         "tokens": "{in} in, {out} out"
     },

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -859,7 +859,9 @@
         "turn": "turn {n}",
         "messageInTurn": "message {i} of {n}",
         "tools": "{count, plural, one {# tool} other {# tools}}",
-        "tokens": "{in} in, {out} out"
+        "tokens": "{in} in, {out} out",
+        "tps": "{n} tok/s",
+        "ttft": "{value} TTFT"
     },
     "jobs": {
         "settingsSections": "Settings sections",

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -1063,6 +1063,9 @@ export function ChatView({
   const queueRef = useRef<string | null>(null);
   const queuedAttachmentsRef = useRef<Attachment[]>([]);
   const resetRollbackRef = useRef<ChatMessage[] | null>(null);
+  // Monotonic id for the on-done history re-projection so only the newest turn's refetch applies
+  // (older async responses are dropped, preventing duplicate/missing bubbles when turns overlap).
+  const doneRefetchSeqRef = useRef(0);
   const sendRef = useRef<(msg: ClientMessage) => void>(() => {});
   const onSandboxUpdateRef = useRef(onSandboxUpdate);
   const sandboxRef = useRef(sandbox);
@@ -1341,13 +1344,16 @@ export function ChatView({
           // The live transcript can't carry persisted-only metadata (timestamps, event indices,
           // per-turn numbering, usage / tok-s). Re-project from the now-persisted event log so the
           // finished turn shows the same data as a reload, preserving any tail that arrived since.
+          // Sequence-guard so a slower earlier refetch can't clobber a newer turn's projection.
+          const refetchSeq = ++doneRefetchSeqRef.current;
           fetchHistory(server, token, sessionId)
-            .then((history) =>
+            .then((history) => {
+              if (refetchSeq !== doneRefetchSeqRef.current) return;
               setMessages((prev) => [
                 ...projectHistoryToMessages(history),
                 ...prev.slice(doneBaselineLen),
-              ]),
-            )
+              ]);
+            })
             .catch(() => {
               // Refetch failed — keep the live transcript; metadata fills in on the next reload.
             });

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -935,6 +935,8 @@ function projectHistoryToMessages(history: HistoryMessage[]): ChatMessage[] {
       model: !isPartial ? (entry.usage?.model ?? undefined) : undefined,
       inputTokens: !isPartial ? entry.usage?.input_tokens : undefined,
       outputTokens: !isPartial ? entry.usage?.output_tokens : undefined,
+      ttftMs: !isPartial ? (entry.usage?.ttft_ms ?? undefined) : undefined,
+      generationMs: !isPartial ? (entry.usage?.generation_ms ?? undefined) : undefined,
     });
   }
 

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -1329,7 +1329,9 @@ export function ChatView({
                   ? { kind: "assistant", content: msg.content, finalStatus: msg.final_status }
                   : { kind: "assistant", content: (updated[i] as { content: string }).content, partial: true };
             }
-            if (!finalWasStreamed && (msg.content || lastStreamIdx === -1)) {
+            if (!finalWasStreamed) {
+              // The backend always persists a final assistant event (even empty), so append it
+              // unconditionally to keep the live transcript in step with the reloaded event log.
               updated.push({ kind: "assistant", content: msg.content, finalStatus: msg.final_status });
             }
             return updated;

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -513,7 +513,27 @@ function findLaterEscalationDecision(
 }
 
 function isTurnTerminalMessage(message: ChatMessage): boolean {
-  return message.kind === "assistant" || (message.kind === "error" && message.turnTerminal === true);
+  // A turn ends at its final assistant answer, never at intermediate narration (partial), so
+  // reset/fork/retry stay anchored to real turn boundaries (matching the backend event log).
+  return (
+    (message.kind === "assistant" && !message.partial)
+    || (message.kind === "error" && message.turnTerminal === true)
+  );
+}
+
+/**
+ * The message index of the assistant answer that terminates the turn enclosing `from` (the nearest
+ * turn-terminal at or after it), or undefined while that turn is still in progress. Lets any message
+ * — a user prompt, an intermediate bubble — drive fork/reset, snapping to its turn boundary.
+ */
+function enclosingTurnTerminalMessageIndex(
+  messages: ChatMessage[],
+  from: number,
+): number | undefined {
+  for (let index = from; index < messages.length; index++) {
+    if (isTurnTerminalMessage(messages[index])) return index;
+  }
+  return undefined;
 }
 
 function completedTurnMessageIndices(messages: ChatMessage[]): number[] {
@@ -893,6 +913,7 @@ function projectHistoryToMessages(history: HistoryMessage[]): ChatMessage[] {
       continue;
     }
 
+    const isPartial = entry.partial === true;
     const durationMs =
       turnStartTs && entry.timestamp
         ? new Date(entry.timestamp).getTime() - new Date(turnStartTs).getTime()
@@ -905,14 +926,35 @@ function projectHistoryToMessages(history: HistoryMessage[]): ChatMessage[] {
       compaction: entry.compaction,
       timestamp: entry.timestamp,
       turnIndex: turn,
+      partial: isPartial || undefined,
+      // Whole-turn stats belong on the final answer, not on intermediate narration.
       turnDurationMs:
-        typeof durationMs === "number" && durationMs >= 0 ? durationMs : undefined,
-      toolCount: turnToolCount || undefined,
-      model: entry.usage?.model ?? undefined,
-      inputTokens: entry.usage?.input_tokens,
-      outputTokens: entry.usage?.output_tokens,
+        !isPartial && typeof durationMs === "number" && durationMs >= 0 ? durationMs : undefined,
+      toolCount: !isPartial ? turnToolCount || undefined : undefined,
+      model: !isPartial ? (entry.usage?.model ?? undefined) : undefined,
+      inputTokens: !isPartial ? entry.usage?.input_tokens : undefined,
+      outputTokens: !isPartial ? entry.usage?.output_tokens : undefined,
     });
   }
+
+  // Number assistant bubbles within each turn ("message 2 of 3") for the metadata tooltip.
+  const assistantIdxByTurn = new Map<number, number[]>();
+  messages.forEach((m, i) => {
+    if (m.kind === "assistant" && m.turnIndex != null) {
+      const arr = assistantIdxByTurn.get(m.turnIndex) ?? [];
+      arr.push(i);
+      assistantIdxByTurn.set(m.turnIndex, arr);
+    }
+  });
+  assistantIdxByTurn.forEach((indices) => {
+    indices.forEach((i, k) => {
+      const m = messages[i];
+      if (m.kind === "assistant") {
+        m.messageIndexInTurn = k + 1;
+        m.turnMessageCount = indices.length;
+      }
+    });
+  });
 
   return groupFoldedMessages(groupChildToolCalls(messages));
 }
@@ -1267,16 +1309,20 @@ export function ChatView({
                 updated.push({ kind: "thinking", content: msg.thinking, ...thinkingMeta });
               }
             }
-            // Replace streaming message with the final content
-            const streamIdx = updated.findLastIndex((m) => m.kind === "streaming");
-            if (streamIdx !== -1) {
-              updated[streamIdx] = {
-                kind: "assistant",
-                content: msg.content,
-                finalStatus: msg.final_status,
-              };
-            } else {
+            // Finalize every streaming bubble. Intermediate segments (text emitted before a tool
+            // call) keep their own content and become partial assistant messages; the last one
+            // carries the authoritative final answer. Matches what reload rebuilds from events.
+            const lastStreamIdx = updated.findLastIndex((m) => m.kind === "streaming");
+            if (lastStreamIdx === -1) {
               updated.push({ kind: "assistant", content: msg.content, finalStatus: msg.final_status });
+            } else {
+              for (let i = 0; i < updated.length; i++) {
+                if (updated[i].kind !== "streaming") continue;
+                updated[i] =
+                  i === lastStreamIdx
+                    ? { kind: "assistant", content: msg.content, finalStatus: msg.final_status }
+                    : { kind: "assistant", content: (updated[i] as { content: string }).content, partial: true };
+              }
             }
             return updated;
           });
@@ -1678,11 +1724,15 @@ export function ChatView({
 
   async function resolveTurnTargetEventIndex(messageIndex: number): Promise<number | undefined> {
     const currentMessages = messages;
+    // Snap any message (user prompt, intermediate bubble) to the terminal of its enclosing turn —
+    // reset/fork operate at turn boundaries, never mid-turn.
+    const terminalIndex = enclosingTurnTerminalMessageIndex(currentMessages, messageIndex);
+    if (terminalIndex == null) return undefined;
     const localTerminalIndices = completedTurnMessageIndices(currentMessages);
-    const localTurnOrdinal = localTerminalIndices.indexOf(messageIndex);
+    const localTurnOrdinal = localTerminalIndices.indexOf(terminalIndex);
     if (localTurnOrdinal === -1) return undefined;
 
-    let targetEventIndex = eventIndexForMessage(currentMessages[messageIndex]);
+    let targetEventIndex = eventIndexForMessage(currentMessages[terminalIndex]);
 
     if (targetEventIndex == null) {
       const history = await fetchHistory(server, token, sessionId);
@@ -1701,11 +1751,14 @@ export function ChatView({
     if (waiting || status !== "connected") return;
 
     const currentMessages = messages;
+    // Reset keeps the whole enclosing turn, so the optimistic slice ends at its terminal, not at
+    // the clicked (possibly mid-turn) message.
+    const terminalIndex = enclosingTurnTerminalMessageIndex(currentMessages, messageIndex);
     setTurnActionBusyIndex(messageIndex);
     try {
       const targetEventIndex = await resolveTurnTargetEventIndex(messageIndex);
 
-      if (targetEventIndex == null) {
+      if (targetEventIndex == null || terminalIndex == null) {
         setMessages((prev) => [
           ...prev,
           { kind: "error", detail: t("errors.resetTarget") },
@@ -1715,7 +1768,7 @@ export function ChatView({
 
       resetRollbackRef.current = currentMessages;
       send({ type: "reset_to_turn", event_index: targetEventIndex });
-      setMessages((prev) => prev.slice(0, messageIndex + 1));
+      setMessages((prev) => prev.slice(0, terminalIndex + 1));
     } finally {
       setTurnActionBusyIndex(null);
     }
@@ -2661,6 +2714,15 @@ export function ChatView({
               {(() => {
                 const renderMessage = (i: number) => {
                   const msg = messages[i];
+                  // Expose actions on every conversational bubble; fork/reset snap to the enclosing
+                  // turn boundary, retry re-runs the latest turn.
+                  const terminalIdx = enclosingTurnTerminalMessageIndex(messages, i);
+                  const inCompletedTurn = terminalIdx != null;
+                  const isLatestTurn = inCompletedTurn && terminalIdx === latestTerminalIndex;
+                  const actionable = msg.kind === "user" || msg.kind === "assistant";
+                  const canFork = actionable && inCompletedTurn;
+                  const canReset = actionable && inCompletedTurn && !isLatestTurn;
+                  const canRetry = actionable && isLatestTurn;
                   return (
                     <Message
                       key={i}
@@ -2668,16 +2730,16 @@ export function ChatView({
                       server={server}
                       sessionId={sessionId}
                       activeLlmActivity={llmActivity}
-                      canFork={msg.kind === "assistant"}
-                      canRetry={i === latestTerminalIndex && isTurnTerminalMessage(msg)}
-                      canReset={i !== latestTerminalIndex && isTurnTerminalMessage(msg)}
+                      canFork={canFork}
+                      canRetry={canRetry}
+                      canReset={canReset}
                       actionDisabled={turnActionsDisabled}
                       onApproval={handleApproval}
                       onEscalation={handleEscalation}
                       onCredentialApproval={handleCredentialEscalation}
-                      onFork={msg.kind === "assistant" ? () => void handleFork(i) : undefined}
-                      onRetry={i === latestTerminalIndex && isTurnTerminalMessage(msg) ? handleRetry : undefined}
-                      onReset={i !== latestTerminalIndex && isTurnTerminalMessage(msg) ? () => void handleReset(i) : undefined}
+                      onFork={canFork ? () => void handleFork(i) : undefined}
+                      onRetry={canRetry ? handleRetry : undefined}
+                      onReset={canReset ? () => void handleReset(i) : undefined}
                     />
                   );
                 };

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -557,7 +557,7 @@ function latestCompletedTurnStartMessageIndex(messages: ChatMessage[]): number {
 }
 
 function eventIndexForMessage(message: ChatMessage): number | undefined {
-  if (message.kind === "assistant" || message.kind === "error") {
+  if (message.kind === "assistant" || message.kind === "error" || message.kind === "user") {
     return typeof message.eventIndex === "number" ? message.eventIndex : undefined;
   }
   return undefined;
@@ -672,6 +672,7 @@ function projectHistoryToMessages(history: HistoryMessage[]): ChatMessage[] {
         compaction: entry.compaction,
         timestamp: entry.timestamp,
         turnIndex: turn,
+        eventIndex: typeof entry.event_index === "number" ? entry.event_index : undefined,
       });
       continue;
     }
@@ -1724,41 +1725,31 @@ export function ChatView({
 
   async function resolveTurnTargetEventIndex(messageIndex: number): Promise<number | undefined> {
     const currentMessages = messages;
-    // Snap any message (user prompt, intermediate bubble) to the terminal of its enclosing turn —
-    // reset/fork operate at turn boundaries, never mid-turn.
-    const terminalIndex = enclosingTurnTerminalMessageIndex(currentMessages, messageIndex);
-    if (terminalIndex == null) return undefined;
-    const localTerminalIndices = completedTurnMessageIndices(currentMessages);
-    const localTurnOrdinal = localTerminalIndices.indexOf(terminalIndex);
-    if (localTurnOrdinal === -1) return undefined;
+    // Event-granular: each message carries its own event index, so reset/fork cut exactly here
+    // (the backend keeps the older turns compacted and rebuilds the cut turn verbatim).
+    const own = eventIndexForMessage(currentMessages[messageIndex]);
+    if (own != null) return own;
 
-    let targetEventIndex = eventIndexForMessage(currentMessages[terminalIndex]);
-
-    if (targetEventIndex == null) {
-      const history = await fetchHistory(server, token, sessionId);
-      const canonicalMessages = projectHistoryToMessages(history);
-      const canonicalTerminalIndices = completedTurnMessageIndices(canonicalMessages);
-      const canonicalMessageIndex = canonicalTerminalIndices[localTurnOrdinal];
-      if (canonicalMessageIndex != null) {
-        targetEventIndex = eventIndexForMessage(canonicalMessages[canonicalMessageIndex]);
-      }
+    // Live message not yet persisted (no event index): refetch and align by position — once the
+    // turn is on disk the reprojection has the same shape, so the same index resolves.
+    const history = await fetchHistory(server, token, sessionId);
+    const canonicalMessages = projectHistoryToMessages(history);
+    const candidate = canonicalMessages[messageIndex];
+    if (candidate != null && candidate.kind === currentMessages[messageIndex].kind) {
+      return eventIndexForMessage(candidate);
     }
-
-    return targetEventIndex;
+    return undefined;
   }
 
   async function handleReset(messageIndex: number) {
     if (waiting || status !== "connected") return;
 
     const currentMessages = messages;
-    // Reset keeps the whole enclosing turn, so the optimistic slice ends at its terminal, not at
-    // the clicked (possibly mid-turn) message.
-    const terminalIndex = enclosingTurnTerminalMessageIndex(currentMessages, messageIndex);
     setTurnActionBusyIndex(messageIndex);
     try {
       const targetEventIndex = await resolveTurnTargetEventIndex(messageIndex);
 
-      if (targetEventIndex == null || terminalIndex == null) {
+      if (targetEventIndex == null) {
         setMessages((prev) => [
           ...prev,
           { kind: "error", detail: t("errors.resetTarget") },
@@ -1768,7 +1759,8 @@ export function ChatView({
 
       resetRollbackRef.current = currentMessages;
       send({ type: "reset_to_turn", event_index: targetEventIndex });
-      setMessages((prev) => prev.slice(0, terminalIndex + 1));
+      // Cut exactly at the clicked message — mid-turn resets keep the bubbles up to here.
+      setMessages((prev) => prev.slice(0, messageIndex + 1));
     } finally {
       setTurnActionBusyIndex(null);
     }
@@ -2714,15 +2706,18 @@ export function ChatView({
               {(() => {
                 const renderMessage = (i: number) => {
                   const msg = messages[i];
-                  // Expose actions on every conversational bubble; fork/reset snap to the enclosing
-                  // turn boundary, retry re-runs the latest turn.
-                  const terminalIdx = enclosingTurnTerminalMessageIndex(messages, i);
-                  const inCompletedTurn = terminalIdx != null;
-                  const isLatestTurn = inCompletedTurn && terminalIdx === latestTerminalIndex;
+                  // Event-granular: fork/reset cut exactly at this message (mid-turn included).
+                  // Retry still re-runs the latest turn.
                   const actionable = msg.kind === "user" || msg.kind === "assistant";
-                  const canFork = actionable && inCompletedTurn;
-                  const canReset = actionable && inCompletedTurn && !isLatestTurn;
-                  const canRetry = actionable && isLatestTurn;
+                  const enclosingTerminal = enclosingTurnTerminalMessageIndex(messages, i);
+                  // A persisted/completed message can be a cut target; its event index is resolved
+                  // (refetched if a freshly-finished turn hasn't been reprojected) when acted on.
+                  const inHistory =
+                    typeof eventIndexForMessage(msg) === "number" || enclosingTerminal != null;
+                  const canFork = actionable && inHistory;
+                  // Resetting the very last bubble removes nothing — offer it only with a tail to drop.
+                  const canReset = canFork && i < messages.length - 1;
+                  const canRetry = actionable && enclosingTerminal === latestTerminalIndex;
                   return (
                     <Message
                       key={i}

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -1279,8 +1279,9 @@ export function ChatView({
   const onMessage = useCallback(
     (msg: ServerMessage) => {
       switch (msg.type) {
-        case "done":
+        case "done": {
           resetRollbackRef.current = null;
+          let doneBaselineLen = 0;
           setMessages((prev) => {
             const updated = [...prev];
             const thinkingMeta = thinkingUsageMeta(msg.usage);
@@ -1334,14 +1335,29 @@ export function ChatView({
               // unconditionally to keep the live transcript in step with the reloaded event log.
               updated.push({ kind: "assistant", content: msg.content, finalStatus: msg.final_status });
             }
+            doneBaselineLen = updated.length;
             return updated;
           });
+          // The live transcript can't carry persisted-only metadata (timestamps, event indices,
+          // per-turn numbering, usage / tok-s). Re-project from the now-persisted event log so the
+          // finished turn shows the same data as a reload, preserving any tail that arrived since.
+          fetchHistory(server, token, sessionId)
+            .then((history) =>
+              setMessages((prev) => [
+                ...projectHistoryToMessages(history),
+                ...prev.slice(doneBaselineLen),
+              ]),
+            )
+            .catch(() => {
+              // Refetch failed — keep the live transcript; metadata fills in on the next reload.
+            });
           if (msg.usage) setUsage(msg.usage);
           void refreshSandbox();
           setLlmActivity(null);
           lastThinkingStartedAtRef.current = null;
           finishWaiting();
           break;
+        }
         case "tool_call": {
           const isGitPush = msg.tool === "git_push";
           if (!isGitPush) setWaiting(true); // agent is active (may restore after reconnect)

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -1312,20 +1312,25 @@ export function ChatView({
                 updated.push({ kind: "thinking", content: msg.thinking, ...thinkingMeta });
               }
             }
-            // Finalize every streaming bubble. Intermediate segments (text emitted before a tool
-            // call) keep their own content and become partial assistant messages; the last one
-            // carries the authoritative final answer. Matches what reload rebuilds from events.
+            // Finalize every streaming bubble (intermediate text emitted before a tool call) into a
+            // partial assistant message. The final answer was streamed only if the last streaming
+            // bubble is the tail — no tool call after it. Otherwise the answer arrived only in the
+            // done payload (e.g. a structured/unattended output that never streamed tokens); the
+            // streamed bubbles are all narration, so append the answer as its own message. Matches
+            // what reload rebuilds from events.
             const lastStreamIdx = updated.findLastIndex((m) => m.kind === "streaming");
-            if (lastStreamIdx === -1) {
+            const finalWasStreamed =
+              lastStreamIdx !== -1
+              && !updated.slice(lastStreamIdx + 1).some((m) => m.kind === "tool_call");
+            for (let i = 0; i < updated.length; i++) {
+              if (updated[i].kind !== "streaming") continue;
+              updated[i] =
+                finalWasStreamed && i === lastStreamIdx
+                  ? { kind: "assistant", content: msg.content, finalStatus: msg.final_status }
+                  : { kind: "assistant", content: (updated[i] as { content: string }).content, partial: true };
+            }
+            if (!finalWasStreamed && (msg.content || lastStreamIdx === -1)) {
               updated.push({ kind: "assistant", content: msg.content, finalStatus: msg.final_status });
-            } else {
-              for (let i = 0; i < updated.length; i++) {
-                if (updated[i].kind !== "streaming") continue;
-                updated[i] =
-                  i === lastStreamIdx
-                    ? { kind: "assistant", content: msg.content, finalStatus: msg.final_status }
-                    : { kind: "assistant", content: (updated[i] as { content: string }).content, partial: true };
-              }
             }
             return updated;
           });

--- a/frontend/src/components/message.tsx
+++ b/frontend/src/components/message.tsx
@@ -91,8 +91,11 @@ function TurnMeta({
   const t = useTranslations("turnMeta");
   if (!timestamp && turnIndex == null) return null;
   const rel = timestamp ? formatRelativeTime(timestamp, locale) : "";
+  // Date and time formatted separately and joined with a space, so there's no comma between them.
   const abs = timestamp
-    ? new Date(timestamp).toLocaleString(locale, { dateStyle: "medium", timeStyle: "short" })
+    ? `${new Date(timestamp).toLocaleDateString(locale, { dateStyle: "medium" })} ${new Date(
+        timestamp,
+      ).toLocaleTimeString(locale, { timeStyle: "short" })}`
     : "";
   const turnLabel = turnIndex != null ? t("turn", { n: turnIndex }) : "";
   const posLabel =

--- a/frontend/src/components/message.tsx
+++ b/frontend/src/components/message.tsx
@@ -334,6 +334,8 @@ function MessageActions({
   inputTokens,
   outputTokens,
   hideMetaWhenRecent,
+  mirrored,
+  className,
 }: {
   copyText?: string;
   canFork?: boolean;
@@ -353,14 +355,17 @@ function MessageActions({
   inputTokens?: number;
   outputTokens?: number;
   hideMetaWhenRecent?: boolean;
+  /** Mirror layout for right-aligned (user) messages: meta on the left, buttons on the right. */
+  mirrored?: boolean;
+  className?: string;
 }) {
   const t = useTranslations("message");
   const hasCopy = typeof copyText === "string" && copyText.length > 0;
   const hasMeta = Boolean(timestamp) || turnIndex != null;
   if (!hasCopy && !canFork && !canRetry && !canReset && !hasMeta) return null;
 
-  return (
-    <div className="mt-2 flex items-center gap-2">
+  const buttons = (
+    <div className="flex items-center gap-2">
       <MessageCopyButton text={copyText ?? ""} className="border border-border/70 p-1.5" />
       <MessageActionButton
         label={t("actions.fork")}
@@ -380,19 +385,38 @@ function MessageActions({
         disabled={disabled}
         onClick={canReset ? onReset : undefined}
       />
-      <TurnMeta
-        timestamp={timestamp}
-        turnIndex={turnIndex}
-        messageIndexInTurn={messageIndexInTurn}
-        turnMessageCount={turnMessageCount}
-        turnDurationMs={turnDurationMs}
-        toolCount={toolCount}
-        model={model}
-        inputTokens={inputTokens}
-        outputTokens={outputTokens}
-        hideWhenRecent={hideMetaWhenRecent}
-        className="ml-auto"
-      />
+    </div>
+  );
+  const meta = (
+    <TurnMeta
+      timestamp={timestamp}
+      turnIndex={turnIndex}
+      messageIndexInTurn={messageIndexInTurn}
+      turnMessageCount={turnMessageCount}
+      turnDurationMs={turnDurationMs}
+      toolCount={toolCount}
+      model={model}
+      inputTokens={inputTokens}
+      outputTokens={outputTokens}
+      hideWhenRecent={hideMetaWhenRecent}
+    />
+  );
+
+  // Buttons and meta sit at opposite ends; the spacer between them spans the row width. Mirrored
+  // (user) rows put meta first / buttons last so the controls stay under the right-aligned bubble.
+  return (
+    <div className={cn("mt-2 flex items-center gap-2", className)}>
+      {mirrored ? (
+        <>
+          {meta}
+          <div className="ml-auto">{buttons}</div>
+        </>
+      ) : (
+        <>
+          {buttons}
+          <div className="ml-auto">{meta}</div>
+        </>
+      )}
     </div>
   );
 }
@@ -558,9 +582,10 @@ export function Message({
     case "user":
       return (
         <div className="group flex flex-col items-end">
+          <div className="flex w-fit max-w-full flex-col items-end md:max-w-[85%]">
           <div
             className={cn(
-              "chat-copy-serif max-w-full rounded-2xl rounded-br-md border border-border/60 bg-muted/30 px-3.5 py-2 text-sm text-foreground md:max-w-[85%]",
+              "chat-copy-serif max-w-full rounded-2xl rounded-br-md border border-border/60 bg-muted/30 px-3.5 py-2 text-sm text-foreground",
             )}
           >
             {message.content ? <MarkdownContent content={message.content} /> : null}
@@ -610,7 +635,10 @@ export function Message({
             timestamp={message.timestamp}
             turnIndex={message.turnIndex}
             hideMetaWhenRecent
+            mirrored
+            className="w-full"
           />
+          </div>
         </div>
       );
 

--- a/frontend/src/components/message.tsx
+++ b/frontend/src/components/message.tsx
@@ -32,11 +32,6 @@ function formatDuration(ms: number, locale: string, precise = true): string {
   return `${Math.round(ms / 1_000)}s`;
 }
 
-function turnAgeMs(iso: string): number {
-  const age = Date.now() - new Date(iso).getTime();
-  return Number.isNaN(age) ? Infinity : age;
-}
-
 function formatRelativeTime(iso: string, locale: string): string {
   const then = new Date(iso).getTime();
   if (Number.isNaN(then)) return "";
@@ -75,7 +70,6 @@ function TurnMeta({
   model,
   inputTokens,
   outputTokens,
-  hideWhenRecent,
   className,
 }: {
   timestamp?: string;
@@ -87,15 +81,11 @@ function TurnMeta({
   model?: string;
   inputTokens?: number;
   outputTokens?: number;
-  hideWhenRecent?: boolean;
   className?: string;
 }) {
   const { locale } = useAppLocale();
   const t = useTranslations("turnMeta");
   if (!timestamp && turnIndex == null) return null;
-  // User turns stay bare for ~10min so a reload never decorates a message a live session left
-  // blank; assistant turns always show (the work is done, the timing is the point).
-  if (hideWhenRecent && timestamp && turnAgeMs(timestamp) < 10 * 60 * 1_000) return null;
   const rel = timestamp ? formatRelativeTime(timestamp, locale) : "";
   const abs = timestamp
     ? new Date(timestamp).toLocaleString(locale, { dateStyle: "medium", timeStyle: "short" })
@@ -333,7 +323,6 @@ function MessageActions({
   model,
   inputTokens,
   outputTokens,
-  hideMetaWhenRecent,
   className,
 }: {
   copyText?: string;
@@ -353,7 +342,6 @@ function MessageActions({
   model?: string;
   inputTokens?: number;
   outputTokens?: number;
-  hideMetaWhenRecent?: boolean;
   className?: string;
 }) {
   const t = useTranslations("message");
@@ -393,7 +381,6 @@ function MessageActions({
         model={model}
         inputTokens={inputTokens}
         outputTokens={outputTokens}
-        hideWhenRecent={hideMetaWhenRecent}
         className="ml-auto"
       />
     </div>
@@ -613,7 +600,6 @@ export function Message({
             onReset={onReset}
             timestamp={message.timestamp}
             turnIndex={message.turnIndex}
-            hideMetaWhenRecent
             className="w-full"
           />
           </div>

--- a/frontend/src/components/message.tsx
+++ b/frontend/src/components/message.tsx
@@ -334,7 +334,6 @@ function MessageActions({
   inputTokens,
   outputTokens,
   hideMetaWhenRecent,
-  mirrored,
   className,
 }: {
   copyText?: string;
@@ -355,8 +354,6 @@ function MessageActions({
   inputTokens?: number;
   outputTokens?: number;
   hideMetaWhenRecent?: boolean;
-  /** Mirror layout for right-aligned (user) messages: meta on the left, buttons on the right. */
-  mirrored?: boolean;
   className?: string;
 }) {
   const t = useTranslations("message");
@@ -364,8 +361,9 @@ function MessageActions({
   const hasMeta = Boolean(timestamp) || turnIndex != null;
   if (!hasCopy && !canFork && !canRetry && !canReset && !hasMeta) return null;
 
-  const buttons = (
-    <div className="flex items-center gap-2">
+  // Controls first, then the meta pushed to the far end of the row (spacer between spans the width).
+  return (
+    <div className={cn("mt-2 flex items-center gap-2", className)}>
       <MessageCopyButton text={copyText ?? ""} className="border border-border/70 p-1.5" />
       <MessageActionButton
         label={t("actions.fork")}
@@ -385,38 +383,19 @@ function MessageActions({
         disabled={disabled}
         onClick={canReset ? onReset : undefined}
       />
-    </div>
-  );
-  const meta = (
-    <TurnMeta
-      timestamp={timestamp}
-      turnIndex={turnIndex}
-      messageIndexInTurn={messageIndexInTurn}
-      turnMessageCount={turnMessageCount}
-      turnDurationMs={turnDurationMs}
-      toolCount={toolCount}
-      model={model}
-      inputTokens={inputTokens}
-      outputTokens={outputTokens}
-      hideWhenRecent={hideMetaWhenRecent}
-    />
-  );
-
-  // Buttons and meta sit at opposite ends; the spacer between them spans the row width. Mirrored
-  // (user) rows put meta first / buttons last so the controls stay under the right-aligned bubble.
-  return (
-    <div className={cn("mt-2 flex items-center gap-2", className)}>
-      {mirrored ? (
-        <>
-          {meta}
-          <div className="ml-auto">{buttons}</div>
-        </>
-      ) : (
-        <>
-          {buttons}
-          <div className="ml-auto">{meta}</div>
-        </>
-      )}
+      <TurnMeta
+        timestamp={timestamp}
+        turnIndex={turnIndex}
+        messageIndexInTurn={messageIndexInTurn}
+        turnMessageCount={turnMessageCount}
+        turnDurationMs={turnDurationMs}
+        toolCount={toolCount}
+        model={model}
+        inputTokens={inputTokens}
+        outputTokens={outputTokens}
+        hideWhenRecent={hideMetaWhenRecent}
+        className="ml-auto"
+      />
     </div>
   );
 }
@@ -635,7 +614,6 @@ export function Message({
             timestamp={message.timestamp}
             turnIndex={message.turnIndex}
             hideMetaWhenRecent
-            mirrored
             className="w-full"
           />
           </div>

--- a/frontend/src/components/message.tsx
+++ b/frontend/src/components/message.tsx
@@ -68,6 +68,8 @@ function shortModel(model: string): string {
 function TurnMeta({
   timestamp,
   turnIndex,
+  messageIndexInTurn,
+  turnMessageCount,
   turnDurationMs,
   toolCount,
   model,
@@ -78,6 +80,8 @@ function TurnMeta({
 }: {
   timestamp?: string;
   turnIndex?: number;
+  messageIndexInTurn?: number;
+  turnMessageCount?: number;
   turnDurationMs?: number;
   toolCount?: number;
   model?: string;
@@ -97,7 +101,11 @@ function TurnMeta({
     ? new Date(timestamp).toLocaleString(locale, { dateStyle: "medium", timeStyle: "short" })
     : "";
   const turnLabel = turnIndex != null ? t("turn", { n: turnIndex }) : "";
-  const tipParts = [turnLabel, abs];
+  const posLabel =
+    messageIndexInTurn != null && turnMessageCount != null && turnMessageCount > 1
+      ? t("messageInTurn", { i: messageIndexInTurn, n: turnMessageCount })
+      : "";
+  const tipParts = [posLabel, turnLabel, abs];
   if (typeof turnDurationMs === "number") tipParts.push(formatDuration(turnDurationMs, locale, false));
   if (typeof toolCount === "number" && toolCount > 0) tipParts.push(t("tools", { count: toolCount }));
   if (model) tipParts.push(shortModel(model));
@@ -318,11 +326,14 @@ function MessageActions({
   onReset,
   timestamp,
   turnIndex,
+  messageIndexInTurn,
+  turnMessageCount,
   turnDurationMs,
   toolCount,
   model,
   inputTokens,
   outputTokens,
+  hideMetaWhenRecent,
 }: {
   copyText?: string;
   canFork?: boolean;
@@ -334,11 +345,14 @@ function MessageActions({
   onReset?: () => void;
   timestamp?: string;
   turnIndex?: number;
+  messageIndexInTurn?: number;
+  turnMessageCount?: number;
   turnDurationMs?: number;
   toolCount?: number;
   model?: string;
   inputTokens?: number;
   outputTokens?: number;
+  hideMetaWhenRecent?: boolean;
 }) {
   const t = useTranslations("message");
   const hasCopy = typeof copyText === "string" && copyText.length > 0;
@@ -369,11 +383,14 @@ function MessageActions({
       <TurnMeta
         timestamp={timestamp}
         turnIndex={turnIndex}
+        messageIndexInTurn={messageIndexInTurn}
+        turnMessageCount={turnMessageCount}
         turnDurationMs={turnDurationMs}
         toolCount={toolCount}
         model={model}
         inputTokens={inputTokens}
         outputTokens={outputTokens}
+        hideWhenRecent={hideMetaWhenRecent}
         className="ml-auto"
       />
     </div>
@@ -581,11 +598,18 @@ export function Message({
               </div>
             ) : null}
           </div>
-          <TurnMeta
+          <MessageActions
+            copyText={message.content}
+            canFork={canFork}
+            canRetry={canRetry}
+            canReset={canReset}
+            disabled={actionDisabled}
+            onFork={onFork}
+            onRetry={onRetry}
+            onReset={onReset}
             timestamp={message.timestamp}
             turnIndex={message.turnIndex}
-            hideWhenRecent
-            className="mt-1"
+            hideMetaWhenRecent
           />
         </div>
       );
@@ -608,6 +632,8 @@ export function Message({
             onReset={onReset}
             timestamp={message.timestamp}
             turnIndex={message.turnIndex}
+            messageIndexInTurn={message.messageIndexInTurn}
+            turnMessageCount={message.turnMessageCount}
             turnDurationMs={message.turnDurationMs}
             toolCount={message.toolCount}
             model={message.model}

--- a/frontend/src/components/message.tsx
+++ b/frontend/src/components/message.tsx
@@ -70,6 +70,8 @@ function TurnMeta({
   model,
   inputTokens,
   outputTokens,
+  ttftMs,
+  generationMs,
   className,
 }: {
   timestamp?: string;
@@ -81,6 +83,8 @@ function TurnMeta({
   model?: string;
   inputTokens?: number;
   outputTokens?: number;
+  ttftMs?: number;
+  generationMs?: number;
   className?: string;
 }) {
   const { locale } = useAppLocale();
@@ -95,6 +99,12 @@ function TurnMeta({
     messageIndexInTurn != null && turnMessageCount != null && turnMessageCount > 1
       ? t("messageInTurn", { i: messageIndexInTurn, n: turnMessageCount })
       : "";
+  // tok/s = provider output tokens / generation seconds (tool waits excluded) — shown inline.
+  const tps =
+    typeof outputTokens === "number" && typeof generationMs === "number" && generationMs > 0
+      ? Math.round((outputTokens / generationMs) * 1000)
+      : undefined;
+
   const tipParts = [posLabel, turnLabel, abs];
   if (typeof turnDurationMs === "number") tipParts.push(formatDuration(turnDurationMs, locale, false));
   if (typeof toolCount === "number" && toolCount > 0) tipParts.push(t("tools", { count: toolCount }));
@@ -107,7 +117,10 @@ function TurnMeta({
       }),
     );
   }
+  if (typeof ttftMs === "number") tipParts.push(t("ttft", { value: formatDuration(ttftMs, locale, true) }));
   const tip = tipParts.filter(Boolean).join(" · ");
+
+  const visible = [rel || turnLabel, tps != null ? t("tps", { n: tps }) : ""].filter(Boolean).join(" · ");
   return (
     <span
       title={tip}
@@ -116,7 +129,7 @@ function TurnMeta({
         className,
       )}
     >
-      {rel || turnLabel}
+      {visible}
     </span>
   );
 }
@@ -323,6 +336,8 @@ function MessageActions({
   model,
   inputTokens,
   outputTokens,
+  ttftMs,
+  generationMs,
   className,
 }: {
   copyText?: string;
@@ -342,6 +357,8 @@ function MessageActions({
   model?: string;
   inputTokens?: number;
   outputTokens?: number;
+  ttftMs?: number;
+  generationMs?: number;
   className?: string;
 }) {
   const t = useTranslations("message");
@@ -381,6 +398,8 @@ function MessageActions({
         model={model}
         inputTokens={inputTokens}
         outputTokens={outputTokens}
+        ttftMs={ttftMs}
+        generationMs={generationMs}
         className="ml-auto"
       />
     </div>
@@ -631,6 +650,8 @@ export function Message({
             model={message.model}
             inputTokens={message.inputTokens}
             outputTokens={message.outputTokens}
+            ttftMs={message.ttftMs}
+            generationMs={message.generationMs}
           />
         </div>
       );

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -180,6 +180,7 @@ export interface HistoryMessage {
   event_index?: number;
   timestamp?: string;
   usage?: { model?: string | null; input_tokens?: number; output_tokens?: number };
+  partial?: boolean;
   reasoning_duration_ms?: number;
   reasoning_tokens?: number;
   tool?: string;
@@ -540,6 +541,11 @@ export type ChatMessage =
       model?: string;
       inputTokens?: number;
       outputTokens?: number;
+      /** Intermediate narration emitted before a tool call, not the turn's final answer. */
+      partial?: boolean;
+      /** 1-based position of this assistant bubble within its turn, and the turn's total. */
+      messageIndexInTurn?: number;
+      turnMessageCount?: number;
     }
   | {
       kind: "compaction_summary";

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -527,6 +527,7 @@ export type ChatMessage =
       compaction?: CompactionAnnotation;
       timestamp?: string;
       turnIndex?: number;
+      eventIndex?: number;
     }
   | {
       kind: "assistant";

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -179,7 +179,13 @@ export interface HistoryMessage {
   final_status?: "success" | "warning";
   event_index?: number;
   timestamp?: string;
-  usage?: { model?: string | null; input_tokens?: number; output_tokens?: number };
+  usage?: {
+    model?: string | null;
+    input_tokens?: number;
+    output_tokens?: number;
+    ttft_ms?: number | null;
+    generation_ms?: number | null;
+  };
   partial?: boolean;
   reasoning_duration_ms?: number;
   reasoning_tokens?: number;
@@ -542,6 +548,8 @@ export type ChatMessage =
       model?: string;
       inputTokens?: number;
       outputTokens?: number;
+      ttftMs?: number;
+      generationMs?: number;
       /** Intermediate narration emitted before a tool call, not the turn's final answer. */
       partial?: boolean;
       /** 1-based position of this assistant bubble within its turn, and the turn's total. */

--- a/src/carapace/agent/loop.py
+++ b/src/carapace/agent/loop.py
@@ -24,6 +24,7 @@ from pydantic_ai.messages import (
     TextPartDelta,
     ThinkingPart,
     ThinkingPartDelta,
+    ToolCallPart,
 )
 from pydantic_ai.usage import UsageLimits
 
@@ -48,6 +49,7 @@ async def run_agent_turn(
     collect_approvals: Callable[[set[str]], Awaitable[dict[str, bool | ToolDenied]]],
     on_token: Callable[[str], Awaitable[None]] | None = None,
     on_thinking_token: Callable[[str], Awaitable[None]] | None = None,
+    on_assistant_text: Callable[[str], Awaitable[None]] | None = None,
     on_messages_snapshot: Callable[[list[Any]], None] | None = None,
     before_llm_call: Callable[[], None] | None = None,
     get_usage_limits: Callable[[], UsageLimits | None] | None = None,
@@ -63,11 +65,26 @@ async def run_agent_turn(
     agent = create_agent(deps)
     usage_model_key = deps.agent_model_id
     current_thinking_parts: list[str] = []
+    # Text the model emits before a tool call is intermediate narration; we flush it as its own
+    # assistant segment so it persists at its real position (between tool groups), not lumped into
+    # the final answer at turn end. Trailing text (no tool after it) is the final output and is
+    # handled by the caller — it is never flushed here.
+    current_text_parts: list[str] = []
     last_thinking = ""
+
+    async def _flush_text_segment() -> None:
+        if not current_text_parts:
+            return
+        segment = "".join(current_text_parts)
+        current_text_parts.clear()
+        if segment.strip() and on_assistant_text is not None:
+            await on_assistant_text(segment)
 
     async def _stream_handler(_ctx: Any, events: Any) -> None:
         async for event in events:
-            if isinstance(event, PartStartEvent) and isinstance(event.part, ThinkingPart) and event.part.content:
+            if isinstance(event, PartStartEvent) and isinstance(event.part, ToolCallPart):
+                await _flush_text_segment()
+            elif isinstance(event, PartStartEvent) and isinstance(event.part, ThinkingPart) and event.part.content:
                 current_thinking_parts.append(event.part.content)
                 if on_thinking_token is not None:
                     await on_thinking_token(event.part.content)
@@ -80,15 +97,18 @@ async def run_agent_turn(
                 if on_thinking_token is not None:
                     await on_thinking_token(event.delta.content_delta)
             elif isinstance(event, PartStartEvent) and isinstance(event.part, TextPart) and event.part.content:
+                current_text_parts.append(event.part.content)
                 if on_token is not None:
                     await on_token(event.part.content)
             elif isinstance(event, PartDeltaEvent) and isinstance(event.delta, TextPartDelta):
+                current_text_parts.append(event.delta.content_delta)
                 if on_token is not None:
                     await on_token(event.delta.content_delta)
 
     if before_llm_call is not None:
         before_llm_call()
     current_thinking_parts.clear()
+    current_text_parts.clear()
     usage_limits = get_usage_limits() if get_usage_limits is not None else None
     result = await agent.run(
         user_input,
@@ -158,6 +178,7 @@ async def run_agent_turn(
         if before_llm_call is not None:
             before_llm_call()
         current_thinking_parts.clear()
+        current_text_parts.clear()
         usage_limits = get_usage_limits() if get_usage_limits is not None else None
         result = await agent.run(
             deps=deps,

--- a/src/carapace/agent/loop.py
+++ b/src/carapace/agent/loop.py
@@ -178,7 +178,10 @@ async def run_agent_turn(
         if before_llm_call is not None:
             before_llm_call()
         current_thinking_parts.clear()
-        current_text_parts.clear()
+        # The just-finished sub-run ended in a deferred-tool request, not the final answer, so any
+        # text it buffered is intermediate narration (e.g. emitted after its last tool call) — flush
+        # it before the next run instead of dropping it.
+        await _flush_text_segment()
         usage_limits = get_usage_limits() if get_usage_limits is not None else None
         result = await agent.run(
             deps=deps,

--- a/src/carapace/server/history.py
+++ b/src/carapace/server/history.py
@@ -52,6 +52,7 @@ class HistoryMessage(BaseModel):
     event_index: int | None = None
     timestamp: str | None = None
     usage: dict[str, Any] | None = None
+    partial: bool | None = None
     reasoning_duration_ms: int | None = None
     reasoning_tokens: int | None = None
     tool: str | None = None

--- a/src/carapace/server/sessions.py
+++ b/src/carapace/server/sessions.py
@@ -155,7 +155,8 @@ class SessionArchiveCommitResponse(BaseModel):
 def _session_message_count(session_id: str) -> int:
     events = server._engine.session_mgr.load_events(session_id)
     if events:
-        return sum(1 for event in events if event.get("role") in {"user", "assistant"})
+        # Partial assistant events are intermediate narration within a turn, not standalone turns.
+        return sum(1 for event in events if event.get("role") in {"user", "assistant"} and not event.get("partial"))
 
     history = _history_from_messages(session_id)
     return sum(1 for message in history if message.role in {"user", "assistant"})

--- a/src/carapace/session/engine.py
+++ b/src/carapace/session/engine.py
@@ -76,6 +76,7 @@ from .transcript import (
     history_for_completed_turn_count,
     is_terminal_history_message,
     normalize_unattended_output_history,
+    rebuild_model_history_from_events,
     task_output_text,
 )
 from .turns import SessionTurnMixin
@@ -543,13 +544,13 @@ class SessionEngine(
             return False
 
         events = self._truncate_incomplete_events(self._session_mgr.load_events(session_id))
-        turns = self._completed_event_turns(events)
-        target = next((turn for turn in turns if turn.end_event_index == event_index), None)
-        if target is None:
+        result = self._sliced_transcript_for_event_cut(session_id, events, event_index)
+        if result is None:
             await self._broadcast(active, "on_error", "Unknown reset target")
             return False
 
-        self._rewrite_session_transcript(session_id, events[: target.end_event_index + 1])
+        prefix_events, history, tree = result
+        self._save_rewound_transcript(session_id, prefix_events, history, tree)
         return True
 
     def fork_session(
@@ -571,15 +572,13 @@ class SessionEngine(
         source_meta = self._session_mgr.load_meta(session_id)
         source_state = active.state.model_copy(deep=True)
         events = self._truncate_incomplete_events(self._session_mgr.load_events(session_id))
-        turns = self._completed_event_turns(events)
-        target = next((turn for turn in turns if turn.end_event_index == event_index), None)
-        if target is None:
+        result = self._sliced_transcript_for_event_cut(session_id, events, event_index)
+        if result is None:
             msg = "Unknown fork target"
             raise ValueError(msg)
 
-        forked_events = events[: target.end_event_index + 1]
-        history = self._truncate_incomplete_model_history(self._session_mgr.load_history(session_id))
-        forked_history, forked_tree = self._compacted_history_and_tree_for_events(session_id, forked_events, history)
+        forked_events, forked_history, forked_tree = result
+        forked_at_tip = event_index == len(events) - 1
         target_unattended = source_state.attributes.unattended if unattended is None else unattended
         target_ask_mode = source_state.attributes.ask_mode if ask_mode is None else ask_mode
         target_yolo_mode = source_state.attributes.yolo_mode if yolo_mode is None else yolo_mode
@@ -621,7 +620,7 @@ class SessionEngine(
         # Seed the context-distribution gauge from the source's last agent request, but only when
         # forking at the tip: for an earlier turn the source's shape reflects more context than the
         # fork actually holds. Cost/usage still start empty — no billing is carried over.
-        if target is turns[-1]:
+        if forked_at_tip:
             source_rec = last_record_for_source(self._session_mgr.load_llm_request_log(session_id), "agent")
             if source_rec is not None:
                 self._session_mgr.save_llm_request_log(forked_session_id, LlmRequestLog(records=[source_rec]))
@@ -702,13 +701,62 @@ class SessionEngine(
         tree = trim_compaction_tree(self._session_mgr.load_compaction(session_id), fold_ids)
         return sliced, tree
 
-    def _rewrite_session_transcript(self, session_id: str, events: list[dict[str, Any]]) -> None:
-        truncated_events = self._truncate_incomplete_events(events)
-        history = self._truncate_incomplete_model_history(self._session_mgr.load_history(session_id))
-        truncated_history, tree = self._compacted_history_and_tree_for_events(session_id, truncated_events, history)
+    def _first_user_event_index(self, events: list[dict[str, Any]], *, start: int) -> int | None:
+        """Index of the first non-slash user event at or after *start* (a turn's prompt)."""
+        for index in range(start, len(events)):
+            event = events[index]
+            content = event.get("content")
+            if event.get("role") == "user" and isinstance(content, str) and not content.startswith("/"):
+                return index
+        return None
 
-        self._session_mgr.save_events(session_id, truncated_events)
-        self._session_mgr.save_history(session_id, truncated_history)
+    def _sliced_transcript_for_event_cut(
+        self, session_id: str, events: list[dict[str, Any]], cut_index: int
+    ) -> tuple[list[dict[str, Any]], list[ModelMessage], SessionCompaction] | None:
+        """Event-granular slice for reset/fork: keep the transcript through *cut_index* inclusive.
+
+        Cuts land on a user prompt or an assistant answer (final or intermediate ``partial``). A
+        final-assistant cut is a turn boundary and reuses the fold-aware turn slice. A mid-turn cut
+        (partial assistant, or a user prompt to rewind to) keeps the compacted older turns verbatim
+        and rebuilds only the *cut turn* from its events — safe because the newest turn is never
+        folded or tool-compacted (compaction runs between turns).
+        """
+        events = self._truncate_incomplete_events(events)
+        if not 0 <= cut_index < len(events):
+            return None
+        cut_event = events[cut_index]
+        role = cut_event.get("role")
+        content = cut_event.get("content")
+        if role not in {"user", "assistant"}:
+            return None
+        if role == "user" and isinstance(content, str) and content.startswith("/"):
+            return None  # slash commands are not branch points
+
+        prefix = events[: cut_index + 1]
+        history = self._truncate_incomplete_model_history(self._session_mgr.load_history(session_id))
+
+        if role == "assistant" and not cut_event.get("partial"):
+            sliced, tree = self._compacted_history_and_tree_for_events(session_id, prefix, history)
+            return prefix, sliced, tree
+
+        completed = self._completed_event_turns(prefix)
+        head_end = completed[-1].end_event_index + 1 if completed else 0
+        head_history, tree = self._compacted_history_and_tree_for_events(session_id, events[:head_end], history)
+        turn_start = self._first_user_event_index(prefix, start=head_end)
+        if turn_start is None:
+            return prefix, head_history, tree
+        tail_history = rebuild_model_history_from_events(prefix[turn_start : cut_index + 1])
+        return prefix, head_history + tail_history, tree
+
+    def _save_rewound_transcript(
+        self,
+        session_id: str,
+        events: list[dict[str, Any]],
+        history: list[ModelMessage],
+        tree: SessionCompaction,
+    ) -> None:
+        self._session_mgr.save_events(session_id, events)
+        self._session_mgr.save_history(session_id, history)
         self._session_mgr.save_compaction(session_id, tree)
         self._session_mgr.clear_llm_request_state(session_id)
 
@@ -716,6 +764,12 @@ class SessionEngine(
         if active is not None:
             active.llm_request_state = None
             active.llm_request_thinking.clear()
+
+    def _rewrite_session_transcript(self, session_id: str, events: list[dict[str, Any]]) -> None:
+        truncated_events = self._truncate_incomplete_events(events)
+        history = self._truncate_incomplete_model_history(self._session_mgr.load_history(session_id))
+        truncated_history, tree = self._compacted_history_and_tree_for_events(session_id, truncated_events, history)
+        self._save_rewound_transcript(session_id, truncated_events, truncated_history, tree)
 
     async def _generate_title(
         self, active: ActiveSession, events: list[dict[str, Any]], *, track_activity: bool = True

--- a/src/carapace/session/transcript.py
+++ b/src/carapace/session/transcript.py
@@ -34,7 +34,12 @@ def completed_event_turns(events: list[dict[str, Any]]) -> list[CompletedEventTu
         if role == "user" and isinstance(content := event.get("content"), str) and not content.startswith("/"):
             start_event_index = index
             user_content = content
-        elif role == "assistant" and start_event_index is not None and user_content is not None:
+        elif (
+            role == "assistant"
+            and not event.get("partial")
+            and start_event_index is not None
+            and user_content is not None
+        ):
             turns.append(
                 CompletedEventTurn(
                     start_event_index=start_event_index,

--- a/src/carapace/session/turns.py
+++ b/src/carapace/session/turns.py
@@ -270,6 +270,16 @@ class SessionTurnMixin(SessionTurnHost):
             active._pending_sends.add(task)
             task.add_done_callback(active._pending_sends.discard)
 
+        async def _assistant_text_cb(text: str) -> None:
+            # Intermediate narration (text the model emitted before a tool call). Persist it as a
+            # partial assistant event so reload renders it between the tool groups; the turn's final
+            # answer is still written once at finalization. ``partial`` keeps turn-boundary detection
+            # (reset/fork/compaction) anchored to the final assistant event only.
+            self._session_mgr.append_events(
+                session_id,
+                [{"role": "assistant", "content": text, "partial": True}],
+            )
+
         try:
             async with active.lock:
                 if active.security:
@@ -300,6 +310,7 @@ class SessionTurnMixin(SessionTurnHost):
                     send_approval_request=_send_approval,
                     collect_approvals=_collect_approvals,
                     on_messages_snapshot=_set_latest_messages,
+                    on_assistant_text=_assistant_text_cb,
                 )
 
                 await self._finalize_successful_turn(
@@ -492,6 +503,7 @@ class SessionTurnMixin(SessionTurnHost):
         send_approval_request: Callable[[ApprovalRequest], Awaitable[None]],
         collect_approvals: Callable[[set[str]], Awaitable[dict[str, bool | ToolDenied]]],
         on_messages_snapshot: Callable[[list[Any]], None],
+        on_assistant_text: Callable[[str], Awaitable[None]],
     ) -> TurnExecutionResult:
         async with self._llm_semaphore:
             with self.llm_request_recording(active):
@@ -504,6 +516,7 @@ class SessionTurnMixin(SessionTurnHost):
                     collect_approvals=collect_approvals,
                     on_token=partial(self._handle_token_chunk, active),
                     on_thinking_token=partial(self._handle_thinking_token_chunk, active),
+                    on_assistant_text=on_assistant_text,
                     on_messages_snapshot=lambda snapshot: on_messages_snapshot(snapshot),
                     before_llm_call=lambda: self._assert_llm_budget_available(active),
                     get_usage_limits=lambda: self._remaining_usage_limits(active),

--- a/src/carapace/session/turns.py
+++ b/src/carapace/session/turns.py
@@ -40,7 +40,13 @@ from ..models.tooling import ToolCallCallback, ToolResult
 from ..notifications.router import NotificationRouter, build_turn_outcome_notification_id
 from ..sandbox.manager import SandboxManager
 from ..security.context import ApprovalSource, ApprovalVerdict, format_denial_message, normalize_optional_message
-from ..usage import BudgetGauge, LlmRequestState, SessionBudgetExceededError, interrupted_request_record
+from ..usage import (
+    BudgetGauge,
+    LlmRequestState,
+    SessionBudgetExceededError,
+    aggregate_turn_generation,
+    interrupted_request_record,
+)
 from ..ws_models import ApprovalRequest, ApprovalResponse, Attachment, FinalStatus, TurnUsage
 from .attachments import augment_prompt
 from .manager import SessionManager
@@ -189,6 +195,9 @@ class SessionTurnMixin(SessionTurnHost):
         # gets a hidden preamble describing any uploaded files.
         agent_input = augment_prompt(user_input, attachments)
         latest_messages: list[ModelMessage] | None = None
+        # Mark where this turn's LLM-request records begin so the turn's generation stats (tok/s,
+        # TTFT, provider token totals) can be aggregated over just this turn's requests.
+        turn_record_start = len(active.llm_request_log.records)
 
         def _set_latest_messages(snapshot: list[Any]) -> None:
             nonlocal latest_messages
@@ -320,6 +329,7 @@ class SessionTurnMixin(SessionTurnHost):
                     turn_result.output,
                     turn_result.thinking,
                     final_status=turn_result.final_status,
+                    turn_record_start=turn_record_start,
                 )
 
         except asyncio.CancelledError:
@@ -564,21 +574,27 @@ class SessionTurnMixin(SessionTurnHost):
         output: str,
         thinking: str,
         final_status: FinalStatus | None = None,
+        turn_record_start: int = 0,
     ) -> None:
         self._session_mgr.save_history(session_id, messages)
         self._session_mgr.save_state(active.state)
         self._save_turn_progress(session_id, active)
         await self._refresh_sandbox_snapshot_after_turn(session_id)
         usage_payload = self._turn_usage_payload(active) or TurnUsage()
+        # Aggregate this turn's agent requests for the reload tooltip: provider token totals, the
+        # turn's TTFT, and generation time summed across requests (tool waits between them excluded,
+        # so tok/s reflects decode speed, not tool latency). Live TurnUsage is broadcast, not stored.
+        stats = aggregate_turn_generation(active.llm_request_log.records[turn_record_start:])
         assistant_event: dict[str, Any] = {"role": "assistant", "content": output}
         if final_status is not None:
             assistant_event["final_status"] = final_status
-        # Persist the bits the turn tooltip shows after reload (live TurnUsage is broadcast, not stored).
-        if usage_payload.model or usage_payload.input_tokens or usage_payload.output_tokens:
+        if usage_payload.model or stats["input_tokens"] or stats["output_tokens"]:
             assistant_event["usage"] = {
                 "model": usage_payload.model,
-                "input_tokens": usage_payload.input_tokens,
-                "output_tokens": usage_payload.output_tokens,
+                "input_tokens": stats["input_tokens"],
+                "output_tokens": stats["output_tokens"],
+                "ttft_ms": stats["ttft_ms"],
+                "generation_ms": stats["generation_ms"],
             }
         self._session_mgr.append_events(session_id, [assistant_event])
         assistant_event_index = len(self._session_mgr.load_events(session_id)) - 1

--- a/src/carapace/usage.py
+++ b/src/carapace/usage.py
@@ -489,6 +489,38 @@ def _duration_ms(start: datetime | None, end: datetime | None) -> int | None:
     return max(0, int((end - start).total_seconds() * 1000))
 
 
+class TurnGenerationStats(TypedDict):
+    input_tokens: int
+    output_tokens: int
+    ttft_ms: int | None
+    generation_ms: int | None
+
+
+def aggregate_turn_generation(records: list[LlmRequestRecord]) -> TurnGenerationStats:
+    """Turn-level generation stats over the turn's completed agent requests (all provider-reported).
+
+    Token totals are summed across requests (the model bills each round's input + output). ``ttft_ms``
+    is the turn's first request's prompt→first-token wait. ``generation_ms`` sums each request's decode
+    window (first token → completion); the gaps between requests are tool execution and are excluded,
+    so a tok/s derived from it reflects decode speed, not how long tools ran.
+    """
+    agent = [r for r in records if r.source == "agent" and r.outcome == "completed"]
+    input_tokens = sum(r.input_tokens for r in agent)
+    output_tokens = sum(r.output_tokens for r in agent)
+    ttft_ms = _duration_ms(agent[0].started_at, agent[0].first_text_at) if agent else None
+    generation_ms: int | None = None
+    for rec in agent:
+        decode = _duration_ms(rec.first_text_at, rec.completed_at)
+        if decode is not None:
+            generation_ms = (generation_ms or 0) + decode
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "ttft_ms": ttft_ms,
+        "generation_ms": generation_ms,
+    }
+
+
 def _normalize_reasoning_tokens(details: dict[str, int]) -> int | None:
     exact = details.get("reasoning_tokens")
     if isinstance(exact, int):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic_ai.messages import PartStartEvent, TextPart, ToolCallPart
 from pydantic_ai.models import Model
 from pydantic_ai.usage import RunUsage
 
@@ -91,3 +92,46 @@ async def test_run_agent_turn_decodes_unattended_structured_outputs(
     assert thinking == ""
     assert final_status == expected_status
     assert isinstance(deps.security.action_log[-1], AgentResponseEntry)
+
+
+@pytest.mark.anyio
+async def test_run_agent_turn_flushes_intermediate_text_before_tool_calls(tmp_path: Path) -> None:
+    """Text emitted before a tool call is flushed as an intermediate segment; the final answer
+    (text with no tool after it) is returned as output, never double-flushed."""
+    deps = _make_deps(tmp_path, unattended=False)
+    fake_agent = MagicMock()
+
+    async def _events() -> Any:
+        yield PartStartEvent(index=0, part=TextPart(content="Let me check the file. "))
+        yield PartStartEvent(index=1, part=ToolCallPart(tool_name="read", args={}, tool_call_id="c1"))
+        yield PartStartEvent(index=2, part=TextPart(content="All done."))
+
+    async def _run(*_args: Any, **kwargs: Any) -> _FakeResult:
+        await kwargs["event_stream_handler"](None, _events())
+        return _FakeResult("All done.")
+
+    fake_agent.run = _run
+
+    segments: list[str] = []
+
+    async def _on_assistant_text(text: str) -> None:
+        segments.append(text)
+
+    async def _send_approval_request(_req: Any) -> None:
+        raise AssertionError("approval loop should not run")
+
+    async def _collect_approvals(_pending: set[str]) -> dict[str, bool]:
+        raise AssertionError("approval loop should not run")
+
+    with patch("carapace.agent.loop.create_agent", return_value=fake_agent):
+        _messages, output_text, _thinking, _status = await run_agent_turn(
+            "read the file",
+            deps,
+            [],
+            _send_approval_request,
+            _collect_approvals,
+            on_assistant_text=_on_assistant_text,
+        )
+
+    assert segments == ["Let me check the file. "]
+    assert output_text == "All done."

--- a/tests/test_llm_request_log.py
+++ b/tests/test_llm_request_log.py
@@ -9,11 +9,53 @@ from carapace.usage import (
     InputShapeRatios,
     LlmRequestLog,
     LlmRequestRecord,
+    aggregate_turn_generation,
     gauge_breakdown_pct_dict,
     input_shape_ratios_from_messages,
     last_record_for_source,
     usage_last_request_row,
 )
+
+
+def test_aggregate_turn_generation_excludes_tool_time() -> None:
+    base = datetime(2026, 6, 22, 12, 0, 0, tzinfo=UTC)
+
+    def _rec(start_s: int, ttft_ms: int, decode_ms: int, out: int, inp: int) -> LlmRequestRecord:
+        started = base + timedelta(seconds=start_s)
+        first_text = started + timedelta(milliseconds=ttft_ms)
+        return LlmRequestRecord(
+            ts=started,
+            source="agent",
+            input_tokens=inp,
+            output_tokens=out,
+            started_at=started,
+            first_text_at=first_text,
+            completed_at=first_text + timedelta(milliseconds=decode_ms),
+        )
+
+    # Two agent requests with a long tool gap between them (request 2 starts 100s later).
+    records = [
+        _rec(start_s=0, ttft_ms=200, decode_ms=1000, out=100, inp=5000),
+        _rec(start_s=100, ttft_ms=400, decode_ms=3000, out=300, inp=8000),
+    ]
+
+    stats = aggregate_turn_generation(records)
+
+    assert stats["input_tokens"] == 13000  # provider input billed across rounds
+    assert stats["output_tokens"] == 400  # provider output summed
+    assert stats["ttft_ms"] == 200  # the turn's first request
+    assert stats["generation_ms"] == 4000  # decode only (1000 + 3000), tool gap excluded
+
+
+def test_aggregate_turn_generation_ignores_non_agent_and_interrupted() -> None:
+    base = datetime(2026, 6, 22, 12, 0, 0, tzinfo=UTC)
+    records = [
+        LlmRequestRecord(ts=base, source="sentinel", output_tokens=999),
+        LlmRequestRecord(ts=base, source="agent", outcome="interrupted", output_tokens=50),
+    ]
+    stats = aggregate_turn_generation(records)
+    assert stats["output_tokens"] == 0
+    assert stats["generation_ms"] is None
 
 
 def test_input_shape_ratios_single_user_only() -> None:

--- a/tests/test_session_engine_core.py
+++ b/tests/test_session_engine_core.py
@@ -285,6 +285,55 @@ def test_fork_session_copies_transcript_and_security_context(tmp_path: Path, db_
     assert len(engine.session_mgr.load_events(sid)) == 5
 
 
+def test_fork_at_partial_assistant_rebuilds_cut_turn(tmp_path: Path, db_factory) -> None:
+    """Forking at an intermediate (partial) assistant keeps the turn's events up to the cut and
+    rebuilds a model history ending on that narration — the basis for continuing mid-turn."""
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path, session_factory=db_factory)
+    sid = engine.session_mgr.create_session(user="thies").session_id
+    engine.get_or_activate(sid)
+    engine.session_mgr.append_events(
+        sid,
+        [
+            {"role": "user", "content": "do it"},
+            {"role": "tool_call", "tool": "read", "args": {"path": "a.txt"}, "detail": "reading", "tool_id": "c1"},
+            {"role": "tool_result", "tool": "read", "result": "contents", "exit_code": 0, "tool_id": "c1"},
+            {"role": "assistant", "content": "let me look closer", "partial": True},
+            {"role": "tool_call", "tool": "exec", "args": {"command": "ls"}, "detail": "run", "tool_id": "c2"},
+            {"role": "tool_result", "tool": "exec", "result": "ok", "exit_code": 0, "tool_id": "c2"},
+            {"role": "assistant", "content": "all done"},
+        ],
+    )
+    engine.session_mgr.save_history(
+        sid,
+        [
+            ModelRequest(parts=[UserPromptPart(content="do it")]),
+            ModelResponse(parts=[ToolCallPart(tool_name="read", args={"path": "a.txt"}, tool_call_id="c1")]),
+            ModelRequest(parts=[ToolReturnPart(tool_name="read", content="contents", tool_call_id="c1")]),
+            ModelResponse(parts=[TextPart(content="let me look closer")]),
+            ModelResponse(parts=[ToolCallPart(tool_name="exec", args={"command": "ls"}, tool_call_id="c2")]),
+            ModelRequest(parts=[ToolReturnPart(tool_name="exec", content="ok", tool_call_id="c2")]),
+            ModelResponse(parts=[TextPart(content="all done")]),
+        ],
+    )
+
+    forked = engine.fork_session(sid, event_index=3, channel_type="web")
+
+    assert _without_timestamps(engine.session_mgr.load_events(forked.session_id)) == [
+        {"role": "user", "content": "do it"},
+        {"role": "tool_call", "tool": "read", "args": {"path": "a.txt"}, "detail": "reading", "tool_id": "c1"},
+        {"role": "tool_result", "tool": "read", "result": "contents", "exit_code": 0, "tool_id": "c1"},
+        {"role": "assistant", "content": "let me look closer", "partial": True},
+    ]
+    history = engine.session_mgr.load_history(forked.session_id)
+    # user prompt, the read tool call/return pair, then the intermediate narration — ending here.
+    assert len(history) == 4
+    assert isinstance(history[0], ModelRequest) and history[0].parts[0].content == "do it"
+    last = history[-1]
+    assert isinstance(last, ModelResponse)
+    assert isinstance(last.parts[0], TextPart) and last.parts[0].content == "let me look closer"
+
+
 def _seed_two_turn_session(engine: Any) -> str:
     sid = engine.session_mgr.create_session(user="thies").session_id
     engine.get_or_activate(sid)
@@ -320,6 +369,30 @@ def _seed_two_turn_session(engine: Any) -> str:
         ),
     )
     return sid
+
+
+@pytest.mark.anyio
+async def test_reset_to_user_message_cuts_after_prompt(tmp_path: Path, db_factory) -> None:
+    """Resetting at a user message keeps the conversation through that prompt (dropping its
+    response), so the user can amend and re-run by sending a follow-up."""
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path, session_factory=db_factory)
+    sid = _seed_two_turn_session(engine)
+
+    ok = await engine.reset_to_turn(sid, 2)  # the "second" user prompt
+
+    assert ok is True
+    assert _without_timestamps(engine.session_mgr.load_events(sid)) == [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "reply one"},
+        {"role": "user", "content": "second"},
+    ]
+    history = engine.session_mgr.load_history(sid)
+    assert len(history) == 3
+    last = history[-1]
+    assert isinstance(last, ModelRequest)
+    assert isinstance(last.parts[0], UserPromptPart)
+    assert last.parts[0].content == "second"
 
 
 def test_fork_at_tip_copies_context_distribution(tmp_path: Path, db_factory) -> None:

--- a/tests/test_session_engine_models.py
+++ b/tests/test_session_engine_models.py
@@ -772,6 +772,26 @@ def test_truncate_incomplete_events_keeps_completed_turn_after_resultless_call(t
         assert engine._completed_event_turns(truncated)[-1].end_event_index == 6
 
 
+def test_completed_event_turns_ignores_partial_assistant_events(tmp_path: Path, db_factory) -> None:
+    """Intermediate narration (partial assistant events) sits inside a turn — the turn must end at
+    its final assistant answer, so reset/fork/compaction stay anchored to real turn boundaries."""
+    with _patch_sentinel():
+        engine = _make_engine(tmp_path, session_factory=db_factory)
+        events: list[dict[str, Any]] = [
+            {"role": "user", "content": "do it"},
+            {"role": "assistant", "content": "let me check the file", "partial": True},
+            {"role": "tool_call", "tool": "exec", "args": {"command": "ls"}, "detail": "run", "tool_id": "c1"},
+            {"role": "tool_result", "tool": "exec", "result": "ok", "exit_code": 0, "tool_id": "c1"},
+            {"role": "assistant", "content": "all done"},
+        ]
+
+        turns = engine._completed_event_turns(events)
+
+        assert len(turns) == 1
+        assert turns[0].start_event_index == 0
+        assert turns[0].end_event_index == 4  # final assistant, not the partial at index 1
+
+
 def test_save_user_message_on_failure_appends_cancelled_parallel_tool_returns(tmp_path: Path, db_factory) -> None:
     with _patch_sentinel():
         engine = _make_engine(tmp_path, session_factory=db_factory)


### PR DESCRIPTION
Stacked on #231 (`feature/session-compaction`).

## Problem
Only a turn's **final** assistant text was ever persisted (one event at turn end). Tool calls/results are written as they happen, so any narration the model emitted *between* tool calls was swallowed. On reload, all tools collapsed into a single group with the answer dumped after them — order lost, intermediate text gone.

## Phase 1 — persist & interleave
- `agent/loop.py`: the stream handler buffers text parts and flushes a segment via a new `on_assistant_text` callback when a `ToolCallPart` starts. Trailing text (no tool after it) is the final answer and is never flushed.
- `turns.py`: `on_assistant_text` appends a `{role: assistant, content, partial: true}` event at its real position.
- `transcript.py`: `completed_event_turns` ignores `partial` events, keeping reset/fork/retry/compaction anchored to the final assistant answer.
- Frontend `done` handler finalizes **every** streaming segment (not just the last), so live matches reload.

## Phase 2 — metadata + actions on all messages
- Turn tooltip gains **"message i of n"** (per-turn bubble numbering).
- Copy + fork + reset exposed on all conversational messages.

## Phase 3 — event-level fork & reset
- Fork/reset cut at **any** message, not just turn boundaries. Every user prompt and assistant bubble (intermediate or final) is a branch point.
- `engine._sliced_transcript_for_event_cut`: a final-assistant cut reuses the fold-aware turn slice; a mid-turn (partial) or user-prompt cut keeps older turns compacted and **rebuilds only the cut turn verbatim from its events** — safe because the newest turn is never folded/tool-compacted. `reset_to_turn`/`fork_session` route through it; retry stays turn-level.
- Reset/fork at a **user prompt** keeps the conversation through that prompt and drops its response — amend and re-run with a follow-up.
- Frontend: messages carry their own event index; fork/reset use it directly (no turn snapping); reset slices optimistically at the clicked message.

## Tests
- `test_run_agent_turn_flushes_intermediate_text_before_tool_calls`, `test_completed_event_turns_ignores_partial_assistant_events`, `test_fork_at_partial_assistant_rebuilds_cut_turn`, `test_reset_to_user_message_cuts_after_prompt`.
- Backend 259 relevant tests green; ruff + pyrefly clean. Frontend 60 tests, tsc + eslint + i18n parity clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session transcript persistence, fork/reset slicing, and live history projection—core chat paths—with substantial test coverage but non-trivial edge cases when turns overlap or history is mid-sync.
> 
> **Overview**
> **Intermediate assistant text** is no longer folded into the final answer only. The agent loop flushes narration when a tool call starts as **`partial` assistant events** in the event log; turn completion, compaction, and message counts treat only the **final** assistant message as the turn boundary.
> 
> The **chat UI** finalizes every streaming segment on `done`, optionally refetches history for timestamps/usage/**message i of n**, and exposes **copy/fork/reset** on user and assistant bubbles. **Fork and reset** cut at a message’s **event index** (including mid-turn partials and user prompts); the session engine slices events and **rebuilds the cut turn** from events when the cut isn’t a final assistant answer.
> 
> **Turn tooltips** add per-bubble position, **tok/s**, and **TTFT** from aggregated LLM request logs (decode time excludes tool gaps). i18n keys added for EN/DE.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 233e96dca155d51f6883cd1640ff260eecff3b39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->