### PR TITLE
✨ feat(knowledge): read-only knowledge repo browser in web UI

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -14,7 +14,17 @@
         "users": "Benutzer",
         "disconnect": "Trennen",
         "github": "thiesgerken/carapace",
-        "apiKeys": "API-Schlüssel"
+        "apiKeys": "API-Schlüssel",
+        "knowledge": "Wissen"
+    },
+    "knowledge": {
+        "title": "Wissen",
+        "root": "Wissen",
+        "loading": "Lädt…",
+        "empty": "Leeres Verzeichnis.",
+        "error": "Laden fehlgeschlagen",
+        "download": "Datei herunterladen",
+        "noPreview": "Für diesen Dateityp ist keine Vorschau verfügbar."
     },
     "account": {
         "menu": "Kontomenü",
@@ -1065,6 +1075,7 @@
             "preferences": "Einstellungen",
             "notifications": "Benachrichtigungen",
             "history": "Verlauf",
+            "knowledge": "Wissen",
             "admin": "Administration"
         },
         "secret": {

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -26,6 +26,8 @@
         "download": "Datei herunterladen",
         "noPreview": "Für diesen Dateityp ist keine Vorschau verfügbar.",
         "untitledSession": "Sitzung öffnen",
+        "copyHash": "Vollständigen Commit-Hash kopieren",
+        "copiedHash": "Kopiert",
         "largeFileNotice": "Syntax-Hervorhebung ist für diese Datei deaktiviert — sie ist zu groß.",
         "skill": {
             "commands": "Befehle",

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -25,7 +25,15 @@
         "error": "Laden fehlgeschlagen",
         "download": "Datei herunterladen",
         "noPreview": "Für diesen Dateityp ist keine Vorschau verfügbar.",
-        "untitledSession": "Sitzung öffnen"
+        "untitledSession": "Sitzung öffnen",
+        "skill": {
+            "commands": "Befehle",
+            "domains": "Domains",
+            "tunnels": "Tunnel",
+            "credentials": "Zugangsdaten",
+            "credential": "Zugangsdatum",
+            "hints": "Hinweise"
+        }
     },
     "account": {
         "menu": "Kontomenü",

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -26,6 +26,7 @@
         "download": "Datei herunterladen",
         "noPreview": "Für diesen Dateityp ist keine Vorschau verfügbar.",
         "untitledSession": "Sitzung öffnen",
+        "largeFileNotice": "Syntax-Hervorhebung ist für diese Datei deaktiviert — sie ist zu groß.",
         "skill": {
             "commands": "Befehle",
             "domains": "Domains",
@@ -838,7 +839,8 @@
                 "missing": "Fehlt",
                 "outdated": "Veraltet",
                 "upToDate": "Aktuell"
-            }
+            },
+            "openInBrowser": "Im Wissens-Repository öffnen"
         },
         "mobile": {
             "details": "Details",

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -24,7 +24,8 @@
         "empty": "Leeres Verzeichnis.",
         "error": "Laden fehlgeschlagen",
         "download": "Datei herunterladen",
-        "noPreview": "Für diesen Dateityp ist keine Vorschau verfügbar."
+        "noPreview": "Für diesen Dateityp ist keine Vorschau verfügbar.",
+        "untitledSession": "Sitzung öffnen"
     },
     "account": {
         "menu": "Kontomenü",

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -29,6 +29,7 @@
         "copyHash": "Vollständigen Commit-Hash kopieren",
         "copiedHash": "Kopiert",
         "largeFileNotice": "Syntax-Hervorhebung ist für diese Datei deaktiviert — sie ist zu groß.",
+        "tooLarge": "Diese Datei ist zu groß für eine Vorschau — bitte herunterladen.",
         "skill": {
             "commands": "Befehle",
             "domains": "Domains",

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -18,7 +18,7 @@
         "knowledge": "Wissen"
     },
     "knowledge": {
-        "title": "Wissen",
+        "title": "Wissens-Repository",
         "root": "Wissen",
         "loading": "Lädt…",
         "empty": "Leeres Verzeichnis.",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -24,7 +24,8 @@
         "empty": "Empty directory.",
         "error": "Failed to load",
         "download": "Download file",
-        "noPreview": "No preview available for this file type."
+        "noPreview": "No preview available for this file type.",
+        "untitledSession": "Open session"
     },
     "account": {
         "menu": "Account menu",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -18,7 +18,7 @@
         "knowledge": "Knowledge"
     },
     "knowledge": {
-        "title": "Knowledge",
+        "title": "Knowledge Repository",
         "root": "Knowledge",
         "loading": "Loading…",
         "empty": "Empty directory.",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -26,6 +26,7 @@
         "download": "Download file",
         "noPreview": "No preview available for this file type.",
         "untitledSession": "Open session",
+        "largeFileNotice": "Syntax highlighting is off for this file — it is too large.",
         "skill": {
             "commands": "Commands",
             "domains": "Domains",
@@ -838,7 +839,8 @@
                 "missing": "Missing",
                 "outdated": "Outdated",
                 "upToDate": "Up to Date"
-            }
+            },
+            "openInBrowser": "Open in the knowledge browser"
         },
         "mobile": {
             "details": "Details",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -29,6 +29,7 @@
         "copyHash": "Copy full commit hash",
         "copiedHash": "Copied",
         "largeFileNotice": "Syntax highlighting is off for this file — it is too large.",
+        "tooLarge": "This file is too large to preview — download it instead.",
         "skill": {
             "commands": "Commands",
             "domains": "Domains",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -14,7 +14,17 @@
         "users": "Users",
         "disconnect": "Disconnect",
         "github": "thiesgerken/carapace",
-        "apiKeys": "API Keys"
+        "apiKeys": "API Keys",
+        "knowledge": "Knowledge"
+    },
+    "knowledge": {
+        "title": "Knowledge",
+        "root": "Knowledge",
+        "loading": "Loading…",
+        "empty": "Empty directory.",
+        "error": "Failed to load",
+        "download": "Download file",
+        "noPreview": "No preview available for this file type."
     },
     "account": {
         "menu": "Account menu",
@@ -1065,6 +1075,7 @@
             "preferences": "Preferences",
             "notifications": "Notifications",
             "history": "History",
+            "knowledge": "Knowledge",
             "admin": "Admin"
         },
         "secret": {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -26,6 +26,8 @@
         "download": "Download file",
         "noPreview": "No preview available for this file type.",
         "untitledSession": "Open session",
+        "copyHash": "Copy full commit hash",
+        "copiedHash": "Copied",
         "largeFileNotice": "Syntax highlighting is off for this file — it is too large.",
         "skill": {
             "commands": "Commands",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -25,7 +25,15 @@
         "error": "Failed to load",
         "download": "Download file",
         "noPreview": "No preview available for this file type.",
-        "untitledSession": "Open session"
+        "untitledSession": "Open session",
+        "skill": {
+            "commands": "Commands",
+            "domains": "Domains",
+            "tunnels": "Tunnels",
+            "credentials": "Credentials",
+            "credential": "Credential",
+            "hints": "Hints"
+        }
     },
     "account": {
         "menu": "Account menu",

--- a/frontend/src/app/(app)/knowledge/page.tsx
+++ b/frontend/src/app/(app)/knowledge/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { KnowledgeView } from "@/components/knowledge-view";
+
+export default function KnowledgePage() {
+  return <KnowledgeView />;
+}

--- a/frontend/src/components/api-keys-view.tsx
+++ b/frontend/src/components/api-keys-view.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/lib/utils";
 
 type Access = "none" | "read" | "write";
 
-const BASE_SCOPES = ["sessions", "jobs", "preferences", "notifications", "history"] as const;
+const BASE_SCOPES = ["sessions", "jobs", "preferences", "notifications", "history", "knowledge"] as const;
 
 const inputClassName = cn(
   "w-full rounded-lg border border-border bg-background px-3 py-2 text-base sm:text-sm",

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Archive, ArchiveRestore, Bot, Check, Copy, ExternalLink, Eye, Globe, Link2, Link2Off, Loader2, Lock, MessageSquare, Pin, Play, RotateCcw, Save, Settings2, Square, Star, Terminal, Trash2 } from "lucide-react";
 import { EmojiText } from "@/components/emoji-text";
@@ -43,6 +44,7 @@ import type {
   TurnUsage,
 } from "@/lib/types";
 import { isRecord } from "@/lib/decoding";
+import { knowledgeBrowseHref } from "@/lib/knowledge-links";
 import { getPresenceClientId } from "@/lib/storage";
 import {
   canArchiveSession,
@@ -2664,12 +2666,13 @@ export function ChatView({
           <span className="truncate">{archiveStatusLabel}</span>
         </div>
         {session?.knowledge_last_archive_path ? (
-          <div
-            className="mt-2 break-all font-mono text-xs text-muted-foreground"
-            title={session.knowledge_last_archive_path}
+          <Link
+            href={knowledgeBrowseHref(session.knowledge_last_archive_path)}
+            title={t("knowledge.openInBrowser")}
+            className="mt-2 block break-all rounded-sm font-mono text-xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             {session.knowledge_last_archive_path}
-          </div>
+          </Link>
         ) : null}
       </section>
 

--- a/frontend/src/components/git-sync.tsx
+++ b/frontend/src/components/git-sync.tsx
@@ -255,6 +255,7 @@ export function SandboxGitControls({
 export interface GlobalGit {
   configured: boolean | null;
   counts: AheadBehindCounts | null;
+  head: { hash: string; subject: string } | null;
   loading: boolean;
   busy: "pull" | "push" | null;
   outcome: ActionOutcome | null;
@@ -267,6 +268,7 @@ export function useGlobalGit(server: string, token: string): GlobalGit {
   const t = useTranslations("git");
   const [configured, setConfigured] = useState<boolean | null>(null);
   const [counts, setCounts] = useState<AheadBehindCounts | null>(null);
+  const [head, setHead] = useState<{ hash: string; subject: string } | null>(null);
   const [loading, setLoading] = useState(false);
   const [busy, setBusy] = useState<"pull" | "push" | null>(null);
   const [outcome, setOutcome] = useState<ActionOutcome | null>(null);
@@ -277,9 +279,11 @@ export function useGlobalGit(server: string, token: string): GlobalGit {
       const status = await getGlobalGit(server, token);
       setConfigured(status.remote_configured);
       setCounts(status.remote_configured ? { ahead: status.ahead, behind: status.behind } : null);
+      setHead(status.head ? { hash: status.head, subject: status.head_subject ?? "" } : null);
       setOutcome((prev) => (prev && !prev.ok ? null : prev));
     } catch {
       setCounts(null);
+      setHead(null);
       setOutcome({ ok: false, errorLabel: t("errors.status"), detail: "" });
     } finally {
       setLoading(false);
@@ -311,6 +315,7 @@ export function useGlobalGit(server: string, token: string): GlobalGit {
   return {
     configured,
     counts,
+    head,
     loading,
     busy,
     outcome,
@@ -333,17 +338,28 @@ export function GlobalGitIndicator({ git, className }: { git: GlobalGit; classNa
   );
 }
 
-/** Full git panel for inside the account menu — hidden when no remote is configured. */
-export function GlobalGitPanel({ git, className }: { git: GlobalGit; className?: string }) {
+/**
+ * Full git panel for inside the account menu — hidden when no remote is configured,
+ * unless `alwaysShow` is set (the knowledge browser shows the refresh control regardless).
+ */
+export function GlobalGitPanel({
+  git,
+  className,
+  alwaysShow = false,
+}: {
+  git: GlobalGit;
+  className?: string;
+  alwaysShow?: boolean;
+}) {
   const t = useTranslations("git");
-  if (git.configured === false) return null;
+  if (git.configured === false && !alwaysShow) return null;
   return (
     <div className={className}>
       <GitSyncControls
         title={t("global.label")}
         description={t("global.help")}
         counts={git.counts}
-        emptyLabel={null}
+        emptyLabel={git.configured === false ? t("noRemote") : null}
         loading={git.loading}
         outcome={git.outcome}
         busy={git.busy}

--- a/frontend/src/components/git-sync.tsx
+++ b/frontend/src/components/git-sync.tsx
@@ -316,18 +316,17 @@ export function useGlobalGit(server: string, token: string): GlobalGit {
       setOutcome(null);
       try {
         const result = await fn();
-        await refresh();
         setOutcome({ ok: result.ok, errorLabel: t(`errors.${action}`), detail: result.message });
-        if (result.ok) {
-          window.dispatchEvent(new Event(KNOWLEDGE_GIT_CHANGED_EVENT));
-        }
+        // Every mounted panel re-reads status off this, the acting one included, so
+        // there is no refresh() call here — it would fetch the same status twice.
+        window.dispatchEvent(new Event(KNOWLEDGE_GIT_CHANGED_EVENT));
       } catch {
         setOutcome({ ok: false, errorLabel: t(`errors.${action}`), detail: "" });
       } finally {
         setBusy(null);
       }
     },
-    [refresh, t],
+    [t],
   );
 
   return {

--- a/frontend/src/components/git-sync.tsx
+++ b/frontend/src/components/git-sync.tsx
@@ -252,6 +252,12 @@ export function SandboxGitControls({
 // B2: backend per-user repo ↔ external remote. Shared between the account-menu
 // indicator dot and the panel inside that menu, so status is fetched once.
 
+/**
+ * Fired after a pull or push moves the knowledge repo. Listened to by every
+ * `useGlobalGit` instance, and by views showing repo contents.
+ */
+export const KNOWLEDGE_GIT_CHANGED_EVENT = "carapace:knowledge-git-changed";
+
 export interface GlobalGit {
   configured: boolean | null;
   counts: AheadBehindCounts | null;
@@ -295,6 +301,15 @@ export function useGlobalGit(server: string, token: string): GlobalGit {
     return () => clearTimeout(id);
   }, [refresh]);
 
+  // Several of these hooks are mounted at once (sidebar indicator, account menu,
+  // knowledge browser). A pull or push from any of them moves the repo for all, so
+  // they re-read status together instead of the others going stale until remount.
+  useEffect(() => {
+    const onChanged = () => void refresh();
+    window.addEventListener(KNOWLEDGE_GIT_CHANGED_EVENT, onChanged);
+    return () => window.removeEventListener(KNOWLEDGE_GIT_CHANGED_EVENT, onChanged);
+  }, [refresh]);
+
   const runAction = useCallback(
     async (action: "pull" | "push", fn: () => Promise<GitActionResult>) => {
       setBusy(action);
@@ -303,6 +318,9 @@ export function useGlobalGit(server: string, token: string): GlobalGit {
         const result = await fn();
         await refresh();
         setOutcome({ ok: result.ok, errorLabel: t(`errors.${action}`), detail: result.message });
+        if (result.ok) {
+          window.dispatchEvent(new Event(KNOWLEDGE_GIT_CHANGED_EVENT));
+        }
       } catch {
         setOutcome({ ok: false, errorLabel: t(`errors.${action}`), detail: "" });
       } finally {

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -1,9 +1,18 @@
 "use client";
 
-import { ChevronRight, Download, File, FileText, Folder, GitCommitHorizontal, Loader2 } from "lucide-react";
+import {
+  ChevronRight,
+  Download,
+  File,
+  FileText,
+  Folder,
+  GitCommitHorizontal,
+  Loader2,
+  MessagesSquare,
+} from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { useTranslations } from "next-intl";
 
 import { useAppShell } from "@/components/app-shell-context";
@@ -66,25 +75,44 @@ function Breadcrumb({ path, rootLabel }: { path: string; rootLabel: string }) {
   );
 }
 
-function EntryRow({ path, entry }: { path: string; entry: KnowledgeEntry }) {
+function entryIcon(entry: KnowledgeEntry): ReactNode {
+  const className = cn(
+    "h-4 w-4 shrink-0",
+    entry.type === "dir" ? "text-accent-foreground/70" : "text-muted-foreground",
+  );
+  if (entry.kind === "session") return <MessagesSquare className={className} />;
+  if (entry.type === "dir") return <Folder className={className} />;
+  return isMarkdown(entry.name) ? <FileText className={className} /> : <File className={className} />;
+}
+
+/**
+ * One row in a directory listing. The row links into the repo; recognized kinds add
+ * a trailing link of their own (a session's title opens the chat), so the row is a
+ * container rather than a single anchor — anchors cannot nest.
+ */
+function EntryRow({ path, entry, untitledLabel }: { path: string; entry: KnowledgeEntry; untitledLabel: string }) {
   const entryPath = path ? `${path}/${entry.name}` : entry.name;
-  const Icon = entry.type === "dir" ? Folder : isMarkdown(entry.name) ? FileText : File;
   return (
-    <Link
-      href={browseHref(entryPath)}
-      className="flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-    >
-      <Icon
-        className={cn(
-          "h-4 w-4 shrink-0",
-          entry.type === "dir" ? "text-accent-foreground/70" : "text-muted-foreground",
-        )}
-      />
-      <span className="min-w-0 flex-1 truncate">{entry.name}</span>
-      {entry.size != null ? (
+    <div className="flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors hover:bg-muted">
+      {entryIcon(entry)}
+      <Link
+        href={browseHref(entryPath)}
+        className="min-w-0 flex-1 truncate rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {entry.name}
+      </Link>
+      {entry.session_id ? (
+        <Link
+          href={`/?session=${encodeURIComponent(entry.session_id)}`}
+          title={entry.label ?? undefined}
+          className="max-w-[55%] shrink truncate rounded-sm text-xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {entry.label ?? untitledLabel}
+        </Link>
+      ) : entry.size != null ? (
         <span className="shrink-0 text-xs tabular-nums text-muted-foreground">{formatSize(entry.size)}</span>
       ) : null}
-    </Link>
+    </div>
   );
 }
 
@@ -202,7 +230,12 @@ export function KnowledgeView() {
           ) : (
             <div className="flex flex-col gap-0.5 rounded-lg border border-border p-1.5">
               {result.entries.map((entry) => (
-                <EntryRow key={entry.name} path={result.path} entry={entry} />
+                <EntryRow
+                  key={entry.name}
+                  path={result.path}
+                  entry={entry}
+                  untitledLabel={t("untitledSession")}
+                />
               ))}
             </div>
           )

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -110,6 +110,9 @@ function EntryRow({
   now: number;
 }) {
   const entryPath = path ? `${path}/${entry.name}` : entry.name;
+  // The commit date is what a reader means by "last changed"; mtime only fills in for
+  // paths no commit covers, since a checkout rewrites it.
+  const changedAt = entry.commit?.committed_at ?? entry.modified;
   return (
     <div className="flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors hover:bg-muted">
       {rowIcon(entry)}
@@ -128,19 +131,29 @@ function EntryRow({
           {entry.label ?? untitledLabel}
         </Link>
       ) : (
-        <span className="flex shrink-0 items-baseline gap-2 text-xs text-muted-foreground">
-          {entry.modified ? (
+        <>
+          {/* Commit column: the first thing to go as the row narrows, since the
+              filename and size stay useful at any width. */}
+          {entry.commit ? (
             <span
-              className="hidden tabular-nums sm:inline"
-              title={formatAbsoluteTime(entry.modified, locale)}
+              className="hidden min-w-0 max-w-[40%] shrink basis-[40%] items-baseline gap-2 text-xs text-muted-foreground lg:flex"
+              title={`${entry.commit.hash} · ${entry.commit.subject}`}
             >
-              {formatRelativeTime(entry.modified, locale, now, justNowLabel)}
+              <span className="shrink-0 font-mono">{entry.commit.hash}</span>
+              <span className="truncate">{entry.commit.subject}</span>
             </span>
           ) : null}
-          {entry.size != null ? (
-            <span className="w-16 text-right tabular-nums">{formatSize(entry.size)}</span>
-          ) : null}
-        </span>
+          <span className="flex shrink-0 items-baseline gap-2 text-xs text-muted-foreground">
+            {changedAt ? (
+              <span className="hidden tabular-nums sm:inline" title={formatAbsoluteTime(changedAt, locale)}>
+                {formatRelativeTime(changedAt, locale, now, justNowLabel)}
+              </span>
+            ) : null}
+            {entry.size != null ? (
+              <span className="w-16 text-right tabular-nums">{formatSize(entry.size)}</span>
+            ) : null}
+          </span>
+        </>
       )}
     </div>
   );

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -144,7 +144,7 @@ function SkillCard({ skill }: { skill: KnowledgeSkill }) {
     <section className="rounded-lg border border-border bg-muted/30 p-4">
       <div className="flex items-baseline gap-2">
         <Puzzle className="h-4 w-4 shrink-0 self-center text-accent-foreground/70" />
-        <h2 className="truncate font-mono text-sm font-semibold">{skill.name}</h2>
+        <h2 className="min-w-0 break-all font-mono text-sm font-semibold">{skill.name}</h2>
       </div>
       {skill.description ? (
         <p className="mt-1.5 text-sm text-muted-foreground">{skill.description}</p>
@@ -156,10 +156,8 @@ function SkillCard({ skill }: { skill: KnowledgeSkill }) {
             <SkillSection label={t("commands")}>
               {commands.map((command) => (
                 <div key={command.name} className="flex min-w-0 flex-col gap-0.5">
-                  <code className="font-mono text-xs font-semibold">{command.name}</code>
-                  <code className="truncate font-mono text-xs text-muted-foreground" title={command.command}>
-                    {command.command}
-                  </code>
+                  <code className="break-all font-mono text-xs font-semibold">{command.name}</code>
+                  <code className="break-all font-mono text-xs text-muted-foreground">{command.command}</code>
                 </div>
               ))}
             </SkillSection>
@@ -168,7 +166,7 @@ function SkillCard({ skill }: { skill: KnowledgeSkill }) {
           {domains.length ? (
             <SkillSection label={t("domains")}>
               {domains.map((domain) => (
-                <code key={domain} className="truncate font-mono text-xs">{domain}</code>
+                <code key={domain} className="break-all font-mono text-xs">{domain}</code>
               ))}
             </SkillSection>
           ) : null}
@@ -177,11 +175,11 @@ function SkillCard({ skill }: { skill: KnowledgeSkill }) {
             <SkillSection label={t("tunnels")}>
               {tunnels.map((tunnel) => (
                 <div key={`${tunnel.host}:${tunnel.remote_port}`} className="min-w-0">
-                  <code className="font-mono text-xs">
+                  <code className="break-all font-mono text-xs">
                     localhost:{tunnel.local_port} → {tunnel.host}:{tunnel.remote_port}
                   </code>
                   {tunnel.description ? (
-                    <span className="ml-2 text-xs text-muted-foreground">{tunnel.description}</span>
+                    <span className="ml-2 break-words text-xs text-muted-foreground">{tunnel.description}</span>
                   ) : null}
                 </div>
               ))}
@@ -192,17 +190,15 @@ function SkillCard({ skill }: { skill: KnowledgeSkill }) {
             <SkillSection label={t("credentials")}>
               {credentials.map((credential) => (
                 <div key={credential.vault_path} className="flex min-w-0 flex-col gap-0.5">
-                  <div className="flex min-w-0 items-baseline gap-2">
-                    <code className="shrink-0 font-mono text-xs font-semibold">
+                  <div className="flex min-w-0 flex-wrap items-baseline gap-x-2">
+                    <code className="break-all font-mono text-xs font-semibold">
                       {credential.env_var ?? credential.file ?? t("credential")}
                     </code>
                     {credential.description ? (
-                      <span className="truncate text-xs text-muted-foreground">{credential.description}</span>
+                      <span className="break-words text-xs text-muted-foreground">{credential.description}</span>
                     ) : null}
                   </div>
-                  <code className="truncate font-mono text-xs text-muted-foreground" title={credential.vault_path}>
-                    {credential.vault_path}
-                  </code>
+                  <code className="break-all font-mono text-xs text-muted-foreground">{credential.vault_path}</code>
                 </div>
               ))}
             </SkillSection>
@@ -211,8 +207,8 @@ function SkillCard({ skill }: { skill: KnowledgeSkill }) {
           {hints.length ? (
             <SkillSection label={t("hints")}>
               {hints.map(([key, value]) => (
-                <div key={key} className="min-w-0 text-xs">
-                  <code className="font-mono font-semibold">{key}</code>
+                <div key={key} className="min-w-0 break-words text-xs">
+                  <code className="break-all font-mono font-semibold">{key}</code>
                   <span className="ml-2 text-muted-foreground">{value}</span>
                 </div>
               ))}

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -5,15 +5,11 @@ import {
   Cable,
   ChevronRight,
   Download,
-  File,
-  FileText,
-  Folder,
   GitCommitHorizontal,
   Globe,
   KeyRound,
   Lightbulb,
   Loader2,
-  MessagesSquare,
   Puzzle,
   Terminal,
 } from "lucide-react";
@@ -33,6 +29,7 @@ import {
   type KnowledgeFileInfo,
   type KnowledgeSkill,
 } from "@/lib/api";
+import { entryIcon } from "@/lib/file-icons";
 import { fencedCodeBlock, languageFromFilePath } from "@/lib/sandbox-read";
 import { cn } from "@/lib/utils";
 
@@ -83,14 +80,13 @@ function Breadcrumb({ path, rootLabel }: { path: string; rootLabel: string }) {
   );
 }
 
-function entryIcon(entry: KnowledgeEntry): ReactNode {
-  const className = cn(
-    "h-4 w-4 shrink-0",
-    entry.type === "dir" ? "text-accent-foreground/70" : "text-muted-foreground",
+function rowIcon(entry: KnowledgeEntry): ReactNode {
+  return entryIcon(
+    entry.name,
+    entry.type,
+    entry.kind,
+    cn("h-4 w-4 shrink-0", entry.type === "dir" ? "text-accent-foreground/70" : "text-muted-foreground"),
   );
-  if (entry.kind === "session") return <MessagesSquare className={className} />;
-  if (entry.type === "dir") return <Folder className={className} />;
-  return isMarkdown(entry.name) ? <FileText className={className} /> : <File className={className} />;
 }
 
 /**
@@ -102,7 +98,7 @@ function EntryRow({ path, entry, untitledLabel }: { path: string; entry: Knowled
   const entryPath = path ? `${path}/${entry.name}` : entry.name;
   return (
     <div className="flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors hover:bg-muted">
-      {entryIcon(entry)}
+      {rowIcon(entry)}
       <Link
         href={browseHref(entryPath)}
         className="min-w-0 flex-1 truncate rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -127,7 +123,9 @@ function EntryRow({ path, entry, untitledLabel }: { path: string; entry: Knowled
 function SkillSection({ icon, label, children }: { icon: ReactNode; label: string; children: ReactNode }) {
   return (
     <div className="flex flex-col gap-1 sm:flex-row sm:gap-3">
-      <div className="flex shrink-0 items-center gap-1.5 pt-0.5 text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground sm:w-32">
+      {/* self-start: the label row must not stretch, or items-center drifts it to the
+          vertical middle of a multi-line value list. */}
+      <div className="flex shrink-0 items-center gap-1.5 self-start pt-0.5 text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground sm:w-32">
         {icon}
         {label}
       </div>

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { ChevronRight, Download, File, FileText, Folder, Loader2 } from "lucide-react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+
+import { useAppShell } from "@/components/app-shell-context";
+import { MarkdownContent } from "@/components/markdown-content";
+import {
+  browseKnowledge,
+  fetchKnowledgeText,
+  knowledgeRawUrl,
+  type KnowledgeBrowseResult,
+  type KnowledgeEntry,
+  type KnowledgeFileInfo,
+} from "@/lib/api";
+import { fencedCodeBlock, languageFromFilePath } from "@/lib/sandbox-read";
+import { cn } from "@/lib/utils";
+
+const MAX_TEXT_PREVIEW_BYTES = 1024 * 1024;
+
+const TEXT_MIMES = new Set([
+  "application/json",
+  "application/xml",
+  "application/yaml",
+  "application/toml",
+  "application/x-sh",
+  "application/javascript",
+]);
+
+function isMarkdown(name: string): boolean {
+  return /\.(md|markdown)$/i.test(name);
+}
+
+function isTextFile(file: KnowledgeFileInfo): boolean {
+  if (file.mime.startsWith("text/") || TEXT_MIMES.has(file.mime)) return true;
+  return languageFromFilePath(file.name) !== "text" || isMarkdown(file.name);
+}
+
+function formatSize(size: number): string {
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function browseHref(path: string): string {
+  return path ? `/knowledge?path=${encodeURIComponent(path)}` : "/knowledge";
+}
+
+function Breadcrumb({ path, rootLabel }: { path: string; rootLabel: string }) {
+  const segments = path ? path.split("/") : [];
+  return (
+    <nav aria-label={rootLabel} className="flex min-w-0 flex-wrap items-center gap-1 text-sm">
+      <Link
+        href={browseHref("")}
+        className="shrink-0 rounded-sm font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {rootLabel}
+      </Link>
+      {segments.map((segment, index) => {
+        const segmentPath = segments.slice(0, index + 1).join("/");
+        const last = index === segments.length - 1;
+        return (
+          <span key={segmentPath} className="flex min-w-0 items-center gap-1">
+            <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
+            {last ? (
+              <span className="truncate font-medium text-foreground">{segment}</span>
+            ) : (
+              <Link
+                href={browseHref(segmentPath)}
+                className="truncate rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                {segment}
+              </Link>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
+}
+
+function EntryRow({ path, entry }: { path: string; entry: KnowledgeEntry }) {
+  const entryPath = path ? `${path}/${entry.name}` : entry.name;
+  const Icon = entry.type === "dir" ? Folder : isMarkdown(entry.name) ? FileText : File;
+  return (
+    <Link
+      href={browseHref(entryPath)}
+      className="flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <Icon
+        className={cn(
+          "h-4 w-4 shrink-0",
+          entry.type === "dir" ? "text-accent-foreground/70" : "text-muted-foreground",
+        )}
+      />
+      <span className="min-w-0 flex-1 truncate">{entry.name}</span>
+      {entry.size != null ? (
+        <span className="shrink-0 text-xs tabular-nums text-muted-foreground">{formatSize(entry.size)}</span>
+      ) : null}
+    </Link>
+  );
+}
+
+function FileContent({
+  server,
+  file,
+  text,
+  noPreviewLabel,
+}: {
+  server: string;
+  file: KnowledgeFileInfo;
+  text: string | null;
+  noPreviewLabel: string;
+}) {
+  if (file.mime.startsWith("image/")) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={knowledgeRawUrl(server, file.path)}
+        alt={file.name}
+        className="max-w-full rounded-lg border border-border"
+      />
+    );
+  }
+  if (text != null) {
+    if (isMarkdown(file.name)) {
+      return <MarkdownContent content={text} />;
+    }
+    return <MarkdownContent content={fencedCodeBlock(languageFromFilePath(file.name), text)} />;
+  }
+  return <p className="text-sm text-muted-foreground">{noPreviewLabel}</p>;
+}
+
+export function KnowledgeView() {
+  const t = useTranslations("knowledge");
+  const tApp = useTranslations("app");
+  const { server } = useAppShell();
+  const searchParams = useSearchParams();
+  const path = (searchParams.get("path") ?? "").replace(/^\/+|\/+$/g, "");
+
+  const [result, setResult] = useState<KnowledgeBrowseResult | null>(null);
+  const [text, setText] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    document.title = `${t("title")} • ${tApp("name")}`;
+  }, [t, tApp]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      setText(null);
+      try {
+        const browsed = await browseKnowledge(server, path);
+        if (cancelled) return;
+        setResult(browsed);
+        if (browsed.type === "file" && isTextFile(browsed) && browsed.size <= MAX_TEXT_PREVIEW_BYTES) {
+          const content = await fetchKnowledgeText(server, browsed.path);
+          if (!cancelled) setText(content);
+        }
+      } catch (browseError) {
+        if (!cancelled) {
+          setResult(null);
+          setError(browseError instanceof Error ? browseError.message : t("error"));
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [server, path, t]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <div className="mx-auto w-full max-w-3xl px-5 py-5 sm:px-6">
+        <div className="flex items-center justify-between gap-3 pb-4">
+          <div className="min-w-0">
+            <h1 className="text-2xl font-semibold tracking-tight">{t("title")}</h1>
+            <div className="mt-2">
+              <Breadcrumb path={path} rootLabel={t("root")} />
+            </div>
+          </div>
+          {result?.type === "file" ? (
+            <a
+              href={knowledgeRawUrl(server, result.path, { download: true })}
+              title={t("download")}
+              aria-label={t("download")}
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <Download className="h-4 w-4" />
+            </a>
+          ) : null}
+        </div>
+
+        {loading ? (
+          <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            {t("loading")}
+          </div>
+        ) : error ? (
+          <p className="py-8 text-sm text-destructive">{error}</p>
+        ) : result?.type === "dir" ? (
+          result.entries.length === 0 ? (
+            <p className="py-8 text-sm text-muted-foreground">{t("empty")}</p>
+          ) : (
+            <div className="flex flex-col gap-0.5 rounded-lg border border-border p-1.5">
+              {result.entries.map((entry) => (
+                <EntryRow key={entry.name} path={result.path} entry={entry} />
+              ))}
+            </div>
+          )
+        ) : result?.type === "file" ? (
+          <FileContent server={server} file={result} text={text} noPreviewLabel={t("noPreview")} />
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -10,6 +10,7 @@ import {
   GitCommitHorizontal,
   Loader2,
   MessagesSquare,
+  Puzzle,
 } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
@@ -25,6 +26,7 @@ import {
   type KnowledgeBrowseResult,
   type KnowledgeEntry,
   type KnowledgeFileInfo,
+  type KnowledgeSkill,
 } from "@/lib/api";
 import { fencedCodeBlock, languageFromFilePath } from "@/lib/sandbox-read";
 import { cn } from "@/lib/utils";
@@ -114,6 +116,111 @@ function EntryRow({ path, entry, untitledLabel }: { path: string; entry: Knowled
         <span className="shrink-0 text-xs tabular-nums text-muted-foreground">{formatSize(entry.size)}</span>
       ) : null}
     </div>
+  );
+}
+
+function SkillSection({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1 sm:flex-row sm:gap-3">
+      <div className="shrink-0 pt-0.5 text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground sm:w-28">
+        {label}
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">{children}</div>
+    </div>
+  );
+}
+
+/** Frontmatter of a skill's SKILL.md as a card: what it exposes, reaches, and needs. */
+function SkillCard({ skill }: { skill: KnowledgeSkill }) {
+  const t = useTranslations("knowledge.skill");
+  const carapace = skill.carapace;
+  const domains = carapace?.network.domains ?? [];
+  const tunnels = carapace?.network.tunnels ?? [];
+  const credentials = carapace?.credentials ?? [];
+  const commands = carapace?.commands ?? [];
+  const hints = Object.entries(carapace?.hints ?? {});
+
+  return (
+    <section className="rounded-lg border border-border bg-muted/30 p-4">
+      <div className="flex items-baseline gap-2">
+        <Puzzle className="h-4 w-4 shrink-0 self-center text-accent-foreground/70" />
+        <h2 className="truncate font-mono text-sm font-semibold">{skill.name}</h2>
+      </div>
+      {skill.description ? (
+        <p className="mt-1.5 text-sm text-muted-foreground">{skill.description}</p>
+      ) : null}
+
+      {commands.length || domains.length || tunnels.length || credentials.length || hints.length ? (
+        <div className="mt-4 flex flex-col gap-3 border-t border-border/70 pt-3 text-sm">
+          {commands.length ? (
+            <SkillSection label={t("commands")}>
+              {commands.map((command) => (
+                <div key={command.name} className="flex min-w-0 flex-col gap-0.5">
+                  <code className="font-mono text-xs font-semibold">{command.name}</code>
+                  <code className="truncate font-mono text-xs text-muted-foreground" title={command.command}>
+                    {command.command}
+                  </code>
+                </div>
+              ))}
+            </SkillSection>
+          ) : null}
+
+          {domains.length ? (
+            <SkillSection label={t("domains")}>
+              {domains.map((domain) => (
+                <code key={domain} className="truncate font-mono text-xs">{domain}</code>
+              ))}
+            </SkillSection>
+          ) : null}
+
+          {tunnels.length ? (
+            <SkillSection label={t("tunnels")}>
+              {tunnels.map((tunnel) => (
+                <div key={`${tunnel.host}:${tunnel.remote_port}`} className="min-w-0">
+                  <code className="font-mono text-xs">
+                    localhost:{tunnel.local_port} → {tunnel.host}:{tunnel.remote_port}
+                  </code>
+                  {tunnel.description ? (
+                    <span className="ml-2 text-xs text-muted-foreground">{tunnel.description}</span>
+                  ) : null}
+                </div>
+              ))}
+            </SkillSection>
+          ) : null}
+
+          {credentials.length ? (
+            <SkillSection label={t("credentials")}>
+              {credentials.map((credential) => (
+                <div key={credential.vault_path} className="flex min-w-0 flex-col gap-0.5">
+                  <div className="flex min-w-0 items-baseline gap-2">
+                    <code className="shrink-0 font-mono text-xs font-semibold">
+                      {credential.env_var ?? credential.file ?? t("credential")}
+                    </code>
+                    {credential.description ? (
+                      <span className="truncate text-xs text-muted-foreground">{credential.description}</span>
+                    ) : null}
+                  </div>
+                  <code className="truncate font-mono text-xs text-muted-foreground" title={credential.vault_path}>
+                    {credential.vault_path}
+                  </code>
+                </div>
+              ))}
+            </SkillSection>
+          ) : null}
+
+          {hints.length ? (
+            <SkillSection label={t("hints")}>
+              {hints.map(([key, value]) => (
+                <div key={key} className="min-w-0 text-xs">
+                  <code className="font-mono font-semibold">{key}</code>
+                  <span className="ml-2 text-muted-foreground">{value}</span>
+                </div>
+              ))}
+            </SkillSection>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
   );
 }
 
@@ -241,7 +348,8 @@ export function KnowledgeView() {
                 ))}
               </div>
             )}
-            {result.doc != null ? (
+            {result.skill ? <div className="mt-6"><SkillCard skill={result.skill} /></div> : null}
+            {result.doc ? (
               <section className="mt-6">
                 <h2 className="mb-2 flex items-center gap-1.5 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
                   <BookText className="h-3.5 w-3.5" />

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { ChevronRight, Download, File, FileText, Folder, Loader2 } from "lucide-react";
+import { ChevronRight, Download, File, FileText, Folder, GitCommitHorizontal, Loader2 } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 
 import { useAppShell } from "@/components/app-shell-context";
+import { GlobalGitPanel, useGlobalGit } from "@/components/git-sync";
 import { MarkdownContent } from "@/components/markdown-content";
 import {
   browseKnowledge,
@@ -137,7 +138,8 @@ function FileContent({
 export function KnowledgeView() {
   const t = useTranslations("knowledge");
   const tApp = useTranslations("app");
-  const { server } = useAppShell();
+  const { server, token } = useAppShell();
+  const git = useGlobalGit(server, token);
   const searchParams = useSearchParams();
   const path = (searchParams.get("path") ?? "").replace(/^\/+|\/+$/g, "");
 
@@ -181,23 +183,34 @@ export function KnowledgeView() {
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
       <div className="mx-auto w-full max-w-3xl px-5 py-5 sm:px-6">
-        <div className="flex items-center justify-between gap-3 pb-4">
-          <div className="min-w-0">
-            <h1 className="text-2xl font-semibold tracking-tight">{t("title")}</h1>
-            <div className="mt-2">
-              <Breadcrumb path={path} rootLabel={t("root")} />
+        <div className="pb-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <h1 className="text-2xl font-semibold tracking-tight">{t("title")}</h1>
+              {git.head ? (
+                <div className="mt-1.5 flex min-w-0 items-baseline gap-2 text-xs text-muted-foreground">
+                  <GitCommitHorizontal className="h-3.5 w-3.5 shrink-0 self-center" />
+                  <span className="shrink-0 font-mono">{git.head.hash}</span>
+                  <span className="truncate" title={git.head.subject}>{git.head.subject}</span>
+                </div>
+              ) : null}
             </div>
+            <GlobalGitPanel git={git} alwaysShow className="w-56 shrink-0" />
           </div>
-          {result?.type === "file" ? (
-            <a
-              href={knowledgeRawUrl(server, result.path, { download: true })}
-              title={t("download")}
-              aria-label={t("download")}
-              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            >
-              <Download className="h-4 w-4" />
-            </a>
-          ) : null}
+
+          <div className="mt-4 flex items-center justify-between gap-3 border-t border-border/70 pt-3">
+            <Breadcrumb path={path} rootLabel={t("root")} />
+            {result?.type === "file" ? (
+              <a
+                href={knowledgeRawUrl(server, result.path, { download: true })}
+                title={t("download")}
+                aria-label={t("download")}
+                className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <Download className="h-4 w-4" />
+              </a>
+            ) : null}
+          </div>
         </div>
 
         {loading ? (

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/lib/api";
 import { entryIcon } from "@/lib/file-icons";
 import { formatAbsoluteTime, formatRelativeTime } from "@/lib/format-time";
+import { knowledgeBrowseHref } from "@/lib/knowledge-links";
 import { fencedCodeBlock, languageFromFilePath } from "@/lib/sandbox-read";
 import { cn } from "@/lib/utils";
 
@@ -45,9 +46,7 @@ function formatSize(size: number): string {
   return `${(size / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-function browseHref(path: string): string {
-  return path ? `/knowledge?path=${encodeURIComponent(path)}` : "/knowledge";
-}
+const browseHref = knowledgeBrowseHref;
 
 function Breadcrumb({ path, rootLabel }: { path: string; rootLabel: string }) {
   const segments = path ? path.split("/") : [];
@@ -266,14 +265,18 @@ function SkillCard({ skill }: { skill: KnowledgeSkill }) {
   );
 }
 
+const MAX_HIGHLIGHTED_CHARS = 128 * 1024;
+
 function FileContent({
   server,
   file,
   noPreviewLabel,
+  largeFileLabel,
 }: {
   server: string;
   file: KnowledgeFileInfo;
   noPreviewLabel: string;
+  largeFileLabel: string;
 }) {
   if (file.mime.startsWith("image/")) {
     return (
@@ -290,6 +293,18 @@ function FileContent({
   if (file.content != null) {
     if (isMarkdown(file.name)) {
       return <MarkdownContent content={file.content} />;
+    }
+    // Shiki tokenizes the whole document up front, which locks the tab on a large
+    // one — session archives run to hundreds of KB. Plain text past the threshold.
+    if (file.content.length > MAX_HIGHLIGHTED_CHARS) {
+      return (
+        <div className="flex flex-col gap-2">
+          <p className="text-xs text-muted-foreground">{largeFileLabel}</p>
+          <pre className="overflow-x-auto rounded-lg border border-border bg-muted/30 p-3 font-mono text-xs leading-relaxed">
+            {file.content}
+          </pre>
+        </div>
+      );
     }
     return <MarkdownContent content={fencedCodeBlock(languageFromFilePath(file.name), file.content)} />;
   }
@@ -413,7 +428,12 @@ export function KnowledgeView() {
             ) : null}
           </>
         ) : result?.type === "file" ? (
-          <FileContent server={server} file={result} noPreviewLabel={t("noPreview")} />
+          <FileContent
+            server={server}
+            file={result}
+            noPreviewLabel={t("noPreview")}
+            largeFileLabel={t("largeFileNotice")}
+          />
         ) : null}
       </div>
     </div>

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -130,7 +130,11 @@ function CopyHash({
       )}
     >
       {commit.short}
-      {copied ? <Check className="h-3 w-3 shrink-0" /> : <Copy className="h-3 w-3 shrink-0 opacity-0 group-hover/row:opacity-60" />}
+      {copied ? (
+        <Check className="h-3 w-3 shrink-0" />
+      ) : (
+        <Copy className="h-3 w-3 shrink-0 opacity-0 transition-opacity group-hover/commit:opacity-60" />
+      )}
     </button>
   );
 }
@@ -164,7 +168,7 @@ function EntryRow({
   // paths no commit covers, since a checkout rewrites it.
   const changedAt = entry.commit?.committed_at ?? entry.modified;
   return (
-    <div className="group/row flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors hover:bg-muted">
+    <div className="flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors hover:bg-muted">
       {rowIcon(entry)}
       <Link
         href={browseHref(entryPath)}
@@ -185,7 +189,7 @@ function EntryRow({
           {/* Commit column: the first thing to go as the row narrows, since the
               filename and size stay useful at any width. */}
           {entry.commit ? (
-            <span className="hidden min-w-0 max-w-[40%] shrink basis-[40%] items-baseline gap-2 text-xs text-muted-foreground lg:flex">
+            <span className="group/commit hidden min-w-0 max-w-[40%] shrink basis-[40%] items-baseline gap-2 text-xs text-muted-foreground lg:flex">
               <CopyHash commit={entry.commit} copyLabel={copyHashLabel} copiedLabel={copiedLabel} />
               <span className="truncate" title={entry.commit.subject}>
                 {entry.commit.subject}

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -22,7 +22,7 @@ import { useTranslations } from "next-intl";
 
 import { useAppShell } from "@/components/app-shell-context";
 import { useAppLocale } from "@/components/locale-provider";
-import { GlobalGitPanel, useGlobalGit } from "@/components/git-sync";
+import { GlobalGitPanel, KNOWLEDGE_GIT_CHANGED_EVENT, useGlobalGit } from "@/components/git-sync";
 import { MarkdownContent } from "@/components/markdown-content";
 import {
   browseKnowledge,
@@ -386,6 +386,15 @@ export function KnowledgeView() {
     document.title = `${t("title")} • ${tApp("name")}`;
   }, [t, tApp]);
 
+  // Bumped to force a re-browse of the same path after a pull/push moves the repo.
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    const onGitChanged = () => setReloadToken((token) => token + 1);
+    window.addEventListener(KNOWLEDGE_GIT_CHANGED_EVENT, onGitChanged);
+    return () => window.removeEventListener(KNOWLEDGE_GIT_CHANGED_EVENT, onGitChanged);
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -409,7 +418,7 @@ export function KnowledgeView() {
     return () => {
       cancelled = true;
     };
-  }, [server, path, t]);
+  }, [server, path, t, reloadToken]);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
@@ -431,7 +440,10 @@ export function KnowledgeView() {
 
           <div className="mt-4 flex items-center justify-between gap-3 border-t border-border/70 pt-3">
             <Breadcrumb path={path} rootLabel={t("root")} />
-            {result?.type === "file" ? (
+            {/* While a new path loads, `result` still holds the previous one — showing
+                its download button would offer the file the user just navigated away
+                from. */}
+            {!loading && result?.type === "file" ? (
               <a
                 href={knowledgeRawUrl(server, result.path, { download: true })}
                 title={t("download")}

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -36,26 +36,18 @@ import { entryIcon } from "@/lib/file-icons";
 import { formatAbsoluteTime, formatRelativeTime } from "@/lib/format-time";
 import { knowledgeBrowseHref } from "@/lib/knowledge-links";
 import { fencedCodeBlock, languageFromFilePath } from "@/lib/sandbox-read";
-import { cn } from "@/lib/utils";
+import { cn, formatBytes } from "@/lib/utils";
 
 function isMarkdown(name: string): boolean {
   return /\.(md|markdown)$/i.test(name);
 }
-
-function formatSize(size: number): string {
-  if (size < 1024) return `${size} B`;
-  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
-  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-const browseHref = knowledgeBrowseHref;
 
 function Breadcrumb({ path, rootLabel }: { path: string; rootLabel: string }) {
   const segments = path ? path.split("/") : [];
   return (
     <nav aria-label={rootLabel} className="flex min-w-0 flex-wrap items-center gap-1 text-sm">
       <Link
-        href={browseHref("")}
+        href={knowledgeBrowseHref("")}
         className="shrink-0 rounded-sm font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         {rootLabel}
@@ -70,7 +62,7 @@ function Breadcrumb({ path, rootLabel }: { path: string; rootLabel: string }) {
               <span className="truncate font-medium text-foreground">{segment}</span>
             ) : (
               <Link
-                href={browseHref(segmentPath)}
+                href={knowledgeBrowseHref(segmentPath)}
                 className="truncate rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 {segment}
@@ -171,44 +163,41 @@ function EntryRow({
     <div className="flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors hover:bg-muted">
       {rowIcon(entry)}
       <Link
-        href={browseHref(entryPath)}
+        href={knowledgeBrowseHref(entryPath)}
         className="min-w-0 flex-1 truncate rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         {entry.name}
       </Link>
+      {/* Flexible middle column, the first thing to go as the row narrows: the session
+          title where there is one, the commit otherwise. A session's commit subject
+          only ever restates the archiving, so the title is the better use of it. */}
       {entry.session_id ? (
         <Link
           href={`/?session=${encodeURIComponent(entry.session_id)}`}
           title={entry.label ?? undefined}
-          className="max-w-[55%] shrink truncate rounded-sm text-xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="hidden min-w-0 max-w-[40%] shrink basis-[40%] truncate rounded-sm text-xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring lg:block"
         >
           {entry.label ?? untitledLabel}
         </Link>
-      ) : (
-        <>
-          {/* Commit column: the first thing to go as the row narrows, since the
-              filename and size stay useful at any width. */}
-          {entry.commit ? (
-            <span className="group/commit hidden min-w-0 max-w-[40%] shrink basis-[40%] items-baseline gap-2 text-xs text-muted-foreground lg:flex">
-              <CopyHash commit={entry.commit} copyLabel={copyHashLabel} copiedLabel={copiedLabel} />
-              <span className="truncate" title={entry.commit.subject}>
-                {entry.commit.subject}
-              </span>
-            </span>
-          ) : null}
-          {/* Both slots keep their width when empty, so directories (no size) line up
-              with files instead of shifting the whole row right. */}
-          <span className="flex shrink-0 items-baseline gap-2 text-xs tabular-nums text-muted-foreground">
-            <span
-              className="hidden w-28 truncate text-right sm:block"
-              title={changedAt ? formatAbsoluteTime(changedAt, locale) : undefined}
-            >
-              {changedAt ? formatRelativeTime(changedAt, locale, now, justNowLabel) : null}
-            </span>
-            <span className="w-16 text-right">{entry.size != null ? formatSize(entry.size) : null}</span>
+      ) : entry.commit ? (
+        <span className="group/commit hidden min-w-0 max-w-[40%] shrink basis-[40%] items-baseline gap-2 text-xs text-muted-foreground lg:flex">
+          <CopyHash commit={entry.commit} copyLabel={copyHashLabel} copiedLabel={copiedLabel} />
+          <span className="truncate" title={entry.commit.subject}>
+            {entry.commit.subject}
           </span>
-        </>
-      )}
+        </span>
+      ) : null}
+      {/* Both slots keep their width when empty, so directories (no size) line up
+          with files instead of shifting the whole row right. */}
+      <span className="flex shrink-0 items-baseline gap-2 text-xs tabular-nums text-muted-foreground">
+        <span
+          className="hidden w-28 truncate text-right sm:block"
+          title={changedAt ? formatAbsoluteTime(changedAt, locale) : undefined}
+        >
+          {changedAt ? formatRelativeTime(changedAt, locale, now, justNowLabel) : null}
+        </span>
+        <span className="w-16 text-right">{entry.size != null ? formatBytes(entry.size) : null}</span>
+      </span>
     </div>
   );
 }
@@ -321,18 +310,28 @@ function SkillCard({ skill }: { skill: KnowledgeSkill }) {
 
 const MAX_HIGHLIGHTED_CHARS = 128 * 1024;
 
+// Kept in step with INLINE_MIME_TYPES on the server, which serves everything else as
+// an attachment — an <img> pointing at those would just break. SVG is not among them:
+// it carries script, and repo contents come from a sandboxed agent's push.
+const INLINE_IMAGE_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp", "image/avif"]);
+
+// MAX_INLINE_TEXT_BYTES on the server: past it, contents are not sent at all.
+const MAX_INLINE_BYTES = 1024 * 1024;
+
 function FileContent({
   server,
   file,
   noPreviewLabel,
   largeFileLabel,
+  tooLargeLabel,
 }: {
   server: string;
   file: KnowledgeFileInfo;
   noPreviewLabel: string;
   largeFileLabel: string;
+  tooLargeLabel: string;
 }) {
-  if (file.mime.startsWith("image/")) {
+  if (INLINE_IMAGE_TYPES.has(file.mime)) {
     return (
       // eslint-disable-next-line @next/next/no-img-element
       <img
@@ -345,11 +344,9 @@ function FileContent({
   // The server inlines contents for anything that decodes as text, so extensionless
   // files (.gitignore, Dockerfile) still render; only binaries fall through.
   if (file.content != null) {
-    if (isMarkdown(file.name)) {
-      return <MarkdownContent content={file.content} />;
-    }
-    // Shiki tokenizes the whole document up front, which locks the tab on a large
-    // one — session archives run to hundreds of KB. Plain text past the threshold.
+    // Both renderers tokenize the whole document up front, which locks the tab on a
+    // large one — session archives run to hundreds of KB. Plain text past the
+    // threshold, markdown included: a big README goes through the same Shiki pass.
     if (file.content.length > MAX_HIGHLIGHTED_CHARS) {
       return (
         <div className="flex flex-col gap-2">
@@ -360,9 +357,18 @@ function FileContent({
         </div>
       );
     }
+    if (isMarkdown(file.name)) {
+      return <MarkdownContent content={file.content} />;
+    }
     return <MarkdownContent content={fencedCodeBlock(languageFromFilePath(file.name), file.content)} />;
   }
-  return <p className="text-sm text-muted-foreground">{noPreviewLabel}</p>;
+  // The server also returns no content for a file past its inline cap, which is not
+  // the same thing as an unsupported type — say which one it is.
+  return (
+    <p className="text-sm text-muted-foreground">
+      {file.size > MAX_INLINE_BYTES ? tooLargeLabel : noPreviewLabel}
+    </p>
+  );
 }
 
 export function KnowledgeView() {
@@ -501,6 +507,7 @@ export function KnowledgeView() {
             file={result}
             noPreviewLabel={t("noPreview")}
             largeFileLabel={t("largeFileNotice")}
+            tooLargeLabel={t("tooLarge")}
           />
         ) : null}
       </div>

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -3,7 +3,9 @@
 import {
   BookText,
   Cable,
+  Check,
   ChevronRight,
+  Copy,
   Download,
   GitCommitHorizontal,
   Globe,
@@ -88,6 +90,51 @@ function rowIcon(entry: KnowledgeEntry): ReactNode {
   );
 }
 
+/** Short hash that copies the full one — what a reader actually needs to paste. */
+function CopyHash({
+  commit,
+  copyLabel,
+  copiedLabel,
+}: {
+  commit: NonNullable<KnowledgeEntry["commit"]>;
+  copyLabel: string;
+  copiedLabel: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = window.setTimeout(() => setCopied(false), 2000);
+    return () => window.clearTimeout(timer);
+  }, [copied]);
+
+  async function copy(): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(commit.hash);
+      setCopied(true);
+    } catch {
+      // Clipboard denied (insecure origin, or the user said no) — leave the label alone.
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => void copy()}
+      title={copied ? copiedLabel : `${copyLabel}: ${commit.hash}`}
+      aria-label={copied ? copiedLabel : `${copyLabel}: ${commit.hash}`}
+      className={cn(
+        "inline-flex shrink-0 items-center gap-1 rounded-sm font-mono transition-colors",
+        "hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        copied && "text-foreground",
+      )}
+    >
+      {commit.short}
+      {copied ? <Check className="h-3 w-3 shrink-0" /> : <Copy className="h-3 w-3 shrink-0 opacity-0 group-hover/row:opacity-60" />}
+    </button>
+  );
+}
+
 /**
  * One row in a directory listing. The row links into the repo; recognized kinds add
  * a trailing link of their own (a session's title opens the chat), so the row is a
@@ -98,6 +145,8 @@ function EntryRow({
   entry,
   untitledLabel,
   justNowLabel,
+  copyHashLabel,
+  copiedLabel,
   locale,
   now,
 }: {
@@ -105,6 +154,8 @@ function EntryRow({
   entry: KnowledgeEntry;
   untitledLabel: string;
   justNowLabel: string;
+  copyHashLabel: string;
+  copiedLabel: string;
   locale: string;
   now: number;
 }) {
@@ -113,7 +164,7 @@ function EntryRow({
   // paths no commit covers, since a checkout rewrites it.
   const changedAt = entry.commit?.committed_at ?? entry.modified;
   return (
-    <div className="flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors hover:bg-muted">
+    <div className="group/row flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors hover:bg-muted">
       {rowIcon(entry)}
       <Link
         href={browseHref(entryPath)}
@@ -134,12 +185,11 @@ function EntryRow({
           {/* Commit column: the first thing to go as the row narrows, since the
               filename and size stay useful at any width. */}
           {entry.commit ? (
-            <span
-              className="hidden min-w-0 max-w-[40%] shrink basis-[40%] items-baseline gap-2 text-xs text-muted-foreground lg:flex"
-              title={`${entry.commit.hash} · ${entry.commit.subject}`}
-            >
-              <span className="shrink-0 font-mono">{entry.commit.hash}</span>
-              <span className="truncate">{entry.commit.subject}</span>
+            <span className="hidden min-w-0 max-w-[40%] shrink basis-[40%] items-baseline gap-2 text-xs text-muted-foreground lg:flex">
+              <CopyHash commit={entry.commit} copyLabel={copyHashLabel} copiedLabel={copiedLabel} />
+              <span className="truncate" title={entry.commit.subject}>
+                {entry.commit.subject}
+              </span>
             </span>
           ) : null}
           {/* Both slots keep their width when empty, so directories (no size) line up
@@ -410,6 +460,8 @@ export function KnowledgeView() {
                     entry={entry}
                     untitledLabel={t("untitledSession")}
                     justNowLabel={tSidebar("time.justNow")}
+                    copyHashLabel={t("copyHash")}
+                    copiedLabel={t("copiedHash")}
                     locale={locale}
                     now={now}
                   />

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -82,9 +82,9 @@ function Breadcrumb({ path, rootLabel }: { path: string; rootLabel: string }) {
   );
 }
 
-function rowIcon(entry: KnowledgeEntry, atRoot: boolean): ReactNode {
+function rowIcon(entry: KnowledgeEntry): ReactNode {
   return entryIcon(
-    { name: entry.name, type: entry.type, kind: entry.kind, atRoot },
+    { name: entry.name, type: entry.type, kind: entry.kind },
     cn("h-4 w-4 shrink-0", entry.type === "dir" ? "text-accent-foreground/70" : "text-muted-foreground"),
   );
 }
@@ -112,7 +112,7 @@ function EntryRow({
   const entryPath = path ? `${path}/${entry.name}` : entry.name;
   return (
     <div className="flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors hover:bg-muted">
-      {rowIcon(entry, path === "")}
+      {rowIcon(entry)}
       <Link
         href={browseHref(entryPath)}
         className="min-w-0 flex-1 truncate rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -2,15 +2,20 @@
 
 import {
   BookText,
+  Cable,
   ChevronRight,
   Download,
   File,
   FileText,
   Folder,
   GitCommitHorizontal,
+  Globe,
+  KeyRound,
+  Lightbulb,
   Loader2,
   MessagesSquare,
   Puzzle,
+  Terminal,
 } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
@@ -119,16 +124,19 @@ function EntryRow({ path, entry, untitledLabel }: { path: string; entry: Knowled
   );
 }
 
-function SkillSection({ label, children }: { label: string; children: ReactNode }) {
+function SkillSection({ icon, label, children }: { icon: ReactNode; label: string; children: ReactNode }) {
   return (
     <div className="flex flex-col gap-1 sm:flex-row sm:gap-3">
-      <div className="shrink-0 pt-0.5 text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground sm:w-28">
+      <div className="flex shrink-0 items-center gap-1.5 pt-0.5 text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground sm:w-32">
+        {icon}
         {label}
       </div>
       <div className="flex min-w-0 flex-1 flex-col gap-1">{children}</div>
     </div>
   );
 }
+
+const sectionIconClass = "h-3.5 w-3.5 shrink-0";
 
 /** Frontmatter of a skill's SKILL.md as a card: what it exposes, reaches, and needs. */
 function SkillCard({ skill }: { skill: KnowledgeSkill }) {
@@ -153,7 +161,7 @@ function SkillCard({ skill }: { skill: KnowledgeSkill }) {
       {commands.length || domains.length || tunnels.length || credentials.length || hints.length ? (
         <div className="mt-4 flex flex-col gap-3 border-t border-border/70 pt-3 text-sm">
           {commands.length ? (
-            <SkillSection label={t("commands")}>
+            <SkillSection icon={<Terminal className={sectionIconClass} />} label={t("commands")}>
               {commands.map((command) => (
                 <div key={command.name} className="flex min-w-0 flex-col gap-0.5">
                   <code className="break-all font-mono text-xs font-semibold">{command.name}</code>
@@ -164,7 +172,7 @@ function SkillCard({ skill }: { skill: KnowledgeSkill }) {
           ) : null}
 
           {domains.length ? (
-            <SkillSection label={t("domains")}>
+            <SkillSection icon={<Globe className={sectionIconClass} />} label={t("domains")}>
               {domains.map((domain) => (
                 <code key={domain} className="break-all font-mono text-xs">{domain}</code>
               ))}
@@ -172,7 +180,7 @@ function SkillCard({ skill }: { skill: KnowledgeSkill }) {
           ) : null}
 
           {tunnels.length ? (
-            <SkillSection label={t("tunnels")}>
+            <SkillSection icon={<Cable className={sectionIconClass} />} label={t("tunnels")}>
               {tunnels.map((tunnel) => (
                 <div key={`${tunnel.host}:${tunnel.remote_port}`} className="min-w-0">
                   <code className="break-all font-mono text-xs">
@@ -187,7 +195,7 @@ function SkillCard({ skill }: { skill: KnowledgeSkill }) {
           ) : null}
 
           {credentials.length ? (
-            <SkillSection label={t("credentials")}>
+            <SkillSection icon={<KeyRound className={sectionIconClass} />} label={t("credentials")}>
               {credentials.map((credential) => (
                 <div key={credential.vault_path} className="flex min-w-0 flex-col gap-0.5">
                   <div className="flex min-w-0 flex-wrap items-baseline gap-x-2">
@@ -205,7 +213,7 @@ function SkillCard({ skill }: { skill: KnowledgeSkill }) {
           ) : null}
 
           {hints.length ? (
-            <SkillSection label={t("hints")}>
+            <SkillSection icon={<Lightbulb className={sectionIconClass} />} label={t("hints")}>
               {hints.map(([key, value]) => (
                 <div key={key} className="min-w-0 break-words text-xs">
                   <code className="break-all font-mono font-semibold">{key}</code>

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -19,6 +19,7 @@ import { useEffect, useState, type ReactNode } from "react";
 import { useTranslations } from "next-intl";
 
 import { useAppShell } from "@/components/app-shell-context";
+import { useAppLocale } from "@/components/locale-provider";
 import { GlobalGitPanel, useGlobalGit } from "@/components/git-sync";
 import { MarkdownContent } from "@/components/markdown-content";
 import {
@@ -30,6 +31,7 @@ import {
   type KnowledgeSkill,
 } from "@/lib/api";
 import { entryIcon } from "@/lib/file-icons";
+import { formatAbsoluteTime, formatRelativeTime } from "@/lib/format-time";
 import { fencedCodeBlock, languageFromFilePath } from "@/lib/sandbox-read";
 import { cn } from "@/lib/utils";
 
@@ -92,7 +94,21 @@ function rowIcon(entry: KnowledgeEntry, atRoot: boolean): ReactNode {
  * a trailing link of their own (a session's title opens the chat), so the row is a
  * container rather than a single anchor — anchors cannot nest.
  */
-function EntryRow({ path, entry, untitledLabel }: { path: string; entry: KnowledgeEntry; untitledLabel: string }) {
+function EntryRow({
+  path,
+  entry,
+  untitledLabel,
+  justNowLabel,
+  locale,
+  now,
+}: {
+  path: string;
+  entry: KnowledgeEntry;
+  untitledLabel: string;
+  justNowLabel: string;
+  locale: string;
+  now: number;
+}) {
   const entryPath = path ? `${path}/${entry.name}` : entry.name;
   return (
     <div className="flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors hover:bg-muted">
@@ -111,9 +127,21 @@ function EntryRow({ path, entry, untitledLabel }: { path: string; entry: Knowled
         >
           {entry.label ?? untitledLabel}
         </Link>
-      ) : entry.size != null ? (
-        <span className="shrink-0 text-xs tabular-nums text-muted-foreground">{formatSize(entry.size)}</span>
-      ) : null}
+      ) : (
+        <span className="flex shrink-0 items-baseline gap-2 text-xs text-muted-foreground">
+          {entry.modified ? (
+            <span
+              className="hidden tabular-nums sm:inline"
+              title={formatAbsoluteTime(entry.modified, locale)}
+            >
+              {formatRelativeTime(entry.modified, locale, now, justNowLabel)}
+            </span>
+          ) : null}
+          {entry.size != null ? (
+            <span className="w-16 text-right tabular-nums">{formatSize(entry.size)}</span>
+          ) : null}
+        </span>
+      )}
     </div>
   );
 }
@@ -257,6 +285,8 @@ function FileContent({
 export function KnowledgeView() {
   const t = useTranslations("knowledge");
   const tApp = useTranslations("app");
+  const tSidebar = useTranslations("sidebar");
+  const { locale } = useAppLocale();
   const { server, token } = useAppShell();
   const git = useGlobalGit(server, token);
   const searchParams = useSearchParams();
@@ -265,6 +295,9 @@ export function KnowledgeView() {
   const [result, setResult] = useState<KnowledgeBrowseResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // Reference point for relative times, refreshed whenever a listing loads. No ticking
+  // timer: rows are re-read on every navigation, so drift only shows on an idle page.
+  const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
     document.title = `${t("title")} • ${tApp("name")}`;
@@ -277,7 +310,10 @@ export function KnowledgeView() {
       setError(null);
       try {
         const browsed = await browseKnowledge(server, path);
-        if (!cancelled) setResult(browsed);
+        if (!cancelled) {
+          setResult(browsed);
+          setNow(Date.now());
+        }
       } catch (browseError) {
         if (!cancelled) {
           setResult(null);
@@ -344,6 +380,9 @@ export function KnowledgeView() {
                     path={result.path}
                     entry={entry}
                     untitledLabel={t("untitledSession")}
+                    justNowLabel={tSidebar("time.justNow")}
+                    locale={locale}
+                    now={now}
                   />
                 ))}
               </div>

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  BookText,
   ChevronRight,
   Download,
   File,
@@ -225,20 +226,31 @@ export function KnowledgeView() {
         ) : error ? (
           <p className="py-8 text-sm text-destructive">{error}</p>
         ) : result?.type === "dir" ? (
-          result.entries.length === 0 ? (
-            <p className="py-8 text-sm text-muted-foreground">{t("empty")}</p>
-          ) : (
-            <div className="flex flex-col gap-0.5 rounded-lg border border-border p-1.5">
-              {result.entries.map((entry) => (
-                <EntryRow
-                  key={entry.name}
-                  path={result.path}
-                  entry={entry}
-                  untitledLabel={t("untitledSession")}
-                />
-              ))}
-            </div>
-          )
+          <>
+            {result.entries.length === 0 ? (
+              <p className="py-8 text-sm text-muted-foreground">{t("empty")}</p>
+            ) : (
+              <div className="flex flex-col gap-0.5 rounded-lg border border-border p-1.5">
+                {result.entries.map((entry) => (
+                  <EntryRow
+                    key={entry.name}
+                    path={result.path}
+                    entry={entry}
+                    untitledLabel={t("untitledSession")}
+                  />
+                ))}
+              </div>
+            )}
+            {result.doc != null ? (
+              <section className="mt-6">
+                <h2 className="mb-2 flex items-center gap-1.5 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                  <BookText className="h-3.5 w-3.5" />
+                  {result.doc_name}
+                </h2>
+                <MarkdownContent content={result.doc} />
+              </section>
+            ) : null}
+          </>
         ) : result?.type === "file" ? (
           <FileContent server={server} file={result} noPreviewLabel={t("noPreview")} />
         ) : null}

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -143,15 +143,16 @@ function EntryRow({
               <span className="truncate">{entry.commit.subject}</span>
             </span>
           ) : null}
-          <span className="flex shrink-0 items-baseline gap-2 text-xs text-muted-foreground">
-            {changedAt ? (
-              <span className="hidden tabular-nums sm:inline" title={formatAbsoluteTime(changedAt, locale)}>
-                {formatRelativeTime(changedAt, locale, now, justNowLabel)}
-              </span>
-            ) : null}
-            {entry.size != null ? (
-              <span className="w-16 text-right tabular-nums">{formatSize(entry.size)}</span>
-            ) : null}
+          {/* Both slots keep their width when empty, so directories (no size) line up
+              with files instead of shifting the whole row right. */}
+          <span className="flex shrink-0 items-baseline gap-2 text-xs tabular-nums text-muted-foreground">
+            <span
+              className="hidden w-28 truncate text-right sm:block"
+              title={changedAt ? formatAbsoluteTime(changedAt, locale) : undefined}
+            >
+              {changedAt ? formatRelativeTime(changedAt, locale, now, justNowLabel) : null}
+            </span>
+            <span className="w-16 text-right">{entry.size != null ? formatSize(entry.size) : null}</span>
           </span>
         </>
       )}

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -80,11 +80,9 @@ function Breadcrumb({ path, rootLabel }: { path: string; rootLabel: string }) {
   );
 }
 
-function rowIcon(entry: KnowledgeEntry): ReactNode {
+function rowIcon(entry: KnowledgeEntry, atRoot: boolean): ReactNode {
   return entryIcon(
-    entry.name,
-    entry.type,
-    entry.kind,
+    { name: entry.name, type: entry.type, kind: entry.kind, atRoot },
     cn("h-4 w-4 shrink-0", entry.type === "dir" ? "text-accent-foreground/70" : "text-muted-foreground"),
   );
 }
@@ -98,7 +96,7 @@ function EntryRow({ path, entry, untitledLabel }: { path: string; entry: Knowled
   const entryPath = path ? `${path}/${entry.name}` : entry.name;
   return (
     <div className="flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors hover:bg-muted">
-      {rowIcon(entry)}
+      {rowIcon(entry, path === "")}
       <Link
         href={browseHref(entryPath)}
         className="min-w-0 flex-1 truncate rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -11,7 +11,6 @@ import { GlobalGitPanel, useGlobalGit } from "@/components/git-sync";
 import { MarkdownContent } from "@/components/markdown-content";
 import {
   browseKnowledge,
-  fetchKnowledgeText,
   knowledgeRawUrl,
   type KnowledgeBrowseResult,
   type KnowledgeEntry,
@@ -20,24 +19,8 @@ import {
 import { fencedCodeBlock, languageFromFilePath } from "@/lib/sandbox-read";
 import { cn } from "@/lib/utils";
 
-const MAX_TEXT_PREVIEW_BYTES = 1024 * 1024;
-
-const TEXT_MIMES = new Set([
-  "application/json",
-  "application/xml",
-  "application/yaml",
-  "application/toml",
-  "application/x-sh",
-  "application/javascript",
-]);
-
 function isMarkdown(name: string): boolean {
   return /\.(md|markdown)$/i.test(name);
-}
-
-function isTextFile(file: KnowledgeFileInfo): boolean {
-  if (file.mime.startsWith("text/") || TEXT_MIMES.has(file.mime)) return true;
-  return languageFromFilePath(file.name) !== "text" || isMarkdown(file.name);
 }
 
 function formatSize(size: number): string {
@@ -108,12 +91,10 @@ function EntryRow({ path, entry }: { path: string; entry: KnowledgeEntry }) {
 function FileContent({
   server,
   file,
-  text,
   noPreviewLabel,
 }: {
   server: string;
   file: KnowledgeFileInfo;
-  text: string | null;
   noPreviewLabel: string;
 }) {
   if (file.mime.startsWith("image/")) {
@@ -126,11 +107,13 @@ function FileContent({
       />
     );
   }
-  if (text != null) {
+  // The server inlines contents for anything that decodes as text, so extensionless
+  // files (.gitignore, Dockerfile) still render; only binaries fall through.
+  if (file.content != null) {
     if (isMarkdown(file.name)) {
-      return <MarkdownContent content={text} />;
+      return <MarkdownContent content={file.content} />;
     }
-    return <MarkdownContent content={fencedCodeBlock(languageFromFilePath(file.name), text)} />;
+    return <MarkdownContent content={fencedCodeBlock(languageFromFilePath(file.name), file.content)} />;
   }
   return <p className="text-sm text-muted-foreground">{noPreviewLabel}</p>;
 }
@@ -144,7 +127,6 @@ export function KnowledgeView() {
   const path = (searchParams.get("path") ?? "").replace(/^\/+|\/+$/g, "");
 
   const [result, setResult] = useState<KnowledgeBrowseResult | null>(null);
-  const [text, setText] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -157,15 +139,9 @@ export function KnowledgeView() {
     (async () => {
       setLoading(true);
       setError(null);
-      setText(null);
       try {
         const browsed = await browseKnowledge(server, path);
-        if (cancelled) return;
-        setResult(browsed);
-        if (browsed.type === "file" && isTextFile(browsed) && browsed.size <= MAX_TEXT_PREVIEW_BYTES) {
-          const content = await fetchKnowledgeText(server, browsed.path);
-          if (!cancelled) setText(content);
-        }
+        if (!cancelled) setResult(browsed);
       } catch (browseError) {
         if (!cancelled) {
           setResult(null);
@@ -231,7 +207,7 @@ export function KnowledgeView() {
             </div>
           )
         ) : result?.type === "file" ? (
-          <FileContent server={server} file={result} text={text} noPreviewLabel={t("noPreview")} />
+          <FileContent server={server} file={result} noPreviewLabel={t("noPreview")} />
         ) : null}
       </div>
     </div>

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
-import { Archive, ArchiveRestore, Bot, Loader2, Lock, LogOut, Mail, MessageSquare, Pin, Save, Settings2, Star, Trash2 } from "lucide-react";
+import { Archive, ArchiveRestore, Bot, BookOpen, Loader2, Lock, LogOut, Mail, MessageSquare, Pin, Save, Settings2, Star, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { EmojiText } from "@/components/emoji-text";
 import { useAppLocale } from "@/components/locale-provider";
@@ -604,6 +605,14 @@ export function Sidebar({
           <VersionBadge frontendVersion={frontendVersion} backendVersion={backendVersion} />
         </div>
         <div className="flex items-center gap-0.5">
+          <Link
+            href="/knowledge"
+            title={t("navigation.knowledge")}
+            aria-label={t("navigation.knowledge")}
+            className="inline-flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            <BookOpen className="h-4 w-4" />
+          </Link>
           <button
             type="button"
             onClick={handleOpenSettings}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1556,6 +1556,8 @@ export interface KnowledgeEntry {
   name: string;
   type: "file" | "dir";
   size: number | null;
+  /** Working-tree mtime, ISO 8601. Files only. */
+  modified: string | null;
   /** Recognized directory convention: a session archive or a skill dir. */
   kind: "session" | "skill" | null;
   /** Human label shown in place of a file's size (a session's title). */

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -585,6 +585,8 @@ export interface GlobalGitStatus {
   remote_configured: boolean;
   ahead: number;
   behind: number;
+  head: string | null;
+  head_subject: string | null;
 }
 
 export interface GitActionResult {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1570,6 +1570,8 @@ export interface KnowledgeFileInfo {
   name: string;
   size: number;
   mime: string;
+  /** Inlined by the server for text files under its size cap; null for binaries. */
+  content: string | null;
 }
 
 export type KnowledgeBrowseResult = KnowledgeDirListing | KnowledgeFileInfo;
@@ -1598,12 +1600,4 @@ export function knowledgeRawUrl(
 ): string {
   const query = opts.download ? "?raw=1&download=1" : "?raw=1";
   return `${server}${knowledgeBrowsePath(path)}${query}`;
-}
-
-export async function fetchKnowledgeText(server: string, path: string): Promise<string> {
-  const res = await fetch(knowledgeRawUrl(server, path));
-  if (!res.ok) {
-    throw new Error(await readErrorMessage(res, "Failed to fetch file"));
-  }
-  return res.text();
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1556,8 +1556,8 @@ export interface KnowledgeEntry {
   name: string;
   type: "file" | "dir";
   size: number | null;
-  /** Recognized directory convention, e.g. a session archive. */
-  kind: "session" | null;
+  /** Recognized directory convention: a session archive or a skill dir. */
+  kind: "session" | "skill" | null;
   /** Human label shown in place of a file's size (a session's title). */
   label: string | null;
   session_id: string | null;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1563,13 +1563,48 @@ export interface KnowledgeEntry {
   session_id: string | null;
 }
 
+export interface SkillCommandDecl {
+  name: string;
+  command: string;
+}
+
+export interface SkillCredentialDecl {
+  vault_path: string;
+  description: string;
+  env_var: string | null;
+  file: string | null;
+  base64: boolean;
+}
+
+export interface SkillNetworkTunnel {
+  host: string;
+  remote_port: number;
+  local_port: number;
+  description: string;
+}
+
+export interface SkillCarapaceConfig {
+  network: { domains: string[]; tunnels: SkillNetworkTunnel[] };
+  credentials: SkillCredentialDecl[];
+  commands: SkillCommandDecl[];
+  hints: Record<string, string>;
+}
+
+export interface KnowledgeSkill {
+  name: string;
+  description: string;
+  /** Null when the skill declares no carapace metadata, or it failed validation. */
+  carapace: SkillCarapaceConfig | null;
+}
+
 export interface KnowledgeDirListing {
   type: "dir";
   /** Recognized directory convention, e.g. a skill dir. */
   kind: "skill" | null;
-  /** Defining document inlined by the server (SKILL.md), rendered below the listing. */
+  /** Defining document inlined by the server (SKILL.md), frontmatter stripped. */
   doc_name: string | null;
   doc: string | null;
+  skill: KnowledgeSkill | null;
   path: string;
   entries: KnowledgeEntry[];
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1556,8 +1556,10 @@ export interface KnowledgeEntry {
   name: string;
   type: "file" | "dir";
   size: number | null;
-  /** Working-tree mtime, ISO 8601. Files only. */
+  /** Working-tree mtime, ISO 8601. Files only; fallback when `commit` is null. */
   modified: string | null;
+  /** Newest commit touching this entry; null for uncommitted paths. */
+  commit: { hash: string; subject: string; committed_at: string } | null;
   /** Recognized directory convention: a session archive or a skill dir. */
   kind: "session" | "skill" | null;
   /** Human label shown in place of a file's size (a session's title). */

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1565,6 +1565,11 @@ export interface KnowledgeEntry {
 
 export interface KnowledgeDirListing {
   type: "dir";
+  /** Recognized directory convention, e.g. a skill dir. */
+  kind: "skill" | null;
+  /** Defining document inlined by the server (SKILL.md), rendered below the listing. */
+  doc_name: string | null;
+  doc: string | null;
   path: string;
   entries: KnowledgeEntry[];
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1556,6 +1556,11 @@ export interface KnowledgeEntry {
   name: string;
   type: "file" | "dir";
   size: number | null;
+  /** Recognized directory convention, e.g. a session archive. */
+  kind: "session" | null;
+  /** Human label shown in place of a file's size (a session's title). */
+  label: string | null;
+  session_id: string | null;
 }
 
 export interface KnowledgeDirListing {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1549,3 +1549,59 @@ export function wsUrl(
   const query = params.toString();
   return `${base}/api/chat/${sessionId}${query ? `?${query}` : ""}`;
 }
+
+export interface KnowledgeEntry {
+  name: string;
+  type: "file" | "dir";
+  size: number | null;
+}
+
+export interface KnowledgeDirListing {
+  type: "dir";
+  path: string;
+  entries: KnowledgeEntry[];
+}
+
+export interface KnowledgeFileInfo {
+  type: "file";
+  path: string;
+  name: string;
+  size: number;
+  mime: string;
+}
+
+export type KnowledgeBrowseResult = KnowledgeDirListing | KnowledgeFileInfo;
+
+function knowledgeBrowsePath(path: string): string {
+  const clean = path.replace(/^\/+/, "").replace(/\/+$/, "");
+  if (!clean) return "/api/knowledge/browse";
+  return `/api/knowledge/browse/${clean.split("/").map(encodeURIComponent).join("/")}`;
+}
+
+export async function browseKnowledge(
+  server: string,
+  path: string,
+): Promise<KnowledgeBrowseResult> {
+  const res = await fetch(`${server}${knowledgeBrowsePath(path)}`);
+  if (!res.ok) {
+    throw new Error(await readErrorMessage(res, "Failed to browse knowledge"));
+  }
+  return (await res.json()) as KnowledgeBrowseResult;
+}
+
+export function knowledgeRawUrl(
+  server: string,
+  path: string,
+  opts: { download?: boolean } = {},
+): string {
+  const query = opts.download ? "?raw=1&download=1" : "?raw=1";
+  return `${server}${knowledgeBrowsePath(path)}${query}`;
+}
+
+export async function fetchKnowledgeText(server: string, path: string): Promise<string> {
+  const res = await fetch(knowledgeRawUrl(server, path));
+  if (!res.ok) {
+    throw new Error(await readErrorMessage(res, "Failed to fetch file"));
+  }
+  return res.text();
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1559,7 +1559,7 @@ export interface KnowledgeEntry {
   /** Working-tree mtime, ISO 8601. Files only; fallback when `commit` is null. */
   modified: string | null;
   /** Newest commit touching this entry; null for uncommitted paths. */
-  commit: { hash: string; subject: string; committed_at: string } | null;
+  commit: { hash: string; short: string; subject: string; committed_at: string } | null;
   /** Recognized directory convention: a session archive or a skill dir. */
   kind: "session" | "skill" | null;
   /** Human label shown in place of a file's size (a session's title). */

--- a/frontend/src/lib/file-icons.tsx
+++ b/frontend/src/lib/file-icons.tsx
@@ -11,10 +11,8 @@ import {
   FileType,
   FileVideo,
   Folder,
-  FolderArchive,
   FolderClock,
   FolderCog,
-  FolderTree,
   GitBranch,
   Hammer,
   Image,
@@ -141,33 +139,17 @@ const EXTENSION_ICONS: Record<string, LucideIcon> = {
 
 export type EntryIconKind = "session" | "skill" | null;
 
-/**
- * The two collections at the repo root. Matched by name and only at the root, so a
- * nested dir that happens to be called "skills" stays a plain folder.
- *
- * ponytail: the session prefix is configurable server-side (SessionCommitConfig,
- * default "sessions"); a renamed one just falls back to the plain folder icon. Tag
- * these server-side if that ever matters.
- */
-const ROOT_DIR_ICONS: Record<string, LucideIcon> = {
-  skills: FolderTree,
-  sessions: FolderArchive,
-};
-
 export interface EntryIconTarget {
   name: string;
   type: "file" | "dir";
   kind: EntryIconKind;
-  /** True when the entry sits directly in the repo root. */
-  atRoot?: boolean;
 }
 
-function lookup({ name, type, kind, atRoot }: EntryIconTarget): LucideIcon {
+function lookup({ name, type, kind }: EntryIconTarget): LucideIcon {
   // Recognized directories keep a folder silhouette so they still read as directories.
   if (type === "dir") {
     if (kind === "session") return FolderClock;
     if (kind === "skill") return FolderCog;
-    if (atRoot) return ROOT_DIR_ICONS[name.toLowerCase()] ?? Folder;
     return Folder;
   }
   const lower = name.toLowerCase();

--- a/frontend/src/lib/file-icons.tsx
+++ b/frontend/src/lib/file-icons.tsx
@@ -11,8 +11,10 @@ import {
   FileType,
   FileVideo,
   Folder,
+  FolderArchive,
   FolderClock,
   FolderCog,
+  FolderTree,
   GitBranch,
   Hammer,
   Image,
@@ -139,11 +141,33 @@ const EXTENSION_ICONS: Record<string, LucideIcon> = {
 
 export type EntryIconKind = "session" | "skill" | null;
 
-function lookup(name: string, type: "file" | "dir", kind: EntryIconKind): LucideIcon {
+/**
+ * The two collections at the repo root. Matched by name and only at the root, so a
+ * nested dir that happens to be called "skills" stays a plain folder.
+ *
+ * ponytail: the session prefix is configurable server-side (SessionCommitConfig,
+ * default "sessions"); a renamed one just falls back to the plain folder icon. Tag
+ * these server-side if that ever matters.
+ */
+const ROOT_DIR_ICONS: Record<string, LucideIcon> = {
+  skills: FolderTree,
+  sessions: FolderArchive,
+};
+
+export interface EntryIconTarget {
+  name: string;
+  type: "file" | "dir";
+  kind: EntryIconKind;
+  /** True when the entry sits directly in the repo root. */
+  atRoot?: boolean;
+}
+
+function lookup({ name, type, kind, atRoot }: EntryIconTarget): LucideIcon {
   // Recognized directories keep a folder silhouette so they still read as directories.
   if (type === "dir") {
     if (kind === "session") return FolderClock;
     if (kind === "skill") return FolderCog;
+    if (atRoot) return ROOT_DIR_ICONS[name.toLowerCase()] ?? Folder;
     return Folder;
   }
   const lower = name.toLowerCase();
@@ -162,12 +186,7 @@ function lookup(name: string, type: "file" | "dir", kind: EntryIconKind): Lucide
  * Returns an element rather than a component so callers do not assign a component
  * to a local during render.
  */
-export function entryIcon(
-  name: string,
-  type: "file" | "dir",
-  kind: EntryIconKind,
-  className: string,
-): ReactNode {
-  const Icon = lookup(name, type, kind);
+export function entryIcon(target: EntryIconTarget, className: string): ReactNode {
+  const Icon = lookup(target);
   return <Icon className={className} />;
 }

--- a/frontend/src/lib/file-icons.tsx
+++ b/frontend/src/lib/file-icons.tsx
@@ -1,0 +1,173 @@
+import {
+  Bot,
+  Braces,
+  Container,
+  File,
+  FileArchive,
+  FileAudio,
+  FileCode,
+  FileSpreadsheet,
+  FileText,
+  FileType,
+  FileVideo,
+  Folder,
+  FolderClock,
+  FolderCog,
+  GitBranch,
+  Hammer,
+  Image,
+  Key,
+  Lock,
+  type LucideIcon,
+  Package,
+  Palette,
+  ScrollText,
+  Scale,
+  Settings2,
+  ShieldCheck,
+  Sparkles,
+  SquareTerminal,
+  User,
+} from "lucide-react";
+import type { ReactNode } from "react";
+
+/** Files whose meaning comes from their exact name, not their extension. */
+const NAME_ICONS: Record<string, LucideIcon> = {
+  "agents.md": Bot,
+  "conversation.json": ScrollText,
+  dockerfile: Container,
+  "skill.md": Package,
+  "soul.md": Sparkles,
+  "security.md": ShieldCheck,
+  "user.md": User,
+  license: Scale,
+  makefile: Hammer,
+  readme: FileText,
+  "readme.md": FileText,
+  ".gitignore": GitBranch,
+  ".gitattributes": GitBranch,
+  ".gitmodules": GitBranch,
+  ".env": Key,
+  "package.json": Package,
+  "pyproject.toml": Package,
+  "requirements.txt": Package,
+  "setup.sh": Hammer,
+};
+
+/** Lockfiles share an icon regardless of ecosystem. */
+const LOCK_NAMES = new Set(["uv.lock", "package-lock.json", "pnpm-lock.yaml", "yarn.lock", "cargo.lock"]);
+
+const EXTENSION_ICONS: Record<string, LucideIcon> = {
+  md: FileText,
+  markdown: FileText,
+  txt: FileText,
+  rst: FileText,
+  log: ScrollText,
+
+  json: Braces,
+  jsonl: Braces,
+  yaml: Settings2,
+  yml: Settings2,
+  toml: Settings2,
+  ini: Settings2,
+  cfg: Settings2,
+  conf: Settings2,
+  env: Key,
+
+  py: FileCode,
+  ts: FileCode,
+  tsx: FileCode,
+  js: FileCode,
+  jsx: FileCode,
+  go: FileCode,
+  rs: FileCode,
+  rb: FileCode,
+  java: FileCode,
+  php: FileCode,
+  c: FileCode,
+  h: FileCode,
+  cpp: FileCode,
+  sql: FileCode,
+  html: FileCode,
+  css: Palette,
+  scss: Palette,
+  sh: SquareTerminal,
+  bash: SquareTerminal,
+  zsh: SquareTerminal,
+  fish: SquareTerminal,
+
+  png: Image,
+  jpg: Image,
+  jpeg: Image,
+  gif: Image,
+  svg: Image,
+  webp: Image,
+  avif: Image,
+  ico: Image,
+  bmp: Image,
+
+  pdf: FileType,
+  csv: FileSpreadsheet,
+  tsv: FileSpreadsheet,
+  xlsx: FileSpreadsheet,
+  ods: FileSpreadsheet,
+
+  zip: FileArchive,
+  gz: FileArchive,
+  tgz: FileArchive,
+  bz2: FileArchive,
+  xz: FileArchive,
+  tar: FileArchive,
+  "7z": FileArchive,
+  rar: FileArchive,
+
+  mp3: FileAudio,
+  wav: FileAudio,
+  flac: FileAudio,
+  ogg: FileAudio,
+  m4a: FileAudio,
+
+  mp4: FileVideo,
+  mov: FileVideo,
+  mkv: FileVideo,
+  webm: FileVideo,
+
+  lock: Lock,
+  pem: Key,
+  key: Key,
+};
+
+export type EntryIconKind = "session" | "skill" | null;
+
+function lookup(name: string, type: "file" | "dir", kind: EntryIconKind): LucideIcon {
+  // Recognized directories keep a folder silhouette so they still read as directories.
+  if (type === "dir") {
+    if (kind === "session") return FolderClock;
+    if (kind === "skill") return FolderCog;
+    return Folder;
+  }
+  const lower = name.toLowerCase();
+  const byName = NAME_ICONS[lower];
+  if (byName) return byName;
+  if (LOCK_NAMES.has(lower)) return Lock;
+
+  const dot = lower.lastIndexOf(".");
+  // A leading dot means a hidden file (.gitignore), not an extension.
+  if (dot <= 0 || dot === lower.length - 1) return File;
+  return EXTENSION_ICONS[lower.slice(dot + 1)] ?? File;
+}
+
+/**
+ * Icon for a directory entry, by kind for directories and name/extension for files.
+ * Returns an element rather than a component so callers do not assign a component
+ * to a local during render.
+ */
+export function entryIcon(
+  name: string,
+  type: "file" | "dir",
+  kind: EntryIconKind,
+  className: string,
+): ReactNode {
+  const Icon = lookup(name, type, kind);
+  return <Icon className={className} />;
+}

--- a/frontend/src/lib/format-time.ts
+++ b/frontend/src/lib/format-time.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared timestamp formatting.
+ *
+ * ponytail: `sidebar.tsx` and `message.tsx` still carry their own near-identical
+ * copies; fold them in here when one of them next needs a change.
+ */
+
+/**
+ * Relative age ("3 days ago"), falling back to an absolute date beyond a week
+ * where "52 weeks ago" stops being useful. Returns "" for unparseable input.
+ */
+export function formatRelativeTime(
+  iso: string,
+  locale: string,
+  now: number,
+  justNowLabel: string,
+): string {
+  const parsed = Date.parse(iso);
+  if (Number.isNaN(parsed)) return "";
+
+  const diff = now - parsed;
+  if (diff < 60_000) return justNowLabel;
+
+  const formatter = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+  if (diff < 3_600_000) return formatter.format(-Math.floor(diff / 60_000), "minute");
+  if (diff < 86_400_000) return formatter.format(-Math.floor(diff / 3_600_000), "hour");
+  if (diff < 604_800_000) return formatter.format(-Math.floor(diff / 86_400_000), "day");
+
+  return new Intl.DateTimeFormat(locale, { day: "2-digit", month: "2-digit", year: "numeric" }).format(parsed);
+}
+
+/** Full date and time, for tooltips. Returns "" for unparseable input. */
+export function formatAbsoluteTime(iso: string, locale: string): string {
+  const parsed = Date.parse(iso);
+  if (Number.isNaN(parsed)) return "";
+  return new Intl.DateTimeFormat(locale, { dateStyle: "medium", timeStyle: "short" }).format(parsed);
+}

--- a/frontend/src/lib/knowledge-links.ts
+++ b/frontend/src/lib/knowledge-links.ts
@@ -1,0 +1,8 @@
+/**
+ * Route helper for the knowledge browser. The path lives in a query param because the
+ * frontend is a static export, which cannot route on arbitrary path segments.
+ */
+export function knowledgeBrowseHref(path: string): string {
+  const clean = path.replace(/^\/+/, "").replace(/\/+$/, "");
+  return clean ? `/knowledge?path=${encodeURIComponent(clean)}` : "/knowledge";
+}

--- a/src/carapace/api_keys.py
+++ b/src/carapace/api_keys.py
@@ -28,6 +28,7 @@ class Scope(StrEnum):
     preferences = "preferences"
     notifications = "notifications"
     history = "history"
+    knowledge = "knowledge"
     admin = "admin"
 
 

--- a/src/carapace/git/store.py
+++ b/src/carapace/git/store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import socket
 from datetime import UTC, datetime
 from pathlib import Path
@@ -10,15 +11,19 @@ from loguru import logger
 
 from ..models.git import FileCommit
 
-# Record separator for the ``git log`` walk in last_commits: a byte that cannot appear
-# in a commit subject, so records stay distinguishable from the NUL-separated paths.
+# Record separator for the ``git log`` walk in last_commits, keeping records
+# distinguishable from the NUL-separated paths. Git does accept a subject containing
+# this byte, so split only where a commit header follows: otherwise a single
+# `git commit -m "$(printf 'a\001b')"` splits its own record, every path in it is
+# dropped, and those entries silently show an older commit.
 _LOG_RECORD_SEP = "%x01"
+_LOG_RECORD_SPLIT = re.compile(r"\x01(?=[0-9a-f]{40}\x00)")
 
 
 def _parse_last_commits(out: str, prefix: str) -> dict[str, FileCommit]:
     """Fold a ``git log -z --name-only`` walk into one commit per immediate child."""
     found: dict[str, FileCommit] = {}
-    for record in out.split("\x01"):
+    for record in _LOG_RECORD_SPLIT.split(out):
         if not record:
             continue
         fields = record.split("\x00")

--- a/src/carapace/git/store.py
+++ b/src/carapace/git/store.py
@@ -3,9 +3,45 @@ from __future__ import annotations
 import asyncio
 import os
 import socket
+from datetime import UTC, datetime
 from pathlib import Path
 
 from loguru import logger
+
+from ..models.git import FileCommit
+
+# Record separator for the ``git log`` walk in last_commits: a byte that cannot appear
+# in a commit subject, so records stay distinguishable from the NUL-separated paths.
+_LOG_RECORD_SEP = "%x01"
+
+
+def _parse_last_commits(out: str, prefix: str) -> dict[str, FileCommit]:
+    """Fold a ``git log -z --name-only`` walk into one commit per immediate child."""
+    found: dict[str, FileCommit] = {}
+    for record in out.split("\x01"):
+        if not record:
+            continue
+        fields = record.split("\x00")
+        if len(fields) < 3:
+            continue
+        short, timestamp, subject, *paths = fields
+        if not short or not timestamp.isdigit():
+            continue
+        commit = FileCommit(
+            hash=short,
+            subject=subject,
+            committed_at=datetime.fromtimestamp(int(timestamp), tz=UTC),
+        )
+        for raw in paths:
+            path = raw.strip("\n")
+            if not path or not path.startswith(prefix):
+                continue
+            # Fold e.g. "skills/weather/src/x.py" to the "weather" row under "skills/".
+            child = path[len(prefix) :].split("/", 1)[0]
+            # Commits arrive newest first, so the first one seen wins.
+            found.setdefault(child, commit)
+    return found
+
 
 # Pre-receive hook script — gates every push through the sentinel.
 # CARAPACE_SESSION_ID, CARAPACE_DEFAULT_BRANCH, and CARAPACE_API_PORT
@@ -416,3 +452,25 @@ class GitStore:
             return None
         short, _, subject = out.partition("\0")
         return short.strip(), subject.strip()
+
+    async def last_commits(self, relative_dir: str, *, limit: int = 2000) -> dict[str, FileCommit]:
+        """Map each immediate child of *relative_dir* to the newest commit touching it.
+
+        One ``git log`` walk for the whole directory rather than a process per entry.
+        Paths are reported relative to the repo root, so each is folded back to the
+        child of *relative_dir* that contains it — that is what a directory row shows.
+
+        ponytail: only the newest *limit* commits touching the directory are walked, so
+        a file untouched for longer reports nothing and the row falls back to its mtime.
+        The cap bounds the cost on a large history (~0.1s for a 1k-commit walk); stream
+        the walk with an early exit once every entry is covered if that stops being
+        enough.
+        """
+        prefix = f"{relative_dir.strip('/')}/" if relative_dir.strip("/") else ""
+        args = ["log", f"-n{limit}", "-z", f"--format={_LOG_RECORD_SEP}%h%x00%ct%x00%s", "--name-only", "HEAD"]
+        if prefix:
+            args += ["--", prefix.rstrip("/")]
+        code, out = await self._run(*args)
+        if code != 0 or not out:
+            return {}
+        return _parse_last_commits(out, prefix)

--- a/src/carapace/git/store.py
+++ b/src/carapace/git/store.py
@@ -408,3 +408,11 @@ class GitStore:
         """Check if the repo has any commits."""
         code, _ = await self._run("rev-parse", "HEAD")
         return code == 0
+
+    async def head_revision(self) -> tuple[str, str] | None:
+        """Return ``(short_hash, subject)`` of HEAD, or ``None`` if there are no commits."""
+        code, out = await self._run("log", "-1", "--format=%h%x00%s")
+        if code != 0 or not out:
+            return None
+        short, _, subject = out.partition("\0")
+        return short.strip(), subject.strip()

--- a/src/carapace/git/store.py
+++ b/src/carapace/git/store.py
@@ -22,13 +22,14 @@ def _parse_last_commits(out: str, prefix: str) -> dict[str, FileCommit]:
         if not record:
             continue
         fields = record.split("\x00")
-        if len(fields) < 3:
+        if len(fields) < 4:
             continue
-        short, timestamp, subject, *paths = fields
-        if not short or not timestamp.isdigit():
+        full, short, timestamp, subject, *paths = fields
+        if not full or not short or not timestamp.isdigit():
             continue
         commit = FileCommit(
-            hash=short,
+            hash=full,
+            short=short,
             subject=subject,
             committed_at=datetime.fromtimestamp(int(timestamp), tz=UTC),
         )
@@ -467,7 +468,14 @@ class GitStore:
         enough.
         """
         prefix = f"{relative_dir.strip('/')}/" if relative_dir.strip("/") else ""
-        args = ["log", f"-n{limit}", "-z", f"--format={_LOG_RECORD_SEP}%h%x00%ct%x00%s", "--name-only", "HEAD"]
+        args = [
+            "log",
+            f"-n{limit}",
+            "-z",
+            f"--format={_LOG_RECORD_SEP}%H%x00%h%x00%ct%x00%s",
+            "--name-only",
+            "HEAD",
+        ]
         if prefix:
             args += ["--", prefix.rstrip("/")]
         code, out = await self._run(*args)

--- a/src/carapace/models/git.py
+++ b/src/carapace/models/git.py
@@ -30,7 +30,10 @@ class GlobalGitStatus(BaseModel):
 class FileCommit(BaseModel):
     """Newest commit touching a given path."""
 
+    # Full hash for copying; `short` is git's own abbreviation, which is repo-dependent
+    # and so cannot be reproduced by truncating the full one.
     hash: str
+    short: str
     subject: str
     committed_at: datetime
 

--- a/src/carapace/models/git.py
+++ b/src/carapace/models/git.py
@@ -20,6 +20,9 @@ class GlobalGitStatus(BaseModel):
     remote_configured: bool = False
     ahead: int = 0
     behind: int = 0
+    # Short hash and subject of the local HEAD; None while the repo has no commits.
+    head: str | None = None
+    head_subject: str | None = None
 
 
 class GitActionResult(BaseModel):

--- a/src/carapace/models/git.py
+++ b/src/carapace/models/git.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime
+
 from pydantic import BaseModel
 
 
@@ -23,6 +25,14 @@ class GlobalGitStatus(BaseModel):
     # Short hash and subject of the local HEAD; None while the repo has no commits.
     head: str | None = None
     head_subject: str | None = None
+
+
+class FileCommit(BaseModel):
+    """Newest commit touching a given path."""
+
+    hash: str
+    subject: str
+    committed_at: datetime
 
 
 class GitActionResult(BaseModel):

--- a/src/carapace/server/__init__.py
+++ b/src/carapace/server/__init__.py
@@ -60,6 +60,7 @@ from .auth import verify_ws_token
 from .history import router as history_router
 from .jobs import _jobs_scheduler_loop
 from .jobs import router as jobs_router
+from .knowledge import router as knowledge_router
 from .notifications import _set_notification_presence as _set_notification_presence
 from .notifications import router as notifications_router
 from .platform_settings import router as platform_settings_router
@@ -733,6 +734,7 @@ async def evaluate_push(req: PushEvalRequest) -> dict[str, str]:
 router.include_router(sessions_router)
 router.include_router(history_router)
 router.include_router(jobs_router)
+router.include_router(knowledge_router)
 router.include_router(session_sandbox_router)
 router.include_router(notifications_router)
 router.include_router(platform_settings_router)

--- a/src/carapace/server/knowledge.py
+++ b/src/carapace/server/knowledge.py
@@ -27,6 +27,10 @@ router = APIRouter()
 # listing response, and huge blobs would bloat it for no benefit.
 MAX_INLINE_TEXT_BYTES = 1024 * 1024
 
+# Markers for the directory conventions the browser renders specially.
+SKILL_DOC = "SKILL.md"
+README_NAMES = frozenset({"readme.md", "readme"})
+
 
 def read_text_content(target: Path, size: int) -> str | None:
     """Decode *target* as UTF-8 text, or return ``None`` if binary or too large.
@@ -50,8 +54,8 @@ class KnowledgeEntry(BaseModel):
     type: Literal["file", "dir"]
     size: int | None = None
     # Recognized directory conventions get a `kind` plus a human label the client
-    # renders where a file would show its size. Extension point for skill dirs.
-    kind: Literal["session"] | None = None
+    # renders where a file would show its size.
+    kind: Literal["session", "skill"] | None = None
     label: str | None = None
     session_id: str | None = None
 
@@ -132,14 +136,12 @@ def build_entry(child: Path) -> KnowledgeEntry:
     if not child.is_dir():
         return KnowledgeEntry(name=child.name, type="file", size=child.stat().st_size)
     archive = session_archive_entry(child)
-    if archive is None:
-        return KnowledgeEntry(name=child.name, type="dir")
-    title, session_id = archive
-    return KnowledgeEntry(name=child.name, type="dir", kind="session", label=title, session_id=session_id)
-
-
-SKILL_DOC = "SKILL.md"
-README_NAMES = frozenset({"readme.md", "readme"})
+    if archive is not None:
+        title, session_id = archive
+        return KnowledgeEntry(name=child.name, type="dir", kind="session", label=title, session_id=session_id)
+    if (child / SKILL_DOC).is_file():
+        return KnowledgeEntry(name=child.name, type="dir", kind="skill")
+    return KnowledgeEntry(name=child.name, type="dir")
 
 
 def find_readme(target: Path, entries: list[KnowledgeEntry]) -> Path | None:

--- a/src/carapace/server/knowledge.py
+++ b/src/carapace/server/knowledge.py
@@ -19,6 +19,27 @@ server = server_module()
 
 router = APIRouter()
 
+# Files above this size are download-only: the browser inlines contents into the
+# listing response, and huge blobs would bloat it for no benefit.
+MAX_INLINE_TEXT_BYTES = 1024 * 1024
+
+
+def read_text_content(target: Path, size: int) -> str | None:
+    """Decode *target* as UTF-8 text, or return ``None`` if binary or too large.
+
+    Same heuristic git uses: a NUL byte means binary. UTF-8 decoding catches the
+    rest, so extensionless files (``.gitignore``, ``Dockerfile``) read as text.
+    """
+    if size > MAX_INLINE_TEXT_BYTES:
+        return None
+    data = target.read_bytes()
+    if b"\0" in data:
+        return None
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+
 
 class KnowledgeEntry(BaseModel):
     name: str
@@ -38,6 +59,9 @@ class KnowledgeFileInfo(BaseModel):
     name: str
     size: int
     mime: str
+    # Decoded contents for text files within MAX_INLINE_TEXT_BYTES; None for binary
+    # or oversized files, which the client offers as a download instead.
+    content: str | None = None
 
 
 def resolve_target(root: Path, raw_path: str) -> Path:
@@ -90,9 +114,12 @@ async def browse_knowledge(
             filename=target.name,
             content_disposition_type="attachment" if download else "inline",
         )
+    size = target.stat().st_size
+    mime = guess_mime(target.name)
     return KnowledgeFileInfo(
         path=rel,
         name=target.name,
-        size=target.stat().st_size,
-        mime=guess_mime(target.name),
+        size=size,
+        mime=mime,
+        content=None if mime.startswith("image/") else read_text_content(target, size),
     )

--- a/src/carapace/server/knowledge.py
+++ b/src/carapace/server/knowledge.py
@@ -14,6 +14,8 @@ from pydantic import BaseModel, ValidationError
 
 from ..api_keys import Access, Scope
 from ..auth import UserIdentity
+from ..git.store import GitStore
+from ..models.git import FileCommit
 from ..models.skills import SkillCarapaceConfig
 from ..session.sent_files import guess_mime
 from ..skills import SkillDocument, parse_skill_document
@@ -54,9 +56,11 @@ class KnowledgeEntry(BaseModel):
     name: str
     type: Literal["file", "dir"]
     size: int | None = None
-    # Files only: mtime of the working-tree file, which is when it last changed on
-    # disk (a checkout or pull rewrites it), not the authoring commit date.
+    # Files only: mtime of the working-tree file. A checkout or pull rewrites it, so
+    # it is only the fallback for entries `commit` does not cover (uncommitted files).
     modified: datetime | None = None
+    # Newest commit touching this entry; None for uncommitted paths.
+    commit: FileCommit | None = None
     # Recognized directory conventions get a `kind` plus a human label the client
     # renders where a file would show its size.
     kind: Literal["session", "skill"] | None = None
@@ -202,6 +206,15 @@ def list_dir(root: Path, target: Path) -> KnowledgeDirListing:
     return listing
 
 
+async def attach_commits(git_store: GitStore, listing: KnowledgeDirListing) -> None:
+    """Fill in each entry's newest commit. Silent no-op on a repo without commits."""
+    commits = await git_store.last_commits(listing.path)
+    if not commits:
+        return
+    for entry in listing.entries:
+        entry.commit = commits.get(entry.name)
+
+
 def parse_carapace_config(document: SkillDocument, skill_name: str) -> SkillCarapaceConfig | None:
     """Validate ``metadata.carapace``, or return None if absent or malformed."""
     raw = document.metadata.get("carapace")
@@ -223,12 +236,15 @@ async def browse_knowledge(
     raw: Annotated[bool, Query()] = False,
     download: Annotated[bool, Query()] = False,
 ) -> KnowledgeDirListing | KnowledgeFileInfo | FileResponse:
-    root = server._knowledge_repo_registry.get_for_user(user.username).knowledge_dir.resolve()
+    handle = server._knowledge_repo_registry.get_for_user(user.username)
+    root = handle.knowledge_dir.resolve()
     if not root.is_dir():
         return KnowledgeDirListing(path="", entries=[])
     target = resolve_target(root, path)
     if target.is_dir():
-        return list_dir(root, target)
+        listing = list_dir(root, target)
+        await attach_commits(handle.git_store, listing)
+        return listing
     if not target.is_file():
         raise HTTPException(status_code=404, detail="Not found")
     rel = target.relative_to(root).as_posix()

--- a/src/carapace/server/knowledge.py
+++ b/src/carapace/server/knowledge.py
@@ -30,6 +30,10 @@ router = APIRouter()
 # listing response, and huge blobs would bloat it for no benefit.
 MAX_INLINE_TEXT_BYTES = 1024 * 1024
 
+# Types safe to render inline on the app origin. SVG is deliberately absent: it
+# carries script.
+INLINE_MIME_TYPES = frozenset({"image/png", "image/jpeg", "image/gif", "image/webp", "image/avif"})
+
 # Markers for the directory conventions the browser renders specially.
 SKILL_DOC = "SKILL.md"
 README_NAMES = frozenset({"readme.md", "readme"})
@@ -78,9 +82,12 @@ def session_archive_entry(directory: Path, root: Path) -> tuple[str | None, str]
     archive = contained_target(directory / "conversation.json", root)
     if archive is None or not archive.is_file():
         return None
-    # ponytail: parses the whole archive (up to ~1 MB) for one field, since
-    # "session" sorts last in the JSON. Cache by (path, mtime) if listing a month
-    # of sessions ever gets slow.
+    # ponytail: parses the whole archive (up to MAX_INLINE_TEXT_BYTES) for one field,
+    # since "session" sorts last in the JSON. Cache by (path, mtime) if listing a
+    # month of sessions ever gets slow. The cap matters: this runs for every subdir
+    # of a listing, on files a pushing client controls the size of.
+    if archive.stat().st_size > MAX_INLINE_TEXT_BYTES:
+        return None
     try:
         payload = json.loads(archive.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, UnicodeDecodeError) as exc:
@@ -130,29 +137,29 @@ class KnowledgeFileInfo(BaseModel):
 
 
 def contained_target(child: Path, root: Path) -> Path | None:
-    """Resolve *child*, or return None if it is unreadable or escapes *root*.
+    """Resolve *child*, or return None if it is unreadable or out of bounds.
 
     Listing a directory means reading through its entries (a SKILL.md, a README, a
-    session's conversation.json), and a symlink committed into the repo can point at
-    any host path. Every such read resolves through here first, so the containment
-    check that ``resolve_target`` applies to the browsed path also covers the reads
-    the listing does on its own.
+    session's conversation.json), and a symlink committed into the repo can point
+    anywhere. Every such read resolves through here first, so the guards that
+    ``resolve_target`` applies to the browsed path also cover the reads the listing
+    does on its own: outside the repo, and inside ``.git`` (which holds the remote
+    URL with its access token).
     """
     try:
         target = child.resolve(strict=True)
     except (OSError, RuntimeError):
         # Broken symlink, symlink loop, or an unreadable parent: nothing to read.
         return None
-    return target if target.is_relative_to(root) else None
+    if not target.is_relative_to(root):
+        return None
+    return None if ".git" in target.relative_to(root).parts else target
 
 
 def resolve_target(root: Path, raw_path: str) -> Path:
-    """Resolve *raw_path* inside *root*, rejecting traversal and ``.git``."""
-    root = root.resolve()
-    target = (root / raw_path).resolve() if raw_path else root
-    if target != root and not target.is_relative_to(root):
-        raise HTTPException(status_code=404, detail="Not found")
-    if ".git" in target.relative_to(root).parts:
+    """Resolve *raw_path* inside an already-resolved *root*, rejecting traversal and ``.git``."""
+    target = contained_target(root / raw_path, root) if raw_path else root
+    if target is None:
         raise HTTPException(status_code=404, detail="Not found")
     return target
 
@@ -219,7 +226,8 @@ def inline_doc(target: Path, entries: list[KnowledgeEntry], listing: KnowledgeDi
 
 
 def list_dir(root: Path, target: Path) -> KnowledgeDirListing:
-    root = root.resolve()
+    # `.git` is filtered by name here rather than left to contained_target, which would
+    # report it as an unreadable entry instead of hiding it.
     entries = [build_entry(child, root) for child in target.iterdir() if child.name != ".git"]
     entries.sort(key=lambda e: (e.type != "dir", e.name.casefold()))
     rel = target.relative_to(root)
@@ -271,11 +279,16 @@ async def browse_knowledge(
         raise HTTPException(status_code=404, detail="Not found")
     rel = target.relative_to(root).as_posix()
     if raw or download:
+        mime = guess_mime(target.name)
+        # Repo contents come from a sandboxed agent's `git push`, and this is served
+        # from the app origin under a cookie session. Only images render inline (the
+        # browser's <img>); a pushed .html or .svg would otherwise run script here.
+        inline = raw and mime in INLINE_MIME_TYPES
         return FileResponse(
             target,
-            media_type=guess_mime(target.name),
+            media_type=mime if inline else "application/octet-stream",
             filename=target.name,
-            content_disposition_type="attachment" if download else "inline",
+            content_disposition_type="inline" if inline else "attachment",
         )
     size = target.stat().st_size
     mime = guess_mime(target.name)
@@ -284,5 +297,7 @@ async def browse_knowledge(
         name=target.name,
         size=size,
         mime=mime,
-        content=None if mime.startswith("image/") else read_text_content(target, size),
+        # Only the types the client renders as an <img> skip their contents; anything
+        # else it cannot display (an SVG, say) is still worth showing as source.
+        content=None if mime in INLINE_MIME_TYPES else read_text_content(target, size),
     )

--- a/src/carapace/server/knowledge.py
+++ b/src/carapace/server/knowledge.py
@@ -139,6 +139,46 @@ def build_entry(child: Path) -> KnowledgeEntry:
 
 
 SKILL_DOC = "SKILL.md"
+README_NAMES = frozenset({"readme.md", "readme"})
+
+
+def find_readme(target: Path, entries: list[KnowledgeEntry]) -> Path | None:
+    """Pick the directory's README, matched case-insensitively against the listing."""
+    for entry in entries:
+        if entry.type == "file" and entry.name.lower() in README_NAMES:
+            return target / entry.name
+    return None
+
+
+def inline_doc(target: Path, entries: list[KnowledgeEntry], listing: KnowledgeDirListing) -> None:
+    """Attach the directory's defining document, so the browser needs no second request.
+
+    A SKILL.md marks a skill dir (the marker SkillRegistry scans for) and gets its
+    frontmatter split out; any other directory falls back to its README.
+    """
+    skill_doc = target / SKILL_DOC
+    if skill_doc.is_file():
+        raw = read_text_content(skill_doc, skill_doc.stat().st_size)
+        if raw is None:
+            return
+        document = parse_skill_document(raw, fallback_name=target.name)
+        listing.kind = "skill"
+        listing.doc_name = SKILL_DOC
+        listing.doc = document.body
+        listing.skill = KnowledgeSkill(
+            name=document.name,
+            description=document.description,
+            carapace=parse_carapace_config(document, target.name),
+        )
+        return
+
+    readme = find_readme(target, entries)
+    if readme is None:
+        return
+    raw = read_text_content(readme, readme.stat().st_size)
+    if raw is not None:
+        listing.doc_name = readme.name
+        listing.doc = raw
 
 
 def list_dir(root: Path, target: Path) -> KnowledgeDirListing:
@@ -146,22 +186,7 @@ def list_dir(root: Path, target: Path) -> KnowledgeDirListing:
     entries.sort(key=lambda e: (e.type != "dir", e.name.casefold()))
     rel = target.relative_to(root.resolve())
     listing = KnowledgeDirListing(path="" if rel == Path() else rel.as_posix(), entries=entries)
-
-    # A SKILL.md marks a skill dir (same marker SkillRegistry scans for); inline it so
-    # the browser can render it under the listing without a second request.
-    skill_doc = target / SKILL_DOC
-    if skill_doc.is_file():
-        raw = read_text_content(skill_doc, skill_doc.stat().st_size)
-        if raw is not None:
-            document = parse_skill_document(raw, fallback_name=target.name)
-            listing.kind = "skill"
-            listing.doc_name = SKILL_DOC
-            listing.doc = document.body
-            listing.skill = KnowledgeSkill(
-                name=document.name,
-                description=document.description,
-                carapace=parse_carapace_config(document, target.name),
-            )
+    inline_doc(target, entries, listing)
     return listing
 
 

--- a/src/carapace/server/knowledge.py
+++ b/src/carapace/server/knowledge.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated, Literal
 
@@ -53,6 +54,9 @@ class KnowledgeEntry(BaseModel):
     name: str
     type: Literal["file", "dir"]
     size: int | None = None
+    # Files only: mtime of the working-tree file, which is when it last changed on
+    # disk (a checkout or pull rewrites it), not the authoring commit date.
+    modified: datetime | None = None
     # Recognized directory conventions get a `kind` plus a human label the client
     # renders where a file would show its size.
     kind: Literal["session", "skill"] | None = None
@@ -134,7 +138,13 @@ def resolve_target(root: Path, raw_path: str) -> Path:
 
 def build_entry(child: Path) -> KnowledgeEntry:
     if not child.is_dir():
-        return KnowledgeEntry(name=child.name, type="file", size=child.stat().st_size)
+        stat = child.stat()
+        return KnowledgeEntry(
+            name=child.name,
+            type="file",
+            size=stat.st_size,
+            modified=datetime.fromtimestamp(stat.st_mtime, tz=UTC),
+        )
     archive = session_archive_entry(child)
     if archive is not None:
         title, session_id = archive

--- a/src/carapace/server/knowledge.py
+++ b/src/carapace/server/knowledge.py
@@ -1,0 +1,98 @@
+"""Read-only browsing of the per-user knowledge repo working tree."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+
+from ..api_keys import Access, Scope
+from ..auth import UserIdentity
+from ..session.sent_files import guess_mime
+from .auth import require
+from .state import server_module
+
+server = server_module()
+
+router = APIRouter()
+
+
+class KnowledgeEntry(BaseModel):
+    name: str
+    type: Literal["file", "dir"]
+    size: int | None = None
+
+
+class KnowledgeDirListing(BaseModel):
+    type: Literal["dir"] = "dir"
+    path: str
+    entries: list[KnowledgeEntry]
+
+
+class KnowledgeFileInfo(BaseModel):
+    type: Literal["file"] = "file"
+    path: str
+    name: str
+    size: int
+    mime: str
+
+
+def resolve_target(root: Path, raw_path: str) -> Path:
+    """Resolve *raw_path* inside *root*, rejecting traversal and ``.git``."""
+    root = root.resolve()
+    target = (root / raw_path).resolve() if raw_path else root
+    if target != root and not target.is_relative_to(root):
+        raise HTTPException(status_code=404, detail="Not found")
+    if ".git" in target.relative_to(root).parts:
+        raise HTTPException(status_code=404, detail="Not found")
+    return target
+
+
+def list_dir(root: Path, target: Path) -> KnowledgeDirListing:
+    entries = [
+        KnowledgeEntry(
+            name=child.name,
+            type="dir" if child.is_dir() else "file",
+            size=None if child.is_dir() else child.stat().st_size,
+        )
+        for child in target.iterdir()
+        if child.name != ".git"
+    ]
+    entries.sort(key=lambda e: (e.type != "dir", e.name.casefold()))
+    rel = target.relative_to(root.resolve())
+    return KnowledgeDirListing(path="" if rel == Path() else rel.as_posix(), entries=entries)
+
+
+@router.get("/knowledge/browse", response_model=None)
+@router.get("/knowledge/browse/{path:path}", response_model=None)
+async def browse_knowledge(
+    user: Annotated[UserIdentity, Depends(require(Scope.knowledge, Access.read))],
+    path: str = "",
+    raw: Annotated[bool, Query()] = False,
+    download: Annotated[bool, Query()] = False,
+) -> KnowledgeDirListing | KnowledgeFileInfo | FileResponse:
+    root = server._knowledge_repo_registry.get_for_user(user.username).knowledge_dir.resolve()
+    if not root.is_dir():
+        return KnowledgeDirListing(path="", entries=[])
+    target = resolve_target(root, path)
+    if target.is_dir():
+        return list_dir(root, target)
+    if not target.is_file():
+        raise HTTPException(status_code=404, detail="Not found")
+    rel = target.relative_to(root).as_posix()
+    if raw or download:
+        return FileResponse(
+            target,
+            media_type=guess_mime(target.name),
+            filename=target.name,
+            content_disposition_type="attachment" if download else "inline",
+        )
+    return KnowledgeFileInfo(
+        path=rel,
+        name=target.name,
+        size=target.stat().st_size,
+        mime=guess_mime(target.name),
+    )

--- a/src/carapace/server/knowledge.py
+++ b/src/carapace/server/knowledge.py
@@ -87,6 +87,11 @@ class KnowledgeDirListing(BaseModel):
     type: Literal["dir"] = "dir"
     path: str
     entries: list[KnowledgeEntry]
+    # Recognized directory conventions get their defining document inlined, rendered
+    # below the listing (a skill dir's SKILL.md).
+    kind: Literal["skill"] | None = None
+    doc_name: str | None = None
+    doc: str | None = None
 
 
 class KnowledgeFileInfo(BaseModel):
@@ -121,11 +126,25 @@ def build_entry(child: Path) -> KnowledgeEntry:
     return KnowledgeEntry(name=child.name, type="dir", kind="session", label=title, session_id=session_id)
 
 
+SKILL_DOC = "SKILL.md"
+
+
 def list_dir(root: Path, target: Path) -> KnowledgeDirListing:
     entries = [build_entry(child) for child in target.iterdir() if child.name != ".git"]
     entries.sort(key=lambda e: (e.type != "dir", e.name.casefold()))
     rel = target.relative_to(root.resolve())
-    return KnowledgeDirListing(path="" if rel == Path() else rel.as_posix(), entries=entries)
+    listing = KnowledgeDirListing(path="" if rel == Path() else rel.as_posix(), entries=entries)
+
+    # A SKILL.md marks a skill dir (same marker SkillRegistry scans for); inline it so
+    # the browser can render it under the listing without a second request.
+    skill_doc = target / SKILL_DOC
+    if skill_doc.is_file():
+        doc = read_text_content(skill_doc, skill_doc.stat().st_size)
+        if doc is not None:
+            listing.kind = "skill"
+            listing.doc_name = SKILL_DOC
+            listing.doc = doc
+    return listing
 
 
 @router.get("/knowledge/browse", response_model=None)

--- a/src/carapace/server/knowledge.py
+++ b/src/carapace/server/knowledge.py
@@ -9,11 +9,13 @@ from typing import Annotated, Literal
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import FileResponse
 from loguru import logger
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from ..api_keys import Access, Scope
 from ..auth import UserIdentity
+from ..models.skills import SkillCarapaceConfig
 from ..session.sent_files import guess_mime
+from ..skills import SkillDocument, parse_skill_document
 from .auth import require
 from .state import server_module
 
@@ -83,15 +85,25 @@ def session_archive_entry(directory: Path) -> tuple[str | None, str] | None:
     )
 
 
+class KnowledgeSkill(BaseModel):
+    """Frontmatter of a skill dir's SKILL.md, rendered as a card above its prose."""
+
+    name: str
+    description: str = ""
+    # None when metadata.carapace is absent or fails validation; the prose still renders.
+    carapace: SkillCarapaceConfig | None = None
+
+
 class KnowledgeDirListing(BaseModel):
     type: Literal["dir"] = "dir"
     path: str
     entries: list[KnowledgeEntry]
     # Recognized directory conventions get their defining document inlined, rendered
-    # below the listing (a skill dir's SKILL.md).
+    # below the listing (a skill dir's SKILL.md, frontmatter stripped into `skill`).
     kind: Literal["skill"] | None = None
     doc_name: str | None = None
     doc: str | None = None
+    skill: KnowledgeSkill | None = None
 
 
 class KnowledgeFileInfo(BaseModel):
@@ -139,12 +151,31 @@ def list_dir(root: Path, target: Path) -> KnowledgeDirListing:
     # the browser can render it under the listing without a second request.
     skill_doc = target / SKILL_DOC
     if skill_doc.is_file():
-        doc = read_text_content(skill_doc, skill_doc.stat().st_size)
-        if doc is not None:
+        raw = read_text_content(skill_doc, skill_doc.stat().st_size)
+        if raw is not None:
+            document = parse_skill_document(raw, fallback_name=target.name)
             listing.kind = "skill"
             listing.doc_name = SKILL_DOC
-            listing.doc = doc
+            listing.doc = document.body
+            listing.skill = KnowledgeSkill(
+                name=document.name,
+                description=document.description,
+                carapace=parse_carapace_config(document, target.name),
+            )
     return listing
+
+
+def parse_carapace_config(document: SkillDocument, skill_name: str) -> SkillCarapaceConfig | None:
+    """Validate ``metadata.carapace``, or return None if absent or malformed."""
+    raw = document.metadata.get("carapace")
+    if raw is None:
+        return None
+    try:
+        return SkillCarapaceConfig.model_validate(raw)
+    except ValidationError as exc:
+        # Skills are user-authored; a bad declaration must not break browsing.
+        logger.warning(f"Invalid metadata.carapace in SKILL.md for skill '{skill_name}': {exc}")
+        return None
 
 
 @router.get("/knowledge/browse", response_model=None)

--- a/src/carapace/server/knowledge.py
+++ b/src/carapace/server/knowledge.py
@@ -68,15 +68,15 @@ class KnowledgeEntry(BaseModel):
     session_id: str | None = None
 
 
-def session_archive_entry(directory: Path) -> tuple[str | None, str] | None:
+def session_archive_entry(directory: Path, root: Path) -> tuple[str | None, str] | None:
     """Return ``(title, session_id)`` if *directory* is a session archive, else ``None``.
 
     Detection is by the ``conversation.json`` marker rather than the path layout,
     so it survives a reconfigured ``path_prefix``. Title may be None for untitled
     (or private, never-titled) sessions; the session id is always the dir name.
     """
-    archive = directory / "conversation.json"
-    if not archive.is_file():
+    archive = contained_target(directory / "conversation.json", root)
+    if archive is None or not archive.is_file():
         return None
     # ponytail: parses the whole archive (up to ~1 MB) for one field, since
     # "session" sorts last in the JSON. Cache by (path, mtime) if listing a month
@@ -129,6 +129,23 @@ class KnowledgeFileInfo(BaseModel):
     content: str | None = None
 
 
+def contained_target(child: Path, root: Path) -> Path | None:
+    """Resolve *child*, or return None if it is unreadable or escapes *root*.
+
+    Listing a directory means reading through its entries (a SKILL.md, a README, a
+    session's conversation.json), and a symlink committed into the repo can point at
+    any host path. Every such read resolves through here first, so the containment
+    check that ``resolve_target`` applies to the browsed path also covers the reads
+    the listing does on its own.
+    """
+    try:
+        target = child.resolve(strict=True)
+    except (OSError, RuntimeError):
+        # Broken symlink, symlink loop, or an unreadable parent: nothing to read.
+        return None
+    return target if target.is_relative_to(root) else None
+
+
 def resolve_target(root: Path, raw_path: str) -> Path:
     """Resolve *raw_path* inside *root*, rejecting traversal and ``.git``."""
     root = root.resolve()
@@ -140,40 +157,44 @@ def resolve_target(root: Path, raw_path: str) -> Path:
     return target
 
 
-def build_entry(child: Path) -> KnowledgeEntry:
-    if not child.is_dir():
-        stat = child.stat()
+def build_entry(child: Path, root: Path) -> KnowledgeEntry:
+    resolved = contained_target(child, root)
+    if resolved is None:
+        # Dangling or escaping symlink: name it, but never read through it.
+        return KnowledgeEntry(name=child.name, type="file")
+    if not resolved.is_dir():
+        stat = resolved.stat()
         return KnowledgeEntry(
             name=child.name,
             type="file",
             size=stat.st_size,
             modified=datetime.fromtimestamp(stat.st_mtime, tz=UTC),
         )
-    archive = session_archive_entry(child)
+    archive = session_archive_entry(resolved, root)
     if archive is not None:
         title, session_id = archive
         return KnowledgeEntry(name=child.name, type="dir", kind="session", label=title, session_id=session_id)
-    if (child / SKILL_DOC).is_file():
+    if contained_target(resolved / SKILL_DOC, root) is not None:
         return KnowledgeEntry(name=child.name, type="dir", kind="skill")
     return KnowledgeEntry(name=child.name, type="dir")
 
 
-def find_readme(target: Path, entries: list[KnowledgeEntry]) -> Path | None:
+def find_readme(target: Path, entries: list[KnowledgeEntry], root: Path) -> Path | None:
     """Pick the directory's README, matched case-insensitively against the listing."""
     for entry in entries:
         if entry.type == "file" and entry.name.lower() in README_NAMES:
-            return target / entry.name
+            return contained_target(target / entry.name, root)
     return None
 
 
-def inline_doc(target: Path, entries: list[KnowledgeEntry], listing: KnowledgeDirListing) -> None:
+def inline_doc(target: Path, entries: list[KnowledgeEntry], listing: KnowledgeDirListing, root: Path) -> None:
     """Attach the directory's defining document, so the browser needs no second request.
 
     A SKILL.md marks a skill dir (the marker SkillRegistry scans for) and gets its
     frontmatter split out; any other directory falls back to its README.
     """
-    skill_doc = target / SKILL_DOC
-    if skill_doc.is_file():
+    skill_doc = contained_target(target / SKILL_DOC, root)
+    if skill_doc is not None and skill_doc.is_file():
         raw = read_text_content(skill_doc, skill_doc.stat().st_size)
         if raw is None:
             return
@@ -188,8 +209,8 @@ def inline_doc(target: Path, entries: list[KnowledgeEntry], listing: KnowledgeDi
         )
         return
 
-    readme = find_readme(target, entries)
-    if readme is None:
+    readme = find_readme(target, entries, root)
+    if readme is None or not readme.is_file():
         return
     raw = read_text_content(readme, readme.stat().st_size)
     if raw is not None:
@@ -198,11 +219,12 @@ def inline_doc(target: Path, entries: list[KnowledgeEntry], listing: KnowledgeDi
 
 
 def list_dir(root: Path, target: Path) -> KnowledgeDirListing:
-    entries = [build_entry(child) for child in target.iterdir() if child.name != ".git"]
+    root = root.resolve()
+    entries = [build_entry(child, root) for child in target.iterdir() if child.name != ".git"]
     entries.sort(key=lambda e: (e.type != "dir", e.name.casefold()))
-    rel = target.relative_to(root.resolve())
+    rel = target.relative_to(root)
     listing = KnowledgeDirListing(path="" if rel == Path() else rel.as_posix(), entries=entries)
-    inline_doc(target, entries, listing)
+    inline_doc(target, entries, listing, root)
     return listing
 
 

--- a/src/carapace/server/knowledge.py
+++ b/src/carapace/server/knowledge.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import FileResponse
+from loguru import logger
 from pydantic import BaseModel
 
 from ..api_keys import Access, Scope
@@ -45,6 +47,40 @@ class KnowledgeEntry(BaseModel):
     name: str
     type: Literal["file", "dir"]
     size: int | None = None
+    # Recognized directory conventions get a `kind` plus a human label the client
+    # renders where a file would show its size. Extension point for skill dirs.
+    kind: Literal["session"] | None = None
+    label: str | None = None
+    session_id: str | None = None
+
+
+def session_archive_entry(directory: Path) -> tuple[str | None, str] | None:
+    """Return ``(title, session_id)`` if *directory* is a session archive, else ``None``.
+
+    Detection is by the ``conversation.json`` marker rather than the path layout,
+    so it survives a reconfigured ``path_prefix``. Title may be None for untitled
+    (or private, never-titled) sessions; the session id is always the dir name.
+    """
+    archive = directory / "conversation.json"
+    if not archive.is_file():
+        return None
+    # ponytail: parses the whole archive (up to ~1 MB) for one field, since
+    # "session" sorts last in the JSON. Cache by (path, mtime) if listing a month
+    # of sessions ever gets slow.
+    try:
+        payload = json.loads(archive.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        # The repo is user-writable; a hand-mangled archive must not break browsing.
+        logger.debug(f"Ignoring unreadable session archive {archive}: {exc}")
+        return None
+    session = payload.get("session") if isinstance(payload, dict) else None
+    if not isinstance(session, dict):
+        return None
+    title = session.get("title")
+    session_id = session.get("session_id")
+    return (title if isinstance(title, str) and title.strip() else None), (
+        session_id if isinstance(session_id, str) and session_id else directory.name
+    )
 
 
 class KnowledgeDirListing(BaseModel):
@@ -75,16 +111,18 @@ def resolve_target(root: Path, raw_path: str) -> Path:
     return target
 
 
+def build_entry(child: Path) -> KnowledgeEntry:
+    if not child.is_dir():
+        return KnowledgeEntry(name=child.name, type="file", size=child.stat().st_size)
+    archive = session_archive_entry(child)
+    if archive is None:
+        return KnowledgeEntry(name=child.name, type="dir")
+    title, session_id = archive
+    return KnowledgeEntry(name=child.name, type="dir", kind="session", label=title, session_id=session_id)
+
+
 def list_dir(root: Path, target: Path) -> KnowledgeDirListing:
-    entries = [
-        KnowledgeEntry(
-            name=child.name,
-            type="dir" if child.is_dir() else "file",
-            size=None if child.is_dir() else child.stat().st_size,
-        )
-        for child in target.iterdir()
-        if child.name != ".git"
-    ]
+    entries = [build_entry(child) for child in target.iterdir() if child.name != ".git"]
     entries.sort(key=lambda e: (e.type != "dir", e.name.casefold()))
     rel = target.relative_to(root.resolve())
     return KnowledgeDirListing(path="" if rel == Path() else rel.as_posix(), entries=entries)

--- a/src/carapace/server/runtime.py
+++ b/src/carapace/server/runtime.py
@@ -9,6 +9,7 @@ from loguru import logger
 
 from ..auth import normalize_username
 from ..knowledge import KnowledgeRepoHandle, KnowledgeRepoRegistry
+from ..models.git import GlobalGitStatus
 from ..models.user import DEFAULT_GIT_AUTHOR, DEFAULT_GIT_BRANCH, UserConfig, UserGitConfig
 from ..sandbox.manager import SandboxManager
 
@@ -189,16 +190,24 @@ class KnowledgeGitRuntime:
             handle.git_store.remote_branch = config.branch
             handle.git_store.author_template = config.author
 
-    async def status_for_user(self, owner: str) -> tuple[bool, int, int]:
-        """Return ``(remote_configured, ahead, behind)`` for the backend ↔ remote boundary."""
+    async def status_for_user(self, owner: str) -> GlobalGitStatus:
+        """Return the backend ↔ remote status; ``head`` is filled even without a remote."""
         normalized_owner = normalize_username(owner)
         async with self._lock:
             handle = self._repo_registry.ensure_user_repo(normalized_owner)
             self._apply_config_to_store(normalized_owner, handle)
+            revision = await handle.git_store.head_revision()
+            head, head_subject = revision if revision is not None else (None, None)
             if not handle.git_store.remote_configured:
-                return False, 0, 0
+                return GlobalGitStatus(head=head, head_subject=head_subject)
             ahead, behind = await handle.git_store.remote_status()
-            return True, ahead, behind
+            return GlobalGitStatus(
+                remote_configured=True,
+                ahead=ahead,
+                behind=behind,
+                head=head,
+                head_subject=head_subject,
+            )
 
     async def pull_for_user(self, owner: str) -> tuple[bool, str]:
         """Pull the backend repo from the external remote and invalidate skills.

--- a/src/carapace/server/sessions.py
+++ b/src/carapace/server/sessions.py
@@ -605,11 +605,10 @@ async def get_global_git(
     user: Annotated[UserIdentity, Depends(require(Scope.sessions, Access.read))],
 ) -> GlobalGitStatus:
     try:
-        configured, ahead, behind = await server._knowledge_git_runtime.status_for_user(user.username)
+        return await server._knowledge_git_runtime.status_for_user(user.username)
     except Exception as exc:
         logger.warning(f"Global git status failed for {user.username}: {exc}")
         raise HTTPException(status_code=502, detail="Could not read global git status") from exc
-    return GlobalGitStatus(remote_configured=configured, ahead=ahead, behind=behind)
 
 
 @router.post("/git/pull", response_model=GitActionResult)

--- a/src/carapace/skills.py
+++ b/src/carapace/skills.py
@@ -11,10 +11,46 @@ from .models.skills import SkillCarapaceConfig, SkillInfo
 
 
 @dataclass(frozen=True)
-class _SkillFrontmatter:
+class SkillDocument:
+    """A parsed SKILL.md: frontmatter fields plus the markdown body below it."""
+
     name: str
     description: str
     metadata: dict[str, Any]
+    body: str
+
+
+def parse_skill_document(text: str, *, fallback_name: str) -> SkillDocument:
+    """Split *text* into frontmatter and body, tolerating missing or invalid YAML."""
+    fallback = SkillDocument(name=fallback_name, description="", metadata={}, body=text)
+    if not text.startswith("---"):
+        return fallback
+
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return fallback
+
+    try:
+        raw = yaml.safe_load(parts[1])
+    except yaml.YAMLError:
+        return fallback
+
+    if not isinstance(raw, dict):
+        return fallback
+
+    metadata = raw.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+
+    name = raw.get("name")
+    if not isinstance(name, str) or not name:
+        name = fallback_name
+
+    description = raw.get("description")
+    if not isinstance(description, str):
+        description = ""
+
+    return SkillDocument(name=name, description=description, metadata=metadata, body=parts[2].lstrip("\n"))
 
 
 class SkillRegistry:
@@ -80,34 +116,5 @@ class SkillRegistry:
             path=skill_dir,
         )
 
-    def _load_frontmatter(self, skill_md: Path, skill_dir: Path) -> _SkillFrontmatter:
-        text = skill_md.read_text()
-        fallback = _SkillFrontmatter(name=skill_dir.name, description="", metadata={})
-        if not text.startswith("---"):
-            return fallback
-
-        parts = text.split("---", 2)
-        if len(parts) < 3:
-            return fallback
-
-        try:
-            raw = yaml.safe_load(parts[1])
-        except yaml.YAMLError:
-            return fallback
-
-        if not isinstance(raw, dict):
-            return fallback
-
-        metadata = raw.get("metadata")
-        if not isinstance(metadata, dict):
-            metadata = {}
-
-        name = raw.get("name")
-        if not isinstance(name, str) or not name:
-            name = skill_dir.name
-
-        description = raw.get("description")
-        if not isinstance(description, str):
-            description = ""
-
-        return _SkillFrontmatter(name=name, description=description, metadata=metadata)
+    def _load_frontmatter(self, skill_md: Path, skill_dir: Path) -> SkillDocument:
+        return parse_skill_document(skill_md.read_text(), fallback_name=skill_dir.name)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -592,6 +592,15 @@ class TestParseLastCommits:
         out = self._record("aaa1111", 1_780_000_000, "root", ["SOUL.md", "skills/weather/SKILL.md"])
         assert sorted(_parse_last_commits(out, "")) == ["SOUL.md", "skills"]
 
+    def test_a_record_separator_in_the_subject_does_not_split_the_record(self):
+        """Git accepts \\x01 in a subject. Splitting on it blindly drops every path in
+        that commit, so those entries silently fall back to an older one."""
+        out = self._record("aaa1111", 1_780_000_000, "pwn\x01deadbeef", ["skills/weather/SKILL.md"])
+
+        found = _parse_last_commits(out, "skills/")
+
+        assert found["weather"].subject == "pwn\x01deadbeef"
+
     def test_paths_outside_the_prefix_are_ignored(self):
         out = self._record("aaa1111", 1_780_000_000, "other", ["sessions/2026/06/x/conversation.json"])
         assert _parse_last_commits(out, "skills/") == {}

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -570,7 +570,8 @@ class TestParseLastCommits:
     """Folding a ``git log -z --name-only`` walk into one commit per child."""
 
     def _record(self, short: str, ts: int, subject: str, paths: list[str]) -> str:
-        return "\x01" + "\x00".join([short, str(ts), subject, *paths])
+        full = short * 5 + short[:5]  # 45 chars, stands in for a 40-char hash
+        return "\x01" + "\x00".join([full[:40], short, str(ts), subject, *paths])
 
     def test_newest_commit_per_child_wins(self):
         out = self._record("aaa1111", 1_780_000_100, "newer", ["skills/weather/SKILL.md"]) + self._record(
@@ -579,9 +580,9 @@ class TestParseLastCommits:
 
         found = _parse_last_commits(out, "skills/")
 
-        assert found["weather"].hash == "aaa1111"
+        assert found["weather"].short == "aaa1111"
         assert found["weather"].subject == "newer"
-        assert found["web"].hash == "bbb2222"
+        assert found["web"].short == "bbb2222"
 
     def test_nested_paths_fold_to_the_child_directory(self):
         out = self._record("aaa1111", 1_780_000_000, "deep", ["skills/weather/src/fetch/api.py"])
@@ -599,7 +600,7 @@ class TestParseLastCommits:
         out = self._record("aaa1111", 1_780_000_100, "merge", []) + self._record(
             "bbb2222", 1_780_000_000, "real", ["skills/weather/SKILL.md"]
         )
-        assert _parse_last_commits(out, "skills/")["weather"].hash == "bbb2222"
+        assert _parse_last_commits(out, "skills/")["weather"].short == "bbb2222"
 
     def test_committed_at_is_utc(self):
         out = self._record("aaa1111", 1_780_000_000, "s", ["skills/weather/SKILL.md"])
@@ -633,3 +634,12 @@ class TestGitStoreLastCommits:
         store = GitStore(tmp_path / "repo", remote_branch="main")
         await store.ensure_repo()
         assert await store.last_commits("") == {}
+
+
+def test_parse_last_commits_keeps_full_and_short_hash():
+    full = "a" * 40
+    out = "\x01" + "\x00".join([full, "aaa1111", "1780000000", "s", "skills/web/SKILL.md"])
+
+    commit = _parse_last_commits(out, "skills/")["web"]
+
+    assert (commit.hash, commit.short) == (full, "aaa1111")

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -116,6 +116,39 @@ class TestGitStoreEnsureRepo:
 
 
 @needs_git
+class TestGitStoreHeadRevision:
+    @pytest.fixture
+    async def store(self, tmp_path: Path) -> GitStore:
+        s = GitStore(tmp_path / "knowledge", remote_branch="main")
+        await s.ensure_repo()
+        return s
+
+    async def test_none_without_commits(self, store: GitStore):
+        assert await store.head_revision() is None
+
+    async def test_returns_short_hash_and_subject(self, store: GitStore):
+        (store.repo_dir / "test.md").write_text("hello")
+        await store.commit(["test.md"], "add test file")
+
+        revision = await store.head_revision()
+
+        assert revision is not None
+        short, subject = revision
+        assert subject == "add test file"
+        _, full = await store._run("rev-parse", "HEAD")
+        assert full.startswith(short)
+
+    async def test_subject_with_null_safe_characters(self, store: GitStore):
+        (store.repo_dir / "test.md").write_text("hello")
+        await store.commit(["test.md"], "\U0001f4be session: add 2026-06-01-21-07-0062199d")
+
+        revision = await store.head_revision()
+
+        assert revision is not None
+        assert revision[1] == "\U0001f4be session: add 2026-06-01-21-07-0062199d"
+
+
+@needs_git
 class TestGitStoreCommit:
     @pytest.fixture
     async def store(self, tmp_path: Path) -> GitStore:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -6,13 +6,14 @@ import base64
 import os
 import stat
 import subprocess
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
 
 from carapace.git.http import GitHttpHandler
-from carapace.git.store import _PRE_RECEIVE_HOOK, GitStore
+from carapace.git.store import _PRE_RECEIVE_HOOK, GitStore, _parse_last_commits
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
@@ -563,3 +564,72 @@ class TestGitHttpHandlerHandle:
         )
 
         assert status == 403
+
+
+class TestParseLastCommits:
+    """Folding a ``git log -z --name-only`` walk into one commit per child."""
+
+    def _record(self, short: str, ts: int, subject: str, paths: list[str]) -> str:
+        return "\x01" + "\x00".join([short, str(ts), subject, *paths])
+
+    def test_newest_commit_per_child_wins(self):
+        out = self._record("aaa1111", 1_780_000_100, "newer", ["skills/weather/SKILL.md"]) + self._record(
+            "bbb2222", 1_780_000_000, "older", ["skills/weather/SKILL.md", "skills/web/SKILL.md"]
+        )
+
+        found = _parse_last_commits(out, "skills/")
+
+        assert found["weather"].hash == "aaa1111"
+        assert found["weather"].subject == "newer"
+        assert found["web"].hash == "bbb2222"
+
+    def test_nested_paths_fold_to_the_child_directory(self):
+        out = self._record("aaa1111", 1_780_000_000, "deep", ["skills/weather/src/fetch/api.py"])
+        assert list(_parse_last_commits(out, "skills/")) == ["weather"]
+
+    def test_root_listing_uses_empty_prefix(self):
+        out = self._record("aaa1111", 1_780_000_000, "root", ["SOUL.md", "skills/weather/SKILL.md"])
+        assert sorted(_parse_last_commits(out, "")) == ["SOUL.md", "skills"]
+
+    def test_paths_outside_the_prefix_are_ignored(self):
+        out = self._record("aaa1111", 1_780_000_000, "other", ["sessions/2026/06/x/conversation.json"])
+        assert _parse_last_commits(out, "skills/") == {}
+
+    def test_merge_commits_without_paths_are_skipped(self):
+        out = self._record("aaa1111", 1_780_000_100, "merge", []) + self._record(
+            "bbb2222", 1_780_000_000, "real", ["skills/weather/SKILL.md"]
+        )
+        assert _parse_last_commits(out, "skills/")["weather"].hash == "bbb2222"
+
+    def test_committed_at_is_utc(self):
+        out = self._record("aaa1111", 1_780_000_000, "s", ["skills/weather/SKILL.md"])
+        assert _parse_last_commits(out, "skills/")["weather"].committed_at == datetime.fromtimestamp(
+            1_780_000_000, tz=UTC
+        )
+
+    def test_malformed_records_are_skipped(self):
+        out = "\x01truncated" + self._record("aaa1111", 1_780_000_000, "ok", ["skills/web/SKILL.md"])
+        assert list(_parse_last_commits(out, "skills/")) == ["web"]
+
+
+@needs_git
+class TestGitStoreLastCommits:
+    async def test_reports_newest_commit_per_entry(self, tmp_path: Path):
+        store = GitStore(tmp_path / "repo", remote_branch="main")
+        await store.ensure_repo()
+        (store.repo_dir / "notes").mkdir()
+        (store.repo_dir / "notes" / "a.md").write_text("a")
+        await store.commit(["notes/a.md"], "add a")
+        (store.repo_dir / "notes" / "b.md").write_text("b")
+        await store.commit(["notes/b.md"], "add b")
+
+        found = await store.last_commits("notes")
+
+        assert found["a.md"].subject == "add a"
+        assert found["b.md"].subject == "add b"
+        assert await store.last_commits("") == {"notes": found["b.md"]}
+
+    async def test_empty_repo_returns_nothing(self, tmp_path: Path):
+        store = GitStore(tmp_path / "repo", remote_branch="main")
+        await store.ensure_repo()
+        assert await store.last_commits("") == {}

--- a/tests/test_knowledge_browse.py
+++ b/tests/test_knowledge_browse.py
@@ -1,0 +1,66 @@
+"""Tests for the knowledge repo browse endpoint helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from carapace.server.knowledge import list_dir, resolve_target
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    root = tmp_path / "knowledge"
+    (root / ".git").mkdir(parents=True)
+    (root / ".git" / "config").write_text("secret")
+    (root / "skills" / "weather").mkdir(parents=True)
+    (root / "skills" / "weather" / "SKILL.md").write_text("---\nname: weather\n---\n")
+    (root / "SOUL.md").write_text("# soul")
+    return root
+
+
+def test_resolve_target_root(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    assert resolve_target(root, "") == root.resolve()
+    assert resolve_target(root, "skills/weather") == (root / "skills" / "weather").resolve()
+
+
+def test_resolve_target_rejects_traversal(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    (tmp_path / "outside.txt").write_text("nope")
+    for bad in ("../outside.txt", "..", "skills/../../outside.txt", "/etc/passwd"):
+        with pytest.raises(HTTPException) as exc:
+            resolve_target(root, bad)
+        assert exc.value.status_code == 404
+
+
+def test_resolve_target_rejects_git_dir(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    for bad in (".git", ".git/config"):
+        with pytest.raises(HTTPException) as exc:
+            resolve_target(root, bad)
+        assert exc.value.status_code == 404
+
+
+def test_resolve_target_rejects_symlink_escape(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    (tmp_path / "outside.txt").write_text("nope")
+    (root / "link.txt").symlink_to(tmp_path / "outside.txt")
+    with pytest.raises(HTTPException):
+        resolve_target(root, "link.txt")
+
+
+def test_list_dir_hides_git_and_sorts_dirs_first(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    listing = list_dir(root, root.resolve())
+    assert listing.path == ""
+    assert [(e.name, e.type) for e in listing.entries] == [("skills", "dir"), ("SOUL.md", "file")]
+    assert listing.entries[1].size == len("# soul")
+
+
+def test_list_dir_subdir_path(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    listing = list_dir(root, (root / "skills" / "weather").resolve())
+    assert listing.path == "skills/weather"
+    assert [e.name for e in listing.entries] == ["SKILL.md"]

--- a/tests/test_knowledge_browse.py
+++ b/tests/test_knowledge_browse.py
@@ -383,3 +383,28 @@ def test_build_entry_reports_symlink_inside_the_repo(tmp_path: Path) -> None:
     entry = build_entry(root / "alias.md", root.resolve())
 
     assert (entry.type, entry.size) == ("file", len("# soul"))
+
+
+def test_list_dir_does_not_read_dot_git_through_a_symlink(tmp_path: Path) -> None:
+    """A symlink pointing back into .git stays inside the repo, so containment alone
+    would pass it — and .git/config holds the remote URL with its access token."""
+    root = _make_repo(tmp_path)
+    notes = root / "notes"
+    notes.mkdir()
+    (notes / "README.md").symlink_to(root / ".git" / "config")
+
+    assert list_dir(root, notes.resolve()).doc is None
+    # And it is not reachable by browsing to it directly either.
+    with pytest.raises(HTTPException):
+        resolve_target(root.resolve(), "notes/README.md")
+
+
+def test_session_archive_entry_ignores_an_oversized_archive(tmp_path: Path) -> None:
+    """Runs for every subdirectory of a listing, on a file the pushing client sizes."""
+    root = _make_repo(tmp_path)
+    directory = root / "sessions" / "2026" / "06" / "huge"
+    directory.mkdir(parents=True)
+    payload = {"session": {"title": "t", "session_id": "s"}, "pad": "x" * (MAX_INLINE_TEXT_BYTES + 1)}
+    (directory / "conversation.json").write_text(json.dumps(payload))
+
+    assert session_archive_entry(directory, root.resolve()) is None

--- a/tests/test_knowledge_browse.py
+++ b/tests/test_knowledge_browse.py
@@ -258,3 +258,46 @@ def test_list_dir_skill_without_frontmatter_falls_back_to_dir_name(tmp_path: Pat
     assert listing.skill is not None
     assert (listing.skill.name, listing.skill.description) == ("bare", "")
     assert listing.doc == "# Bare skill\n"
+
+
+def test_list_dir_inlines_readme_for_plain_dir(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    (root / "notes").mkdir()
+    (root / "notes" / "README.md").write_text("# Notes\n\nProse.\n")
+
+    listing = list_dir(root, (root / "notes").resolve())
+
+    assert listing.kind is None
+    assert listing.skill is None
+    assert (listing.doc_name, listing.doc) == ("README.md", "# Notes\n\nProse.\n")
+
+
+def test_list_dir_readme_match_is_case_insensitive(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    (root / "notes").mkdir()
+    (root / "notes" / "readme.md").write_text("lower\n")
+
+    listing = list_dir(root, (root / "notes").resolve())
+
+    assert (listing.doc_name, listing.doc) == ("readme.md", "lower\n")
+
+
+def test_list_dir_skill_doc_wins_over_readme(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    skill = root / "skills" / "weather"
+    (skill / "README.md").write_text("readme body\n")
+
+    listing = list_dir(root, skill.resolve())
+
+    assert (listing.kind, listing.doc_name) == ("skill", "SKILL.md")
+    assert "readme body" not in (listing.doc or "")
+
+
+def test_list_dir_readme_frontmatter_is_not_stripped(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    (root / "notes").mkdir()
+    (root / "notes" / "README.md").write_text("---\ntitle: keep\n---\n\nBody.\n")
+
+    listing = list_dir(root, (root / "notes").resolve())
+
+    assert listing.doc == "---\ntitle: keep\n---\n\nBody.\n"

--- a/tests/test_knowledge_browse.py
+++ b/tests/test_knowledge_browse.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -316,3 +318,15 @@ def test_build_entry_session_wins_over_skill(tmp_path: Path) -> None:
     (directory / "SKILL.md").write_text("---\nname: odd\n---\n")
 
     assert build_entry(directory).kind == "session"
+
+
+def test_build_entry_reports_file_mtime(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    target = root / "SOUL.md"
+    os.utime(target, (1_780_000_000, 1_780_000_000))
+
+    entry = build_entry(target)
+
+    assert entry.modified == datetime.fromtimestamp(1_780_000_000, tz=UTC)
+    # Directories carry no mtime: the client shows a title or nothing for them.
+    assert build_entry(root / "skills").modified is None

--- a/tests/test_knowledge_browse.py
+++ b/tests/test_knowledge_browse.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 from fastapi import HTTPException
 
-from carapace.server.knowledge import MAX_INLINE_TEXT_BYTES, list_dir, read_text_content, resolve_target
+from carapace.server.knowledge import (
+    MAX_INLINE_TEXT_BYTES,
+    build_entry,
+    list_dir,
+    read_text_content,
+    resolve_target,
+    session_archive_entry,
+)
 
 
 def _make_repo(tmp_path: Path) -> Path:
@@ -101,3 +109,54 @@ def test_read_text_content_rejects_binary(tmp_path: Path, name: str, data: bytes
 def test_read_text_content_rejects_oversized(tmp_path: Path) -> None:
     target = _write(tmp_path, "big.txt", b"x")
     assert read_text_content(target, MAX_INLINE_TEXT_BYTES + 1) is None
+
+
+def _archive(root: Path, session_id: str, payload: object) -> Path:
+    directory = root / "sessions" / "2026" / "06" / session_id
+    directory.mkdir(parents=True)
+    (directory / "conversation.json").write_text(json.dumps(payload))
+    return directory
+
+
+def test_session_archive_entry_reads_title(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    directory = _archive(
+        root,
+        "2026-06-01-21-07-0062199d",
+        {"session": {"session_id": "2026-06-01-21-07-0062199d", "title": "Weather skill"}},
+    )
+    assert session_archive_entry(directory) == ("Weather skill", "2026-06-01-21-07-0062199d")
+
+
+def test_session_archive_entry_untitled_falls_back_to_dir_name(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    directory = _archive(root, "2026-06-02-10-00-abcdef01", {"session": {"title": "   "}})
+    assert session_archive_entry(directory) == (None, "2026-06-02-10-00-abcdef01")
+
+
+def test_session_archive_entry_ignores_plain_dir(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    assert session_archive_entry(root / "skills" / "weather") is None
+
+
+def test_session_archive_entry_tolerates_corrupt_json(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    directory = root / "sessions" / "2026" / "06" / "broken"
+    directory.mkdir(parents=True)
+    (directory / "conversation.json").write_text("{not json")
+    assert session_archive_entry(directory) is None
+
+
+def test_build_entry_tags_session_dirs(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    directory = _archive(
+        root,
+        "2026-06-03-08-30-11223344",
+        {"session": {"session_id": "2026-06-03-08-30-11223344", "title": "Groceries"}},
+    )
+
+    entry = build_entry(directory)
+
+    assert (entry.kind, entry.label, entry.session_id) == ("session", "Groceries", "2026-06-03-08-30-11223344")
+    assert build_entry(root / "skills").kind is None
+    assert build_entry(root / "SOUL.md").kind is None

--- a/tests/test_knowledge_browse.py
+++ b/tests/test_knowledge_browse.py
@@ -127,18 +127,18 @@ def test_session_archive_entry_reads_title(tmp_path: Path) -> None:
         "2026-06-01-21-07-0062199d",
         {"session": {"session_id": "2026-06-01-21-07-0062199d", "title": "Weather skill"}},
     )
-    assert session_archive_entry(directory) == ("Weather skill", "2026-06-01-21-07-0062199d")
+    assert session_archive_entry(directory, root.resolve()) == ("Weather skill", "2026-06-01-21-07-0062199d")
 
 
 def test_session_archive_entry_untitled_falls_back_to_dir_name(tmp_path: Path) -> None:
     root = _make_repo(tmp_path)
     directory = _archive(root, "2026-06-02-10-00-abcdef01", {"session": {"title": "   "}})
-    assert session_archive_entry(directory) == (None, "2026-06-02-10-00-abcdef01")
+    assert session_archive_entry(directory, root.resolve()) == (None, "2026-06-02-10-00-abcdef01")
 
 
 def test_session_archive_entry_ignores_plain_dir(tmp_path: Path) -> None:
     root = _make_repo(tmp_path)
-    assert session_archive_entry(root / "skills" / "weather") is None
+    assert session_archive_entry((root / "skills" / "weather").resolve(), root.resolve()) is None
 
 
 def test_session_archive_entry_tolerates_corrupt_json(tmp_path: Path) -> None:
@@ -146,7 +146,7 @@ def test_session_archive_entry_tolerates_corrupt_json(tmp_path: Path) -> None:
     directory = root / "sessions" / "2026" / "06" / "broken"
     directory.mkdir(parents=True)
     (directory / "conversation.json").write_text("{not json")
-    assert session_archive_entry(directory) is None
+    assert session_archive_entry(directory, root.resolve()) is None
 
 
 def test_build_entry_tags_session_dirs(tmp_path: Path) -> None:
@@ -157,11 +157,11 @@ def test_build_entry_tags_session_dirs(tmp_path: Path) -> None:
         {"session": {"session_id": "2026-06-03-08-30-11223344", "title": "Groceries"}},
     )
 
-    entry = build_entry(directory)
+    entry = build_entry(directory, root.resolve())
 
     assert (entry.kind, entry.label, entry.session_id) == ("session", "Groceries", "2026-06-03-08-30-11223344")
-    assert build_entry(root / "skills").kind is None
-    assert build_entry(root / "SOUL.md").kind is None
+    assert build_entry(root / "skills", root.resolve()).kind is None
+    assert build_entry(root / "SOUL.md", root.resolve()).kind is None
 
 
 def test_list_dir_inlines_skill_doc(tmp_path: Path) -> None:
@@ -308,8 +308,8 @@ def test_list_dir_readme_frontmatter_is_not_stripped(tmp_path: Path) -> None:
 def test_build_entry_tags_skill_dirs(tmp_path: Path) -> None:
     root = _make_repo(tmp_path)
 
-    assert build_entry(root / "skills" / "weather").kind == "skill"
-    assert build_entry(root / "skills").kind is None
+    assert build_entry(root / "skills" / "weather", root.resolve()).kind == "skill"
+    assert build_entry(root / "skills", root.resolve()).kind is None
 
 
 def test_build_entry_session_wins_over_skill(tmp_path: Path) -> None:
@@ -317,7 +317,7 @@ def test_build_entry_session_wins_over_skill(tmp_path: Path) -> None:
     directory = _archive(root, "2026-06-04-09-00-deadbeef", {"session": {"title": "Odd one"}})
     (directory / "SKILL.md").write_text("---\nname: odd\n---\n")
 
-    assert build_entry(directory).kind == "session"
+    assert build_entry(directory, root.resolve()).kind == "session"
 
 
 def test_build_entry_reports_file_mtime(tmp_path: Path) -> None:
@@ -325,8 +325,61 @@ def test_build_entry_reports_file_mtime(tmp_path: Path) -> None:
     target = root / "SOUL.md"
     os.utime(target, (1_780_000_000, 1_780_000_000))
 
-    entry = build_entry(target)
+    entry = build_entry(target, root.resolve())
 
     assert entry.modified == datetime.fromtimestamp(1_780_000_000, tz=UTC)
     # Directories carry no mtime: the client shows a title or nothing for them.
-    assert build_entry(root / "skills").modified is None
+    assert build_entry(root / "skills", root.resolve()).modified is None
+
+
+def test_list_dir_does_not_read_through_escaping_skill_doc(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    (tmp_path / "secret.txt").write_text("HOST SECRET")
+    escaping = root / "skills" / "escaping"
+    escaping.mkdir()
+    (escaping / "SKILL.md").symlink_to(tmp_path / "secret.txt")
+
+    listing = list_dir(root, escaping.resolve())
+
+    assert (listing.doc, listing.skill, listing.kind) == (None, None, None)
+
+
+def test_list_dir_does_not_read_through_escaping_readme(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    (tmp_path / "secret.txt").write_text("HOST SECRET")
+    notes = root / "notes"
+    notes.mkdir()
+    (notes / "README.md").symlink_to(tmp_path / "secret.txt")
+
+    assert list_dir(root, notes.resolve()).doc is None
+
+
+def test_session_archive_entry_ignores_escaping_conversation(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    (tmp_path / "secret.json").write_text(json.dumps({"session": {"title": "leaked"}}))
+    directory = root / "sessions" / "2026" / "06" / "escaping"
+    directory.mkdir(parents=True)
+    (directory / "conversation.json").symlink_to(tmp_path / "secret.json")
+
+    assert session_archive_entry(directory, root.resolve()) is None
+    assert build_entry(directory, root.resolve()).kind is None
+
+
+def test_build_entry_tolerates_broken_symlink(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    (root / "dangling.md").symlink_to(tmp_path / "does-not-exist")
+
+    entry = build_entry(root / "dangling.md", root.resolve())
+
+    assert (entry.name, entry.type, entry.size, entry.modified) == ("dangling.md", "file", None, None)
+    # The whole listing must still render around it.
+    assert "dangling.md" in [e.name for e in list_dir(root, root.resolve()).entries]
+
+
+def test_build_entry_reports_symlink_inside_the_repo(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    (root / "alias.md").symlink_to(root / "SOUL.md")
+
+    entry = build_entry(root / "alias.md", root.resolve())
+
+    assert (entry.type, entry.size) == ("file", len("# soul"))

--- a/tests/test_knowledge_browse.py
+++ b/tests/test_knowledge_browse.py
@@ -301,3 +301,18 @@ def test_list_dir_readme_frontmatter_is_not_stripped(tmp_path: Path) -> None:
     listing = list_dir(root, (root / "notes").resolve())
 
     assert listing.doc == "---\ntitle: keep\n---\n\nBody.\n"
+
+
+def test_build_entry_tags_skill_dirs(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+
+    assert build_entry(root / "skills" / "weather").kind == "skill"
+    assert build_entry(root / "skills").kind is None
+
+
+def test_build_entry_session_wins_over_skill(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    directory = _archive(root, "2026-06-04-09-00-deadbeef", {"session": {"title": "Odd one"}})
+    (directory / "SKILL.md").write_text("---\nname: odd\n---\n")
+
+    assert build_entry(directory).kind == "session"

--- a/tests/test_knowledge_browse.py
+++ b/tests/test_knowledge_browse.py
@@ -169,10 +169,92 @@ def test_list_dir_inlines_skill_doc(tmp_path: Path) -> None:
     listing = list_dir(root, skill.resolve())
 
     assert (listing.kind, listing.doc_name) == ("skill", "SKILL.md")
-    assert listing.doc == "---\nname: weather\n---\n"
+    # Frontmatter-only SKILL.md: nothing left in the body once it is stripped.
+    assert listing.doc == ""
+    assert listing.skill is not None and listing.skill.name == "weather"
 
 
 def test_list_dir_without_skill_doc_has_no_kind(tmp_path: Path) -> None:
     root = _make_repo(tmp_path)
     listing = list_dir(root, (root / "skills").resolve())
     assert (listing.kind, listing.doc_name, listing.doc) == (None, None, None)
+
+
+_SKILL_MD = """---
+name: weather
+description: Forecast via Home Assistant
+metadata:
+  carapace:
+    network:
+      domains:
+        - homeassistant.example
+    credentials:
+      - vault_path: vault/abc
+        env_var: HA_TOKEN
+    commands:
+      - name: weather
+        command: uv run weather
+---
+
+# Weather
+
+Body prose.
+"""
+
+
+def _skill(root: Path, name: str, text: str) -> Path:
+    directory = root / "skills" / name
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "SKILL.md").write_text(text)
+    return directory
+
+
+def test_list_dir_strips_frontmatter_into_skill(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    _skill(root, "weather", _SKILL_MD)
+
+    listing = list_dir(root, (root / "skills" / "weather").resolve())
+
+    assert listing.kind == "skill"
+    assert listing.doc == "# Weather\n\nBody prose.\n"
+    assert listing.skill is not None
+    assert (listing.skill.name, listing.skill.description) == ("weather", "Forecast via Home Assistant")
+    carapace = listing.skill.carapace
+    assert carapace is not None
+    assert carapace.network.domains == ["homeassistant.example"]
+    assert [c.name for c in carapace.commands] == ["weather"]
+    assert [c.env_var for c in carapace.credentials] == ["HA_TOKEN"]
+
+
+def test_list_dir_skill_without_carapace_metadata(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    _skill(root, "plain", "---\nname: plain\ndescription: No metadata\n---\n\nBody.\n")
+
+    listing = list_dir(root, (root / "skills" / "plain").resolve())
+
+    assert listing.skill is not None
+    assert listing.skill.carapace is None
+    assert listing.doc == "Body.\n"
+
+
+def test_list_dir_skill_with_invalid_carapace_keeps_prose(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    # commands must be a list of {name, command}; a bare string fails validation.
+    _skill(root, "broken", "---\nname: broken\nmetadata:\n  carapace:\n    commands: nope\n---\n\nBody.\n")
+
+    listing = list_dir(root, (root / "skills" / "broken").resolve())
+
+    assert listing.skill is not None
+    assert listing.skill.carapace is None
+    assert listing.doc == "Body.\n"
+
+
+def test_list_dir_skill_without_frontmatter_falls_back_to_dir_name(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    _skill(root, "bare", "# Bare skill\n")
+
+    listing = list_dir(root, (root / "skills" / "bare").resolve())
+
+    assert listing.skill is not None
+    assert (listing.skill.name, listing.skill.description) == ("bare", "")
+    assert listing.doc == "# Bare skill\n"

--- a/tests/test_knowledge_browse.py
+++ b/tests/test_knowledge_browse.py
@@ -160,3 +160,19 @@ def test_build_entry_tags_session_dirs(tmp_path: Path) -> None:
     assert (entry.kind, entry.label, entry.session_id) == ("session", "Groceries", "2026-06-03-08-30-11223344")
     assert build_entry(root / "skills").kind is None
     assert build_entry(root / "SOUL.md").kind is None
+
+
+def test_list_dir_inlines_skill_doc(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    skill = root / "skills" / "weather"
+
+    listing = list_dir(root, skill.resolve())
+
+    assert (listing.kind, listing.doc_name) == ("skill", "SKILL.md")
+    assert listing.doc == "---\nname: weather\n---\n"
+
+
+def test_list_dir_without_skill_doc_has_no_kind(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    listing = list_dir(root, (root / "skills").resolve())
+    assert (listing.kind, listing.doc_name, listing.doc) == (None, None, None)

--- a/tests/test_knowledge_browse.py
+++ b/tests/test_knowledge_browse.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 from fastapi import HTTPException
 
-from carapace.server.knowledge import list_dir, resolve_target
+from carapace.server.knowledge import MAX_INLINE_TEXT_BYTES, list_dir, read_text_content, resolve_target
 
 
 def _make_repo(tmp_path: Path) -> Path:
@@ -64,3 +64,40 @@ def test_list_dir_subdir_path(tmp_path: Path) -> None:
     listing = list_dir(root, (root / "skills" / "weather").resolve())
     assert listing.path == "skills/weather"
     assert [e.name for e in listing.entries] == ["SKILL.md"]
+
+
+def _write(tmp_path: Path, name: str, data: bytes) -> Path:
+    target = tmp_path / name
+    target.write_bytes(data)
+    return target
+
+
+@pytest.mark.parametrize(
+    "name,data",
+    [
+        (".gitignore", b"__pycache__/\n*.pyc\n"),  # no extension to guess from
+        ("Dockerfile", b"FROM python:3.12\n"),
+        ("notes.md", "# über\n".encode()),  # multi-byte UTF-8
+        ("empty", b""),
+    ],
+)
+def test_read_text_content_returns_text(tmp_path: Path, name: str, data: bytes) -> None:
+    target = _write(tmp_path, name, data)
+    assert read_text_content(target, len(data)) == data.decode("utf-8")
+
+
+@pytest.mark.parametrize(
+    "name,data",
+    [
+        ("logo.png", b"\x89PNG\r\n\x1a\n\x00\x00binary"),  # NUL byte
+        ("data.bin", b"\xff\xfe\xfd\xfc"),  # invalid UTF-8
+    ],
+)
+def test_read_text_content_rejects_binary(tmp_path: Path, name: str, data: bytes) -> None:
+    target = _write(tmp_path, name, data)
+    assert read_text_content(target, len(data)) is None
+
+
+def test_read_text_content_rejects_oversized(tmp_path: Path) -> None:
+    target = _write(tmp_path, "big.txt", b"x")
+    assert read_text_content(target, MAX_INLINE_TEXT_BYTES + 1) is None


### PR DESCRIPTION
## Summary

Read-only viewer for the server-side knowledge repo in the web UI, as a foundation for later augmented displays (skill metadata cards, session archive links, per-file-type views).

### Backend
- New `GET /api/knowledge/browse[/{path}]` (`src/carapace/server/knowledge.py`): resolves against the requesting user's knowledge repo working tree.
  - Directory → JSON listing (`{path, entries: [{name, type, size}]}`), dirs first, `.git` hidden.
  - File → JSON metadata (`{path, name, size, mime}`), or raw content with `?raw=1` (inline) / `?download=1` (attachment).
  - 404 on traversal attempts, symlink escapes, and anything under `.git`.
- New `knowledge` API key scope; cookie sessions bypass scopes as usual.

### Frontend
- `/knowledge` page (static-export compatible: path lives in `?path=` query param) with breadcrumb, directory listing, and file preview: markdown via existing `MarkdownContent`, code via Shiki fence helpers, images inline, download fallback for binaries and files >1 MB.
- Sidebar book icon links to the page; `knowledge` scope selectable in API key creation; en/de translations.

### Extension points
- Dir/file distinction and metadata responses come from the server, so special displays (skill dirs, session archives) can be added by tagging listing entries and switching renderers client-side — no API reshaping needed.

## Testing
- `tests/test_knowledge_browse.py`: traversal/symlink/.git rejection, listing order, path formatting.
- Full suite: 1025 passed, `pyrefly check` clean, frontend lint + 60 tests + static build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated read API over user-writable repo content with path/symlink hardening; mistakes could leak paths or tokens, but behavior is read-only and heavily covered by new tests.
> 
> **Overview**
> Adds a **read-only knowledge repository browser** in the web app, backed by a new **`GET /api/knowledge/browse`** API on each user’s server-side knowledge git working tree.
> 
> The API returns directory listings with **per-entry git commit metadata** (via a batched `git log` walk), recognizes **session archives** (`conversation.json`) and **skill dirs** (`SKILL.md`), inlines text/README/skill prose with size caps, and serves raw/download for files—with **traversal, `.git`, and symlink-escape guards** and conservative inline MIME rules (no SVG/HTML script risk). Access is gated by a new **`knowledge` API key scope** (also exposed in the API keys UI).
> 
> The **`/knowledge`** page (`?path=` for static export) provides breadcrumbs, listings with session links and copyable commit hashes, **skill metadata cards** from `metadata.carapace`, and file previews (markdown, highlighted code, images). **Global git** UI now shows **HEAD** and uses a **`carapace:knowledge-git-changed`** event so pull/push refreshes all mounted panels and the browser; chat **knowledge archive paths** link into the browser. En/de copy and sidebar navigation complete the feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15ea56aacd1b6b60f6b4278b95302db7e034877e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->