### PR TITLE
✨ feat(skills): stdio MCP servers via an in-sandbox bridge

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -98,6 +98,9 @@ metadata:
         auth:
           type: bearer
           vault_path: dev/linear-mcp-token
+      - name: karakeep
+        command: npx -y @karakeep/mcp
+        description: Karakeep bookmarks (stdio server, runs in the sandbox)
 ---
 ```
 
@@ -146,19 +149,32 @@ Notes:
 - `command` must be a single non-empty line.
 - Alias names must be unique across active skills. If an active skill already owns an alias, activating another skill with the same alias fails.
 
-**`mcp`** — optional list of MCP servers the skill connects to. While the skill is active, each server's tools are exposed to the agent as regular tools named `<name>_<tool>`. Each entry has:
+**`mcp`** — optional list of MCP servers the skill connects to. While the skill is active, each server's tools are exposed to the agent as regular, typed tools named `<name>_<tool>` (built from the server's own JSON Schemas). Each entry is one of two transports.
+
+Common fields:
 
 - `name` — server name, used as the tool-name prefix. Must start with a letter and contain only letters, numbers, or underscores.
-- `url` — the server's HTTP(S) endpoint (streamable HTTP transport).
 - `description` — optional human-readable explanation for approvals and docs.
-- `auth` — optional authentication. Currently only `type: bearer` with a `vault_path`: the token is read from the vault at activation and sent as `Authorization: Bearer <token>`. The auth block is a tagged union so other methods (e.g. OAuth) can be added later.
 
-Notes:
+**HTTP transport** — set `url`:
+
+- `url` — the server's HTTP(S) endpoint (streamable HTTP transport).
+- `auth` — optional. Currently only `type: bearer` with a `vault_path`: the token is read from the vault at activation and sent as `Authorization: Bearer <token>`. The auth block is a tagged union so other methods (e.g. OAuth) can be added later.
+- The connection is made by the **backend process**; the URL is pinned to the declared value.
+
+**stdio transport** — set `command`:
+
+- `command` — a shell command that starts the MCP server (e.g. `npx -y @karakeep/mcp`, `uv run --directory /workspace/skills/foo mcp-server`).
+- The server process runs **inside the sandbox**, one spawn per operation (once to enumerate tools at activation, once per tool call), bridged by the baked-in `carapace-mcp-bridge`. Nothing persists between calls, so the process model matches an ordinary `exec` — no long-lived connection.
+- `auth` does not apply. The server inherits the skill's context-injected credentials, so declare any secrets it needs under `credentials` with an `env_var` (or `file`); they are injected into the bridge exec under this skill's context.
+- The server may reach the skill's declared `network.domains` (the bridge runs under the skill context), and stateful servers that expect a session across calls are not supported (each call is a fresh process — same limitation as invoking mcp2cli per call).
+
+Notes (both transports):
 
 - The declared servers are part of the `use_skill` approval, like domains and credentials. Every individual MCP tool call is still reviewed by the sentinel (shown as `mcp:<server>:<tool>`), with the usual escalate-to-user path.
-- MCP requests are made by the backend process, not from inside the sandbox. The URL is pinned to the declared value.
 - Oversized text results are spilled to a file in the sandbox (same mechanism as `exec` output).
 - Server tools disappear when the session ends; there is no explicit deactivation, matching context grants.
+- Skills that need full control (OAuth, stateful sessions, custom output shaping) can still wrap a server as a CLI with `mcp2cli` and a `commands` alias instead; `mcp` is the shortcut for the common case.
 
 ## Context-scoped access
 

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -304,7 +304,9 @@ function SkillCard({ skill }: { skill: KnowledgeSkill }) {
                       <span className="break-words text-xs text-muted-foreground">{server.description}</span>
                     ) : null}
                   </div>
-                  <code className="break-all font-mono text-xs text-muted-foreground">{server.url}</code>
+                  <code className="break-all font-mono text-xs text-muted-foreground">
+                    {server.command ? `stdio: ${server.command}` : server.url}
+                  </code>
                   {server.auth ? (
                     <code className="break-all font-mono text-xs text-muted-foreground">
                       {t("mcpAuth", { type: server.auth.type })} · {server.auth.vault_path}

--- a/frontend/src/components/tool-call-badge.tsx
+++ b/frontend/src/components/tool-call-badge.tsx
@@ -704,8 +704,8 @@ export function ToolCallBadge({
 
             // Count MCP servers declared by use_skill
             const declaredMcp = isUseSkillTool && Array.isArray(args.declared_mcp)
-              ? (args.declared_mcp as Array<{ name: string; url: string }>) : [];
-            const mcpTooltip = declaredMcp.map(s => `${s.name} (${s.url})`).join("\n");
+              ? (args.declared_mcp as Array<{ name: string; url?: string; command?: string }>) : [];
+            const mcpTooltip = declaredMcp.map(s => `${s.name} (${s.command ? `stdio: ${s.command}` : s.url})`).join("\n");
 
             return (
               <>
@@ -865,7 +865,7 @@ export function ToolCallBadge({
               {(() => {
                 const servers = (
                   Array.isArray(args.declared_mcp) ? args.declared_mcp : []
-                ) as Array<{ name: string; url: string; description?: string }>;
+                ) as Array<{ name: string; url?: string; command?: string; description?: string }>;
                 return servers.length > 0 ? (
                   <div className="text-[11px] text-muted-foreground">
                     <span className="font-medium text-foreground/70"><Plug className="inline h-3 w-3 -translate-y-px mr-1" />{t("details.mcpServers")} </span>
@@ -873,7 +873,7 @@ export function ToolCallBadge({
                       <span key={s.name} title={s.description || undefined}>
                         {i > 0 && ", "}
                         <span className="font-mono">{s.name}</span>
-                        <span className="text-muted-foreground/70"> ({s.url})</span>
+                        <span className="text-muted-foreground/70"> ({s.command ? `stdio: ${s.command}` : s.url})</span>
                       </span>
                     ))}
                   </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1594,7 +1594,8 @@ export interface SkillMcpBearerAuth {
 
 export interface SkillMcpDecl {
   name: string;
-  url: string;
+  url: string | null;
+  command: string | null;
   description: string;
   auth: SkillMcpBearerAuth | null;
 }

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -27,6 +27,14 @@ RUN chmod +x /usr/local/bin/setup-proxy.sh
 COPY ccred /usr/local/bin/ccred
 RUN chmod +x /usr/local/bin/ccred
 
+# Self-contained venv for the stdio MCP bridge (skill-declared stdio MCP servers).
+# Baked at build time so no dependency resolution happens at runtime (the sandbox's
+# egress is proxy/domain-gated and would block a runtime `pip`/`uv` fetch).
+RUN uv venv /opt/carapace-mcp --python 3.14 \
+   && uv pip install --python /opt/carapace-mcp/bin/python "mcp>=1.20,<2"
+COPY carapace-mcp-bridge /usr/local/bin/carapace-mcp-bridge
+RUN chmod +x /usr/local/bin/carapace-mcp-bridge
+
 RUN mkdir -p /workspace \
    && git config --global --add safe.directory /workspace
 

--- a/sandbox/carapace-mcp-bridge
+++ b/sandbox/carapace-mcp-bridge
@@ -1,0 +1,113 @@
+#!/opt/carapace-mcp/bin/python
+"""carapace-mcp-bridge — stateless stdio MCP bridge for carapace sandboxes.
+
+Spawns a stdio MCP server, runs the ``initialize`` handshake, then either
+lists its tools (with their real JSON Schemas) or calls one tool, and prints
+a single JSON result envelope to stdout. One process per operation; nothing
+persists between calls. The carapace backend invokes this via ``exec`` inside
+the sandbox, once per skill activation (``list``) and once per tool call
+(``call``).
+
+The server command and any tool arguments are passed base64-encoded so the
+whole invocation is a fixed, shell-safe command string. The result envelope is
+emitted on a single line prefixed with ``_MARKER`` so the backend can recover
+it even when the sandbox merges the child's stderr into the captured output.
+
+Envelope: ``{"ok": true, "result": <tools list | tool result>}`` or
+``{"ok": false, "error": "<Type>: <message>"}``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import json
+import os
+import sys
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+# Must stay in sync with _MCP_BRIDGE_MARKER in src/carapace/agent/tools.py.
+_MARKER = "@@CARAPACE_MCP@@"
+
+
+def _server_params(server_cmd: str) -> StdioServerParameters:
+    # Run through the shell so arbitrary command strings (npx ..., uv run ...) work,
+    # and forward the full environment so context-injected credentials reach the server.
+    return StdioServerParameters(command="bash", args=["-lc", server_cmd], env=dict(os.environ))
+
+
+async def _list(server_cmd: str) -> list[dict]:
+    async with (
+        stdio_client(_server_params(server_cmd), errlog=sys.stderr) as (read, write),
+        ClientSession(read, write) as session,
+    ):
+        await session.initialize()
+        result = await session.list_tools()
+        return [
+            {"name": t.name, "description": t.description or "", "input_schema": t.inputSchema} for t in result.tools
+        ]
+
+
+async def _call(server_cmd: str, tool: str, arguments: dict) -> object:
+    async with (
+        stdio_client(_server_params(server_cmd), errlog=sys.stderr) as (read, write),
+        ClientSession(read, write) as session,
+    ):
+        await session.initialize()
+        result = await session.call_tool(tool, arguments=arguments or {})
+        if result.structuredContent is not None:
+            payload: object = result.structuredContent
+        else:
+            payload = "\n".join(
+                getattr(block, "text", "") for block in result.content if getattr(block, "type", None) == "text"
+            )
+        if result.isError:
+            message = payload if isinstance(payload, str) else json.dumps(payload)
+            raise RuntimeError(message or "MCP tool call reported an error")
+        return payload
+
+
+def _describe(exc: BaseException) -> str:
+    # Unwrap ExceptionGroup (asyncio TaskGroup) down to the real leaf causes so the
+    # envelope carries the server's actual error, not "unhandled errors in a TaskGroup".
+    if isinstance(exc, BaseExceptionGroup):
+        return "; ".join(_describe(sub) for sub in exc.exceptions)
+    return f"{type(exc).__name__}: {exc}"
+
+
+def _emit(envelope: dict) -> None:
+    sys.stdout.write(_MARKER + json.dumps(envelope) + "\n")
+    sys.stdout.flush()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="carapace-mcp-bridge")
+    sub = parser.add_subparsers(dest="mode", required=True)
+    for mode in ("list", "call"):
+        p = sub.add_parser(mode)
+        p.add_argument("--server", required=True, help="base64-encoded server command string")
+        if mode == "call":
+            p.add_argument("--tool", required=True)
+            p.add_argument("--args", default="", help="base64-encoded JSON arguments object")
+    ns = parser.parse_args()
+
+    server_cmd = base64.b64decode(ns.server).decode()
+    try:
+        if ns.mode == "list":
+            result: object = asyncio.run(_list(server_cmd))
+        else:
+            arguments = json.loads(base64.b64decode(ns.args).decode()) if ns.args else {}
+            result = asyncio.run(_call(server_cmd, ns.tool, arguments))
+    except BaseException as exc:
+        if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+            raise
+        _emit({"ok": False, "error": _describe(exc)})
+        sys.exit(1)
+    _emit({"ok": True, "result": result})
+
+
+if __name__ == "__main__":
+    main()

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -4,6 +4,8 @@ import base64
 import json
 import re
 import secrets
+import shlex
+from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path, PurePosixPath
 from typing import Annotated, Any
@@ -11,10 +13,10 @@ from typing import Annotated, Any
 import httpx
 from loguru import logger
 from pydantic import Field
-from pydantic_ai import Agent, DeferredToolRequests, RunContext, ToolDenied, ToolOutput
+from pydantic_ai import Agent, DeferredToolRequests, ModelRetry, RunContext, Tool, ToolDenied, ToolOutput
 from pydantic_ai.mcp import CallToolFunc, MCPToolset
 from pydantic_ai.messages import BinaryContent, ToolReturn
-from pydantic_ai.toolsets import CombinedToolset
+from pydantic_ai.toolsets import CombinedToolset, FunctionToolset
 from pydantic_ai.toolsets.abstract import AbstractToolset
 
 from .. import security as security
@@ -497,6 +499,81 @@ async def _cache_skill_credentials(
     return "\n".join(parts), names_map
 
 
+@dataclass
+class _ContextInjection:
+    """Per-exec credential/domain/tunnel data resolved from active context grants."""
+
+    extra_env: dict[str, str] = field(default_factory=dict)
+    domains: set[str] = field(default_factory=set)
+    tunnels: list[Any] = field(default_factory=list)
+    file_creds: list[tuple[str, str, str]] = field(default_factory=list)  # (skill, path, value)
+    injected_creds: list[tuple[str, str]] = field(default_factory=list)  # (skill, vault_path)
+    missing_cached: list[tuple[str, str]] = field(default_factory=list)  # (skill, vault_path)
+
+
+async def _collect_context_injection(ctx: RunContext[Deps], contexts: list[str]) -> _ContextInjection:
+    """Build per-exec injection (env/files/domains/tunnels) from matching context grants.
+
+    Shared by the ``exec`` tool and the stdio MCP bridge so both inject a skill's
+    declared credentials, domains, and tunnels identically. Credential values come
+    from the session cache, re-fetched from the vault on a cache miss.
+    """
+    inj = _ContextInjection()
+    grants = ctx.deps.session_state.context_grants
+    session_id = ctx.deps.session_state.session_id
+    for ctx_name in contexts:
+        grant = grants.get(ctx_name)
+        if grant is None:
+            continue
+        inj.domains.update(grant.domains)
+        inj.tunnels.extend(grant.tunnels)
+        inj.domains.update(tunnel.host for tunnel in grant.tunnels)
+        for decl in grant.credential_decls:
+            if not (decl.env_var or decl.file):
+                continue
+            cached = ctx.deps.sandbox.get_cached_credential(session_id, decl.vault_path)
+            if cached is None:
+                # Cache miss (e.g. after backend restart) — re-fetch from vault
+                logger.info(f"Credential cache miss for {decl.vault_path!r} (skill {ctx_name!r}), re-fetching")
+                try:
+                    cached = await ctx.deps.credential_registry.fetch(decl.vault_path)
+                    ctx.deps.sandbox.cache_credential(session_id, decl.vault_path, cached)
+                except Exception:
+                    inj.missing_cached.append((ctx_name, decl.vault_path))
+                    continue
+            if decl.base64:
+                cached = base64.b64decode(cached).decode()
+            inj.injected_creds.append((ctx_name, decl.vault_path))
+            if decl.env_var:
+                inj.extra_env[decl.env_var] = cached
+            if decl.file:
+                inj.file_creds.append((ctx_name, decl.file, cached))
+    return inj
+
+
+def _notify_injected_creds_callback(ctx: RunContext[Deps], injected_creds: list[tuple[str, str]]) -> Any:
+    """Build an after-exec callback that logs each skill-declared credential as used."""
+
+    def _notify() -> None:
+        grants = ctx.deps.session_state.context_grants
+        for ctx_name, vp in injected_creds:
+            grant = grants.get(ctx_name)
+            if grant is None:
+                continue
+            cred_name = grant.credential_names.get(vp, "")
+            display = cred_name or vp
+            ctx.deps.security.notify_credential_decision(
+                vp,
+                f"[skill] {display}",
+                name=cred_name,
+                approval_source="skill",
+                approval_verdict="allow",
+                approval_explanation=f"skill-declared credential ({ctx_name})",
+            )
+
+    return _notify
+
+
 async def _mcp_bearer_token(ctx: RunContext[Deps], decl: SkillMcpDecl) -> str | None:
     """Resolve the bearer token for an MCP server from the session credential cache, re-fetching on miss."""
     if decl.auth is None:
@@ -511,12 +588,47 @@ async def _mcp_bearer_token(ctx: RunContext[Deps], decl: SkillMcpDecl) -> str | 
     return cached
 
 
-def _mcp_process_tool_call(skill_name: str, decl: SkillMcpDecl) -> Any:
-    """Build a ``process_tool_call`` hook that routes every MCP tool call through the security gate.
+async def _gate_mcp_call(ctx: RunContext[Deps], gate_name: str, gate_args: dict[str, Any]) -> ToolDenied | None:
+    """Sentinel gate for one MCP tool call (or emit the approved-start notice if pre-approved)."""
+    if not ctx.tool_call_approved:
+        return await _gate(ctx, gate_name, gate_args)
+    _notify_approved_start(ctx, gate_name, gate_args)
+    return None
 
-    The hook mirrors the ``exec`` tool's flow: sentinel gate (with approval
-    escalation), action-log entry, spill-to-file for oversized text results,
-    and UI notification.
+
+async def _emit_mcp_result(ctx: RunContext[Deps], gate_name: str, result: Any) -> Any:
+    """Apply spill-to-file + truncation to an MCP tool result and notify the UI.
+
+    Returns the model-facing value: the original result when small, or a preview
+    string (with the spill path) when oversized. Shared by HTTP and stdio paths.
+    """
+    text: str | None = None
+    if isinstance(result, str):
+        text = result
+    elif isinstance(result, dict | list):
+        try:
+            text = json.dumps(result, default=str)
+        except (TypeError, ValueError):
+            text = None
+
+    if text is None:
+        _notify_result(ctx, gate_name, f"[non-text MCP tool result: {type(result).__name__}]")
+        return result
+
+    max_chars = ctx.deps.config.agent.tool_output_max_chars
+    if 0 < max_chars < len(text):
+        spilled = await _prepare_exec_tool_result(ctx, text)
+        return _emit_tool_result(ctx, gate_name, spilled)
+
+    _notify_result(ctx, gate_name, text)
+    return result
+
+
+def _mcp_process_tool_call(skill_name: str, decl: SkillMcpDecl) -> Any:
+    """Build a ``process_tool_call`` hook that routes each HTTP MCP call through the security gate.
+
+    Mirrors the ``exec`` flow: sentinel gate (with approval escalation),
+    action-log entry, spill-to-file for oversized results, and UI notification.
     """
 
     async def _process(
@@ -527,11 +639,8 @@ def _mcp_process_tool_call(skill_name: str, decl: SkillMcpDecl) -> Any:
     ) -> Any:
         gate_name = f"mcp:{decl.name}:{name}"
         gate_args = {"skill": skill_name, "server": decl.name, "url": decl.url, "tool": name, "args": tool_args}
-        if not ctx.tool_call_approved:
-            if denied := await _gate(ctx, gate_name, gate_args):
-                return denied
-        else:
-            _notify_approved_start(ctx, gate_name, gate_args)
+        if denied := await _gate_mcp_call(ctx, gate_name, gate_args):
+            return denied
 
         try:
             result = await call_tool(name, tool_args)
@@ -540,37 +649,127 @@ def _mcp_process_tool_call(skill_name: str, decl: SkillMcpDecl) -> Any:
             raise
 
         ctx.deps.security.append(ToolResultEntry(tool=gate_name, status="success"))
-
-        text: str | None = None
-        if isinstance(result, str):
-            text = result
-        elif isinstance(result, dict | list):
-            try:
-                text = json.dumps(result, default=str)
-            except (TypeError, ValueError):
-                text = None
-
-        if text is None:
-            _notify_result(ctx, gate_name, f"[non-text MCP tool result: {type(result).__name__}]")
-            return result
-
-        max_chars = ctx.deps.config.agent.tool_output_max_chars
-        if 0 < max_chars < len(text):
-            spilled = await _prepare_exec_tool_result(ctx, text)
-            return _emit_tool_result(ctx, gate_name, spilled)
-
-        _notify_result(ctx, gate_name, text)
-        return result
+        return await _emit_mcp_result(ctx, gate_name, result)
 
     return _process
+
+
+# --- stdio MCP (server runs in the sandbox, bridged per operation) ---
+
+# Prefix the bridge writes its JSON result envelope with. Must match _MARKER in
+# sandbox/carapace-mcp-bridge. Lets us recover the envelope even when the sandbox
+# merges the child's stderr into the captured output.
+_MCP_BRIDGE_MARKER = "@@CARAPACE_MCP@@"
+_MCP_BRIDGE_CMD = "carapace-mcp-bridge"
+
+
+def _parse_bridge_envelope(output: str) -> dict[str, Any]:
+    """Extract the bridge's JSON result envelope from (possibly noisy) exec output."""
+    for line in output.splitlines():
+        if line.startswith(_MCP_BRIDGE_MARKER):
+            return json.loads(line[len(_MCP_BRIDGE_MARKER) :])
+    raise ValueError(f"MCP bridge produced no result envelope. Output tail: {output[-500:]!r}")
+
+
+async def _run_stdio_bridge(
+    ctx: RunContext[Deps],
+    skill_name: str,
+    decl: SkillMcpDecl,
+    mode: str,
+    *,
+    tool: str | None = None,
+    args: dict[str, Any] | None = None,
+) -> Any:
+    """Run the bridge in the sandbox under the skill's context and return the unwrapped result.
+
+    Raises ``RuntimeError`` (message = the server's error) when the envelope reports failure.
+    """
+    server_b64 = base64.b64encode((decl.command or "").encode()).decode()
+    parts = [_MCP_BRIDGE_CMD, mode, "--server", server_b64]
+    if mode == "call":
+        parts += ["--tool", shlex.quote(tool or "")]
+        if args:
+            parts += ["--args", base64.b64encode(json.dumps(args).encode()).decode()]
+    command = " ".join(parts)
+
+    inj = await _collect_context_injection(ctx, [skill_name])
+    exec_result = await ctx.deps.sandbox.exec_command(
+        ctx.deps.session_state.session_id,
+        command,
+        contexts=[skill_name],
+        extra_env=inj.extra_env or None,
+        context_domains=inj.domains or None,
+        context_tunnels=inj.tunnels or None,
+        context_file_creds=inj.file_creds or None,
+        after_exec_credential_notify=_notify_injected_creds_callback(ctx, inj.injected_creds)
+        if inj.injected_creds
+        else None,
+    )
+    envelope = _parse_bridge_envelope(exec_result.output)
+    if not envelope.get("ok"):
+        raise RuntimeError(envelope.get("error", "unknown MCP bridge error"))
+    return envelope["result"]
+
+
+def _stdio_mcp_tool_handler(skill_name: str, decl: SkillMcpDecl, tool_name: str) -> Any:
+    """Build the call handler for one stdio MCP tool: gate, run the bridge, emit the result."""
+
+    async def _handler(ctx: RunContext[Deps], **tool_args: Any) -> Any:
+        gate_name = f"mcp:{decl.name}:{tool_name}"
+        gate_args = {
+            "skill": skill_name,
+            "server": decl.name,
+            "command": decl.command,
+            "tool": tool_name,
+            "args": tool_args,
+        }
+        if denied := await _gate_mcp_call(ctx, gate_name, gate_args):
+            return denied
+
+        try:
+            result = await _run_stdio_bridge(ctx, skill_name, decl, "call", tool=tool_name, args=tool_args)
+        except Exception as exc:
+            ctx.deps.security.append(ToolResultEntry(tool=gate_name, status="error"))
+            raise ModelRetry(f"MCP tool '{decl.name}_{tool_name}' failed: {exc}") from exc
+
+        ctx.deps.security.append(ToolResultEntry(tool=gate_name, status="success"))
+        return await _emit_mcp_result(ctx, gate_name, result)
+
+    return _handler
+
+
+async def _build_stdio_mcp_toolset(
+    ctx: RunContext[Deps], skill_name: str, decl: SkillMcpDecl
+) -> AbstractToolset[Deps] | None:
+    """Enumerate a stdio server's tools via the bridge and register them as typed function tools."""
+    tool_defs = await _run_stdio_bridge(ctx, skill_name, decl, "list")
+    tools: list[Tool[Deps]] = []
+    for td in tool_defs:
+        raw_name = td.get("name")
+        schema = td.get("input_schema") or {"type": "object", "properties": {}}
+        if not raw_name:
+            continue
+        tools.append(
+            Tool.from_schema(
+                _stdio_mcp_tool_handler(skill_name, decl, raw_name),
+                name=f"{decl.name}_{raw_name}",
+                description=td.get("description") or "",
+                json_schema=schema,
+                takes_ctx=True,
+            )
+        )
+    if not tools:
+        return None
+    return FunctionToolset(tools=tools)
 
 
 async def build_skill_mcp_toolset(ctx: RunContext[Deps]) -> AbstractToolset[Deps] | None:
     """Dynamic toolset factory: expose MCP tools declared by active skill grants.
 
     Evaluated per run step by pydantic-ai, so tools appear right after
-    ``use_skill`` registers a grant. Toolset instances are cached on ``Deps``
-    to avoid re-connecting on every step.
+    ``use_skill`` registers a grant. Built toolsets are cached on ``Deps`` so
+    HTTP servers are not re-connected and stdio servers are not re-enumerated
+    on every step.
     """
     toolsets: list[AbstractToolset[Deps]] = []
     for skill_name, grant in ctx.deps.session_state.context_grants.items():
@@ -579,16 +778,21 @@ async def build_skill_mcp_toolset(ctx: RunContext[Deps]) -> AbstractToolset[Deps
             toolset = ctx.deps.mcp_toolsets.get(key)
             if toolset is None:
                 try:
-                    token = await _mcp_bearer_token(ctx, decl)
+                    if decl.is_stdio:
+                        toolset = await _build_stdio_mcp_toolset(ctx, skill_name, decl)
+                    else:
+                        token = await _mcp_bearer_token(ctx, decl)
+                        toolset = MCPToolset(
+                            decl.url,
+                            auth=token,
+                            id=f"mcp:{key}",
+                            process_tool_call=_mcp_process_tool_call(skill_name, decl),
+                        ).prefixed(decl.name)
                 except Exception as exc:
                     logger.warning(f"Skipping MCP server {decl.display} (skill {skill_name!r}): {exc}")
                     continue
-                toolset = MCPToolset(
-                    decl.url,
-                    auth=token,
-                    id=f"mcp:{key}",
-                    process_tool_call=_mcp_process_tool_call(skill_name, decl),
-                ).prefixed(decl.name)
+                if toolset is None:
+                    continue
                 ctx.deps.mcp_toolsets[key] = toolset
             toolsets.append(toolset)
     if not toolsets:
@@ -1094,64 +1298,19 @@ def create_agent(deps: Deps) -> Agent[Deps, str | TaskDone | TaskFailed | Deferr
         session_id = ctx.deps.session_state.session_id
 
         # Build per-exec injection data from matching context grants
-        extra_env: dict[str, str] = {}
-        context_domains: set[str] = set()
-        context_tunnels = []
-        context_file_creds: list[tuple[str, str, str]] = []  # (skill_name, file_path, value)
-        missing_cached: list[tuple[str, str]] = []
-        injected_creds: list[tuple[str, str]] = []  # (ctx_name, vault_path)
-        for ctx_name in contexts:
-            grant = grants[ctx_name]
-            context_domains.update(grant.domains)
-            context_tunnels.extend(grant.tunnels)
-            context_domains.update(tunnel.host for tunnel in grant.tunnels)
-            for decl in grant.credential_decls:
-                if not (decl.env_var or decl.file):
-                    continue
-                cached = ctx.deps.sandbox.get_cached_credential(session_id, decl.vault_path)
-                if cached is None:
-                    # Cache miss (e.g. after backend restart) — re-fetch from vault
-                    logger.info(
-                        f"Credential cache miss for {decl.vault_path!r} (skill {ctx_name!r}), re-fetching from vault"
-                    )
-                    try:
-                        cached = await ctx.deps.credential_registry.fetch(decl.vault_path)
-                        ctx.deps.sandbox.cache_credential(session_id, decl.vault_path, cached)
-                    except Exception:
-                        missing_cached.append((ctx_name, decl.vault_path))
-                        continue
-                if decl.base64:
-                    cached = base64.b64decode(cached).decode()
-                injected_creds.append((ctx_name, decl.vault_path))
-                if decl.env_var:
-                    extra_env[decl.env_var] = cached
-                if decl.file:
-                    context_file_creds.append((ctx_name, decl.file, cached))
-
-        def _notify_injected_skill_creds() -> None:
-            for ctx_name, vp in injected_creds:
-                grant = grants[ctx_name]
-                cred_name = grant.credential_names.get(vp, "")
-                display = cred_name or vp
-                ctx.deps.security.notify_credential_decision(
-                    vp,
-                    f"[skill] {display}",
-                    name=cred_name,
-                    approval_source="skill",
-                    approval_verdict="allow",
-                    approval_explanation=f"skill-declared credential ({ctx_name})",
-                )
+        inj = await _collect_context_injection(ctx, contexts)
+        notify = _notify_injected_creds_callback(ctx, inj.injected_creds)
 
         try:
             exec_result = await ctx.deps.sandbox.exec_command(
                 session_id,
                 command,
                 contexts=contexts,
-                extra_env=extra_env or None,
-                context_domains=context_domains or None,
-                context_tunnels=context_tunnels or None,
-                context_file_creds=context_file_creds or None,
-                after_exec_credential_notify=_notify_injected_skill_creds if injected_creds else None,
+                extra_env=inj.extra_env or None,
+                context_domains=inj.domains or None,
+                context_tunnels=inj.tunnels or None,
+                context_file_creds=inj.file_creds or None,
+                after_exec_credential_notify=notify if inj.injected_creds else None,
             )
             result = exec_result.output
             exit_code = exec_result.exit_code
@@ -1160,8 +1319,9 @@ def create_agent(deps: Deps) -> Agent[Deps, str | TaskDone | TaskFailed | Deferr
             result = f"Error: {exc}"
             exit_code = -1
 
-        if missing_cached:
-            lines = "\n".join(f"  - skill {name!r}, vault path {vp!r}" for name, vp in dict.fromkeys(missing_cached))
+        if inj.missing_cached:
+            missing = dict.fromkeys(inj.missing_cached)
+            lines = "\n".join(f"  - skill {name!r}, vault path {vp!r}" for name, vp in missing)
             result = (
                 "Warning: these credentials are not in the session cache and were not injected "
                 "(re-run use_skill for the skill if you need them):\n"

--- a/src/carapace/agent/tools.py
+++ b/src/carapace/agent/tools.py
@@ -778,9 +778,9 @@ async def build_skill_mcp_toolset(ctx: RunContext[Deps]) -> AbstractToolset[Deps
             toolset = ctx.deps.mcp_toolsets.get(key)
             if toolset is None:
                 try:
-                    if decl.is_stdio:
+                    if decl.command is not None:
                         toolset = await _build_stdio_mcp_toolset(ctx, skill_name, decl)
-                    else:
+                    elif decl.url is not None:
                         token = await _mcp_bearer_token(ctx, decl)
                         toolset = MCPToolset(
                             decl.url,
@@ -788,6 +788,8 @@ async def build_skill_mcp_toolset(ctx: RunContext[Deps]) -> AbstractToolset[Deps
                             id=f"mcp:{key}",
                             process_tool_call=_mcp_process_tool_call(skill_name, decl),
                         ).prefixed(decl.name)
+                    else:  # unreachable: the model validates url xor command
+                        continue
                 except Exception as exc:
                     logger.warning(f"Skipping MCP server {decl.display} (skill {skill_name!r}): {exc}")
                     continue

--- a/src/carapace/models/skills.py
+++ b/src/carapace/models/skills.py
@@ -88,10 +88,21 @@ class SkillMcpDecl(BaseModel):
 
     ``name`` doubles as the tool-name prefix: the server's tools are exposed to
     the agent as ``<name>_<tool>`` while the skill is active.
+
+    A declaration is one of two transports:
+
+    - **HTTP** — set ``url`` (streamable HTTP); optional ``auth`` (bearer token
+      from the vault). The connection is made by the backend process.
+    - **stdio** — set ``command`` (a shell command that starts the server); the
+      process runs inside the sandbox, one spawn per operation, bridged by
+      ``carapace-mcp-bridge``. The server inherits the skill's context-injected
+      credentials (declare them under ``credentials`` with an ``env_var``), so
+      ``auth`` does not apply.
     """
 
     name: str
-    url: str
+    url: str | None = None
+    command: str | None = None
     description: str = ""
     auth: SkillMcpAuth | None = None
 
@@ -101,13 +112,23 @@ class SkillMcpDecl(BaseModel):
             raise ValueError(
                 "skill mcp name must start with a letter and contain only letters, numbers, or underscores"
             )
-        if not self.url.startswith(("http://", "https://")):
+        if bool(self.url) == bool(self.command):
+            raise ValueError("skill mcp declaration must set exactly one of 'url' (HTTP) or 'command' (stdio)")
+        if self.url is not None and not self.url.startswith(("http://", "https://")):
             raise ValueError("skill mcp url must be an http(s) URL")
+        if self.command is not None and self.auth is not None:
+            raise ValueError("skill mcp 'auth' applies to HTTP servers only; stdio servers use skill credentials")
         return self
 
     @property
+    def is_stdio(self) -> bool:
+        return self.command is not None
+
+    @property
     def display(self) -> str:
-        return f"{self.name} ({self.url})"
+        target = self.command if self.is_stdio else self.url
+        prefix = "stdio: " if self.is_stdio else ""
+        return f"{self.name} ({prefix}{target})"
 
 
 class SkillCarapaceConfig(BaseModel):

--- a/tests/test_skill_mcp_stdio.py
+++ b/tests/test_skill_mcp_stdio.py
@@ -1,0 +1,261 @@
+"""Tests for skill-declared stdio MCP servers (bridged through the sandbox)."""
+
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+from pydantic_ai import ModelRetry, ToolDenied
+from pydantic_ai.toolsets import FunctionToolset
+
+from carapace.agent.tools import (
+    _build_stdio_mcp_toolset,
+    _parse_bridge_envelope,
+    _run_stdio_bridge,
+    _stdio_mcp_tool_handler,
+    build_skill_mcp_toolset,
+)
+from carapace.models.skills import ContextGrant, SkillCarapaceConfig, SkillMcpBearerAuth, SkillMcpDecl
+from carapace.security.context import SecurityDeniedError
+
+BRIDGE = Path(__file__).resolve().parents[1] / "sandbox" / "carapace-mcp-bridge"
+
+# ── Model ───────────────────────────────────────────────────────────
+
+
+class TestStdioDecl:
+    def test_valid_stdio(self):
+        decl = SkillMcpDecl(name="fs", command="npx -y server-filesystem /tmp")
+        assert decl.is_stdio
+        assert decl.url is None
+        assert decl.display == "fs (stdio: npx -y server-filesystem /tmp)"
+
+    def test_exactly_one_transport_required(self):
+        with pytest.raises(ValidationError):  # neither
+            SkillMcpDecl(name="x")
+        with pytest.raises(ValidationError):  # both
+            SkillMcpDecl(name="x", url="https://e.example/mcp", command="run")
+
+    def test_auth_not_allowed_on_stdio(self):
+        with pytest.raises(ValidationError):
+            SkillMcpDecl(name="x", command="run", auth=SkillMcpBearerAuth(vault_path="v/t"))
+
+    def test_http_still_valid(self):
+        decl = SkillMcpDecl(name="h", url="https://e.example/mcp")
+        assert not decl.is_stdio
+
+    def test_config_accepts_mixed_transports(self):
+        cfg = SkillCarapaceConfig.model_validate(
+            {"mcp": [{"name": "a", "url": "https://e.example/mcp"}, {"name": "b", "command": "run-b"}]}
+        )
+        assert [s.is_stdio for s in cfg.mcp] == [False, True]
+
+
+# ── Envelope parsing ────────────────────────────────────────────────
+
+
+class TestParseEnvelope:
+    def test_extracts_marker_line_amid_noise(self):
+        out = 'server stderr line\n[stderr] warning\n@@CARAPACE_MCP@@{"ok": true, "result": [1, 2]}\n'
+        assert _parse_bridge_envelope(out) == {"ok": True, "result": [1, 2]}
+
+    def test_missing_envelope_raises(self):
+        with pytest.raises(ValueError, match="no result envelope"):
+            _parse_bridge_envelope("just some output\n[exit code: 1]")
+
+
+# ── _run_stdio_bridge ───────────────────────────────────────────────
+
+
+def _bridge_ctx(*, output: str) -> MagicMock:
+    ctx = MagicMock()
+    ctx.deps.session_state.session_id = "sid"
+    ctx.deps.session_state.context_grants = {
+        "s": ContextGrant(skill_name="s", mcp_servers=[SkillMcpDecl(name="srv", command="run-server")])
+    }
+    ctx.deps.sandbox.get_cached_credential = MagicMock(return_value=None)
+    ctx.deps.sandbox.exec_command = AsyncMock(return_value=MagicMock(output=output))
+    return ctx
+
+
+class TestRunStdioBridge:
+    async def test_list_builds_command_and_returns_result(self):
+        env = '@@CARAPACE_MCP@@{"ok": true, "result": [{"name": "t"}]}'
+        ctx = _bridge_ctx(output=env)
+        decl = ctx.deps.session_state.context_grants["s"].mcp_servers[0]
+        result = await _run_stdio_bridge(ctx, "s", decl, "list")
+        assert result == [{"name": "t"}]
+        command = ctx.deps.sandbox.exec_command.await_args.args[1]
+        assert command.startswith("carapace-mcp-bridge list --server ")
+        server_b64 = command.split("--server ")[1]
+        assert base64.b64decode(server_b64).decode() == "run-server"
+
+    async def test_call_encodes_args(self):
+        env = '@@CARAPACE_MCP@@{"ok": true, "result": "done"}'
+        ctx = _bridge_ctx(output=env)
+        decl = ctx.deps.session_state.context_grants["s"].mcp_servers[0]
+        result = await _run_stdio_bridge(ctx, "s", decl, "call", tool="search", args={"q": "x"})
+        assert result == "done"
+        command = ctx.deps.sandbox.exec_command.await_args.args[1]
+        assert "--tool search" in command
+        args_b64 = command.split("--args ")[1]
+        assert json.loads(base64.b64decode(args_b64).decode()) == {"q": "x"}
+
+    async def test_error_envelope_raises(self):
+        ctx = _bridge_ctx(output='@@CARAPACE_MCP@@{"ok": false, "error": "boom"}')
+        decl = ctx.deps.session_state.context_grants["s"].mcp_servers[0]
+        with pytest.raises(RuntimeError, match="boom"):
+            await _run_stdio_bridge(ctx, "s", decl, "list")
+
+
+# ── Tool handler gating ─────────────────────────────────────────────
+
+
+def _handler_ctx(*, approved: bool = False) -> MagicMock:
+    ctx = MagicMock()
+    ctx.tool_call_approved = approved
+    ctx.deps.config.agent.tool_output_max_chars = 16_000
+    ctx.deps.tool_result_callback = None
+    ctx.deps.tool_call_callback = None
+    ctx.deps.assert_llm_budget_available = None
+    ctx.deps.llm_usage_limits = None
+    return ctx
+
+
+class TestStdioToolHandler:
+    async def test_denied_returns_tool_denied_without_running(self):
+        decl = SkillMcpDecl(name="srv", command="run")
+        handler = _stdio_mcp_tool_handler("s", decl, "search")
+        ctx = _handler_ctx()
+        with (
+            patch("carapace.agent.tools.security.evaluate_with", AsyncMock(side_effect=SecurityDeniedError("no"))),
+            patch("carapace.agent.tools._run_stdio_bridge", AsyncMock()) as run,
+        ):
+            result = await handler(ctx, q="x")
+        assert isinstance(result, ToolDenied)
+        run.assert_not_awaited()
+
+    async def test_allowed_runs_bridge_and_returns_result(self):
+        decl = SkillMcpDecl(name="srv", command="run")
+        handler = _stdio_mcp_tool_handler("s", decl, "search")
+        ctx = _handler_ctx()
+        with (
+            patch("carapace.agent.tools.security.evaluate_with", AsyncMock(return_value=None)) as gate,
+            patch("carapace.agent.tools._run_stdio_bridge", AsyncMock(return_value={"hits": 3})),
+        ):
+            result = await handler(ctx, q="x")
+        assert result == {"hits": 3}
+        assert gate.await_args.args[2] == "mcp:srv:search"
+
+    async def test_bridge_failure_becomes_model_retry(self):
+        decl = SkillMcpDecl(name="srv", command="run")
+        handler = _stdio_mcp_tool_handler("s", decl, "search")
+        ctx = _handler_ctx()
+        with (
+            patch("carapace.agent.tools.security.evaluate_with", AsyncMock(return_value=None)),
+            patch("carapace.agent.tools._run_stdio_bridge", AsyncMock(side_effect=RuntimeError("server down"))),
+            pytest.raises(ModelRetry, match="server down"),
+        ):
+            await handler(ctx, q="x")
+
+
+# ── Toolset build + enumeration ─────────────────────────────────────
+
+
+class TestBuildStdioToolset:
+    async def test_enumeration_registers_prefixed_tools(self):
+        decl = SkillMcpDecl(name="srv", command="run")
+        ctx = MagicMock()
+        obj_schema = {"type": "object", "properties": {"q": {"type": "string"}}}
+        tool_defs = [
+            {"name": "search", "description": "d", "input_schema": obj_schema},
+            {"name": "fetch", "description": "", "input_schema": {"type": "object", "properties": {}}},
+        ]
+        with patch("carapace.agent.tools._run_stdio_bridge", AsyncMock(return_value=tool_defs)):
+            toolset = await _build_stdio_mcp_toolset(ctx, "s", decl)
+        assert isinstance(toolset, FunctionToolset)
+        assert sorted(toolset.tools.keys()) == ["srv_fetch", "srv_search"]
+
+    async def test_empty_enumeration_returns_none(self):
+        decl = SkillMcpDecl(name="srv", command="run")
+        with patch("carapace.agent.tools._run_stdio_bridge", AsyncMock(return_value=[])):
+            assert await _build_stdio_mcp_toolset(MagicMock(), "s", decl) is None
+
+    async def test_factory_caches_stdio_toolset(self):
+        decl = SkillMcpDecl(name="srv", command="run")
+        ctx = MagicMock()
+        ctx.deps.session_state.context_grants = {"s": ContextGrant(skill_name="s", mcp_servers=[decl])}
+        ctx.deps.mcp_toolsets = {}
+        tool_defs = [{"name": "t", "description": "", "input_schema": {"type": "object", "properties": {}}}]
+        with patch("carapace.agent.tools._run_stdio_bridge", AsyncMock(return_value=tool_defs)) as run:
+            first = await build_skill_mcp_toolset(ctx)
+            second = await build_skill_mcp_toolset(ctx)
+        assert first is second
+        run.assert_awaited_once()  # enumerated once, then cached
+
+
+# ── Bridge script end-to-end (real subprocess against a fake server) ─
+
+_FAKE_SERVER = textwrap.dedent(
+    """
+    from mcp.server.fastmcp import FastMCP
+    mcp = FastMCP("demo")
+
+    @mcp.tool()
+    def echo(text: str, times: int = 1) -> str:
+        "Echo text a number of times."
+        return " ".join([text] * times)
+
+    if __name__ == "__main__":
+        mcp.run()
+    """
+)
+
+
+@pytest.fixture
+def fake_server(tmp_path: Path) -> str:
+    path = tmp_path / "srv.py"
+    path.write_text(_FAKE_SERVER)
+    return f"{sys.executable} {path}"
+
+
+def _run_bridge(server_cmd: str, *args: str) -> dict:
+    server_b64 = base64.b64encode(server_cmd.encode()).decode()
+    proc = subprocess.run(
+        [sys.executable, str(BRIDGE), args[0], "--server", server_b64, *args[1:]],
+        capture_output=True,
+        text=True,
+    )
+    for line in proc.stdout.splitlines():
+        if line.startswith("@@CARAPACE_MCP@@"):
+            return json.loads(line.removeprefix("@@CARAPACE_MCP@@"))
+    raise AssertionError(f"no envelope. stdout={proc.stdout!r} stderr={proc.stderr!r}")
+
+
+class TestBridgeScriptEndToEnd:
+    def test_list_emits_real_json_schema(self, fake_server: str):
+        env = _run_bridge(fake_server, "list")
+        assert env["ok"] is True
+        (tool,) = env["result"]
+        assert tool["name"] == "echo"
+        # real JSON Schema, not a flattened param list
+        assert tool["input_schema"]["properties"]["text"]["type"] == "string"
+        assert tool["input_schema"]["required"] == ["text"]
+
+    def test_call_passes_structured_args(self, fake_server: str):
+        args_b64 = base64.b64encode(json.dumps({"text": "hi", "times": 3}).encode()).decode()
+        env = _run_bridge(fake_server, "call", "--tool", "echo", "--args", args_b64)
+        assert env["ok"] is True
+        assert env["result"] == {"result": "hi hi hi"}
+
+    def test_unknown_tool_reports_clean_error(self, fake_server: str):
+        env = _run_bridge(fake_server, "call", "--tool", "nope")
+        assert env["ok"] is False
+        assert "nope" in env["error"]


### PR DESCRIPTION
**Stacked on #244** (base branch = `feature/skill-mcp-connections`, not `main`). Review/merge #244 first.

Adds a second MCP transport: skills can declare **stdio** MCP servers, whose process runs **inside the sandbox**. The shortcut for the four mcp2cli-wrapped stdio skills in lumi (karakeep/affine/bring/paperless), which the agent struggles to discover/understand through the CLI.

## Declaration

```yaml
metadata:
  carapace:
    mcp:
      - name: karakeep
        command: npx -y @karakeep/mcp   # stdio: runs in the sandbox
      - name: linear
        url: https://mcp.linear.app/mcp # HTTP: runs in the backend (from #244)
