### PR TITLE
✨ feat(knowledge): vault-presence status + OAuth provisioning hint in the viewer

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -38,6 +38,11 @@
             "credential": "Zugangsdatum",
             "mcp": "MCP-Server",
             "mcpAuth": "{type}-Auth",
+            "vaultPresent": "Im Vault vorhanden",
+            "vaultAbsent": "Nicht im Vault",
+            "vaultError": "Vault nicht erreichbar",
+            "oauthHint": "Kein OAuth-Token hinterlegt. Erzeuge eines mit",
+            "oauthHintStore": "und speichere das JSON im obigen Vault-Eintrag.",
             "hints": "Hinweise"
         }
     },

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -38,6 +38,11 @@
             "credential": "Credential",
             "mcp": "MCP servers",
             "mcpAuth": "{type} auth",
+            "vaultPresent": "Found in vault",
+            "vaultAbsent": "Not found in vault",
+            "vaultError": "Vault unreachable",
+            "oauthHint": "No OAuth token stored. Generate one with",
+            "oauthHintStore": "then save the JSON in the vault entry above.",
             "hints": "Hints"
         }
     },

--- a/frontend/src/components/knowledge-view.tsx
+++ b/frontend/src/components/knowledge-view.tsx
@@ -3,6 +3,7 @@
 import {
   BookText,
   Cable,
+  CircleAlert,
   Check,
   ChevronRight,
   Copy,
@@ -15,6 +16,7 @@ import {
   Plug,
   Puzzle,
   Terminal,
+  X,
 } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
@@ -220,7 +222,23 @@ function SkillSection({ icon, label, children }: { icon: ReactNode; label: strin
 const sectionIconClass = "h-3.5 w-3.5 shrink-0";
 
 /** Frontmatter of a skill's SKILL.md as a card: what it exposes, reaches, and needs. */
-function SkillCard({ skill }: { skill: KnowledgeSkill }) {
+function VaultBadge({ status }: { status?: string }) {
+  const t = useTranslations("knowledge.skill");
+  if (!status) return null;
+  const map: Record<string, { icon: ReactNode; cls: string; label: string }> = {
+    present: { icon: <Check className="h-3 w-3" />, cls: "text-emerald-600 dark:text-emerald-400", label: t("vaultPresent") },
+    absent: { icon: <X className="h-3 w-3" />, cls: "text-red-600 dark:text-red-400", label: t("vaultAbsent") },
+    error: { icon: <CircleAlert className="h-3 w-3" />, cls: "text-muted-foreground", label: t("vaultError") },
+  };
+  const s = map[status] ?? map.error;
+  return (
+    <span className={`inline-flex items-center gap-0.5 text-[10px] ${s.cls}`} title={s.label}>
+      {s.icon}
+    </span>
+  );
+}
+
+function SkillCard({ skill, vaultStatus }: { skill: KnowledgeSkill; vaultStatus?: Record<string, string> }) {
   const t = useTranslations("knowledge.skill");
   const carapace = skill.carapace;
   const domains = carapace?.network.domains ?? [];
@@ -288,7 +306,10 @@ function SkillCard({ skill }: { skill: KnowledgeSkill }) {
                       <span className="break-words text-xs text-muted-foreground">{credential.description}</span>
                     ) : null}
                   </div>
-                  <code className="break-all font-mono text-xs text-muted-foreground">{credential.vault_path}</code>
+                  <div className="flex min-w-0 items-center gap-1">
+                    <code className="break-all font-mono text-xs text-muted-foreground">{credential.vault_path}</code>
+                    <VaultBadge status={vaultStatus?.[credential.vault_path]} />
+                  </div>
                 </div>
               ))}
             </SkillSection>
@@ -308,9 +329,21 @@ function SkillCard({ skill }: { skill: KnowledgeSkill }) {
                     {server.command ? `stdio: ${server.command}` : server.url}
                   </code>
                   {server.auth ? (
-                    <code className="break-all font-mono text-xs text-muted-foreground">
-                      {t("mcpAuth", { type: server.auth.type })} · {server.auth.vault_path}
-                    </code>
+                    <div className="flex min-w-0 items-center gap-1">
+                      <code className="break-all font-mono text-xs text-muted-foreground">
+                        {t("mcpAuth", { type: server.auth.type })} · {server.auth.vault_path}
+                      </code>
+                      <VaultBadge status={vaultStatus?.[server.auth.vault_path]} />
+                    </div>
+                  ) : null}
+                  {server.auth?.type === "oauth" && vaultStatus?.[server.auth.vault_path] !== "present" ? (
+                    <p className="mt-0.5 text-[11px] text-muted-foreground">
+                      {t("oauthHint")}{" "}
+                      <code className="break-all font-mono">
+                        python scripts/mcp_oauth_blob.py --token-url … --client-id … --refresh-token …
+                      </code>{" "}
+                      {t("oauthHintStore")}
+                    </p>
                   ) : null}
                 </div>
               ))}
