### PR TITLE
✨ feat(jobs): archive previous sessions on new run

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -34,6 +34,7 @@ jobs:
     unattended: true
     ask_mode: false
     yolo_mode: false
+    archive_previous_sessions: false
     persistent_session_id: null
     agent_model_name: null
     sentinel_model_name: null
@@ -53,6 +54,7 @@ jobs:
 | `unattended`            | Whether a fresh session created for this job runs without a user approval path                             |
 | `ask_mode`              | Restrict a fresh session to read-only operations outside the sandbox while keeping sentinel review enabled |
 | `yolo_mode`             | Bypass sentinel review for a fresh session                                                                 |
+| `archive_previous_sessions` | When a fresh session is created, archive earlier still-open sessions from this job (fresh-session jobs only) |
 | `persistent_session_id` | Reuse an existing attended session instead of creating a fresh one                                         |
 | `agent_model_name`      | Optional agent model override for fresh sessions                                                           |
 | `sentinel_model_name`   | Optional sentinel model override for fresh sessions                                                        |
@@ -91,6 +93,8 @@ If `persistent_session_id` is not set, each run creates a new session with:
 
 This is the usual pattern for unattended automation.
 
+If `archive_previous_sessions` is set, the run archives any earlier sessions created by this job (`channel_ref: "job:<job-id>"`) that are not already archived: each is committed to knowledge, marked archived, and has its sandbox torn down. Sessions with an agent turn still running are skipped. This keeps a recurring job (e.g. a daily digest) from accumulating idle sessions and sandboxes. It only applies to fresh-session jobs and is rejected together with `persistent_session_id`.
+
 ### Persistent session job
 
 If `persistent_session_id` is set, the run reuses an existing session instead of creating a new one.
@@ -102,6 +106,7 @@ Restrictions enforced by validation:
 - it must not be archived
 - job-level session mode overrides are not allowed
 - job-level model overrides are not allowed
+- `archive_previous_sessions` is not allowed
 
 Use this when you want recurring work to accumulate in one long-lived session thread.
 

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -958,7 +958,9 @@
             "prompt": "Prompt",
             "expression": "Ausdruck",
             "timeZone": "Zeitzone",
-            "inputOptional": "Eingabe (optional)"
+            "inputOptional": "Eingabe (optional)",
+            "archivePreviousSessions": "Vorherige Sitzungen archivieren",
+            "archivePreviousSessionsHelp": "Beim Start einer neuen Sitzung alle noch offenen früheren Sitzungen dieses Jobs archivieren."
         },
         "placeholders": {
             "name": "Nächtliche Inbox-Prüfung",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -958,7 +958,9 @@
             "prompt": "Prompt",
             "expression": "Expression",
             "timeZone": "Time Zone",
-            "inputOptional": "Input (Optional)"
+            "inputOptional": "Input (Optional)",
+            "archivePreviousSessions": "Archive previous sessions",
+            "archivePreviousSessionsHelp": "When a new session starts, archive any earlier sessions still open from this job."
         },
         "placeholders": {
             "name": "Nightly inbox review",

--- a/frontend/src/components/jobs-view.tsx
+++ b/frontend/src/components/jobs-view.tsx
@@ -84,6 +84,7 @@ function createEmptyJob(): JobDefinition {
     unattended: true,
     ask_mode: false,
     yolo_mode: false,
+    archive_previous_sessions: false,
     persistent_session_id: null,
     agent_model_name: null,
     sentinel_model_name: null,
@@ -808,7 +809,11 @@ export function JobsView({
                     label={t("fields.persistentSession")}
                     description={draft.unattended ? t("fields.persistentSessionDisabled") : t("fields.persistentSessionToggleHelp")}
                     disabled={saving || running || draft.unattended}
-                    onCheckedChange={(enabled) => updateDraft({ persistent_session_id: enabled ? "" : null })}
+                    onCheckedChange={(enabled) =>
+                      updateDraft({
+                        persistent_session_id: enabled ? "" : null,
+                        archive_previous_sessions: enabled ? false : draft.archive_previous_sessions,
+                      })}
                     className="rounded-xl border border-border/70 bg-background px-3 py-3"
                   />
                 </div>
@@ -825,6 +830,15 @@ export function JobsView({
                         onClick: () => toggleJobSessionOption(key),
                       }))}
                     />
+
+                    <SwitchRow
+                      checked={draft.archive_previous_sessions}
+                      label={t("fields.archivePreviousSessions")}
+                      description={t("fields.archivePreviousSessionsHelp")}
+                      disabled={saving || running}
+                      onCheckedChange={(archive_previous_sessions) => updateDraft({ archive_previous_sessions })}
+                      className="rounded-xl border border-border/70 bg-background px-3 py-3"
+                    />
                   </div>
                 ) : null}
 