```

`SkillMcpDecl` is now `url` (HTTP) **xor** `command` (stdio). stdio servers inherit the skill's context-injected credentials, so `auth` is HTTP-only — declare secrets under `credentials` with an `env_var`.

## How it works

- **Not persistent.** Same process model as mcp2cli: the server is spawned once at activation to enumerate tools, and once per tool call, by a baked-in `carapace-mcp-bridge`. Nothing is held open — so the sandbox's per-session exec lock, lifecycle, and pod-restart handling are all untouched. No streaming, no long-lived connection.
- **Real schemas.** The bridge speaks MCP over stdio and returns the server's own `inputSchema` (JSON Schema) per tool. The backend registers them as typed pydantic-ai tools via `Tool.from_schema` (`<server>_<tool>`), so the model sees proper params — the thing driving mcp2cli-through-a-shell-alias doesn't give it. Args pass as a JSON dict, not reconstructed CLI flags.
- **Same guardrails as HTTP (#244).** Each call is sentinel-gated as `mcp:<server>:<tool>` with escalate-to-user; oversized results spill to a sandbox file. The gate + result-emit + bearer-token helpers are shared between transports.
- **Enumeration** happens lazily in the dynamic-toolset factory and is cached on `Deps` (restart-safe: rebuilds on first use after a backend restart). The bridge invocation is base64-encoded (server command + args), and its result rides a marked line so it survives the sandbox merging the child's stderr into stdout.
- **exec injection refactor.** The exec tool's credential/domain/tunnel/file injection is factored into `_collect_context_injection`, reused by the bridge so a stdio server gets the skill's declared env, domains, and tunnels identically.

## Sandbox image

Adds a dedicated `/opt/carapace-mcp` venv (`mcp` package) + the `carapace-mcp-bridge` script. Baked at build time because the sandbox's egress is proxy/domain-gated — no runtime dependency resolution. CI builds `context: sandbox`, so the image change is validated there.

## Escape hatch

Skills needing OAuth, stateful sessions, or custom output shaping keep using mcp2cli + a `commands` alias. `mcp` is the shortcut for the common (stateless, per-call) case.

## Testing

- 19 new tests (`tests/test_skill_mcp_stdio.py`): model xor-validation, envelope parsing, bridge command construction + injection, handler gate deny/allow/error→ModelRetry, enumeration→typed-toolset + caching, and a **real end-to-end subprocess test of the bridge** against a live fake stdio server (verifies real JSON Schema out, structured args in, clean errors).
- Full suite: 1112 passed. ruff + eslint + tsc clean. Image build not run locally (CI covers it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent tool wiring, sandbox image, and arbitrary skill-declared shell commands in the sandbox; guardrails mirror HTTP MCP but stdio expands the attack surface for malicious or misconfigured skills.
> 
> **Overview**
> Adds a **stdio MCP transport** for skill metadata: each MCP entry must set exactly **`url`** (existing HTTP path from the backend) or **`command`** (shell that starts a stdio server in the sandbox). HTTP **`auth`** stays HTTP-only; stdio servers rely on skill **`credentials`** injected into the bridge exec.
> 
> **Runtime:** Activation and each tool call spawn a fresh server process inside the sandbox via baked-in **`carapace-mcp-bridge`** (new venv + script in the sandbox image). The bridge lists tools with real JSON Schemas or invokes one tool and returns a marked JSON envelope; the agent registers **`FunctionToolset`** tools (`<server>_<tool>`) with the same sentinel gating, spill-to-file, and result handling as HTTP MCP. **`_collect_context_injection`** is shared with **`exec`** so domains, tunnels, and creds match skill context.
> 
> **UI/docs:** Knowledge view and tool-call badges show `stdio: <command>` when applicable; API types allow nullable `url`/`command`.
> 
> **Tests:** New `test_skill_mcp_stdio.py` covers validation, bridge parsing, gating, caching, and subprocess e2e against a fake server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dda728be04857b6ec7db4887209c0a422ffa3aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->