### PR TITLE
✨ feat(skills): declare MCP server connections in skill metadata

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -91,6 +91,13 @@ metadata:
     commands:
       - name: web-search
         command: uv run --directory /workspace/skills/web-search scripts/search.py
+    mcp:
+      - name: linear
+        url: https://mcp.linear.app/mcp
+        description: Linear issue tracking
+        auth:
+          type: bearer
+          vault_path: dev/linear-mcp-token
 ---
 ```
 
@@ -138,6 +145,20 @@ Notes:
 - The wrapper uses shell `exec` so the launcher shell is replaced by the real command.
 - `command` must be a single non-empty line.
 - Alias names must be unique across active skills. If an active skill already owns an alias, activating another skill with the same alias fails.
+
+**`mcp`** — optional list of MCP servers the skill connects to. While the skill is active, each server's tools are exposed to the agent as regular tools named `<name>_<tool>`. Each entry has:
+
+- `name` — server name, used as the tool-name prefix. Must start with a letter and contain only letters, numbers, or underscores.
+- `url` — the server's HTTP(S) endpoint (streamable HTTP transport).
+- `description` — optional human-readable explanation for approvals and docs.
+- `auth` — optional authentication. Currently only `type: bearer` with a `vault_path`: the token is read from the vault at activation and sent as `Authorization: Bearer <token>`. The auth block is a tagged union so other methods (e.g. OAuth) can be added later.
+
+Notes:
+
+- The declared servers are part of the `use_skill` approval, like domains and credentials. Every individual MCP tool call is still reviewed by the sentinel (shown as `mcp:<server>:<tool>`), with the usual escalate-to-user path.
+- MCP requests are made by the backend process, not from inside the sandbox. The URL is pinned to the declared value.
+- Oversized text results are spilled to a file in the sandbox (same mechanism as `exec` output).
+- Server tools disappear when the session ends; there is no explicit deactivation, matching context grants.
 
 ## Context-scoped access
 

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -563,6 +563,7 @@
             "deniedByUser": "Vom Benutzer abgelehnt.",
             "contexts": "Kontext:",
             "domains": "Domains:",
+            "mcpServers": "MCP-Server:",
             "credentials": "Zugangsdaten",
             "name": "Name",
             "path": "Pfad",

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -36,6 +36,8 @@
             "tunnels": "Tunnel",
             "credentials": "Zugangsdaten",
             "credential": "Zugangsdatum",
+            "mcp": "MCP-Server",
+            "mcpAuth": "{type}-Auth",
             "hints": "Hinweise"
         }
     },

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -563,6 +563,7 @@
             "deniedByUser": "Denied by user.",
             "contexts": "Contexts:",
             "domains": "Domains:",
+            "mcpServers": "MCP servers:",
             "credentials": "Credentials",
             "name": "Name",
             "path": "Path",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -36,6 +36,8 @@
             "tunnels": "Tunnels",
             "credentials": "Credentials",
             "credential": "Credential",
+            "mcp": "MCP servers",
+            "mcpAuth": "{type} auth",
             "hints": "Hints"
         }
     },

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -12,6 +12,7 @@ import {
   KeyRound,
   Lightbulb,
   Loader2,
+  Plug,
   Puzzle,
   Terminal,
 } from "lucide-react";
@@ -226,6 +227,7 @@ function SkillCard({ skill }: { skill: KnowledgeSkill }) {
   const tunnels = carapace?.network.tunnels ?? [];
   const credentials = carapace?.credentials ?? [];
   const commands = carapace?.commands ?? [];
+  const mcpServers = carapace?.mcp ?? [];
   const hints = Object.entries(carapace?.hints ?? {});
 
   return (
@@ -238,7 +240,7 @@ function SkillCard({ skill }: { skill: KnowledgeSkill }) {
         <p className="mt-1.5 text-sm text-muted-foreground">{skill.description}</p>
       ) : null}
 
-      {commands.length || domains.length || tunnels.length || credentials.length || hints.length ? (
+      {commands.length || domains.length || tunnels.length || credentials.length || mcpServers.length || hints.length ? (
         <div className="mt-4 flex flex-col gap-3 border-t border-border/70 pt-3 text-sm">
           {commands.length ? (
             <SkillSection icon={<Terminal className={sectionIconClass} />} label={t("commands")}>
@@ -287,6 +289,27 @@ function SkillCard({ skill }: { skill: KnowledgeSkill }) {
                     ) : null}
                   </div>
                   <code className="break-all font-mono text-xs text-muted-foreground">{credential.vault_path}</code>
+                </div>
+              ))}
+            </SkillSection>
+          ) : null}
+
+          {mcpServers.length ? (
+            <SkillSection icon={<Plug className={sectionIconClass} />} label={t("mcp")}>
+              {mcpServers.map((server) => (
+                <div key={server.name} className="flex min-w-0 flex-col gap-0.5">
+                  <div className="flex min-w-0 flex-wrap items-baseline gap-x-2">
+                    <code className="break-all font-mono text-xs font-semibold">{server.name}</code>
+                    {server.description ? (
+                      <span className="break-words text-xs text-muted-foreground">{server.description}</span>
+                    ) : null}
+                  </div>
+                  <code className="break-all font-mono text-xs text-muted-foreground">{server.url}</code>
+                  {server.auth ? (
+                    <code className="break-all font-mono text-xs text-muted-foreground">
+                      {t("mcpAuth", { type: server.auth.type })} · {server.auth.vault_path}
+                    </code>
+                  ) : null}
                 </div>
               ))}
             </SkillSection>

--- a/frontend/src/components/tool-call-badge.tsx
+++ b/frontend/src/components/tool-call-badge.tsx
@@ -11,6 +11,7 @@ import {
   Globe,
   KeyRound,
   Loader2,
+  Plug,
   Puzzle,
   Replace,
   Send,
@@ -701,8 +702,21 @@ export function ToolCallBadge({
               ? (args.declared_domains as string[]).join("\n")
               : childCalls?.filter(c => c.tool === "proxy_domain").map(c => c.args.domain as string ?? "").join("\n") ?? "";
 
+            // Count MCP servers declared by use_skill
+            const declaredMcp = isUseSkillTool && Array.isArray(args.declared_mcp)
+              ? (args.declared_mcp as Array<{ name: string; url: string }>) : [];
+            const mcpTooltip = declaredMcp.map(s => `${s.name} (${s.url})`).join("\n");
+
             return (
               <>
+                {declaredMcp.length > 0 && (
+                  <span
+                    className="inline-flex items-center gap-0.5 rounded bg-blue-500/15 px-1.5 py-0.5 text-[10px] text-blue-600 dark:text-blue-400"
+                    title={mcpTooltip}
+                  >
+                    <Plug className="h-2.5 w-2.5" />{declaredMcp.length}
+                  </span>
+                )}
                 {credCount > 0 && (
                   <span
                     className="inline-flex items-center gap-0.5 rounded bg-blue-500/15 px-1.5 py-0.5 text-[10px] text-blue-600 dark:text-blue-400"
@@ -842,6 +856,24 @@ export function ToolCallBadge({
                       <span key={d}>
                         {i > 0 && ", "}
                         <span className="font-mono">{d}</span>
+                      </span>
+                    ))}
+                  </div>
+                ) : null;
+              })()}
+
+              {(() => {
+                const servers = (
+                  Array.isArray(args.declared_mcp) ? args.declared_mcp : []
+                ) as Array<{ name: string; url: string; description?: string }>;
+                return servers.length > 0 ? (
+                  <div className="text-[11px] text-muted-foreground">
+                    <span className="font-medium text-foreground/70"><Plug className="inline h-3 w-3 -translate-y-px mr-1" />{t("details.mcpServers")} </span>
+                    {servers.map((s, i) => (
+                      <span key={s.name} title={s.description || undefined}>
+                        {i > 0 && ", "}
+                        <span className="font-mono">{s.name}</span>
+                        <span className="text-muted-foreground/70"> ({s.url})</span>
                       </span>
                     ))}
                   </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1587,10 +1587,23 @@ export interface SkillNetworkTunnel {
   description: string;
 }
 
+export interface SkillMcpBearerAuth {
+  type: "bearer";
+  vault_path: string;
+}
+
+export interface SkillMcpDecl {
+  name: string;
+  url: string;
+  description: string;
+  auth: SkillMcpBearerAuth | null;
+}
+
 export interface SkillCarapaceConfig {
   network: { domains: string[]; tunnels: SkillNetworkTunnel[] };
   credentials: SkillCredentialDecl[];
   commands: SkillCommandDecl[];
+  mcp: SkillMcpDecl[];
   hints: Record<string, string>;
 }
 

--- a/src/carapace/agent/deps.py
+++ b/src/carapace/agent/deps.py
@@ -50,6 +50,11 @@ class Deps(BaseModel):
         description="carapace-registered model id (custom id or provider:name); usage keys, not provider wire ids.",
     )
 
+    # Live MCPToolset instances keyed by "<skill>:<server>", built lazily from
+    # active context grants. Cached here so per-run-step toolset evaluation
+    # reuses connections instead of re-handshaking every step.
+    mcp_toolsets: dict[str, Any] = {}
+
     tool_call_callback: ToolCallCallback | None = None
     tool_result_callback: Callable[[ToolResult], None] | None = None
     append_session_events: Callable[[list[dict[str, Any]]], None] | None = None

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -216,6 +216,29 @@ def _skill_command_alias_conflict(skill_name: str, knowledge_dir: Path, activate
     return f"Cannot activate skill '{skill_name}' because these command aliases conflict with active skills: {details}."
 
 
+def _skill_mcp_name_conflict(
+    skill_name: str, declared_mcp: list[SkillMcpDecl], context_grants: dict[str, ContextGrant]
+) -> str | None:
+    """Reject activation if a declared MCP name is already registered by another active skill.
+
+    MCP tools are exposed with the prefix ``<name>_`` only, so two active skills sharing a
+    name would collide on tool names pointing at different servers.
+    """
+    active: dict[str, str] = {}
+    for other, grant in context_grants.items():
+        if other == skill_name:
+            continue
+        for server in grant.mcp_servers:
+            active[server.name] = other
+    conflicts = [(decl.name, active[decl.name]) for decl in declared_mcp if decl.name in active]
+    if not conflicts:
+        return None
+    details = ", ".join(f"{name!r} (already registered by {owner!r})" for name, owner in conflicts)
+    return (
+        f"Cannot activate skill '{skill_name}' because these MCP server names conflict with active skills: {details}."
+    )
+
+
 def _extract_leading_command_token(command: str) -> str | None:
     match = re.match(
         r"^\s*(?P<token>(?:" + re.escape(SKILL_COMMAND_SHIM_DIR) + r"/)?[A-Za-z0-9][A-Za-z0-9._-]*)", command
@@ -565,12 +588,42 @@ def _mcp_process_tool_call(skill_name: str, decl: SkillMcpDecl) -> Any:
     return _process
 
 
+async def _prewarm_skill_mcp(ctx: RunContext[Deps], skill_name: str, grant: ContextGrant) -> list[str]:
+    """Eagerly build a skill's MCP servers at activation; return per-server status lines.
+
+    A server whose auth/connection fails is reported (graceful degradation) but does not
+    abort activation — the skill still loads and the agent is told which servers are
+    unavailable instead of being falsely promised their tools.
+    """
+    lines: list[str] = []
+    for decl in grant.mcp_servers:
+        key = f"{skill_name}:{decl.name}"
+        try:
+            token = await _mcp_bearer_token(ctx, decl)
+            toolset = MCPToolset(
+                decl.url,
+                auth=token,
+                id=f"mcp:{key}",
+                process_tool_call=_mcp_process_tool_call(skill_name, decl),
+            ).prefixed(decl.name)
+        except Exception as exc:
+            logger.warning(f"MCP server {decl.display} (skill {skill_name!r}) unavailable: {exc}")
+            lines.append(
+                f"MCP server '{decl.name}' is UNAVAILABLE: {exc}. The skill is active, but its "
+                f"{decl.name}_* tools will not work until this is resolved."
+            )
+            continue
+        ctx.deps.mcp_toolsets[key] = toolset
+        lines.append(f"MCP server '{decl.name}' ready — tools available as {decl.name}_*.")
+    return lines
+
+
 async def build_skill_mcp_toolset(ctx: RunContext[Deps]) -> AbstractToolset[Deps] | None:
     """Dynamic toolset factory: expose MCP tools declared by active skill grants.
 
     Evaluated per run step by pydantic-ai, so tools appear right after
     ``use_skill`` registers a grant. Toolset instances are cached on ``Deps``
-    to avoid re-connecting on every step.
+    to avoid re-connecting on every step (activation pre-warms the cache).
     """
     toolsets: list[AbstractToolset[Deps]] = []
     for skill_name, grant in ctx.deps.session_state.context_grants.items():
@@ -755,6 +808,9 @@ def create_agent(deps: Deps) -> Agent[Deps, str | TaskDone | TaskFailed | Deferr
         ):
             return conflict_message
 
+        if mcp_conflict := _skill_mcp_name_conflict(skill_name, declared_mcp, ctx.deps.session_state.context_grants):
+            return mcp_conflict
+
         # Resolve human-readable names from the vault for UI display
         cred_registry = ctx.deps.credential_registry
         for entry in declared_creds_payload:
@@ -851,11 +907,10 @@ def create_agent(deps: Deps) -> Agent[Deps, str | TaskDone | TaskFailed | Deferr
                 "Network tunnels available for: " + ", ".join(tunnel.display for tunnel in declared_tunnels)
             )
         if declared_mcp:
-            status_lines.append(
-                "MCP servers registered: "
-                + ", ".join(decl.display for decl in declared_mcp)
-                + ". Their tools are now available as regular tools named '<server>_<tool>'."
-            )
+            # Eagerly connect declared MCP servers so tools are ready and any failure
+            # (missing/unresolvable credential, unreachable server) is reported now
+            # instead of falsely promising the tools.
+            status_lines.extend(await _prewarm_skill_mcp(ctx, skill_name, grant))
         if cred_msg:
             status_lines.extend(cred_msg.splitlines())
 

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import json
 import re
 import secrets
 from datetime import date
@@ -11,14 +12,17 @@ import httpx
 from loguru import logger
 from pydantic import Field
 from pydantic_ai import Agent, DeferredToolRequests, RunContext, ToolDenied, ToolOutput
+from pydantic_ai.mcp import CallToolFunc, MCPToolset
 from pydantic_ai.messages import BinaryContent, ToolReturn
+from pydantic_ai.toolsets import CombinedToolset
+from pydantic_ai.toolsets.abstract import AbstractToolset
 
 from .. import security as security
 from ..config import load_workspace_file
 from ..credentials import CredentialBackendError
 from ..llm import model_settings_for_config, model_supports_vision
 from ..models.credentials import CredentialMetadata
-from ..models.skills import ContextGrant, SkillCarapaceConfig, SkillCredentialDecl
+from ..models.skills import ContextGrant, SkillCarapaceConfig, SkillCredentialDecl, SkillMcpDecl
 from ..models.tooling import SentFileInfo, ToolResult, normalize_tool_call_args
 from ..sandbox.manager import READ_TOOL_MAX_LINE_WINDOW, UploadError, UploadTooLargeError
 from ..sandbox.runtime import SkillActivationError
@@ -493,6 +497,107 @@ async def _cache_skill_credentials(
     return "\n".join(parts), names_map
 
 
+async def _mcp_bearer_token(ctx: RunContext[Deps], decl: SkillMcpDecl) -> str | None:
+    """Resolve the bearer token for an MCP server from the session credential cache, re-fetching on miss."""
+    if decl.auth is None:
+        return None
+    session_id = ctx.deps.session_state.session_id
+    vault_path = decl.auth.vault_path
+    cached = ctx.deps.sandbox.get_cached_credential(session_id, vault_path)
+    if cached is None:
+        logger.info(f"Credential cache miss for {vault_path!r} (MCP server {decl.name!r}), re-fetching from vault")
+        cached = await ctx.deps.credential_registry.fetch(vault_path)
+        ctx.deps.sandbox.cache_credential(session_id, vault_path, cached)
+    return cached
+
+
+def _mcp_process_tool_call(skill_name: str, decl: SkillMcpDecl) -> Any:
+    """Build a ``process_tool_call`` hook that routes every MCP tool call through the security gate.
+
+    The hook mirrors the ``exec`` tool's flow: sentinel gate (with approval
+    escalation), action-log entry, spill-to-file for oversized text results,
+    and UI notification.
+    """
+
+    async def _process(
+        ctx: RunContext[Deps],
+        call_tool: CallToolFunc,
+        name: str,
+        tool_args: dict[str, Any],
+    ) -> Any:
+        gate_name = f"mcp:{decl.name}:{name}"
+        gate_args = {"skill": skill_name, "server": decl.name, "url": decl.url, "tool": name, "args": tool_args}
+        if not ctx.tool_call_approved:
+            if denied := await _gate(ctx, gate_name, gate_args):
+                return denied
+        else:
+            _notify_approved_start(ctx, gate_name, gate_args)
+
+        try:
+            result = await call_tool(name, tool_args)
+        except Exception:
+            ctx.deps.security.append(ToolResultEntry(tool=gate_name, status="error"))
+            raise
+
+        ctx.deps.security.append(ToolResultEntry(tool=gate_name, status="success"))
+
+        text: str | None = None
+        if isinstance(result, str):
+            text = result
+        elif isinstance(result, dict | list):
+            try:
+                text = json.dumps(result, default=str)
+            except (TypeError, ValueError):
+                text = None
+
+        if text is None:
+            _notify_result(ctx, gate_name, f"[non-text MCP tool result: {type(result).__name__}]")
+            return result
+
+        max_chars = ctx.deps.config.agent.tool_output_max_chars
+        if 0 < max_chars < len(text):
+            spilled = await _prepare_exec_tool_result(ctx, text)
+            return _emit_tool_result(ctx, gate_name, spilled)
+
+        _notify_result(ctx, gate_name, text)
+        return result
+
+    return _process
+
+
+async def build_skill_mcp_toolset(ctx: RunContext[Deps]) -> AbstractToolset[Deps] | None:
+    """Dynamic toolset factory: expose MCP tools declared by active skill grants.
+
+    Evaluated per run step by pydantic-ai, so tools appear right after
+    ``use_skill`` registers a grant. Toolset instances are cached on ``Deps``
+    to avoid re-connecting on every step.
+    """
+    toolsets: list[AbstractToolset[Deps]] = []
+    for skill_name, grant in ctx.deps.session_state.context_grants.items():
+        for decl in grant.mcp_servers:
+            key = f"{skill_name}:{decl.name}"
+            toolset = ctx.deps.mcp_toolsets.get(key)
+            if toolset is None:
+                try:
+                    token = await _mcp_bearer_token(ctx, decl)
+                except Exception as exc:
+                    logger.warning(f"Skipping MCP server {decl.display} (skill {skill_name!r}): {exc}")
+                    continue
+                toolset = MCPToolset(
+                    decl.url,
+                    auth=token,
+                    id=f"mcp:{key}",
+                    process_tool_call=_mcp_process_tool_call(skill_name, decl),
+                ).prefixed(decl.name)
+                ctx.deps.mcp_toolsets[key] = toolset
+            toolsets.append(toolset)
+    if not toolsets:
+        return None
+    if len(toolsets) == 1:
+        return toolsets[0]
+    return CombinedToolset(toolsets)
+
+
 def build_system_prompt(deps: Deps) -> str:
     parts: list[str] = []
 
@@ -637,9 +742,11 @@ def create_agent(deps: Deps) -> Agent[Deps, str | TaskDone | TaskFailed | Deferr
         declared_tunnels = carapace_cfg.network.tunnels if carapace_cfg else []
         declared_creds = carapace_cfg.credentials if carapace_cfg else []
         declared_commands = carapace_cfg.commands if carapace_cfg else []
+        declared_mcp = carapace_cfg.mcp if carapace_cfg else []
         declared_creds_payload = [decl.model_dump(mode="json") for decl in declared_creds]
         declared_tunnels_payload = [decl.model_dump(mode="json") for decl in declared_tunnels]
         declared_commands_payload = [decl.model_dump(mode="json") for decl in declared_commands]
+        declared_mcp_payload = [decl.model_dump(mode="json") for decl in declared_mcp]
 
         if conflict_message := _skill_command_alias_conflict(
             skill_name,
@@ -665,6 +772,7 @@ def create_agent(deps: Deps) -> Agent[Deps, str | TaskDone | TaskFailed | Deferr
                 "declared_domains": declared_domains,
                 "declared_tunnels": declared_tunnels_payload,
                 "declared_commands": declared_commands_payload,
+                "declared_mcp": declared_mcp_payload,
             }
 
             if denied := await _gate(ctx, "use_skill", gate_args):
@@ -682,6 +790,7 @@ def create_agent(deps: Deps) -> Agent[Deps, str | TaskDone | TaskFailed | Deferr
             domains=set(declared_domains),
             tunnels=list(declared_tunnels),
             credential_decls=list(declared_creds),
+            mcp_servers=list(declared_mcp),
         )
         ctx.deps.session_state.context_grants[skill_name] = grant
         ctx.deps.security.append(
@@ -690,11 +799,20 @@ def create_agent(deps: Deps) -> Agent[Deps, str | TaskDone | TaskFailed | Deferr
                 domains=declared_domains,
                 tunnels=[tunnel.display for tunnel in declared_tunnels],
                 vault_paths=[c.vault_path for c in declared_creds],
+                mcp_servers=[decl.display for decl in declared_mcp],
             ),
         )
 
-        # Cache credential values for per-exec injection
-        cred_msg, cred_names = await _cache_skill_credentials(ctx, declared_creds, skill_name)
+        # Cache credential values for per-exec injection (incl. MCP bearer tokens)
+        mcp_cred_decls = [
+            SkillCredentialDecl(
+                vault_path=decl.auth.vault_path,
+                description=f"Bearer token for MCP server '{decl.name}'",
+            )
+            for decl in declared_mcp
+            if decl.auth is not None
+        ]
+        cred_msg, cred_names = await _cache_skill_credentials(ctx, declared_creds + mcp_cred_decls, skill_name)
         grant.credential_names = cred_names
 
         sandbox_msg = ""
@@ -731,6 +849,12 @@ def create_agent(deps: Deps) -> Agent[Deps, str | TaskDone | TaskFailed | Deferr
         if declared_tunnels:
             status_lines.append(
                 "Network tunnels available for: " + ", ".join(tunnel.display for tunnel in declared_tunnels)
+            )
+        if declared_mcp:
+            status_lines.append(
+                "MCP servers registered: "
+                + ", ".join(decl.display for decl in declared_mcp)
+                + ". Their tools are now available as regular tools named '<server>_<tool>'."
             )
         if cred_msg:
             status_lines.extend(cred_msg.splitlines())
@@ -1056,5 +1180,11 @@ def create_agent(deps: Deps) -> Agent[Deps, str | TaskDone | TaskFailed | Deferr
         )
 
         return _emit_tool_result(ctx, "exec", result, exit_code)
+
+    # --- MCP (skill-declared servers; tools appear while the skill is active) ---
+
+    @agent.toolset
+    async def skill_mcp_servers(ctx: RunContext[Deps]) -> AbstractToolset[Deps] | None:
+        return await build_skill_mcp_toolset(ctx)
 
     return agent

--- a/src/carapace/models/skills.py
+++ b/src/carapace/models/skills.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from collections.abc import Callable, Mapping
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -70,12 +70,53 @@ class SkillCommandDecl(BaseModel):
         return self
 
 
+class SkillMcpBearerAuth(BaseModel):
+    """Static bearer token auth for an MCP server; the token is read from the vault."""
+
+    type: Literal["bearer"] = "bearer"
+    vault_path: str
+
+
+# Discriminated union so further auth methods (e.g. oauth) can be added as new variants.
+SkillMcpAuth = Annotated[SkillMcpBearerAuth, Field(discriminator="type")]
+
+_SKILL_MCP_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
+
+
+class SkillMcpDecl(BaseModel):
+    """An MCP server connection declared in a skill's carapace metadata.
+
+    ``name`` doubles as the tool-name prefix: the server's tools are exposed to
+    the agent as ``<name>_<tool>`` while the skill is active.
+    """
+
+    name: str
+    url: str
+    description: str = ""
+    auth: SkillMcpAuth | None = None
+
+    @model_validator(mode="after")
+    def _validate(self) -> SkillMcpDecl:
+        if not _SKILL_MCP_NAME_RE.match(self.name):
+            raise ValueError(
+                "skill mcp name must start with a letter and contain only letters, numbers, or underscores"
+            )
+        if not self.url.startswith(("http://", "https://")):
+            raise ValueError("skill mcp url must be an http(s) URL")
+        return self
+
+    @property
+    def display(self) -> str:
+        return f"{self.name} ({self.url})"
+
+
 class SkillCarapaceConfig(BaseModel):
     """Parsed carapace config declared inline in SKILL.md frontmatter."""
 
     network: SkillNetworkConfig = SkillNetworkConfig()
     credentials: list[SkillCredentialDecl] = []
     commands: list[SkillCommandDecl] = []
+    mcp: list[SkillMcpDecl] = []
     hints: dict[str, str] = {}
 
     @model_validator(mode="after")
@@ -85,6 +126,11 @@ class SkillCarapaceConfig(BaseModel):
             if command.name in seen_names:
                 raise ValueError(f"duplicate skill command name {command.name!r} is not allowed")
             seen_names.add(command.name)
+        seen_mcp: set[str] = set()
+        for server in self.mcp:
+            if server.name in seen_mcp:
+                raise ValueError(f"duplicate skill mcp name {server.name!r} is not allowed")
+            seen_mcp.add(server.name)
         return self
 
 
@@ -100,6 +146,7 @@ class ContextGrant(BaseModel):
     tunnels: list[NetworkTunnel] = []
     credential_decls: list[SkillCredentialDecl] = []
     credential_names: dict[str, str] = {}  # vault_path → human-readable name
+    mcp_servers: list[SkillMcpDecl] = []
 
     @property
     def vault_paths(self) -> set[str]:
@@ -120,6 +167,7 @@ def context_grants_session_summary(
             "tunnels": [tunnel.display for tunnel in grant.tunnels],
             "vault_paths": sorted(grant.vault_paths),
             "cached_credentials": cached,
+            "mcp_servers": [server.display for server in grant.mcp_servers],
         }
     return summary
 

--- a/src/carapace/security/context.py
+++ b/src/carapace/security/context.py
@@ -105,6 +105,7 @@ class ContextGrantEntry(BaseModel):
     domains: list[str] = []
     tunnels: list[str] = []
     vault_paths: list[str] = []
+    mcp_servers: list[str] = []
 
 
 ActionLogEntry = Annotated[

--- a/src/carapace/security/sentinel.py
+++ b/src/carapace/security/sentinel.py
@@ -46,14 +46,20 @@ You have tools to read skill source code and documentation.
 Skills are trusted user-authored content. Use them to understand
 what a script does when you see the agent running skill commands.
 
-About use_skill: when you see a use_skill call, the `declared_domains`
-and `declared_creds` fields are NOT requested by the agent — they are
+About use_skill: when you see a use_skill call, the `declared_domains`,
+`declared_creds`, and `declared_mcp` fields are NOT requested by the agent — they are
 declared by the skill itself in its SKILL.md `metadata.carapace` frontmatter and
 automatically bundled into the call for your review. Approving
-use_skill implicitly grants all declared domains and credentials
-for the duration of that skill's usage. Your job is to judge whether
-activating the skill makes sense for the user's request, not whether
-each individual credential or domain is justified separately.
+use_skill implicitly grants all declared domains, credentials, and MCP
+server connections for the duration of that skill's usage. Your job is
+to judge whether activating the skill makes sense for the user's
+request, not whether each individual credential or domain is justified
+separately.
+
+MCP tool calls appear as tools named `mcp:<server>:<tool>`. The server
+connection itself was approved with use_skill, but each individual call
+still comes to you: judge whether the specific tool and arguments fit
+the user's request, exactly as you would for an exec command.
 
 Always respond using the requested structured output schema.
 
@@ -119,12 +125,14 @@ def _format_entry(entry: ActionLogEntry) -> str:
             if explanation:
                 line += f" ({explanation})"
             return line
-        case ContextGrantEntry(skill_name=name, domains=domains, vault_paths=vault_paths):
+        case ContextGrantEntry(skill_name=name, domains=domains, vault_paths=vault_paths, mcp_servers=mcp_servers):
             parts = [f"[context_grant]: {name}"]
             if domains:
                 parts.append(f"domains={sorted(domains)}")
             if vault_paths:
                 parts.append(f"credentials={sorted(vault_paths)}")
+            if mcp_servers:
+                parts.append(f"mcp_servers={sorted(mcp_servers)}")
             return " ".join(parts)
         case _:
             return f"[unknown]: {entry}"

--- a/tests/test_knowledge_browse.py
+++ b/tests/test_knowledge_browse.py
@@ -196,6 +196,12 @@ metadata:
     commands:
       - name: weather
         command: uv run weather
+    mcp:
+      - name: hass
+        url: https://homeassistant.example/api/mcp
+        auth:
+          type: bearer
+          vault_path: vault/abc
 ---
 
 # Weather
@@ -226,6 +232,8 @@ def test_list_dir_strips_frontmatter_into_skill(tmp_path: Path) -> None:
     assert carapace.network.domains == ["homeassistant.example"]
     assert [c.name for c in carapace.commands] == ["weather"]
     assert [c.env_var for c in carapace.credentials] == ["HA_TOKEN"]
+    assert [(s.name, s.url) for s in carapace.mcp] == [("hass", "https://homeassistant.example/api/mcp")]
+    assert carapace.mcp[0].auth is not None and carapace.mcp[0].auth.vault_path == "vault/abc"
 
 
 def test_list_dir_skill_without_carapace_metadata(tmp_path: Path) -> None:

--- a/tests/test_skill_mcp.py
+++ b/tests/test_skill_mcp.py
@@ -1,0 +1,176 @@
+"""Tests for skill-declared MCP server connections."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+from pydantic_ai import ToolDenied
+from pydantic_ai.toolsets.prefixed import PrefixedToolset
+
+from carapace.agent.tools import _mcp_process_tool_call, build_skill_mcp_toolset
+from carapace.models.skills import (
+    ContextGrant,
+    SkillCarapaceConfig,
+    SkillMcpBearerAuth,
+    SkillMcpDecl,
+    context_grants_session_summary,
+)
+from carapace.security.context import ContextGrantEntry, SecurityDeniedError
+from carapace.security.sentinel import _format_entry
+
+# ── Models ──────────────────────────────────────────────────────────
+
+
+class TestSkillMcpDecl:
+    def test_valid(self):
+        decl = SkillMcpDecl(
+            name="linear",
+            url="https://mcp.linear.app/mcp",
+            auth=SkillMcpBearerAuth(vault_path="dev/linear-token"),
+        )
+        assert decl.auth is not None and decl.auth.type == "bearer"
+        assert decl.display == "linear (https://mcp.linear.app/mcp)"
+
+    def test_auth_optional(self):
+        decl = SkillMcpDecl(name="local", url="http://localhost:8000/mcp")
+        assert decl.auth is None
+
+    @pytest.mark.parametrize("name", ["1abc", "with-dash", "with.dot", "with space", ""])
+    def test_invalid_name(self, name: str):
+        with pytest.raises(ValidationError):
+            SkillMcpDecl(name=name, url="https://example.com/mcp")
+
+    @pytest.mark.parametrize("url", ["ftp://example.com", "example.com/mcp", "file:///tmp/x"])
+    def test_invalid_url(self, url: str):
+        with pytest.raises(ValidationError):
+            SkillMcpDecl(name="ok", url=url)
+
+    def test_auth_from_yaml_shape(self):
+        cfg = SkillCarapaceConfig.model_validate(
+            {"mcp": [{"name": "l", "url": "https://x.example/mcp", "auth": {"type": "bearer", "vault_path": "dev/t"}}]}
+        )
+        assert cfg.mcp[0].auth is not None and cfg.mcp[0].auth.vault_path == "dev/t"
+
+    def test_duplicate_names_rejected(self):
+        with pytest.raises(ValidationError):
+            SkillCarapaceConfig.model_validate(
+                {"mcp": [{"name": "a", "url": "https://x.example/mcp"}, {"name": "a", "url": "https://y.example/mcp"}]}
+            )
+
+
+class TestGrantIntegration:
+    def test_grant_holds_mcp_servers(self):
+        grant = ContextGrant(skill_name="s", mcp_servers=[SkillMcpDecl(name="m", url="https://x.example/mcp")])
+        summary = context_grants_session_summary("sid", {"s": grant}, lambda _sid, _vp: None)
+        assert summary["s"]["mcp_servers"] == ["m (https://x.example/mcp)"]
+
+    def test_sentinel_formats_grant_entry(self):
+        entry = ContextGrantEntry(skill_name="s", mcp_servers=["m (https://x.example/mcp)"])
+        assert "mcp_servers=" in _format_entry(entry)
+
+
+# ── Toolset factory ─────────────────────────────────────────────────
+
+
+def _ctx_with_grants(grants: dict, *, cached_token: str | None = "tok") -> MagicMock:
+    ctx = MagicMock()
+    ctx.deps.session_state.session_id = "sid"
+    ctx.deps.session_state.context_grants = grants
+    ctx.deps.mcp_toolsets = {}
+    ctx.deps.sandbox.get_cached_credential = MagicMock(return_value=cached_token)
+    ctx.deps.credential_registry.fetch = AsyncMock(return_value="fetched-tok")
+    ctx.deps.sandbox.cache_credential = MagicMock()
+    return ctx
+
+
+class TestBuildSkillMcpToolset:
+    async def test_no_grants_returns_none(self):
+        assert await build_skill_mcp_toolset(_ctx_with_grants({})) is None
+
+    async def test_single_server_prefixed_and_cached(self):
+        decl = SkillMcpDecl(name="linear", url="https://x.example/mcp", auth=SkillMcpBearerAuth(vault_path="dev/t"))
+        ctx = _ctx_with_grants({"s": ContextGrant(skill_name="s", mcp_servers=[decl])})
+        toolset = await build_skill_mcp_toolset(ctx)
+        assert isinstance(toolset, PrefixedToolset)
+        assert toolset.prefix == "linear"
+        assert ctx.deps.mcp_toolsets["s:linear"] is toolset
+        # second evaluation reuses the cached instance
+        assert await build_skill_mcp_toolset(ctx) is toolset
+
+    async def test_token_refetched_on_cache_miss(self):
+        decl = SkillMcpDecl(name="m", url="https://x.example/mcp", auth=SkillMcpBearerAuth(vault_path="dev/t"))
+        ctx = _ctx_with_grants({"s": ContextGrant(skill_name="s", mcp_servers=[decl])}, cached_token=None)
+        assert await build_skill_mcp_toolset(ctx) is not None
+        ctx.deps.credential_registry.fetch.assert_awaited_once_with("dev/t")
+        ctx.deps.sandbox.cache_credential.assert_called_once_with("sid", "dev/t", "fetched-tok")
+
+    async def test_token_fetch_failure_skips_server(self):
+        decl = SkillMcpDecl(name="m", url="https://x.example/mcp", auth=SkillMcpBearerAuth(vault_path="dev/t"))
+        ctx = _ctx_with_grants({"s": ContextGrant(skill_name="s", mcp_servers=[decl])}, cached_token=None)
+        ctx.deps.credential_registry.fetch = AsyncMock(side_effect=KeyError("missing"))
+        assert await build_skill_mcp_toolset(ctx) is None
+
+
+# ── process_tool_call gating ────────────────────────────────────────
+
+
+def _process_ctx(*, approved: bool = False) -> MagicMock:
+    ctx = MagicMock()
+    ctx.tool_call_approved = approved
+    ctx.deps.config.agent.tool_output_max_chars = 16_000
+    ctx.deps.tool_result_callback = None
+    ctx.deps.tool_call_callback = None
+    ctx.deps.assert_llm_budget_available = None
+    ctx.deps.llm_usage_limits = None
+    return ctx
+
+
+class TestMcpProcessToolCall:
+    async def test_denied_call_returns_tool_denied_without_calling_server(self):
+        decl = SkillMcpDecl(name="m", url="https://x.example/mcp")
+        hook = _mcp_process_tool_call("s", decl)
+        ctx = _process_ctx()
+        call_tool = AsyncMock()
+        with patch("carapace.agent.tools.security.evaluate_with", AsyncMock(side_effect=SecurityDeniedError("no"))):
+            result = await hook(ctx, call_tool, "search", {"q": "x"})
+        assert isinstance(result, ToolDenied)
+        call_tool.assert_not_awaited()
+
+    async def test_allowed_call_passes_through(self):
+        decl = SkillMcpDecl(name="m", url="https://x.example/mcp")
+        hook = _mcp_process_tool_call("s", decl)
+        ctx = _process_ctx()
+        call_tool = AsyncMock(return_value={"items": [1, 2]})
+        with patch("carapace.agent.tools.security.evaluate_with", AsyncMock(return_value=None)) as gate:
+            result = await hook(ctx, call_tool, "search", {"q": "x"})
+        assert result == {"items": [1, 2]}
+        call_tool.assert_awaited_once_with("search", {"q": "x"})
+        gate_args = gate.await_args.args
+        assert gate_args[2] == "mcp:m:search"
+
+    async def test_approved_call_skips_gate(self):
+        decl = SkillMcpDecl(name="m", url="https://x.example/mcp")
+        hook = _mcp_process_tool_call("s", decl)
+        ctx = _process_ctx(approved=True)
+        call_tool = AsyncMock(return_value="ok")
+        with patch("carapace.agent.tools.security.evaluate_with", AsyncMock()) as gate:
+            result = await hook(ctx, call_tool, "search", {})
+        assert result == "ok"
+        gate.assert_not_awaited()
+
+    async def test_oversized_text_result_is_spilled(self):
+        decl = SkillMcpDecl(name="m", url="https://x.example/mcp")
+        hook = _mcp_process_tool_call("s", decl)
+        ctx = _process_ctx()
+        ctx.deps.config.agent.tool_output_max_chars = 1000
+        ctx.deps.session_state.session_id = "sid"
+        write_result = MagicMock(exit_code=0)
+        ctx.deps.sandbox.file_write = AsyncMock(return_value=write_result)
+        call_tool = AsyncMock(return_value="x" * 5000)
+        with patch("carapace.agent.tools.security.evaluate_with", AsyncMock(return_value=None)):
+            result = await hook(ctx, call_tool, "search", {})
+        assert isinstance(result, str)
+        assert "Full output saved to" in result
+        ctx.deps.sandbox.file_write.assert_awaited_once()

--- a/tests/test_skill_mcp.py
+++ b/tests/test_skill_mcp.py
@@ -9,7 +9,12 @@ from pydantic import ValidationError
 from pydantic_ai import ToolDenied
 from pydantic_ai.toolsets.prefixed import PrefixedToolset
 
-from carapace.agent.tools import _mcp_process_tool_call, build_skill_mcp_toolset
+from carapace.agent.tools import (
+    _mcp_process_tool_call,
+    _prewarm_skill_mcp,
+    _skill_mcp_name_conflict,
+    build_skill_mcp_toolset,
+)
 from carapace.models.skills import (
     ContextGrant,
     SkillCarapaceConfig,
@@ -174,3 +179,61 @@ class TestMcpProcessToolCall:
         assert isinstance(result, str)
         assert "Full output saved to" in result
         ctx.deps.sandbox.file_write.assert_awaited_once()
+
+
+# ── Duplicate MCP name conflict (issue #2) ──────────────────────────
+
+
+class TestMcpNameConflict:
+    def test_conflict_across_active_skills(self):
+        grants = {
+            "other": ContextGrant(
+                skill_name="other", mcp_servers=[SkillMcpDecl(name="linear", url="https://a.example/mcp")]
+            )
+        }
+        declared = [SkillMcpDecl(name="linear", url="https://b.example/mcp")]
+        msg = _skill_mcp_name_conflict("new", declared, grants)
+        assert msg is not None and "linear" in msg and "other" in msg
+
+    def test_no_conflict_distinct_names(self):
+        grants = {
+            "other": ContextGrant(
+                skill_name="other", mcp_servers=[SkillMcpDecl(name="linear", url="https://a.example/mcp")]
+            )
+        }
+        declared = [SkillMcpDecl(name="github", url="https://b.example/mcp")]
+        assert _skill_mcp_name_conflict("new", declared, grants) is None
+
+    def test_reactivating_same_skill_is_not_a_conflict(self):
+        grants = {
+            "me": ContextGrant(skill_name="me", mcp_servers=[SkillMcpDecl(name="linear", url="https://a.example/mcp")])
+        }
+        declared = [SkillMcpDecl(name="linear", url="https://a.example/mcp")]
+        assert _skill_mcp_name_conflict("me", declared, grants) is None
+
+
+# ── Activation prewarm reports honest status (issue #1) ─────────────
+
+
+class TestPrewarmStatus:
+    async def test_ready_when_build_succeeds(self):
+        ctx = MagicMock()
+        ctx.deps.mcp_toolsets = {}
+        grant = ContextGrant(skill_name="s", mcp_servers=[SkillMcpDecl(name="srv", url="https://e.example/mcp")])
+        with (
+            patch("carapace.agent.tools._mcp_bearer_token", AsyncMock(return_value="tok")),
+            patch("carapace.agent.tools._mcp_process_tool_call", MagicMock(return_value=None)),
+        ):
+            lines = await _prewarm_skill_mcp(ctx, "s", grant)
+        assert "s:srv" in ctx.deps.mcp_toolsets
+        assert any("ready" in ln and "srv_*" in ln for ln in lines)
+
+    async def test_unavailable_when_token_fails_without_promising_tools(self):
+        ctx = MagicMock()
+        ctx.deps.mcp_toolsets = {}
+        grant = ContextGrant(skill_name="s", mcp_servers=[SkillMcpDecl(name="srv", url="https://e.example/mcp")])
+        with patch("carapace.agent.tools._mcp_bearer_token", AsyncMock(side_effect=KeyError("missing"))):
+            lines = await _prewarm_skill_mcp(ctx, "s", grant)
+        assert "s:srv" not in ctx.deps.mcp_toolsets
+        assert any("UNAVAILABLE" in ln for ln in lines)
+        assert not any("ready" in ln for ln in lines)


### PR DESCRIPTION
Skills can now declare MCP servers in `SKILL.md` frontmatter under `metadata.carapace.mcp`. While the skill is active, each server's tools are exposed to the agent as regular tools named `<server>_<tool>` — no more CLI wrappers like mcp2cli for HTTP MCP servers.

## Example

```yaml
metadata:
  carapace:
    mcp:
      - name: linear
        url: https://mcp.linear.app/mcp
        description: Linear issue tracking
        auth:
          type: bearer
          vault_path: dev/linear-mcp-token