@@ -840,6 +854,7 @@ export function JobsView({
                           updateDraft({
                             persistent_session_id: persistentSessionId,
                             unattended: persistentSessionId.trim() ? false : draft.unattended,
+                            archive_previous_sessions: persistentSessionId.trim() ? false : draft.archive_previous_sessions,
                             private: persistentSessionId.trim() ? false : draft.private,
                             ask_mode: persistentSessionId.trim() ? false : draft.ask_mode,
                             yolo_mode: persistentSessionId.trim() ? false : draft.yolo_mode,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -140,6 +140,7 @@ export interface JobDefinition {
   unattended: boolean;
   ask_mode: boolean;
   yolo_mode: boolean;
+  archive_previous_sessions: boolean;
   persistent_session_id?: string | null;
   agent_model_name?: string | null;
   sentinel_model_name?: string | null;

--- a/src/carapace/models/jobs.py
+++ b/src/carapace/models/jobs.py
@@ -54,6 +54,7 @@ class JobDefinitionInput(BaseModel):
     unattended: bool = True
     ask_mode: bool = False
     yolo_mode: bool = False
+    archive_previous_sessions: bool = False
     persistent_session_id: str | None = None
     agent_model_name: str | None = None
     sentinel_model_name: str | None = None
@@ -98,6 +99,8 @@ class JobDefinitionInput(BaseModel):
             raise ValueError("job session mode overrides cannot be used with persistent_session_id")
         if any((self.agent_model_name, self.sentinel_model_name, self.title_model_name)):
             raise ValueError("job model overrides cannot be used with persistent_session_id")
+        if self.archive_previous_sessions:
+            raise ValueError("job archive_previous_sessions cannot be used with persistent_session_id")
         self.persistent_session_id = persistent_session_id
         return self
 

--- a/src/carapace/server/jobs.py
+++ b/src/carapace/server/jobs.py
@@ -15,7 +15,7 @@ from ..models.jobs import JobDefinition, JobDefinitionInput, JobsFile
 from ..models.session import SessionJobRunContext
 from ..user_defaults import apply_job_model_defaults, effective_user_budget
 from .auth import require
-from .sessions import SessionInfo, _session_info_from_state
+from .sessions import SessionInfo, _session_info_from_state, archive_session
 from .state import server_module
 
 server = server_module()
@@ -85,6 +85,11 @@ async def _run_job_definition(
         job_user = server._auth_store.get_user(job.user)
         if job_user is None:
             raise_job_conflict("Job owner was not found")
+        # Snapshot prior-run sessions before creating the new one, so a concurrent run's
+        # freshly-created session can't end up in the archive set.
+        previous_session_ids = (
+            server._engine.session_mgr.find_sessions("job", f"job:{job.id}") if job.archive_previous_sessions else []
+        )
         state = server._engine.session_mgr.create_session(
             channel_type="job",
             channel_ref=f"job:{job.id}",
@@ -103,6 +108,12 @@ async def _run_job_definition(
             title_model_name=job.title_model_name,
         )
         created_new_session = True
+
+        for previous_id in previous_session_ids:
+            try:
+                await archive_session(previous_id)
+            except Exception as exc:
+                logger.warning(f"Job {job.id} failed to archive previous session {previous_id}: {exc}")
     else:
         state = server._engine.session_mgr.load_state(job.persistent_session_id)
         if state is None or not server._engine.session_mgr.is_owned_by(state.session_id, job.user):

--- a/src/carapace/server/sessions.py
+++ b/src/carapace/server/sessions.py
@@ -310,6 +310,43 @@ async def get_session(
     )
 
 
+async def archive_session(session_id: str) -> None:
+    """Mark a session archived, commit it to knowledge (unless private), and tear down its sandbox.
+
+    Mirrors the archive branch of update_session. No-ops if the session is missing,
+    already archived, or has an agent turn running.
+    """
+    state = server._engine.session_mgr.load_state(session_id)
+    if state is None or state.attributes.archived:
+        return
+    if server._engine.is_agent_running(session_id):
+        return
+
+    previous_attributes = state.attributes
+    next_attributes = state.attributes.model_copy(update={"archived": True})
+    state.attributes = next_attributes
+    server._engine.session_mgr.save_state(state)
+    server._engine.update_active_state(session_id, attributes=next_attributes)
+
+    try:
+        if server._session_archive.enabled and not next_attributes.private:
+            await server._session_archive.commit_session(
+                session_id,
+                trigger="archive",
+                is_agent_running=lambda: server._engine.is_agent_running(session_id),
+            )
+    except Exception:
+        # Roll back the archived flag so a transient commit failure doesn't strand
+        # the session as archived-but-not-committed (archive_session would no-op next run).
+        state.attributes = previous_attributes
+        server._engine.session_mgr.save_state(state)
+        server._engine.update_active_state(session_id, attributes=previous_attributes)
+        raise
+
+    server._engine.deactivate(session_id)
+    await server._engine.sandbox_mgr.destroy_session(session_id)
+
+
 @router.patch("/sessions/{session_id}", response_model=SessionInfo)
 async def update_session(
     session_id: str,

--- a/src/carapace/session/manager.py
+++ b/src/carapace/session/manager.py
@@ -211,6 +211,18 @@ class SessionManager:
         with self._session_factory() as db:
             return db.scalars(stmt).first()
 
+    def find_sessions(self, channel_type: str, channel_ref: str) -> list[str]:
+        stmt = (
+            select(SessionRow.session_id)
+            .where(
+                SessionRow.channel_type == channel_type,
+                SessionRow.channel_ref == channel_ref,
+            )
+            .order_by(SessionRow.last_active.desc())
+        )
+        with self._session_factory() as db:
+            return list(db.scalars(stmt).all())
+
     def delete_session(self, session_id: str) -> bool:
         with self._session_factory.begin() as db:
             row = db.get(SessionRow, session_id)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 
+import pytest
+from pydantic import ValidationError
+
 from carapace.jobs import JobsScheduler, JobsStore, build_job_run_message
 from carapace.models.jobs import JobDefinition
 
@@ -14,6 +17,19 @@ def test_jobs_store_roundtrip(db_factory):
 
     loaded = store.load()
     assert [entry.id for entry in loaded.jobs] == ["daily"]
+
+
+def test_archive_previous_sessions_conflicts_with_persistent_session():
+    with pytest.raises(ValidationError, match="archive_previous_sessions"):
+        JobDefinition(
+            user="thies",
+            id="daily",
+            name="Daily",
+            prompt="Summarize.",
+            unattended=False,
+            persistent_session_id="sess-1",
+            archive_previous_sessions=True,
+        )
 
 
 def test_build_job_run_message_includes_trigger_context_and_payload():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2034,6 +2034,54 @@ def test_run_job_creates_fresh_session_and_submits_message(client, auth_headers,
     assert '{"source":"calendar","items":3}' in message
 
 
+def test_run_job_archives_previous_sessions(client, auth_headers, monkeypatch):
+    monkeypatch.setattr(srv._engine, "submit_message", AsyncMock())
+
+    create_resp = client.post(
+        "/api/jobs",
+        headers=auth_headers,
+        json={
+            "id": "morning-digest",
+            "name": "Morning Digest",
+            "prompt": "Summarize overnight.",
+            "archive_previous_sessions": True,
+            "triggers": [],
+        },
+    )
+    assert create_resp.status_code == 201
+
+    first = client.post("/api/jobs/morning-digest/run", headers=auth_headers).json()
+    second = client.post("/api/jobs/morning-digest/run", headers=auth_headers).json()
+
+    assert first["session_id"] != second["session_id"]
+    assert srv._engine.session_mgr.load_state(first["session_id"]).attributes.archived is True
+    assert srv._engine.session_mgr.load_state(second["session_id"]).attributes.archived is False
+    srv._engine.sandbox_mgr.destroy_session.assert_any_await(first["session_id"])
+
+
+def test_run_job_archive_rolls_back_flag_on_commit_failure(client, auth_headers, monkeypatch):
+    monkeypatch.setattr(srv._engine, "submit_message", AsyncMock())
+    monkeypatch.setattr(srv._session_archive, "commit_session", AsyncMock(side_effect=RuntimeError("boom")))
+
+    client.post(
+        "/api/jobs",
+        headers=auth_headers,
+        json={
+            "id": "morning-digest",
+            "name": "Morning Digest",
+            "prompt": "Summarize overnight.",
+            "archive_previous_sessions": True,
+            "triggers": [],
+        },
+    )
+
+    first = client.post("/api/jobs/morning-digest/run", headers=auth_headers).json()
+    client.post("/api/jobs/morning-digest/run", headers=auth_headers)
+
+    # Commit failed, so the flag is rolled back and the session is left for a later retry.
+    assert srv._engine.session_mgr.load_state(first["session_id"]).attributes.archived is False
+
+
 def test_run_job_uses_existing_persistent_session(client, auth_headers, monkeypatch):
     submit_message = AsyncMock()
     monkeypatch.setattr(srv._engine, "submit_message", submit_message)


### PR DESCRIPTION
## What

Adds an `archive_previous_sessions` flag to job definitions. When a fresh-session job runs, any earlier sessions it created (`channel_ref: job:<id>`) that aren't already archived get **committed to knowledge, marked archived, and have their sandboxes torn down**. Sessions with an agent turn still running are skipped.

Mutually exclusive with `persistent_session_id` (validated).

## Why

A recurring job (e.g. a daily morning digest) creates a new session + sandbox every run. Without this, those idle sessions and sandboxes accumulate forever. The existing inactivity *autosave* only commits to knowledge — it never flips `archived` or frees the sandbox. This gives jobs a deterministic, self-cleaning option that frees yesterday's resources exactly when today's run starts.

## Changes

- `models/jobs.py` — new `archive_previous_sessions: bool` field + validation against `persistent_session_id`.
- `session/manager.py` — `find_sessions()` (plural) to list sessions by channel ref.
- `server/sessions.py` — `archive_session()` helper (mirrors the PATCH archive branch: archive attr + commit-unless-private + deactivate + destroy sandbox).
- `server/jobs.py` — fresh-session runs archive prior job sessions when the flag is set; per-session failures are logged, not fatal.
- Frontend: type, draft default, a `SwitchRow` in the fresh-session options (hidden/cleared in persistent mode), en/de strings.
- Docs: `docs/jobs.md` field table, fresh-session section, persistent-session restriction.
- Tests: integration test (run job twice → first archived + sandbox destroyed, second not) and a validation test.

## Notes

- Only fires when the job runs *again*, so the last session lingers until the next run — expected.
- No-op in persistent-session mode.
- Does **not** address the separate "no notification on unattended completion" issue — that's a notification-preference default, solved by running the digest as an attended session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automated archiving commits session knowledge and destroys sandboxes on job runs; failures are mostly isolated, but incorrect channel matching or commit rollback edge cases could affect session lifecycle.
> 
> **Overview**
> Adds **`archive_previous_sessions`** on job definitions so recurring fresh-session jobs can retire older runs instead of leaving idle sessions and sandboxes around.
> 
> When enabled, a run **snapshots** existing `job:<id>` session IDs **before** creating the new session, then calls a shared **`archive_session`** helper on each prior session (knowledge commit unless private, `archived` flag, sandbox teardown). Sessions still running an agent turn are skipped; per-session archive failures are logged and do not block the new run. The flag is **mutually exclusive** with `persistent_session_id` (model validation).
> 
> Supporting pieces: **`find_sessions`** by channel ref, Jobs UI switch (cleared when persistent session is used), en/de strings, **`docs/jobs.md`**, and integration tests for archive-on-second-run and rollback when knowledge commit fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce375127b35b5a7816d42af75b7159a5527c1b79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->