@@ -515,7 +548,7 @@ export function KnowledgeView() {
                 ))}
               </div>
             )}
-            {result.skill ? <div className="mt-6"><SkillCard skill={result.skill} /></div> : null}
+            {result.skill ? <div className="mt-6"><SkillCard skill={result.skill} vaultStatus={result.vault_status} /></div> : null}
             {result.doc ? (
               <section className="mt-6">
                 <h2 className="mb-2 flex items-center gap-1.5 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1592,12 +1592,17 @@ export interface SkillMcpBearerAuth {
   vault_path: string;
 }
 
+export interface SkillMcpOAuthAuth {
+  type: "oauth";
+  vault_path: string;
+}
+
 export interface SkillMcpDecl {
   name: string;
   url: string | null;
   command: string | null;
   description: string;
-  auth: SkillMcpBearerAuth | null;
+  auth: SkillMcpBearerAuth | SkillMcpOAuthAuth | null;
 }
 
 export interface SkillCarapaceConfig {
@@ -1623,6 +1628,8 @@ export interface KnowledgeDirListing {
   doc_name: string | null;
   doc: string | null;
   skill: KnowledgeSkill | null;
+  /** Per vault_path referenced by the skill: "present" | "absent" | "error". */
+  vault_status?: Record<string, string>;
   path: string;
   entries: KnowledgeEntry[];
 }

--- a/src/carapace/server/knowledge.py
+++ b/src/carapace/server/knowledge.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, ValidationError
 from ..api_keys import Access, Scope
 from ..auth import UserIdentity
 from ..git.store import GitStore
+from ..models.credentials import CredentialRegistryProtocol
 from ..models.git import FileCommit
 from ..models.skills import SkillCarapaceConfig
 from ..session.sent_files import guess_mime
@@ -123,6 +124,9 @@ class KnowledgeDirListing(BaseModel):
     doc_name: str | None = None
     doc: str | None = None
     skill: KnowledgeSkill | None = None
+    # Per secret vault_path referenced by the skill (credentials + mcp auth):
+    # "present" | "absent" | "error" (vault unreachable). Empty unless a skill dir.
+    vault_status: dict[str, str] = {}
 
 
 class KnowledgeFileInfo(BaseModel):
@@ -258,6 +262,27 @@ def parse_carapace_config(document: SkillDocument, skill_name: str) -> SkillCara
         return None
 
 
+def _skill_secret_refs(cfg: SkillCarapaceConfig) -> list[str]:
+    """All vault paths a skill references (credentials + MCP auth), de-duplicated."""
+    refs = {c.vault_path for c in cfg.credentials}
+    refs |= {m.auth.vault_path for m in cfg.mcp if m.auth is not None}
+    return sorted(refs)
+
+
+async def resolve_vault_status(cfg: SkillCarapaceConfig, registry: CredentialRegistryProtocol) -> dict[str, str]:
+    """Check each referenced vault path for existence (metadata only, never values)."""
+    status: dict[str, str] = {}
+    for ref in _skill_secret_refs(cfg):
+        try:
+            await registry.fetch_metadata(ref)
+            status[ref] = "present"
+        except KeyError:
+            status[ref] = "absent"
+        except Exception:
+            status[ref] = "error"
+    return status
+
+
 @router.get("/knowledge/browse", response_model=None)
 @router.get("/knowledge/browse/{path:path}", response_model=None)
 async def browse_knowledge(
@@ -274,6 +299,12 @@ async def browse_knowledge(
     if target.is_dir():
         listing = list_dir(root, target)
         await attach_commits(handle.git_store, listing)
+        if listing.skill is not None and listing.skill.carapace is not None:
+            try:
+                registry = await server._credential_registry_for_user(user.username)
+                listing.vault_status = await resolve_vault_status(listing.skill.carapace, registry)
+            except Exception as exc:
+                logger.warning(f"Vault status lookup failed for skill '{target.name}': {exc}")
         return listing
     if not target.is_file():
         raise HTTPException(status_code=404, detail="Not found")

--- a/tests/test_knowledge_browse.py
+++ b/tests/test_knowledge_browse.py
@@ -16,6 +16,7 @@ from carapace.server.knowledge import (
     list_dir,
     read_text_content,
     resolve_target,
+    resolve_vault_status,
     session_archive_entry,
 )
 
@@ -416,3 +417,43 @@ def test_session_archive_entry_ignores_an_oversized_archive(tmp_path: Path) -> N
     (directory / "conversation.json").write_text(json.dumps(payload))
 
     assert session_archive_entry(directory, root.resolve()) is None
+
+
+# ── Vault presence status ───────────────────────────────────────────
+
+
+class _FakeRegistry:
+    """Minimal credential registry: only paths in `present` resolve; `errors` raise."""
+
+    def __init__(self, present: set[str], errors: set[str] | None = None) -> None:
+        self._present = present
+        self._errors = errors or set()
+
+    async def fetch_metadata(self, vault_path: str):
+        from carapace.credentials import CredentialBackendError
+        from carapace.models.credentials import CredentialMetadata
+
+        if vault_path in self._errors:
+            raise CredentialBackendError("vault down")
+        if vault_path not in self._present:
+            raise KeyError(vault_path)
+        return CredentialMetadata(vault_path=vault_path, name=vault_path)
+
+
+async def test_resolve_vault_status_present_absent_error():
+    from carapace.models.skills import SkillCarapaceConfig
+
+    cfg = SkillCarapaceConfig.model_validate(
+        {
+            "credentials": [
+                {"vault_path": "vault/have", "env_var": "A"},
+                {"vault_path": "vault/missing", "env_var": "B"},
+            ],
+            "mcp": [
+                {"name": "o", "url": "https://e.example/mcp", "auth": {"type": "oauth", "vault_path": "vault/down"}},
+            ],
+        }
+    )
+    registry = _FakeRegistry(present={"vault/have"}, errors={"vault/down"})
+    status = await resolve_vault_status(cfg, registry)
+    assert status == {"vault/have": "present", "vault/missing": "absent", "vault/down": "error"}


### PR DESCRIPTION
**Stacked on #249** (base = `feature/skill-mcp-oauth`). Chain: #244 → #247 → #249 → this.

The knowledge viewer's skill card now shows, for every secret a skill references (credential `vault_path`s and MCP `auth.vault_path`s), whether it exists in your vault — and for OAuth servers without a token, how to provision one.

## What you see

- ✓ green check — found in vault
- ✗ red cross — not found (secret ref points at a missing entry)
- ⚠ muted — vault unreachable

Next to each credential row and each MCP auth line. For an `oauth` server whose token is absent, a one-line hint appears with the `scripts/mcp_oauth_blob.py` command and "save the JSON in the vault entry above" — the stand-in for the deferred interactive populate button.

## How

- **Backend**: `browse_knowledge` enriches a skill listing with `vault_status: {vault_path -> "present"|"absent"|"error"}`, resolved via the per-user credential registry (`_credential_registry_for_user`). Metadata-only (`fetch_metadata`, never values), one call per referenced ref, and **best-effort** — any vault error is caught so a down/misconfigured vault never breaks browsing.
- **Frontend**: a small `VaultBadge` next to each ref; the OAuth hint; `SkillMcpOAuthAuth` added to the TS types (so `auth.type === "oauth"` type-checks); en/de strings.

## Notes

- Read-only, user-facing view of the user's *own* vault — no sentinel/agent involvement.
- The interactive DCR+PKCE "populate" button remains deferred (agreed); this ships the instructions instead.

## Testing

- `resolve_vault_status` unit test (present/absent/error) with a fake registry.
- Full suite: 1129 passed. pyrefly + ruff + eslint + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only metadata checks against the user’s own credential registry; failures are swallowed so knowledge browse keeps working.
> 
> **Overview**
> The knowledge browser’s **skill card** now shows whether each referenced **vault path** (credentials and MCP auth) exists in the signed-in user’s vault, without loading secret values.
> 
> **Backend:** Skill directory listings from `browse_knowledge` include optional `vault_status` (`present` / `absent` / `error`), resolved via the per-user credential registry using **metadata-only** `fetch_metadata`. Lookups are best-effort so vault outages do not break browsing.
> 
> **Frontend:** A `VaultBadge` appears beside credential and MCP auth paths; missing **OAuth** tokens get a short hint pointing at `scripts/mcp_oauth_blob.py` and saving JSON to the vault entry. Types add `SkillMcpOAuthAuth` and wire `vault_status` through the API. **en/de** strings cover badge labels and the OAuth hint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b025f3c16e35bfaf775b55dac9f11e830735afb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->