```

## How it works

- **Registration**: a `@agent.toolset` dynamic factory (evaluated per run step by pydantic-ai) builds `MCPToolset` instances from active context grants, so tools appear immediately after `use_skill` and only while the grant exists. Instances are cached on `Deps` to avoid re-handshaking every step.
- **Approval**: declared servers ride along in the `use_skill` gate payload (like `declared_domains`/`declared_creds`), are recorded in the context grant + sentinel action log, and show up in the frontend use_skill badge (count chip + expanded list, en/de).
- **Sentinel**: every individual MCP tool call routes through `security.evaluate_with` via a `process_tool_call` hook, shown as `mcp:<server>:<tool>`, with the usual allow/escalate/deny + user-approval flow. `ToolDenied`/`ApprovalRequired` semantics are identical to built-in tools.
- **Long outputs**: oversized text results spill to a sandbox file (`/tmp/carapace-tool-output/...`), same mechanism and preview format as `exec`.
- **Auth**: bearer token read from the vault at activation, cached in the session credential cache, re-fetched on cache miss (e.g. backend restart). `auth` is a discriminated union so oauth can be added as a new variant without restructuring. Vault write-back (token refresh) is out of scope.

## Notes

- MCP requests are made by the backend process (not the sandbox); the URL is pinned to the declared value and every call is sentinel-reviewed.
- Streamable HTTP transport only; connections end with the session (matching context-grant semantics — there is no skill deactivation).

## Testing

- 22 new tests (`tests/test_skill_mcp.py`): model validation, grant/summary integration, toolset factory caching + token re-fetch, gate deny/allow/approved/spill paths.
- Full suite: 1041 passed. ruff + eslint + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Backend-initiated outbound HTTP to user-declared MCP URLs with vault bearer tokens, plus per-call sentinel review—security-sensitive even with pinning and gating.
> 
> **Overview**
> Skills can declare **MCP servers** in `metadata.carapace.mcp`. While a skill is active, each server’s tools show up as `<name>_<tool>` via a dynamic `@agent.toolset` that builds cached `MCPToolset` connections from context grants.
> 
> **Activation & security:** `use_skill` now bundles `declared_mcp` into the approval payload, extends context grants and action logs, caches bearer tokens from the vault, pre-warms connections (reporting **UNAVAILABLE** on failure), and rejects duplicate MCP server names across active skills. Each MCP call is gated as `mcp:<server>:<tool>` through the sentinel, with oversized text results spilled like `exec`.
> 
> **UI & docs:** Knowledge skill cards, `use_skill` badges, and en/de strings surface MCP servers; docs describe the new frontmatter field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc60bee0bd95a5f54ede1477f3089d2d6d0bbabc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->